### PR TITLE
Plan 3a: Failure-inspector drawer

### DIFF
--- a/docs/superpowers/plans/2026-04-29-admin-drawer.md
+++ b/docs/superpowers/plans/2026-04-29-admin-drawer.md
@@ -1,0 +1,295 @@
+# Failure-Inspector Drawer — Plan 3a
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Click any job row in the Pipelines page → a right-side drawer slides in with a phase timeline, the job's step records, Linear/repo/PR context, and a "View workflow logs" link. Closing the drawer preserves the user's place in the table.
+
+**Architecture:** Adds one new backend route `/api/jobs/:id/steps` (returning the existing `getStepsByJobId` rows). Adds one new shared admin-ui module `src/admin-ui/drawer.ts` for the drawer markup + open/close/render JS — separate from any single page module so the next plan can reuse it from Overview if needed. Wires the drawer into the Pipelines page: each `<tr>` gets `data-job-id`, click handler calls `window.openJobDrawer(id)`. Uses the already-defined `.drawer`/`.drawer-header`/`.drawer-body`/`.drawer-footer` CSS from Plan 1 Task 3 (already in `components.ts`).
+
+**Out of scope (later plans):**
+- Gap-analysis preview (no backend storage today; would need a migration).
+- "Destroy machine" / "Reset & re-dispatch" action buttons (need new endpoints).
+- Drawer access from the Overview page (Plan 4 may add).
+
+**Branching:** `admin-overhaul-3a-drawer` off `admin-overhaul`. PR back to `admin-overhaul`.
+
+---
+
+## File Structure
+
+```
+src/log.ts                        — MODIFIED. Add getJobById(id) helper used by the new route.
+src/admin.ts                      — MODIFIED. Add GET /api/jobs/:id/steps route returning { job, steps }.
+src/__tests__/admin.test.ts       — MODIFIED. Add tests for the new endpoint (200 with valid id, 404 with bad id, 401 without auth).
+src/admin-ui/drawer.ts            — NEW. Exports drawerHtml + drawerScript strings. Owns markup + open/close + render functions; reads /api/jobs/:id/steps; renders into a single drawer DOM that's injected once.
+src/admin-ui/index.ts             — MODIFIED. Inject drawerHtml + drawerScript alongside other modules (drawerScript must run after auth but it doesn't matter where relative to pages).
+src/admin-ui/pages/pipelines.ts   — MODIFIED. Each rendered <tr> gets data-job-id={job.id}; tbody gets a delegated click listener that calls window.openJobDrawer(id) — but ignores clicks landing on <a> elements (the PR link still navigates).
+src/admin-ui/__tests__/drawer.test.ts  — NEW. Structural test: drawerHtml has the expected ids; drawerScript exposes openJobDrawer/closeJobDrawer on window and uses /api/jobs/.
+```
+
+---
+
+## Task 1: Add `getJobById` to `src/log.ts`
+
+**Files:**
+- Modify: `src/log.ts`
+- Modify: `src/__tests__/jobs.test.ts` (add a unit test)
+
+- [ ] **Step 1: TDD — add the failing test**
+
+In `src/__tests__/jobs.test.ts`, add a test that inserts a job via `appendLog` and reads it back via `getJobById(id)`. Assert all expected fields round-trip.
+
+- [ ] **Step 2: Implement**
+
+Add to `src/log.ts`:
+
+```ts
+export function getJobById(id: number): Job | null {
+  const db = getDb();
+  const row = db
+    .prepare(`SELECT id, dispatched_at as dispatchedAt, /* ... full SELECT matching other helpers ... */ FROM dispatch_log WHERE id = ?`)
+    .get(id) as Job | undefined;
+  return row ?? null;
+}
+```
+
+The full SELECT clause must match the existing helpers `listLog` / `getInFlightJobs` so the row shape is identical. Find them in `src/log.ts` and copy the column list verbatim.
+
+- [ ] **Step 3: Run** — `npm test -- src/__tests__/jobs.test.ts`. Pass.
+
+- [ ] **Step 4: Commit** — `feat(log): add getJobById helper`
+
+---
+
+## Task 2: Add `GET /api/jobs/:id/steps` route
+
+**Files:**
+- Modify: `src/admin.ts`
+- Modify: `src/__tests__/admin.test.ts`
+
+- [ ] **Step 1: TDD — failing tests**
+
+Add to `src/__tests__/admin.test.ts`:
+
+```ts
+describe("admin job-detail endpoint", () => {
+  it("returns 401 without auth", async () => {
+    const res = await request("/api/jobs/1/steps", "GET", "code");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 404 for unknown job id", async () => {
+    const token = await login("code");
+    const res = await request("/api/jobs/99999/steps", "GET", "code", undefined, token);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns the job and its steps for a real id", async () => {
+    const token = await login("code");
+    const jobId = log.appendLog({ /* minimal fields */ });
+    const res = await request(`/api/jobs/${jobId}/steps`, "GET", "code", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.job.id).toBe(jobId);
+    expect(Array.isArray(body.steps)).toBe(true);
+  });
+});
+```
+
+(The exact `appendLog` arg shape — copy from another existing test in the same file. Don't invent fields.)
+
+- [ ] **Step 2: Wire the route**
+
+In `src/admin.ts` (between the existing `/api/log` and `/api/reaper/summary` blocks):
+
+```ts
+const jobStepsMatch = url.match(/^\/api\/jobs\/(\d+)\/steps$/);
+if (jobStepsMatch && method === "GET") {
+  const jobId = Number.parseInt(jobStepsMatch[1], 10);
+  const job = getJobById(jobId);
+  if (!job) return json(res, 404, { error: "job not found" });
+  return json(res, 200, { job, steps: getStepsByJobId(jobId) });
+}
+```
+
+Add the imports: `getJobById` from `./log.js`, `getStepsByJobId` from `./step-log.js`.
+
+- [ ] **Step 3: Run tests**
+
+`npm test -- src/__tests__/admin.test.ts`. All 3 new tests pass.
+
+- [ ] **Step 4: Commit** — `feat(admin): add /api/jobs/:id/steps endpoint`
+
+---
+
+## Task 3: Build the drawer module
+
+**Files:**
+- Create: `src/admin-ui/drawer.ts`
+- Modify: `src/admin-ui/index.ts`
+
+- [ ] **Step 1: Build `drawerHtml`**
+
+The drawer is rendered once into the DOM and shown/hidden via a `.open` class on the wrapper. Markup:
+
+```html
+<div id="job-drawer-wrap" class="job-drawer-wrap">
+  <div class="drawer-backdrop" onclick="closeJobDrawer()"></div>
+  <div class="drawer">
+    <div class="drawer-header">
+      <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px">
+        <div style="min-width:0;flex:1">
+          <div id="drawer-issue-row" style="display:flex;align-items:center;gap:8px;margin-bottom:6px"></div>
+          <h2 id="drawer-title" style="font-size:17px;font-weight:600;margin:0">—</h2>
+          <div id="drawer-meta" style="font-size:12px;color:var(--fg-tertiary);margin-top:4px"></div>
+        </div>
+        <button class="btn btn-ghost btn-icon" onclick="closeJobDrawer()" title="Close">×</button>
+      </div>
+    </div>
+    <div class="drawer-body">
+      <div id="drawer-failure-alert"></div>
+      <div class="section-h"><h3>Pipeline</h3><span class="section-meta" id="drawer-elapsed"></span></div>
+      <div class="timeline" id="drawer-timeline"></div>
+
+      <div class="section-h"><h3>Steps</h3><span class="section-meta" id="drawer-step-count"></span></div>
+      <div id="drawer-steps"></div>
+
+      <div class="section-h"><h3>Context</h3></div>
+      <div id="drawer-context" style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:24px"></div>
+    </div>
+    <div class="drawer-footer">
+      <div style="display:flex;gap:6px"></div>
+      <div style="display:flex;gap:6px">
+        <a id="drawer-logs-link" class="btn btn-sm" href="" target="_blank" hidden>View workflow logs ↗</a>
+        <button class="btn btn-primary btn-sm" onclick="closeJobDrawer()">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Add a small CSS rule (in components.ts? or inline in drawerHtml as a `<style>` block — prefer components.ts):
+
+```css
+.job-drawer-wrap { display: none; }
+.job-drawer-wrap.open { display: block; }
+.drawer-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 90; }
+/* .drawer is already styled in components.ts; it should already be position:fixed; right:0; */
+```
+
+(Check `components.ts` first — if `.drawer` doesn't have positioning, add it. The Plan 1 port likely already covered this — verify and only add what's missing.)
+
+- [ ] **Step 2: Build `drawerScript`**
+
+IIFE with:
+
+- `let currentJob = null;` — state for the open drawer.
+- `async function openJobDrawer(jobId)` — fetches `/api/jobs/${jobId}/steps`, populates the drawer, adds `.open` to the wrapper. Disables body scroll while open.
+- `function closeJobDrawer()` — removes `.open`, re-enables body scroll, clears `currentJob`.
+- ESC key handler: when wrapper has `.open`, ESC closes.
+- `renderDrawer(job, steps)`:
+  - Issue row: `<span class="mono text-tertiary" style="font-size:12px">{job.issueIdentifier ?? '—'}</span>` + status badge using `.badge.success/.fail/.running/.warn`.
+  - Title: `job.issueTitle ?? job.issueIdentifier ?? '—'`.
+  - Meta: `<span class="mono">{teamKey}</span> · {repo} · {executionMode} · started {fmtAgo(dispatchedAt)}`.
+  - Failure alert: if `job.status === 'failed'`, show `<div class="alert fail">` with status reason text — the existing log entry has only `status`, not a structured failure object, so use a generic message ("Job failed during {phase}." or similar).
+  - Pipeline timeline: derive 5 phases from the existing `phase-pipe` logic in `pipelines.ts` (queued / planning / implementing / review / done). Map `job.phase` and `job.status` to the colored markers per the design ref (`tl-marker.done/.active/.fail`).
+  - Step records: render each step as a row with `stepId`, `stepType`, `status`, duration, and a logs link if `logsUrl` is set. Empty-state if no records.
+  - Context grid: render 4-6 fields (Linear issue with link, Repository, Project/team, Runner, Machine if available, PR link if available). Use `<a class="text-accent" href="https://linear.app/issue/{identifier}" target="_blank">{identifier} ↗</a>` and the PR url verbatim.
+  - Footer logs link: if `job.runId` and the repo is known, set `drawer-logs-link` href to `https://github.com/{owner}/{repo}/actions/runs/{runId}`. Otherwise `hidden`.
+- `window.openJobDrawer = openJobDrawer; window.closeJobDrawer = closeJobDrawer;`
+- Local `fmtAgo`, `fmtDuration` helpers (same as elsewhere — duplication acceptable; future polish task can DRY).
+- All `window.api` / `window.esc`. No `var`.
+
+- [ ] **Step 3: Wire into `index.ts`**
+
+```ts
+import { drawerHtml, drawerScript } from "./drawer.js";
+// inside <main> or before </body>: ${drawerHtml}
+// inside <script>: ...${drawerScript}
+```
+
+The drawer markup goes OUTSIDE `<main>` (it's a global UI element rendered above the page content) — append it just before `</body>`.
+
+- [ ] **Step 4: Verify** — `npm run typecheck && npm test`. Pass.
+
+- [ ] **Step 5: Commit** — `feat(admin): add failure-inspector drawer`
+
+---
+
+## Task 4: Wire row clicks on the Pipelines page
+
+**Files:**
+- Modify: `src/admin-ui/pages/pipelines.ts`
+
+- [ ] **Step 1: Add `data-job-id` to each `<tr>`**
+
+In `loadLog()`'s row generation, set `tr.setAttribute('data-job-id', String(item.type === 'group' ? item.impl.id : item.entry.id))` for each row. (For grouped rows, the implementation row owns the drawer — its id is the meaningful one.)
+
+- [ ] **Step 2: Add a delegated click handler on `tbody`**
+
+Inside the `registerPage('jobs', ...)` block, after `loadLog()`:
+
+```ts
+const tbody = document.getElementById('log-body');
+if (tbody && !tbody.dataset.drawerWired) {
+  tbody.addEventListener('click', function (e) {
+    if (e.target.closest('a')) return; // let PR link navigate
+    const tr = e.target.closest('tr');
+    const id = tr && tr.dataset.jobId;
+    if (id) window.openJobDrawer(Number(id));
+  });
+  tbody.dataset.drawerWired = '1';
+}
+```
+
+(The `dataset.drawerWired` check prevents duplicate listeners across multiple `loadLog()` invocations.)
+
+- [ ] **Step 3: Verify** — `npm run typecheck && npm test`. Pass.
+
+- [ ] **Step 4: Commit** — `feat(admin): open drawer on Pipelines row click`
+
+---
+
+## Task 5: Drawer structural test + final verification
+
+**Files:**
+- Create: `src/admin-ui/__tests__/drawer.test.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+import { drawerHtml, drawerScript } from "../drawer.js";
+
+describe("job drawer", () => {
+  it("declares the expected drawer ids", () => {
+    for (const id of ["job-drawer-wrap", "drawer-issue-row", "drawer-title", "drawer-meta", "drawer-failure-alert", "drawer-elapsed", "drawer-timeline", "drawer-steps", "drawer-context", "drawer-logs-link", "drawer-step-count"]) {
+      expect(drawerHtml).toContain(`id="${id}"`);
+    }
+  });
+  it("exposes openJobDrawer and closeJobDrawer on window", () => {
+    expect(drawerScript).toContain("window.openJobDrawer = openJobDrawer");
+    expect(drawerScript).toContain("window.closeJobDrawer = closeJobDrawer");
+  });
+  it("fetches /api/jobs/:id/steps", () => {
+    expect(drawerScript).toMatch(/\/api\/jobs\//);
+    expect(drawerScript).toContain("/steps");
+  });
+  it("uses window.api/window.esc only", () => {
+    const stripped = drawerScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+});
+```
+
+Final pass: `npm run typecheck && npm test`. All green.
+
+Commit: `test(admin): structural tests for drawer module`.
+
+---
+
+## Risks
+
+- **`getJobById` SELECT-clause drift:** if the column list doesn't exactly match `listLog`/`getInFlightJobs`, the returned shape will differ subtly and break the drawer's `job.fieldName` reads. Prevention: copy the SELECT column list verbatim. The new test asserts shape parity by reading every field used by the drawer.
+- **PR row click noise:** the existing PR link uses `<a target="_blank">`. The delegated click handler must check `e.target.closest('a')` and skip — otherwise both navigations fire and the drawer opens behind the new tab.
+- **Drawer-already-open state:** if the user clicks two rows quickly, the second openJobDrawer call should replace the first job's data. Implementation just overwrites `currentJob` and re-renders — no race.
+- **No gap analysis available:** the failure alert shows a generic message. This is honest — Plan 4 or later can add gap analysis once it's stored server-side.

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -8,6 +8,7 @@ import type * as ConfigModule from "../config.js";
 import type * as DedupModule from "../dedup.js";
 import type * as RunnerModeModule from "../runner-mode.js";
 import type * as LogModule from "../log.js";
+import type * as StepLogModule from "../step-log.js";
 
 class MockRequest extends EventEmitter {
   url?: string;
@@ -51,6 +52,7 @@ let config: typeof ConfigModule;
 let dedup: typeof DedupModule;
 let runnerMode: typeof RunnerModeModule;
 let log: typeof LogModule;
+let stepLog: typeof StepLogModule;
 
 beforeEach(async () => {
   vi.resetModules();
@@ -61,8 +63,10 @@ beforeEach(async () => {
   dedup = await import("../dedup.js");
   runnerMode = await import("../runner-mode.js");
   log = await import("../log.js");
+  stepLog = await import("../step-log.js");
   config.initMappingsTable();
   log.initLogTable();
+  stepLog.initStepLogTable();
   runnerMode.initSettingsTable();
 });
 
@@ -898,6 +902,36 @@ describe("admin sessions", () => {
     const token = await login("secret");
     const res = await request("/api/sessions/machine-abc", "DELETE", "secret", undefined, token);
     expect(res.statusCode).toBe(503);
+  });
+});
+
+describe("admin job-detail endpoint", () => {
+  it("returns 401 without auth", async () => {
+    const res = await request("/api/jobs/1/steps", "GET", "secret");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 404 for unknown job id", async () => {
+    const token = await login("secret");
+    const res = await request("/api/jobs/99999/steps", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error).toBe("job not found");
+  });
+
+  it("returns 200 with job and steps for a known job", async () => {
+    const token = await login("secret");
+    const id = log.appendLog({
+      issueId: "issue-detail",
+      issueIdentifier: "ENG-99",
+      issueTitle: "Detail test",
+      teamKey: "eng",
+      repo: "org/repo",
+    });
+    const res = await request(`/api/jobs/${id}/steps`, "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.job.id).toBe(id);
+    expect(Array.isArray(body.steps)).toBe(true);
   });
 });
 

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -305,3 +305,25 @@ describe("schema migration", () => {
     expect(jobs.find((j) => j.issueId === "legacy")?.runnerMode).toBeNull();
   });
 });
+
+describe("getJobById", () => {
+  it("returns the inserted row by id", () => {
+    const id = log.appendLog({
+      issueId: "issue-by-id",
+      issueIdentifier: "ENG-42",
+      issueTitle: "Get by ID test",
+      teamKey: "eng",
+      repo: "org/repo",
+    });
+    const job = log.getJobById(id);
+    expect(job).not.toBeNull();
+    expect(job!.id).toBe(id);
+    expect(job!.issueId).toBe("issue-by-id");
+    expect(job!.issueIdentifier).toBe("ENG-42");
+    expect(job!.status).toBe("dispatched");
+  });
+
+  it("returns null for unknown id", () => {
+    expect(log.getJobById(99999999)).toBeNull();
+  });
+});

--- a/src/admin-ui/__tests__/drawer.test.ts
+++ b/src/admin-ui/__tests__/drawer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { drawerHtml, drawerScript } from "../drawer.js";
+
+describe("job drawer", () => {
+  it("declares the expected drawer ids", () => {
+    for (const id of [
+      "job-drawer-wrap",
+      "drawer-issue-row",
+      "drawer-title",
+      "drawer-meta",
+      "drawer-failure-alert",
+      "drawer-elapsed",
+      "drawer-timeline",
+      "drawer-steps",
+      "drawer-context",
+      "drawer-logs-link",
+      "drawer-step-count",
+    ]) {
+      expect(drawerHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("exposes openJobDrawer and closeJobDrawer on window", () => {
+    expect(drawerScript).toContain("window.openJobDrawer = openJobDrawer");
+    expect(drawerScript).toContain("window.closeJobDrawer = closeJobDrawer");
+  });
+
+  it("fetches /api/jobs/:id/steps", () => {
+    expect(drawerScript).toMatch(/\/api\/jobs\//);
+    expect(drawerScript).toContain("/steps");
+  });
+
+  it("uses window.api/window.esc only", () => {
+    const stripped = drawerScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+
+  it("uses const/let, not var", () => {
+    expect(drawerScript).not.toMatch(/\bvar\s+\w/);
+  });
+
+  it("registers an ESC handler to close the drawer", () => {
+    expect(drawerScript).toMatch(/keydown/);
+    expect(drawerScript).toMatch(/Escape/);
+  });
+});

--- a/src/admin-ui/components.ts
+++ b/src/admin-ui/components.ts
@@ -395,6 +395,8 @@ export const componentsCss = `
 .text-secondary { color: var(--fg-secondary); }
 .text-tertiary { color: var(--fg-tertiary); }
 .text-quaternary { color: var(--fg-quaternary); }
+.text-accent { color: var(--accent); }
+.text-accent:hover { color: var(--accent-hover); }
 
 /* ── Phase pipeline ────────────────────────────────────────── */
 .phase-pipe {

--- a/src/admin-ui/drawer.ts
+++ b/src/admin-ui/drawer.ts
@@ -133,7 +133,7 @@ export const drawerScript = `
       { label: 'Queued', detail: 'queued in Linear' },
       { label: 'Planning', detail: 'claude-plan.yml' },
       { label: 'Implementing', detail: job.executionMode ? window.esc(job.executionMode) + ' run' : 'implementation run' },
-      { label: 'Review', detail: job.prUrl ? 'PR opened: #' + (job.prUrl.split('/').pop() || '') : 'awaiting PR' },
+      { label: 'Review', detail: job.prUrl ? 'PR opened: #' + window.esc(job.prUrl.split('/').pop() || '') : 'awaiting PR' },
       { label: 'Done', detail: 'merged' }
     ];
 
@@ -318,11 +318,13 @@ export const drawerScript = `
       }
       if (!res.ok) {
         console.error('Failed to load job:', res.status);
+        document.getElementById('drawer-title').textContent = 'Failed to load job';
         return;
       }
       json = await res.json();
     } catch (err) {
       console.error('Failed to fetch job steps:', err);
+      document.getElementById('drawer-title').textContent = 'Failed to load job';
       return;
     }
 

--- a/src/admin-ui/drawer.ts
+++ b/src/admin-ui/drawer.ts
@@ -1,0 +1,351 @@
+export const drawerHtml = `
+<div id="job-drawer-wrap" class="job-drawer-wrap" hidden>
+  <div class="drawer-backdrop" onclick="closeJobDrawer()"></div>
+  <div class="drawer">
+    <div class="drawer-header">
+      <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px">
+        <div style="min-width:0;flex:1">
+          <div id="drawer-issue-row" style="display:flex;align-items:center;gap:8px;margin-bottom:6px"></div>
+          <h2 id="drawer-title" style="font-size:17px;font-weight:600;margin:0">—</h2>
+          <div id="drawer-meta" style="font-size:12px;color:var(--fg-tertiary);margin-top:4px"></div>
+        </div>
+        <button class="btn btn-ghost btn-icon" onclick="closeJobDrawer()" title="Close">×</button>
+      </div>
+    </div>
+    <div class="drawer-body">
+      <div id="drawer-failure-alert"></div>
+      <div class="section-h"><h3>Pipeline</h3><span class="section-meta" id="drawer-elapsed"></span></div>
+      <div class="timeline" id="drawer-timeline"></div>
+      <div class="section-h"><h3>Steps</h3><span class="section-meta" id="drawer-step-count"></span></div>
+      <div id="drawer-steps"></div>
+      <div class="section-h"><h3>Context</h3></div>
+      <div id="drawer-context" style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:24px"></div>
+    </div>
+    <div class="drawer-footer">
+      <div></div>
+      <div style="display:flex;gap:6px">
+        <a id="drawer-logs-link" class="btn btn-sm" href="" target="_blank" hidden>View workflow logs ↗</a>
+        <button class="btn btn-primary btn-sm" onclick="closeJobDrawer()">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+export const drawerScript = `
+(function () {
+  let currentJobId = null;
+  let mappingsCache = null;
+
+  async function ensureMappings() {
+    if (!mappingsCache) {
+      const r = await window.api('/api/mappings');
+      mappingsCache = await r.json();
+    }
+    return mappingsCache;
+  }
+
+  function fmtAgo(tsOrIso) {
+    const ms = typeof tsOrIso === 'number' ? tsOrIso : new Date(tsOrIso).getTime();
+    const diff = Date.now() - ms;
+    if (diff < 60000) return 'just now';
+    if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago';
+    if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago';
+    return Math.floor(diff / 86400000) + 'd ago';
+  }
+
+  function fmtDuration(ms) {
+    if (ms < 1000) return ms + 'ms';
+    if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+    const m = Math.floor(ms / 60000);
+    const s = Math.floor((ms % 60000) / 1000);
+    return m + 'm ' + s + 's';
+  }
+
+  function badgeForStatus(s) {
+    let kind;
+    if (s === 'running') kind = 'running';
+    else if (s === 'failed' || s === 'timed_out') kind = 'fail';
+    else if (s === 'completed') kind = 'success';
+    else kind = 'neutral';
+    const label = s || 'unknown';
+    return '<span class="badge ' + kind + '"><span class="dot"></span>' + window.esc(label) + '</span>';
+  }
+
+  function renderIssueRow(job) {
+    const issueRow = document.getElementById('drawer-issue-row');
+    issueRow.innerHTML =
+      '<span class="mono text-tertiary" style="font-size:12px">' + window.esc(job.issueIdentifier || '—') + '</span>'
+      + badgeForStatus(job.status);
+    if (job.dispatchNumber > 1) {
+      issueRow.innerHTML += '<span class="badge warn"><span class="dot"></span>attempt ' + job.dispatchNumber + '</span>';
+    }
+  }
+
+  function renderTitle(job) {
+    document.getElementById('drawer-title').textContent = job.issueTitle || job.issueIdentifier || '—';
+  }
+
+  function renderMeta(job) {
+    const meta = document.getElementById('drawer-meta');
+    const parts = [];
+    if (job.teamKey) parts.push('<span class="mono">' + window.esc(job.teamKey) + '</span>');
+    if (job.repo) parts.push(window.esc(job.repo));
+    if (job.executionMode) parts.push(window.esc(job.executionMode));
+    parts.push('started ' + fmtAgo(job.dispatchedAt));
+    meta.innerHTML = parts.join(' · ');
+  }
+
+  function renderElapsed(job, steps) {
+    const elapsedEl = document.getElementById('drawer-elapsed');
+    let endMs = null;
+    if (job.status === 'completed' || job.status === 'failed' || job.status === 'timed_out') {
+      if (job.completedAt) {
+        endMs = job.completedAt;
+      } else {
+        // Try to get from the most recent step
+        for (let i = steps.length - 1; i >= 0; i--) {
+          if (steps[i].endedAt) {
+            endMs = new Date(steps[i].endedAt).getTime();
+            break;
+          }
+        }
+      }
+    }
+    const startMs = job.dispatchedAt;
+    const durationMs = endMs ? endMs - startMs : Date.now() - startMs;
+    elapsedEl.textContent = fmtDuration(durationMs) + ' elapsed';
+  }
+
+  function renderFailureAlert(job) {
+    const alertEl = document.getElementById('drawer-failure-alert');
+    if (job.status === 'failed') {
+      alertEl.innerHTML = '<div class="alert fail" style="margin-bottom:16px"><div class="alert-icon">&#9888;</div><div style="flex:1"><div class="alert-title">Job failed</div><div class="alert-desc">Failed during execution.</div></div></div>';
+    } else if (job.status === 'timed_out') {
+      alertEl.innerHTML = '<div class="alert warn" style="margin-bottom:16px"><div class="alert-icon">&#9888;</div><div style="flex:1"><div class="alert-title">Job timed out</div><div class="alert-desc">Workflow exceeded timeout.</div></div></div>';
+    } else {
+      alertEl.innerHTML = '';
+    }
+  }
+
+  function renderTimeline(job) {
+    const phases = [
+      { label: 'Queued', detail: 'queued in Linear' },
+      { label: 'Planning', detail: 'claude-plan.yml' },
+      { label: 'Implementing', detail: job.executionMode ? window.esc(job.executionMode) + ' run' : 'implementation run' },
+      { label: 'Review', detail: job.prUrl ? 'PR opened: #' + (job.prUrl.split('/').pop() || '') : 'awaiting PR' },
+      { label: 'Done', detail: 'merged' }
+    ];
+
+    let activeIndex = 0;
+    const mode = job.executionMode || '';
+    if (mode === 'planning') {
+      activeIndex = 1;
+    } else if (mode === 'fly-machines' || mode === 'github-actions') {
+      activeIndex = 2;
+      if (job.prUrl) activeIndex = 3;
+      if (job.status === 'completed' && job.prUrl) activeIndex = 4;
+    } else {
+      activeIndex = 0;
+    }
+
+    const timelineEl = document.getElementById('drawer-timeline');
+    let html = '';
+    for (let i = 0; i < phases.length; i++) {
+      const phase = phases[i];
+      let cls = '';
+      let markerText = String(i + 1);
+      if (i < activeIndex) {
+        cls = 'done';
+        markerText = '&#10003;';
+      } else if (i === activeIndex) {
+        if (job.status === 'failed' || job.status === 'timed_out') {
+          cls = 'fail';
+          markerText = '&#10007;';
+        } else if (job.status === 'running') {
+          cls = 'active';
+          markerText = '&bull;';
+        }
+      }
+      html += '<div class="tl-item">'
+        + '<div class="tl-marker ' + cls + '">' + markerText + '</div>'
+        + '<div class="tl-content">'
+        + '<div class="tl-title">' + window.esc(phase.label) + '</div>'
+        + '<div class="tl-meta">' + phase.detail + '</div>'
+        + '</div>'
+        + '</div>';
+    }
+    timelineEl.innerHTML = html;
+  }
+
+  function renderSteps(steps) {
+    const stepsEl = document.getElementById('drawer-steps');
+    const countEl = document.getElementById('drawer-step-count');
+    if (!steps || steps.length === 0) {
+      stepsEl.innerHTML = '<div style="font-size:12px;color:var(--fg-tertiary);padding:8px 0">No step records</div>';
+      countEl.textContent = 'no step records';
+      return;
+    }
+    countEl.textContent = steps.length + ' step' + (steps.length === 1 ? '' : 's');
+    let html = '';
+    for (const step of steps) {
+      let badgeKind;
+      if (step.status === 'running') badgeKind = 'running';
+      else if (step.status === 'failed') badgeKind = 'fail';
+      else if (step.status === 'completed') badgeKind = 'success';
+      else badgeKind = 'neutral';
+
+      const logsLink = step.logsUrl
+        ? '<a class="btn btn-sm" href="' + window.esc(step.logsUrl) + '" target="_blank" style="font-size:11px">Logs ↗</a>'
+        : '';
+
+      html += '<div style="display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid var(--border-subtle);font-size:12.5px">'
+        + '<div><span class="mono text-secondary">' + window.esc(step.stepId) + '</span>'
+        + ' <span class="text-tertiary" style="margin-left:8px">' + window.esc(step.stepType) + '</span></div>'
+        + '<div style="display:flex;gap:8px;align-items:center">'
+        + logsLink
+        + '<span class="badge ' + badgeKind + '"><span class="dot"></span>' + window.esc(step.status) + '</span>'
+        + '</div>'
+        + '</div>';
+    }
+    stepsEl.innerHTML = html;
+  }
+
+  function renderContext(job, mappings) {
+    const contextEl = document.getElementById('drawer-context');
+    const fields = [];
+
+    const mapping = mappings && job.teamKey ? mappings[job.teamKey] : null;
+    const owner = mapping ? mapping.owner : null;
+
+    if (job.issueIdentifier) {
+      fields.push({
+        label: 'Linear issue',
+        value: '<a class="text-accent" href="https://linear.app/issue/' + window.esc(job.issueIdentifier) + '" target="_blank">' + window.esc(job.issueIdentifier) + ' &#8599;</a>'
+      });
+    }
+
+    if (job.repo) {
+      const repoDisplay = owner ? window.esc(owner) + '/' + window.esc(job.repo) : '?/' + window.esc(job.repo);
+      fields.push({ label: 'Repository', value: '<span class="mono">' + repoDisplay + '</span>' });
+    }
+
+    if (job.teamKey) {
+      fields.push({ label: 'Project', value: '<span class="mono">' + window.esc(job.teamKey) + '</span>' });
+    }
+
+    if (job.executionMode) {
+      let runnerVal = window.esc(job.executionMode);
+      if (job.runnerMode && job.runnerMode !== job.executionMode) {
+        runnerVal += ' <span style="color:var(--fg-tertiary)">(' + window.esc(job.runnerMode) + ')</span>';
+      }
+      fields.push({ label: 'Runner', value: runnerVal });
+    }
+
+    if (job.machineId) {
+      fields.push({ label: 'Machine', value: '<span class="mono">' + window.esc(job.machineId) + '</span>' });
+    }
+
+    if (job.prUrl) {
+      const prNum = job.prUrl.split('/').pop() || '';
+      fields.push({
+        label: 'Pull request',
+        value: '<a class="text-accent" href="' + window.esc(job.prUrl) + '" target="_blank">#' + window.esc(prNum) + ' &#8599;</a>'
+      });
+    }
+
+    let html = '';
+    for (const f of fields) {
+      html += '<div class="field"><div class="field-label">' + window.esc(f.label) + '</div><div style="font-size:12.5px">' + f.value + '</div></div>';
+    }
+    contextEl.innerHTML = html;
+  }
+
+  function renderLogsLink(job, mappings) {
+    const logsLink = document.getElementById('drawer-logs-link');
+    const mapping = mappings && job.teamKey ? mappings[job.teamKey] : null;
+    const owner = mapping ? mapping.owner : null;
+    if (job.runId && owner && job.repo) {
+      logsLink.href = 'https://github.com/' + owner + '/' + job.repo + '/actions/runs/' + job.runId;
+      logsLink.removeAttribute('hidden');
+    } else {
+      logsLink.setAttribute('hidden', '');
+    }
+  }
+
+  function renderDrawer(job, steps, mappings) {
+    renderIssueRow(job);
+    renderTitle(job);
+    renderMeta(job);
+    renderElapsed(job, steps);
+    renderFailureAlert(job);
+    renderTimeline(job);
+    renderSteps(steps);
+    renderContext(job, mappings);
+    renderLogsLink(job, mappings);
+  }
+
+  async function openJobDrawer(id) {
+    currentJobId = id;
+    const wrap = document.getElementById('job-drawer-wrap');
+    document.getElementById('drawer-title').textContent = 'Loading…';
+    document.getElementById('drawer-issue-row').innerHTML = '';
+    document.getElementById('drawer-meta').innerHTML = '';
+    document.getElementById('drawer-elapsed').textContent = '';
+    document.getElementById('drawer-failure-alert').innerHTML = '';
+    document.getElementById('drawer-timeline').innerHTML = '';
+    document.getElementById('drawer-steps').innerHTML = '';
+    document.getElementById('drawer-step-count').textContent = '';
+    document.getElementById('drawer-context').innerHTML = '';
+    document.getElementById('drawer-logs-link').setAttribute('hidden', '');
+    wrap.removeAttribute('hidden');
+    document.body.style.overflow = 'hidden';
+
+    let mappings;
+    try {
+      mappings = await ensureMappings();
+    } catch (err) {
+      console.error('Failed to load mappings:', err);
+      mappings = null;
+    }
+
+    let json;
+    try {
+      const res = await window.api('/api/jobs/' + id + '/steps');
+      if (res.status === 404) {
+        document.getElementById('drawer-title').textContent = 'Job not found';
+        return;
+      }
+      if (!res.ok) {
+        console.error('Failed to load job:', res.status);
+        return;
+      }
+      json = await res.json();
+    } catch (err) {
+      console.error('Failed to fetch job steps:', err);
+      return;
+    }
+
+    if (currentJobId !== id) return;
+
+    renderDrawer(json.job, json.steps, mappings);
+  }
+
+  function closeJobDrawer() {
+    const wrap = document.getElementById('job-drawer-wrap');
+    if (wrap) wrap.setAttribute('hidden', '');
+    document.body.style.overflow = '';
+    currentJobId = null;
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') {
+      const wrap = document.getElementById('job-drawer-wrap');
+      if (wrap && !wrap.hasAttribute('hidden')) closeJobDrawer();
+    }
+  });
+
+  window.openJobDrawer = openJobDrawer;
+  window.closeJobDrawer = closeJobDrawer;
+})();
+`;

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -12,6 +12,7 @@ import { reaperHtml, reaperScript } from "./pages/reaper.js";
 import { sessionsHtml, sessionsScript } from "./pages/sessions.js";
 import { auditHtml, auditScript } from "./pages/audit.js";
 import { stubsHtml } from "./pages/stubs.js";
+import { drawerHtml, drawerScript } from "./drawer.js";
 
 const head = `<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -49,7 +50,8 @@ const body = `<body>
   </div>
 </div>
 ${shell}
-<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}</script>
+${drawerHtml}
+<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${drawerScript}</script>
 </body></html>`;
 
 export const adminHtml = head + body;

--- a/src/admin-ui/pages/pipelines.ts
+++ b/src/admin-ui/pages/pipelines.ts
@@ -102,6 +102,7 @@ export const pipelinesScript = `
 
       for (const item of grouped) {
         const tr = document.createElement('tr');
+        tr.setAttribute('data-job-id', String(item.type === 'group' ? item.impl.id : item.entry.id));
         if (item.type === 'group') {
           const plan = item.plan;
           const impl = item.impl;
@@ -156,6 +157,7 @@ export const pipelinesScript = `
         }
         tbody.appendChild(tr);
       }
+      wireRowClicks();
       setLastUpdated('lu-log');
     } catch (err) {
       console.error('loadLog failed:', err);
@@ -163,8 +165,22 @@ export const pipelinesScript = `
   }
   window.loadLog = loadLog;
 
+  function wireRowClicks() {
+    const tbody = document.getElementById('log-body');
+    if (!tbody || tbody.dataset.drawerWired) return;
+    tbody.addEventListener('click', function (e) {
+      const target = e.target;
+      if (target.closest('a')) return;
+      const tr = target.closest('tr');
+      const id = tr && tr.getAttribute('data-job-id');
+      if (id && window.openJobDrawer) window.openJobDrawer(Number(id));
+    });
+    tbody.dataset.drawerWired = '1';
+  }
+
   window.registerPage('jobs', function () {
     loadLog();
+    wireRowClicks();
     setInterval(function () { loadLog(); }, 15000);
   });
 })();

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -25,7 +25,8 @@ import {
 } from "./runner-mode.js";
 import { getDb, listDispatched, deleteDispatched, getReaperSummary, listReaperActions } from "./dedup.js";
 import { getLastSweepAt } from "./reaper.js";
-import { listLog, getInFlightJobs, updateJobStatus } from "./log.js";
+import { listLog, getInFlightJobs, updateJobStatus, getJobById } from "./log.js";
+import { getStepsByJobId } from "./step-log.js";
 import { listMachines, destroyMachine, listAppSecrets, setAppSecrets, unsetAppSecret } from "./fly-machines.js";
 import { removeAIWorkingLabel } from "./linear.js";
 import { adminHtml } from "./admin-html.js";
@@ -158,6 +159,15 @@ export function handleAdminRequest(
 
     if (url === "/api/log" && method === "GET") {
       json(res, 200, listLog());
+      return true;
+    }
+
+    const jobStepsMatch = url.match(/^\/api\/jobs\/(\d+)\/steps$/);
+    if (jobStepsMatch && method === "GET") {
+      const jobId = Number.parseInt(jobStepsMatch[1], 10);
+      const job = getJobById(jobId);
+      if (!job) { json(res, 404, { error: "job not found" }); return true; }
+      json(res, 200, { job, steps: getStepsByJobId(jobId) });
       return true;
     }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -294,6 +294,17 @@ function mapRows(rows: RawRow[]): Job[] {
   }));
 }
 
+/** Returns the job with the given id, or null if not found. */
+export function getJobById(id: number): Job | null {
+  const row = getDb()
+    .prepare(
+      "SELECT * FROM dispatch_log WHERE id = ?",
+    )
+    .get(id) as RawRow | undefined;
+  if (!row) return null;
+  return mapRows([row])[0];
+}
+
 /** Finds the most recent job for a given Fly machine ID. Returns null if not found. */
 export function getJobByMachineId(machineId: string): Job | null {
   const row = getDb()


### PR DESCRIPTION
## Summary

Plan 3a of 5. Click any Pipelines row → a right-side drawer slides in with the job's phase timeline, step records, Linear/repo/PR context, and a "View workflow logs" link.

- New backend route `GET /api/jobs/:id/steps` (auth-protected; returns `{ job, steps }`).
- New `getJobById(id)` helper in `src/log.ts` matching `listLog`'s row shape.
- New shared module `src/admin-ui/drawer.ts` — markup rendered once, shown/hidden via `hidden` attribute on the wrapper, ESC closes, body scroll locked.
- Pipelines page wires row clicks via delegation; PR-link clicks still navigate as before.
- 5-phase timeline derived from `executionMode` + `status` + `prUrl`. Step records list rendered from the new endpoint.
- Mappings cached lazily for owner lookup in the GitHub Actions logs URL.
- 4 commits + 1 review-fix commit + structural tests; 604 tests pass.

Out of scope (later): gap-analysis preview (no backend storage today), "Destroy machine" / "Reset & re-dispatch" action buttons (need new endpoints).

Plan: `docs/superpowers/plans/2026-04-29-admin-drawer.md`. PR base: `admin-overhaul`.

## Test plan

- [ ] Click a row on `#jobs` — drawer opens with the right job
- [ ] ESC closes the drawer
- [ ] Click the backdrop closes the drawer
- [ ] Click the PR link in a row — opens PR in new tab without opening drawer
- [ ] Click two rows quickly — second click wins, no stale data
- [ ] Drawer for a failed job shows the failure alert + correct timeline marker
- [ ] Drawer for a job with `runId` and known mapping shows the workflow logs button
- [ ] Drawer for a job without `runId` hides the workflow logs button
- [ ] Drawer for an unknown id shows "Job not found" in the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)