### PR TITLE
Plan 2: Overview KPI dashboard

### DIFF
--- a/docs/superpowers/plans/2026-04-29-admin-overview-dashboard.md
+++ b/docs/superpowers/plans/2026-04-29-admin-overview-dashboard.md
@@ -1,0 +1,233 @@
+# Admin Overview Dashboard — Plan 2
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Replace the `overview` stub with the four-question dashboard from `design_handoff_admin_overhaul/design/overview.jsx`. Answer at a glance: (1) what's running, (2) where am I at capacity, (3) what failed recently, (4) what blockers do we have.
+
+**Architecture:** All computation client-side from the existing `/api/log`, `/api/mappings`, `/api/runner-mode`, `/api/reaper/summary` endpoints. No new backend code. The page module follows the established `pages/<name>.ts` pattern: exports `overviewHtml` + `overviewScript`. The stub for `overview` in `src/admin-ui/pages/stubs.ts` gets removed (the new section replaces it via the same `data-page="overview"` route).
+
+**Scope explicitly excluded (Plan 4):**
+- The "Top alerts" red-banner strip about specific blockers (e.g. PAYMENTS missing secret) — needs server-side blockers logic. The "Why isn't this running?" card uses a derived signal (projects at concurrency cap) instead of the full blocker taxonomy.
+- The Linear-issue-level blocker reasons (`secret`, `dedup`, `linear-dep`).
+
+**Tech Stack:** Same as Plan 1 — TypeScript ESM, template literal strings, Vitest. No new deps.
+
+**Branching:** This work is on `admin-overhaul-2-overview`, branched from `admin-overhaul`. PRs back to `admin-overhaul` (the integration branch). Final merge to `main` happens after Plans 2-5 are all done.
+
+---
+
+## File Structure
+
+**New / modified files:**
+
+```
+src/admin-ui/pages/overview.ts          — NEW. Overview page module.
+src/admin-ui/pages/stubs.ts             — MODIFIED. Remove the "overview" entry from stubsHtml.
+src/admin-ui/index.ts                   — MODIFIED. Inject overviewHtml + overviewScript.
+src/admin-ui/__tests__/overview.test.ts — NEW. Spot-check structural HTML + a small unit test for the KPI computation logic if extractable.
+```
+
+**Helpers to add inside `overview.ts`** (private to that module's IIFE):
+- `fmtAgo(ms)` — same shape as the one already inside reaper.ts. Skip extraction; keep DRY for future polish.
+- `fmtDuration(ms)` — same as in pipelines.ts/sessions.ts.
+- `sparkline(values)` — returns an HTML string of `<div class="bar" style="height:Y%">` divs.
+- `capacityMeter(used, max)` — returns an HTML string with a `.meter > .fill` and a label.
+
+If any of these end up duplicated more than 3 times across pages, defer DRY to a future cleanup plan.
+
+---
+
+## Computation reference
+
+| KPI | Source | Computation |
+|---|---|---|
+| Running now | `/api/log` | `entries.filter(e => e.status === 'running')`. Length is the count; the entries also feed the "Running now" card. |
+| Capacity used | `/api/mappings` + running entries | `running.length` and `Object.values(mappings).reduce((s,m) => s + (m.maxInProgressAiIssues ?? 3), 0)` for the max. |
+| Blocked | derived | Count of teams where `runningCount(team) >= maxInProgressAiIssues(team)`. Show as "N at capacity" with a subtitle pointing to the future `blockers` page (Plan 4) for the full taxonomy. |
+| Failed (24h) | `/api/log` | `entries.filter(e => e.status === 'failed' && Date.now() - new Date(e.dispatchedAt).getTime() < 86400000)`. |
+| 24h sparkline | `/api/log` | Bucket entries by hour over the last 24h; produce an array of 24 numbers. |
+| Project capacity grid | `/api/mappings` + running counts | One row per project. Renders `capacityMeter(running, max)` and the `runner` (executionMode) badge. |
+
+---
+
+## Task 1: Add the overview page module
+
+**Files:**
+- Create: `src/admin-ui/pages/overview.ts`
+
+- [ ] **Step 1: Implement `overviewHtml`**
+
+Mirror the layout from `design/overview.jsx`. Key sections in order:
+
+1. `<header class="page-header">` with title "Overview", subtitle showing reaper last sweep (placeholder text — JS fills in), and a "↻ Refresh" button calling `loadOverview()`.
+2. `<div class="kpi-grid">` — four `<div class="kpi">` tiles with ids `kpi-running`, `kpi-capacity`, `kpi-blocked`, `kpi-failed`. Each KPI has spans for `value`, `unit`, `sub`, plus a `<div class="spark" data-spark="dispatch24h">` placeholder in the running tile.
+3. **Two-up grid** (CSS grid, `1.5fr 1fr`) with two cards:
+   - "Running now" — table with columns Issue / Phase / Duration. `<tbody id="overview-running-body">`. Empty state.
+   - "At capacity" — list of teams whose running == max. Title is "Why isn't this running?". Subtitle: "Full blocker taxonomy on Plan 4 — Blockers page".
+4. **Recent failures card** — table with columns Issue / Failed at / Summary / When. `<tbody id="overview-failures-body">`. Empty state.
+5. **Project capacity grid card** — table with columns Project / Repo / Runner / Provider / Utilization / Queued (queued is unimplemented — show "—"). `<tbody id="overview-projects-body">`. Empty state.
+
+- [ ] **Step 2: Implement `overviewScript`**
+
+IIFE with the following:
+
+```ts
+export const overviewScript = `
+(function () {
+  function fmtAgo(ts) { /* same as reaper.ts */ }
+  function fmtDuration(ms) { /* same as pipelines.ts */ }
+  function sparkline(values) { /* compute max, return divs */ }
+  function capacityMeter(used, max) { /* meter > fill + label */ }
+
+  async function loadOverview() {
+    const [logRes, mappingsRes, reaperRes] = await Promise.all([
+      window.api('/api/log'),
+      window.api('/api/mappings'),
+      window.api('/api/reaper/summary'),
+    ]);
+    const log = await logRes.json();
+    const mappings = await mappingsRes.json();
+    const reaper = await reaperRes.json();
+
+    renderKpis(log, mappings);
+    renderRunningNow(log);
+    renderAtCapacity(log, mappings);
+    renderRecentFailures(log);
+    renderProjectGrid(log, mappings);
+    renderHeaderSubtitle(reaper);
+  }
+
+  function runningCounts(log) { /* { teamKey: count } */ }
+  function renderKpis(log, mappings) { /* fill kpi-* nodes */ }
+  function renderRunningNow(log) { /* tbody rows from running entries */ }
+  function renderAtCapacity(log, mappings) { /* list teams at cap */ }
+  function renderRecentFailures(log) { /* tbody rows from failed entries within 24h */ }
+  function renderProjectGrid(log, mappings) { /* one row per project */ }
+  function renderHeaderSubtitle(reaper) { /* update last-sweep text */ }
+
+  window.loadOverview = loadOverview;
+  window.registerPage('overview', function () {
+    loadOverview();
+    setInterval(loadOverview, 30000);
+  });
+})();
+`;
+```
+
+Concrete details for each render function — the implementer fills in based on the [Computation reference](#computation-reference) table above. Use `window.esc()` for any user-supplied strings (issue titles, repo names).
+
+**Status badge mapping** (consistent with Pipelines page): `running` → `.badge.running`, `failed` → `.badge.fail`, `completed` → `.badge.success`, `queued`/`dispatched` → `.badge.neutral`.
+
+**Failed filter:** include only entries where `status === 'failed'` AND `Date.now() - new Date(e.dispatchedAt).getTime() < 86400000`. Sort by dispatchedAt desc. Limit to 8 rows in the recent-failures card.
+
+**At-capacity logic:** for each team in `mappings`, count `running.filter(r => r.teamKey === key).length`; if `count >= mapping.maxInProgressAiIssues`, include in the list. Each row shows `<span class="mono">TEAM</span> <span class="text-secondary">at capacity (N/M)</span>`. Empty state: "All projects have available capacity."
+
+**Sparkline source:** bucket the last 24h of dispatches into 24 hourly buckets. Skip if log < 1 entry; render `'<div class="text-tertiary">no data</div>'`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/admin-ui/pages/overview.ts
+git commit -m "feat(admin): add overview page module"
+```
+
+---
+
+## Task 2: Wire overview into the shell + remove its stub
+
+**Files:**
+- Modify: `src/admin-ui/index.ts`
+- Modify: `src/admin-ui/pages/stubs.ts`
+
+- [ ] **Step 1: Import + inject `overviewHtml` and `overviewScript`** in `src/admin-ui/index.ts` alongside the other page imports/injections.
+
+- [ ] **Step 2: Remove the `overview` stub** from `src/admin-ui/pages/stubs.ts` — delete the `stubPage("overview", ...)` line in the `stubsHtml` array. Leave the other 13 stubs intact.
+
+- [ ] **Step 3: Verify** — `npm run typecheck && npm test`. The `pages-render.test.ts` still passes because the overview route is still covered (just by a real page now instead of a stub).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/admin-ui/index.ts src/admin-ui/pages/stubs.ts
+git commit -m "feat(admin): wire overview page, remove its stub"
+```
+
+---
+
+## Task 3: Add overview test
+
+**Files:**
+- Create: `src/admin-ui/__tests__/overview.test.ts`
+
+- [ ] **Step 1: Write structural tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { overviewHtml, overviewScript } from "../pages/overview.js";
+
+describe("overview page", () => {
+  it("declares all four KPI tile ids", () => {
+    for (const id of ["kpi-running", "kpi-capacity", "kpi-blocked", "kpi-failed"]) {
+      expect(overviewHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("declares the four card body ids the script targets", () => {
+    for (const id of ["overview-running-body", "overview-failures-body", "overview-projects-body"]) {
+      expect(overviewHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("registers the 'overview' route and exposes loadOverview on window", () => {
+    expect(overviewScript).toContain("window.registerPage('overview'");
+    expect(overviewScript).toContain("window.loadOverview = loadOverview");
+  });
+
+  it("uses the existing data endpoints (no new backend)", () => {
+    expect(overviewScript).toContain("/api/log");
+    expect(overviewScript).toContain("/api/mappings");
+    expect(overviewScript).toContain("/api/reaper/summary");
+    // Anti-test: verifies no accidental new endpoint slipped in.
+    expect(overviewScript).not.toMatch(/\/api\/(blockers|kpis|overview)\b/);
+  });
+});
+```
+
+- [ ] **Step 2: Run** — `npm test -- src/admin-ui/__tests__/overview.test.ts`. Expect PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/admin-ui/__tests__/overview.test.ts
+git commit -m "test(admin): structural tests for overview page module"
+```
+
+---
+
+## Task 4: Final verification
+
+- [ ] **Step 1:** `npm run typecheck && npm test` — all pass.
+- [ ] **Step 2:** `npm run dev` and visit `#overview`. Verify:
+  - Four KPI tiles populate (running, capacity, blocked-as-at-capacity-count, failed-24h).
+  - Running-now table shows entries when there are any in-flight jobs.
+  - At-capacity list shows teams at their concurrency cap (or empty-state message).
+  - Recent failures table shows up to 8 failures from the last 24h.
+  - Project capacity grid shows one row per mapping with a meter.
+  - Sparkline renders in the running tile.
+  - 30s auto-refresh works.
+- [ ] **Step 3:** If issues, fix in place, run tests, commit.
+
+---
+
+## Self-review
+
+- **Spec coverage:** Four KPIs ✓, running-now ✓, blockers-via-capacity (with Plan 4 caveat) ✓, recent failures ✓, project capacity grid ✓, sparkline ✓.
+- **Out of scope:** PAYMENTS-style alert strip (Plan 4), full blocker taxonomy (Plan 4), risk scoring (Plan 4).
+- **No new backend:** The "anti-test" in Task 3 guards against accidental new endpoint introduction.
+- **Type/name consistency:** `overviewHtml`, `overviewScript` follow the page-module pattern. `data-page="overview"` matches the sidebar route key.
+
+## Risks
+
+- **Empty `/api/log`:** if the log is empty (fresh install), KPIs show 0 and the running-now / failures lists show empty states. This is fine but should be visually pleasant — confirm in Step 2 of Task 4.
+- **Sparkline precision:** hourly bucketing of < 24h of data can look misleading. Fall back to "no data" string if log length is 0; otherwise render whatever is there.
+- **Per-team running counts:** rely on `teamKey` field present on log entries. Verify by inspecting a sample entry; if missing, the at-capacity card and project grid will show 0s (not crash). Should still work because the existing Pipelines page also reads `teamKey` from log entries.

--- a/src/admin-ui/__tests__/overview.test.ts
+++ b/src/admin-ui/__tests__/overview.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { overviewHtml, overviewScript } from "../pages/overview.js";
+
+describe("overview page", () => {
+  it("declares all four KPI tile ids", () => {
+    for (const id of ["kpi-running", "kpi-capacity", "kpi-blocked", "kpi-failed"]) {
+      expect(overviewHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("declares the card body ids the script targets", () => {
+    for (const id of ["overview-running-body", "overview-failures-body", "overview-projects-body", "overview-atcap-body"]) {
+      expect(overviewHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("registers the 'overview' route and exposes loadOverview on window", () => {
+    expect(overviewScript).toContain("window.registerPage('overview'");
+    expect(overviewScript).toContain("window.loadOverview = loadOverview");
+  });
+
+  it("uses the existing data endpoints (no new backend)", () => {
+    expect(overviewScript).toContain("/api/log");
+    expect(overviewScript).toContain("/api/mappings");
+    expect(overviewScript).toContain("/api/reaper/summary");
+    expect(overviewScript).not.toMatch(/\/api\/(blockers|kpis|overview)\b/);
+  });
+
+  it("has no bare api(/esc( calls (must use window.api/window.esc)", () => {
+    const scriptWithoutWindow = overviewScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(scriptWithoutWindow).not.toMatch(/\bapi\(/);
+    expect(scriptWithoutWindow).not.toMatch(/\besc\(/);
+  });
+
+  it("uses const/let, not var", () => {
+    expect(overviewScript).not.toMatch(/\bvar\s+\w/);
+  });
+});

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -4,6 +4,7 @@ import { sidebarHtml } from "./sidebar.js";
 import { themeJs } from "./theme.js";
 import { routerJs } from "./router.js";
 import { authJs } from "./auth.js";
+import { overviewHtml, overviewScript } from "./pages/overview.js";
 import { settingsHtml, settingsScript } from "./pages/settings.js";
 import { projectsHtml, projectsScript } from "./pages/projects.js";
 import { pipelinesHtml, pipelinesScript } from "./pages/pipelines.js";
@@ -27,6 +28,7 @@ const head = `<!DOCTYPE html>
 const shell = `<div id="admin-page" class="app-shell hidden">
   <aside class="sidebar">${sidebarHtml()}</aside>
   <main class="main">
+    ${overviewHtml}
     ${settingsHtml}
     ${projectsHtml}
     ${pipelinesHtml}
@@ -47,7 +49,7 @@ const body = `<body>
   </div>
 </div>
 ${shell}
-<script>${themeJs}${authJs}${routerJs}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}</script>
+<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}</script>
 </body></html>`;
 
 export const adminHtml = head + body;

--- a/src/admin-ui/pages/overview.ts
+++ b/src/admin-ui/pages/overview.ts
@@ -84,7 +84,7 @@ export const overviewHtml = `
       </div>
       <div class="card-body tight">
         <table class="tbl">
-          <thead><tr><th>Issue</th><th>Failed at</th><th>Summary</th><th style="text-align:right">When</th></tr></thead>
+          <thead><tr><th>Issue</th><th>Failed at</th><th style="text-align:right">When</th></tr></thead>
           <tbody id="overview-failures-body"></tbody>
         </table>
         <div id="overview-failures-empty" class="hidden text-tertiary" style="padding:12px">No failures in the last 24h</div>
@@ -152,7 +152,7 @@ export const overviewScript = `
 
   function capacityMeter(used, max) {
     const pct = max > 0 ? Math.round((used / max) * 100) : 0;
-    const color = pct >= 100 ? 'var(--red)' : pct >= 75 ? 'var(--yellow)' : 'var(--green, var(--accent))';
+    const color = pct >= 100 ? 'var(--st-fail-dot)' : pct >= 75 ? 'var(--st-warn-dot)' : 'var(--accent)';
     return '<div style="display:flex;align-items:center;gap:8px">'
       + '<div style="flex:1;height:6px;background:var(--border-subtle);border-radius:3px;overflow:hidden">'
       + '<div style="width:' + Math.min(pct, 100) + '%;height:100%;background:' + color + ';border-radius:3px"></div>'
@@ -168,6 +168,7 @@ export const overviewScript = `
   }
 
   function dispatch24hBuckets(log) {
+    if (!log || log.length === 0) return [];
     const now = Date.now();
     const buckets = new Array(24).fill(0);
     for (const e of log) {
@@ -206,7 +207,7 @@ export const overviewScript = `
       return cnt >= cap;
     }).length;
 
-    const teams = new Set(running.map(function (r) { return r.teamKey; }));
+    const teams = new Set(running.filter(function (r) { return r.teamKey; }).map(function (r) { return r.teamKey; }));
 
     const rv = document.getElementById('kpi-running-value');
     if (rv) rv.textContent = String(running.length);
@@ -310,10 +311,9 @@ export const overviewScript = `
       const issueLabel = e.issueIdentifier || e.issueId || '—';
       const failedAt = e.dispatchedAt ? new Date(e.dispatchedAt).toLocaleString() : '—';
       const when = e.dispatchedAt ? fmtAgo(e.dispatchedAt) : '—';
-      tr.innerHTML = '<td><span class="mono text-secondary">' + window.esc(issueLabel) + '</span>'
-        + (e.issueTitle ? ' <span class="text-secondary">' + window.esc(e.issueTitle) + '</span>' : '') + '</td>'
+      tr.innerHTML = '<td class="col-grow"><span class="mono text-secondary">' + window.esc(issueLabel) + '</span>'
+        + (e.issueTitle ? ' <span>' + window.esc(e.issueTitle) + '</span>' : '') + '</td>'
         + '<td class="mono text-tertiary" style="white-space:nowrap">' + failedAt + '</td>'
-        + '<td class="text-secondary col-grow">' + (e.issueTitle ? window.esc(e.issueTitle) : '&mdash;') + '</td>'
         + '<td style="text-align:right" class="mono text-tertiary">' + when + '</td>';
       tbody.appendChild(tr);
     });

--- a/src/admin-ui/pages/overview.ts
+++ b/src/admin-ui/pages/overview.ts
@@ -1,0 +1,384 @@
+export const overviewHtml = `
+<section data-page="overview" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Overview</h1>
+      <div class="page-subtitle" id="overview-subtitle">&mdash;</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadOverview()">&#8635; Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+
+    <!-- KPI grid -->
+    <div class="kpi-grid">
+      <div class="kpi" id="kpi-running">
+        <div class="kpi-label">Running now</div>
+        <div class="kpi-value"><span id="kpi-running-value">0</span></div>
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+          <span class="kpi-trend" id="kpi-running-sub">across 0 teams</span>
+          <div class="spark" data-spark="dispatch24h" style="width:80px" id="kpi-spark"></div>
+        </div>
+      </div>
+      <div class="kpi" id="kpi-capacity">
+        <div class="kpi-label">Capacity used</div>
+        <div class="kpi-value">
+          <span id="kpi-capacity-value">0</span><span class="kpi-unit" id="kpi-capacity-unit">/ 0</span>
+        </div>
+        <span class="kpi-trend" id="kpi-capacity-sub">0% of total slots</span>
+      </div>
+      <div class="kpi" id="kpi-blocked">
+        <div class="kpi-label">Blocked</div>
+        <div class="kpi-value"><span id="kpi-blocked-value">0</span></div>
+        <span class="kpi-trend" id="kpi-blocked-sub">at concurrency cap</span>
+      </div>
+      <div class="kpi" id="kpi-failed">
+        <div class="kpi-label">Failed (24h)</div>
+        <div class="kpi-value"><span id="kpi-failed-value">0</span></div>
+        <span class="kpi-trend" id="kpi-failed-sub">in last 24h</span>
+      </div>
+    </div>
+
+    <!-- Two-up: Running now + At capacity -->
+    <div style="display:grid;grid-template-columns:1.5fr 1fr;gap:16px">
+      <div class="card">
+        <div class="card-header">
+          <div>
+            <h2 class="card-title">Running now</h2>
+            <div class="card-subtitle" id="overview-running-subtitle">0 jobs</div>
+          </div>
+          <button class="btn btn-ghost btn-sm" onclick="window.navigate('jobs')">View all</button>
+        </div>
+        <div class="card-body tight">
+          <table class="tbl">
+            <thead><tr><th>Issue</th><th>Phase</th><th style="text-align:right">Duration</th></tr></thead>
+            <tbody id="overview-running-body"></tbody>
+          </table>
+          <div id="overview-running-empty" class="hidden text-tertiary" style="padding:12px">No jobs in flight</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div>
+            <h2 class="card-title">Why isn&rsquo;t this running?</h2>
+            <div class="card-subtitle">Full blocker taxonomy on Plan 4 &mdash; Blockers page</div>
+          </div>
+        </div>
+        <div class="card-body">
+          <div id="overview-atcap-body" style="display:flex;flex-direction:column;gap:8px"></div>
+          <div id="overview-atcap-empty" class="hidden text-tertiary" style="padding:4px 0">All projects have available capacity.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Recent failures -->
+    <div class="card">
+      <div class="card-header">
+        <div>
+          <h2 class="card-title">Recent failures</h2>
+          <div class="card-subtitle">Last 8 failures in the past 24h</div>
+        </div>
+        <button class="btn btn-ghost btn-sm" onclick="window.navigate('jobs')">All jobs</button>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Issue</th><th>Failed at</th><th>Summary</th><th style="text-align:right">When</th></tr></thead>
+          <tbody id="overview-failures-body"></tbody>
+        </table>
+        <div id="overview-failures-empty" class="hidden text-tertiary" style="padding:12px">No failures in the last 24h</div>
+      </div>
+    </div>
+
+    <!-- Project capacity grid -->
+    <div class="card">
+      <div class="card-header">
+        <div>
+          <h2 class="card-title">Project capacity</h2>
+          <div class="card-subtitle">Concurrency caps and current utilization per project</div>
+        </div>
+        <button class="btn btn-ghost btn-sm" onclick="window.navigate('projects')">Manage</button>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Project</th><th>Repo</th><th>Runner</th><th>Provider</th><th>Utilization</th><th style="text-align:right">Queued</th></tr></thead>
+          <tbody id="overview-projects-body"></tbody>
+        </table>
+        <div id="overview-projects-empty" class="hidden text-tertiary" style="padding:12px">No projects configured</div>
+      </div>
+    </div>
+
+  </div>
+</section>
+`;
+
+export const overviewScript = `
+(function () {
+  function fmtAgo(ts) {
+    const s = Math.floor((Date.now() - new Date(ts).getTime()) / 1000);
+    if (s < 60) return s + 's ago';
+    const m = Math.floor(s / 60);
+    if (m < 60) return m + 'm ago';
+    const h = Math.floor(m / 60);
+    return h + 'h ago';
+  }
+
+  function fmtDuration(ms) {
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return s + 's';
+    const m = Math.floor(s / 60);
+    if (m < 60) return m + 'm ' + (s % 60) + 's';
+    const h = Math.floor(m / 60);
+    return h + 'h ' + (m % 60) + 'm';
+  }
+
+  function sparkline(values) {
+    if (!values || values.length === 0) {
+      return '<div class="text-tertiary" style="font-size:11px">no data</div>';
+    }
+    const max = Math.max(...values, 1);
+    const h = 24;
+    const w = Math.floor(80 / values.length);
+    const bars = values.map(function (v) {
+      const barH = Math.max(2, Math.round((v / max) * h));
+      return '<rect x="0" y="' + (h - barH) + '" width="' + (w - 1) + '" height="' + barH + '" fill="var(--accent)" opacity="0.7"/>';
+    });
+    const svgW = w * values.length;
+    return '<svg width="' + svgW + '" height="' + h + '" viewBox="0 0 ' + svgW + ' ' + h + '" style="display:block">'
+      + bars.map(function (b, i) { return '<g transform="translate(' + (i * w) + ',0)">' + b + '</g>'; }).join('')
+      + '</svg>';
+  }
+
+  function capacityMeter(used, max) {
+    const pct = max > 0 ? Math.round((used / max) * 100) : 0;
+    const color = pct >= 100 ? 'var(--red)' : pct >= 75 ? 'var(--yellow)' : 'var(--green, var(--accent))';
+    return '<div style="display:flex;align-items:center;gap:8px">'
+      + '<div style="flex:1;height:6px;background:var(--border-subtle);border-radius:3px;overflow:hidden">'
+      + '<div style="width:' + Math.min(pct, 100) + '%;height:100%;background:' + color + ';border-radius:3px"></div>'
+      + '</div>'
+      + '<span class="mono text-secondary" style="font-size:11px;white-space:nowrap">' + used + '/' + max + '</span>'
+      + '</div>';
+  }
+
+  function statusBadge(status) {
+    const map = { running: 'running', failed: 'fail', completed: 'success' };
+    const kind = map[status] || 'neutral';
+    return '<span class="badge ' + kind + '">' + window.esc(status) + '</span>';
+  }
+
+  function dispatch24hBuckets(log) {
+    const now = Date.now();
+    const buckets = new Array(24).fill(0);
+    for (const e of log) {
+      const ts = new Date(e.dispatchedAt).getTime();
+      const age = now - ts;
+      if (age < 0 || age >= 86400000) continue;
+      const bucket = Math.floor(age / 3600000);
+      buckets[23 - bucket]++;
+    }
+    return buckets;
+  }
+
+  function renderHeaderSubtitle(reaper) {
+    const el = document.getElementById('overview-subtitle');
+    if (!el) return;
+    el.textContent = 'last sweep ' + (reaper.lastSweepAt ? fmtAgo(reaper.lastSweepAt) : 'never');
+  }
+
+  function renderKpis(log, mappings, running) {
+    const now = Date.now();
+    const failed24h = log.filter(function (e) {
+      return e.status === 'failed' && (now - new Date(e.dispatchedAt).getTime()) < 86400000;
+    });
+
+    const mappingEntries = Object.entries(mappings);
+    const sumMax = mappingEntries.reduce(function (acc, pair) {
+      return acc + (pair[1].maxInProgressAiIssues != null ? pair[1].maxInProgressAiIssues : 3);
+    }, 0);
+    const pct = sumMax > 0 ? Math.round((running.length / sumMax) * 100) : 0;
+
+    const atCapCount = mappingEntries.filter(function (pair) {
+      const key = pair[0];
+      const m = pair[1];
+      const cap = m.maxInProgressAiIssues != null ? m.maxInProgressAiIssues : 3;
+      const cnt = running.filter(function (r) { return r.teamKey === key; }).length;
+      return cnt >= cap;
+    }).length;
+
+    const teams = new Set(running.map(function (r) { return r.teamKey; }));
+
+    const rv = document.getElementById('kpi-running-value');
+    if (rv) rv.textContent = String(running.length);
+    const rs = document.getElementById('kpi-running-sub');
+    if (rs) rs.textContent = 'across ' + teams.size + ' team' + (teams.size === 1 ? '' : 's');
+
+    const cv = document.getElementById('kpi-capacity-value');
+    if (cv) cv.textContent = String(running.length);
+    const cu = document.getElementById('kpi-capacity-unit');
+    if (cu) cu.textContent = '/ ' + sumMax;
+    const cs = document.getElementById('kpi-capacity-sub');
+    if (cs) cs.textContent = pct + '% of total slots';
+
+    const bv = document.getElementById('kpi-blocked-value');
+    if (bv) bv.textContent = String(atCapCount);
+
+    const fv = document.getElementById('kpi-failed-value');
+    if (fv) fv.textContent = String(failed24h.length);
+
+    const spark = document.getElementById('kpi-spark');
+    if (spark) spark.innerHTML = sparkline(dispatch24hBuckets(log));
+  }
+
+  function renderRunningNow(running) {
+    const tbody = document.getElementById('overview-running-body');
+    const empty = document.getElementById('overview-running-empty');
+    const subtitle = document.getElementById('overview-running-subtitle');
+    if (!tbody || !empty) return;
+    if (subtitle) subtitle.textContent = running.length + ' job' + (running.length === 1 ? '' : 's');
+    tbody.innerHTML = '';
+    if (running.length === 0) {
+      empty.classList.remove('hidden');
+      return;
+    }
+    empty.classList.add('hidden');
+    const now = Date.now();
+    running.slice(0, 6).forEach(function (e) {
+      const tr = document.createElement('tr');
+      const issueLabel = e.issueIdentifier || e.issueId || '—';
+      const title = e.issueTitle ? window.esc(e.issueTitle) : '';
+      const duration = e.dispatchedAt ? fmtDuration(now - new Date(e.dispatchedAt).getTime()) : '—';
+      tr.innerHTML = '<td class="col-grow">'
+        + '<div><span class="mono" style="color:var(--fg-tertiary);margin-right:8px">' + window.esc(issueLabel) + '</span>'
+        + (title ? '<span>' + title + '</span>' : '') + '</div>'
+        + '<div style="font-size:11px;color:var(--fg-tertiary);margin-top:2px">'
+        + window.esc(e.teamKey || '—') + ' &middot; ' + window.esc(e.repo || '—')
+        + '</div></td>'
+        + '<td>' + statusBadge(e.status) + '</td>'
+        + '<td style="text-align:right" class="mono text-secondary">' + duration + '</td>';
+      tbody.appendChild(tr);
+    });
+  }
+
+  function renderAtCapacity(running, mappings) {
+    const body = document.getElementById('overview-atcap-body');
+    const empty = document.getElementById('overview-atcap-empty');
+    if (!body || !empty) return;
+    body.innerHTML = '';
+    const atCap = Object.entries(mappings).filter(function (pair) {
+      const key = pair[0];
+      const m = pair[1];
+      const cap = m.maxInProgressAiIssues != null ? m.maxInProgressAiIssues : 3;
+      const cnt = running.filter(function (r) { return r.teamKey === key; }).length;
+      return cnt >= cap;
+    });
+    if (atCap.length === 0) {
+      empty.classList.remove('hidden');
+      return;
+    }
+    empty.classList.add('hidden');
+    atCap.forEach(function (pair) {
+      const key = pair[0];
+      const m = pair[1];
+      const cap = m.maxInProgressAiIssues != null ? m.maxInProgressAiIssues : 3;
+      const cnt = running.filter(function (r) { return r.teamKey === key; }).length;
+      const div = document.createElement('div');
+      div.innerHTML = '<span class="mono">' + window.esc(key) + '</span> '
+        + '<span class="text-secondary">at capacity (' + cnt + '/' + cap + ')</span>';
+      body.appendChild(div);
+    });
+  }
+
+  function renderRecentFailures(log) {
+    const tbody = document.getElementById('overview-failures-body');
+    const empty = document.getElementById('overview-failures-empty');
+    if (!tbody || !empty) return;
+    const now = Date.now();
+    const failures = log.filter(function (e) {
+      return e.status === 'failed' && (now - new Date(e.dispatchedAt).getTime()) < 86400000;
+    }).sort(function (a, b) {
+      return new Date(b.dispatchedAt).getTime() - new Date(a.dispatchedAt).getTime();
+    }).slice(0, 8);
+    tbody.innerHTML = '';
+    if (failures.length === 0) {
+      empty.classList.remove('hidden');
+      return;
+    }
+    empty.classList.add('hidden');
+    failures.forEach(function (e) {
+      const tr = document.createElement('tr');
+      const issueLabel = e.issueIdentifier || e.issueId || '—';
+      const failedAt = e.dispatchedAt ? new Date(e.dispatchedAt).toLocaleString() : '—';
+      const when = e.dispatchedAt ? fmtAgo(e.dispatchedAt) : '—';
+      tr.innerHTML = '<td><span class="mono text-secondary">' + window.esc(issueLabel) + '</span>'
+        + (e.issueTitle ? ' <span class="text-secondary">' + window.esc(e.issueTitle) + '</span>' : '') + '</td>'
+        + '<td class="mono text-tertiary" style="white-space:nowrap">' + failedAt + '</td>'
+        + '<td class="text-secondary col-grow">' + (e.issueTitle ? window.esc(e.issueTitle) : '&mdash;') + '</td>'
+        + '<td style="text-align:right" class="mono text-tertiary">' + when + '</td>';
+      tbody.appendChild(tr);
+    });
+  }
+
+  function renderProjectGrid(log, mappings) {
+    const tbody = document.getElementById('overview-projects-body');
+    const empty = document.getElementById('overview-projects-empty');
+    if (!tbody || !empty) return;
+    const entries = Object.entries(mappings);
+    tbody.innerHTML = '';
+    if (entries.length === 0) {
+      empty.classList.remove('hidden');
+      return;
+    }
+    empty.classList.add('hidden');
+    const running = log.filter(function (e) { return e.status === 'running'; });
+    entries.forEach(function (pair) {
+      const key = pair[0];
+      const m = pair[1];
+      const cap = m.maxInProgressAiIssues != null ? m.maxInProgressAiIssues : 3;
+      const cnt = running.filter(function (r) { return r.teamKey === key; }).length;
+      const isFly = m.executionMode === 'fly-machines';
+      const runnerKind = isFly ? 'success' : 'info';
+      const runnerLabel = isFly ? 'fly' : 'gha';
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td><span class="mono" style="font-weight:600">' + window.esc(key) + '</span></td>'
+        + '<td class="mono text-secondary">' + window.esc((m.owner || '?') + '/' + (m.repo || '?')) + '</td>'
+        + '<td><span class="badge ' + runnerKind + '">' + runnerLabel + '</span></td>'
+        + '<td class="text-secondary">' + window.esc(m.provider || 'anthropic') + '</td>'
+        + '<td>' + capacityMeter(cnt, cap) + '</td>'
+        + '<td style="text-align:right" class="mono text-secondary">&mdash;</td>';
+      tbody.appendChild(tr);
+    });
+  }
+
+  async function loadOverview() {
+    try {
+      const [logRes, mappingsRes, reaperRes] = await Promise.all([
+        window.api('/api/log'),
+        window.api('/api/mappings'),
+        window.api('/api/reaper/summary'),
+      ]);
+      const log = await logRes.json();
+      const mappings = await mappingsRes.json();
+      const reaper = await reaperRes.json();
+      const safeLog = Array.isArray(log) ? log : [];
+      const safeMappings = mappings && typeof mappings === 'object' && !Array.isArray(mappings) ? mappings : {};
+      const running = safeLog.filter(function (e) { return e.status === 'running'; });
+      renderHeaderSubtitle(reaper);
+      renderKpis(safeLog, safeMappings, running);
+      renderRunningNow(running);
+      renderAtCapacity(running, safeMappings);
+      renderRecentFailures(safeLog);
+      renderProjectGrid(safeLog, safeMappings);
+    } catch (err) {
+      console.error('loadOverview failed:', err);
+    }
+  }
+
+  window.loadOverview = loadOverview;
+
+  window.registerPage('overview', function () {
+    loadOverview();
+    setInterval(loadOverview, 30000);
+  });
+})();
+`;

--- a/src/admin-ui/pages/stubs.ts
+++ b/src/admin-ui/pages/stubs.ts
@@ -19,7 +19,6 @@ function stubPage(route: string, title: string, subtitle: string, phase: string,
 }
 
 export const stubsHtml = [
-  stubPage("overview", "Overview", "The four-question dashboard", "Plan 2", "KPIs (running, capacity, blocked, failed-24h), running-now strip, blockers card, recent failures, project capacity grid."),
   stubPage("issues", "Issues", "Linear issue inbox", "Plan 4", "Matched issues, plan state, dispatchable. Backed by /api/linear/issues (new endpoint)."),
   stubPage("pulls", "Pull requests", "PRs opened by the bot", "Plan 4", "Risk-scored, awaiting CI/review. Backed by /api/github/pulls (new endpoint)."),
   stubPage("blockers", "Blockers", "Why each issue isn't running", "Plan 4", "Surfaces concurrency cap, missing secrets, dedup, Linear deps, Bedrock region, Fly config — derived from poll-selection.ts."),


### PR DESCRIPTION
## Summary

Plan 2 of 5. Replaces the `overview` stub with the four-question dashboard:

- **Four KPIs:** Running, Capacity used, Blocked (teams at concurrency cap), Failed (24h)
- **Two-up grid:** Running-now table + At-capacity card ("Why isn't this running?")
- **Recent failures** table (last 24h, max 8 rows)
- **Project capacity grid** with `capacityMeter` per project
- **24h sparkline** in the running tile + 30s auto-refresh

All computation client-side from existing `/api/log`, `/api/mappings`, `/api/reaper/summary`. **No new backend.** The full blocker taxonomy (secrets, dedup, Linear deps) is deferred to Plan 4.

Plan: `docs/superpowers/plans/2026-04-29-admin-overview-dashboard.md`. PRs back to `admin-overhaul` (the integration branch); main keeps the current 3-tab admin until Plans 2–5 all land.

## Test plan

- [ ] `#overview` route renders four populated KPI tiles
- [ ] Running-now table populates when there are in-flight jobs (otherwise empty state)
- [ ] At-capacity list shows teams at their concurrency cap (otherwise "All projects have available capacity")
- [ ] Recent failures table shows up to 8 entries from the last 24h
- [ ] Project capacity grid shows one row per mapping with a colored meter (green/amber/red)
- [ ] Sparkline shows bars when log has data, "no data" when empty
- [ ] 30s auto-refresh updates KPI values

🤖 Generated with [Claude Code](https://claude.com/claude-code)