### PR TITLE
Plan 4a: Linear Issues inbox page

### DIFF
--- a/docs/superpowers/plans/2026-04-29-admin-issues.md
+++ b/docs/superpowers/plans/2026-04-29-admin-issues.md
@@ -1,0 +1,272 @@
+# Issues Page (Linear Inbox) — Plan 4a
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Replace the `issues` route stub with a real Linear inbox showing AI-Implement-labeled issues, their lifecycle bucket (needs planning / ready / in-progress), the matched team, and a link to Linear.
+
+**Architecture:** Add a single new auth-protected route `GET /api/linear/issues` that wraps `fetchAIImplementIssueSnapshot()` (already exposed by `src/linear.ts`) and shapes the result for the UI. New page module `src/admin-ui/pages/issues.ts` consumes it. Remove the `issues` stub from `stubs.ts`. The poller's existing 60s cadence remains the source of truth — this endpoint just exposes the same query for human consumption (no caching layer in this plan).
+
+**Out of scope (later):**
+- Manual dispatch trigger from the issues UI (would require POST endpoints).
+- Filtering/searching the inbox (basic page, no toolbar).
+- "Why isn't this dispatchable?" explanations (Plan 4c covers that on the Blockers page).
+- Cross-referencing with the in-flight job log to show "currently being implemented" state — `inProgressCountsByTeam` gives the count signal; the per-issue "is this one being worked on" can wait.
+
+**Branching:** `admin-overhaul-4a-issues` off `admin-overhaul`. PR back to `admin-overhaul`.
+
+---
+
+## File Structure
+
+```
+src/admin.ts                              — MODIFIED. Add GET /api/linear/issues route.
+src/__tests__/admin.test.ts               — MODIFIED. Tests for 401, 200-with-stub, 502 on Linear failure.
+src/admin-ui/pages/issues.ts              — NEW. Issues page module.
+src/admin-ui/pages/stubs.ts               — MODIFIED. Remove "issues" entry.
+src/admin-ui/index.ts                     — MODIFIED. Inject issuesHtml + issuesScript.
+src/admin-ui/__tests__/issues.test.ts     — NEW. Structural tests.
+```
+
+---
+
+## Endpoint contract
+
+`GET /api/linear/issues` (auth-protected). Response body:
+
+```ts
+{
+  issues: Array<{
+    id: string;                // Linear internal id
+    identifier: string;        // e.g. "CORE-1042"
+    title: string;
+    teamKey: string;           // e.g. "CORE"
+    stateName: string;         // Linear workflow state name
+    stateType: string;         // Linear state type (started/unstarted/etc.)
+    bucket: 'needs-planning' | 'ready';
+  }>;
+  inProgressCountsByTeam: Record<string, number>;
+}
+```
+
+`bucket` is derived: items in `snapshot.needsPlanning` get `'needs-planning'`; items in `snapshot.readyForImplementation` get `'ready'`. The arrays are concatenated and sorted by `identifier` ascending.
+
+On Linear API failure: respond 502 with `{ error: string }` so the UI can show a real error instead of a stuck spinner.
+
+---
+
+## Task 1: Add the `/api/linear/issues` route
+
+**Files:**
+- Modify: `src/admin.ts`
+- Modify: `src/__tests__/admin.test.ts`
+
+- [ ] **Step 1: TDD — failing tests**
+
+Add to `admin.test.ts`:
+
+```ts
+describe("admin linear issues endpoint", () => {
+  it("returns 401 without auth", async () => {
+    const res = await request("/api/linear/issues", "GET", "code");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns the snapshot shape on success", async () => {
+    // Mock fetchAIImplementIssueSnapshot via vi.mock or stub.
+    // Verify res.statusCode === 200, body has issues array + inProgressCountsByTeam.
+  });
+
+  it("returns 502 when Linear throws", async () => {
+    // Mock fetchAIImplementIssueSnapshot to reject. Verify 502 + error message.
+  });
+});
+```
+
+The mock pattern depends on how `vi.mock` is used elsewhere in this file — find an existing test that mocks an external call (e.g. the reaper/jobs tests likely mock fly-machines) and follow the same pattern. If `vi.mock("../linear.js", ...)` is needed at the top, add it.
+
+If mocking turns out to be heavyweight, fallback approach: call the route directly with a fake `linearApiKey` and assert on the network failure path (Linear request will fail with a real fetch error → 502). The "shape on success" test then becomes integration-only and can be skipped — comment the skip with `/* TODO: requires Linear mock */`.
+
+- [ ] **Step 2: Wire the route**
+
+In `src/admin.ts`, inside the auth-protected `if (url.startsWith("/api/")) { ... }` block, after the `/api/log` route:
+
+```ts
+if (url === "/api/linear/issues" && method === "GET") {
+  try {
+    const snapshot = await fetchAIImplementIssueSnapshot(config.linearApiKey);
+    const issues = [
+      ...snapshot.readyForImplementation.map((i) => ({ ...shape(i), bucket: "ready" as const })),
+      ...snapshot.needsPlanning.map((i) => ({ ...shape(i), bucket: "needs-planning" as const })),
+    ].sort((a, b) => a.identifier.localeCompare(b.identifier));
+    return json(res, 200, {
+      issues,
+      inProgressCountsByTeam: snapshot.inProgressCountsByTeam,
+    });
+  } catch (err) {
+    return json(res, 502, { error: String(err instanceof Error ? err.message : err) });
+  }
+}
+```
+
+Add a small helper at module scope:
+
+```ts
+function shape(i: LinearIssue) {
+  return {
+    id: i.id,
+    identifier: i.identifier,
+    title: i.title,
+    teamKey: i.team.key,
+    stateName: i.state.name,
+    stateType: i.state.type,
+  };
+}
+```
+
+Add the import: `import { fetchAIImplementIssueSnapshot, type LinearIssue } from "./linear.js";`. Group near the existing imports.
+
+- [ ] **Step 3: Run tests** — pass.
+
+- [ ] **Step 4: Commit** — `feat(admin): add /api/linear/issues endpoint`
+
+---
+
+## Task 2: Build the Issues page module
+
+**Files:**
+- Create: `src/admin-ui/pages/issues.ts`
+
+- [ ] **Step 1: Build `issuesHtml`**
+
+```html
+<section data-page="issues" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Issues</h1>
+      <div class="page-subtitle" id="issues-subtitle">—</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadIssues()">↻ Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="issues-error" class="alert fail" hidden></div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Inbox</h2>
+        <div class="card-subtitle"><span id="issues-count">—</span></div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Issue</th><th>Team</th><th>State</th><th>Plan</th><th></th></tr></thead>
+          <tbody id="issues-body"></tbody>
+        </table>
+        <div id="issues-empty" class="hidden text-tertiary" style="padding:12px">
+          No AI-Implement labeled issues found in Linear.
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header"><h2 class="card-title">In progress by team</h2></div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Team</th><th style="text-align:right">Currently implementing</th></tr></thead>
+          <tbody id="issues-progress-body"></tbody>
+        </table>
+        <div id="issues-progress-empty" class="hidden text-tertiary" style="padding:12px">No teams currently working.</div>
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+- [ ] **Step 2: Build `issuesScript`**
+
+IIFE with:
+
+- `async function loadIssues()`:
+  1. Hide `#issues-error`.
+  2. `const res = await window.api('/api/linear/issues');`
+  3. If `!res.ok`: read body for error message, show `#issues-error` with `{error}` text and `<div class="alert-title">Failed to load Linear issues</div>`. Empty the body and return.
+  4. Else: parse, render the tables.
+- `renderIssuesTable(issues)`: one row per issue. Each row:
+  - Issue cell: `<span class="mono">{identifier}</span> <span>{title}</span>` (esc both).
+  - Team cell: `<span class="mono">{teamKey}</span>`.
+  - State cell: `<span class="badge {kind}"><span class="dot"></span>{stateName}</span>` where `kind` is derived from `stateType`: `started` → `running`, `unstarted`/`backlog` → `neutral`, `completed` → `success`, `cancelled` → `warn`, others → `neutral`.
+  - Plan cell: `<span class="badge {kind}">{label}</span>` where `bucket === 'ready'` → `success`/`Ready` and `bucket === 'needs-planning'` → `info`/`Plan pending`.
+  - Last cell: `<a class="text-accent" href="https://linear.app/issue/{identifier}" target="_blank">Open ↗</a>`.
+- `renderProgressTable(counts)`: one row per `[teamKey, count]` where count > 0; sort by team key. Empty state if all zero.
+- `renderSubtitle(issues, counts)`: `"{N} matched · {M} currently implementing"`.
+- Local `setLastUpdated` not needed; the subtitle is the freshness signal.
+- Window exposures: `loadIssues`.
+- `registerPage('issues', () => { loadIssues(); setInterval(loadIssues, 60000); })` — refresh every minute (matches the poller cadence).
+
+`const`/`let` only. `window.api()`/`window.esc()` only.
+
+- [ ] **Step 3: Commit** — `feat(admin): add issues page module`
+
+---
+
+## Task 3: Wire + remove the stub
+
+**Files:**
+- Modify: `src/admin-ui/index.ts`
+- Modify: `src/admin-ui/pages/stubs.ts`
+
+- [ ] **Step 1:** Import + inject `issuesHtml` and `issuesScript` in `index.ts`.
+- [ ] **Step 2:** Remove the `stubPage("issues", ...)` line from `stubsHtml` in `stubs.ts`.
+- [ ] **Step 3:** `npm run typecheck && npm test` — `pages-render.test.ts` still passes (issues route now covered by a real page).
+- [ ] **Step 4:** Commit — `feat(admin): wire issues page, remove its stub`
+
+---
+
+## Task 4: Structural tests + final verify
+
+**File:** `src/admin-ui/__tests__/issues.test.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+import { issuesHtml, issuesScript } from "../pages/issues.js";
+
+describe("issues page", () => {
+  it("declares the expected ids", () => {
+    for (const id of ["issues-subtitle", "issues-error", "issues-count", "issues-body", "issues-empty", "issues-progress-body"]) {
+      expect(issuesHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("registers the 'issues' route and exposes loadIssues", () => {
+    expect(issuesScript).toContain("window.registerPage('issues'");
+    expect(issuesScript).toContain("window.loadIssues = loadIssues");
+  });
+
+  it("calls /api/linear/issues", () => {
+    expect(issuesScript).toContain("/api/linear/issues");
+  });
+
+  it("uses window.api/window.esc only", () => {
+    const stripped = issuesScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+
+  it("uses const/let, not var", () => {
+    expect(issuesScript).not.toMatch(/\bvar\s+\w/);
+  });
+});
+```
+
+Final: `npm run typecheck && npm test`. All pass.
+
+Commit: `test(admin): structural tests for issues page module`.
+
+---
+
+## Risks
+
+- **Linear rate limits:** the poller already calls this query every 60s and the new endpoint hits the same path. If admins keep the Issues page open, the request rate doubles. Acceptable for now; if Linear pushes back we add caching with a 30s TTL in a future polish task.
+- **Auth-protected behind admin code, but Linear API key is server-side:** the endpoint never returns the key, just the resulting issue data. ✓
+- **Empty state vs error state confusion:** an empty Linear inbox returns `issues: []` with 200. The page must render the empty-state row, not the error alert. The script's `!res.ok` check handles that correctly.
+- **Bucket sort:** the design ref sorts by team then identifier. We sort just by identifier to keep the implementation simple. If the user prefers grouping by team, that's a small future tweak.

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -9,6 +9,7 @@ import type * as DedupModule from "../dedup.js";
 import type * as RunnerModeModule from "../runner-mode.js";
 import type * as LogModule from "../log.js";
 import type * as StepLogModule from "../step-log.js";
+import type * as LinearModuleType from "../linear.js";
 
 class MockRequest extends EventEmitter {
   url?: string;
@@ -53,11 +54,13 @@ let dedup: typeof DedupModule;
 let runnerMode: typeof RunnerModeModule;
 let log: typeof LogModule;
 let stepLog: typeof StepLogModule;
+let linear: typeof LinearModuleType;
 
 beforeEach(async () => {
   vi.resetModules();
   dbPath = path.join(os.tmpdir(), `admin-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
   process.env.DEDUP_DB_PATH = dbPath;
+  linear = await import("../linear.js");
   admin = await import("../admin.js");
   config = await import("../config.js");
   dedup = await import("../dedup.js");
@@ -952,5 +955,63 @@ describe("admin dedup", () => {
     const del = await request("/api/dedup/issue-del", "DELETE", "secret", undefined, token);
     expect(del.statusCode).toBe(200);
     expect(dedup.isAlreadyDispatched("issue-del")).toBe(false);
+  });
+});
+
+describe("admin linear issues endpoint", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without auth token", async () => {
+    const res = await request("/api/linear/issues", "GET", "secret");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 502 on Linear failure", async () => {
+    vi.spyOn(linear, "fetchAIImplementIssueSnapshot").mockRejectedValueOnce(
+      new Error("Linear API error: 401"),
+    );
+    const token = await login("secret");
+    const res = await request("/api/linear/issues", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body).error).toContain("Linear API error");
+  });
+
+  it("returns 200 with shaped issues on success", async () => {
+    const stubSnapshot = {
+      readyForImplementation: [
+        {
+          id: "issue-1",
+          identifier: "CORE-100",
+          title: "Implement feature X",
+          team: { id: "team-1", key: "CORE" },
+          state: { id: "state-1", name: "Todo", type: "unstarted" },
+        },
+      ],
+      needsPlanning: [
+        {
+          id: "issue-2",
+          identifier: "CORE-50",
+          title: "Plan something",
+          team: { id: "team-1", key: "CORE" },
+          state: { id: "state-2", name: "Backlog", type: "backlog" },
+        },
+      ],
+      inProgressCountsByTeam: { CORE: 2 },
+    };
+    vi.spyOn(linear, "fetchAIImplementIssueSnapshot").mockResolvedValueOnce(stubSnapshot);
+    const token = await login("secret");
+    const res = await request("/api/linear/issues", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues).toHaveLength(2);
+    expect(body.inProgressCountsByTeam).toEqual({ CORE: 2 });
+    // Sorted by identifier (localeCompare): "CORE-100" < "CORE-50" lexicographically
+    expect(body.issues[0].identifier).toBe("CORE-100");
+    expect(body.issues[0].bucket).toBe("ready");
+    expect(body.issues[1].identifier).toBe("CORE-50");
+    expect(body.issues[1].bucket).toBe("needs-planning");
   });
 });

--- a/src/admin-ui/__tests__/issues.test.ts
+++ b/src/admin-ui/__tests__/issues.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { issuesHtml, issuesScript } from "../pages/issues.js";
+
+describe("issues page", () => {
+  it("declares the expected ids", () => {
+    for (const id of ["issues-subtitle", "issues-error", "issues-count", "issues-body", "issues-empty", "issues-progress-body"]) {
+      expect(issuesHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("registers the 'issues' route and exposes loadIssues", () => {
+    expect(issuesScript).toContain("window.registerPage('issues'");
+    expect(issuesScript).toContain("window.loadIssues = loadIssues");
+  });
+
+  it("calls /api/linear/issues", () => {
+    expect(issuesScript).toContain("/api/linear/issues");
+  });
+
+  it("uses window.api/window.esc only", () => {
+    const stripped = issuesScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+
+  it("uses const/let, not var", () => {
+    expect(issuesScript).not.toMatch(/\bvar\s+\w/);
+  });
+});

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -11,6 +11,7 @@ import { pipelinesHtml, pipelinesScript } from "./pages/pipelines.js";
 import { reaperHtml, reaperScript } from "./pages/reaper.js";
 import { sessionsHtml, sessionsScript } from "./pages/sessions.js";
 import { auditHtml, auditScript } from "./pages/audit.js";
+import { issuesHtml, issuesScript } from "./pages/issues.js";
 import { stubsHtml } from "./pages/stubs.js";
 import { drawerHtml, drawerScript } from "./drawer.js";
 import { stepperHtml, stepperScript } from "./stepper.js";
@@ -37,6 +38,7 @@ const shell = `<div id="admin-page" class="app-shell hidden">
     ${reaperHtml}
     ${sessionsHtml}
     ${auditHtml}
+    ${issuesHtml}
     ${stubsHtml}
   </main>
 </div>`;
@@ -53,7 +55,7 @@ const body = `<body>
 ${shell}
 ${drawerHtml}
 ${stepperHtml}
-<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${drawerScript}${stepperScript}</script>
+<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${drawerScript}${stepperScript}</script>
 </body></html>`;
 
 export const adminHtml = head + body;

--- a/src/admin-ui/pages/issues.ts
+++ b/src/admin-ui/pages/issues.ts
@@ -70,7 +70,7 @@ export const issuesScript = `
         : '<span class="badge info"><span class="dot"></span>Plan pending</span>';
       tr.innerHTML = '<td><span class="mono">' + window.esc(issue.identifier) + '</span> ' + window.esc(issue.title) + '</td>'
         + '<td><span class="mono">' + window.esc(issue.teamKey) + '</span></td>'
-        + '<td><span class="badge ' + stateKind + '">' + window.esc(issue.stateName) + '</span></td>'
+        + '<td><span class="badge ' + stateKind + '"><span class="dot"></span>' + window.esc(issue.stateName) + '</span></td>'
         + '<td>' + planBadge + '</td>'
         + '<td><a class="text-accent" href="https://linear.app/issue/' + window.esc(issue.identifier) + '" target="_blank">Open ↗</a></td>';
       tbody.appendChild(tr);
@@ -120,6 +120,8 @@ export const issuesScript = `
       errorEl.hidden = false;
       document.getElementById('issues-body').innerHTML = '';
       document.getElementById('issues-progress-body').innerHTML = '';
+      document.getElementById('issues-empty').classList.add('hidden');
+      document.getElementById('issues-progress-empty').classList.add('hidden');
       document.getElementById('issues-count').textContent = '—';
       document.getElementById('issues-subtitle').textContent = '—';
       return;

--- a/src/admin-ui/pages/issues.ts
+++ b/src/admin-ui/pages/issues.ts
@@ -1,0 +1,136 @@
+export const issuesHtml = `
+<section data-page="issues" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Issues</h1>
+      <div class="page-subtitle" id="issues-subtitle">—</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadIssues()">↻ Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="issues-error" class="alert fail" hidden></div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Inbox</h2>
+        <div class="card-subtitle"><span id="issues-count">—</span></div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Issue</th><th>Team</th><th>State</th><th>Plan</th><th></th></tr></thead>
+          <tbody id="issues-body"></tbody>
+        </table>
+        <div id="issues-empty" class="hidden text-tertiary" style="padding:12px">No AI-Implement labeled issues found in Linear.</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header"><h2 class="card-title">In progress by team</h2></div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Team</th><th style="text-align:right">Currently implementing</th></tr></thead>
+          <tbody id="issues-progress-body"></tbody>
+        </table>
+        <div id="issues-progress-empty" class="hidden text-tertiary" style="padding:12px">No teams currently working.</div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+export const issuesScript = `
+(function () {
+  function stateBadgeKind(stateType) {
+    if (stateType === 'started') return 'running';
+    if (stateType === 'completed') return 'success';
+    if (stateType === 'cancelled') return 'warn';
+    return 'neutral';
+  }
+
+  function renderInbox(issues) {
+    const countEl = document.getElementById('issues-count');
+    const tbody = document.getElementById('issues-body');
+    const emptyEl = document.getElementById('issues-empty');
+    countEl.textContent = issues.length + ' matched';
+    tbody.innerHTML = '';
+    if (issues.length === 0) {
+      emptyEl.classList.remove('hidden');
+      tbody.closest('table').style.display = 'none';
+      return;
+    }
+    emptyEl.classList.add('hidden');
+    tbody.closest('table').style.display = '';
+    for (const issue of issues) {
+      const tr = document.createElement('tr');
+      const stateKind = stateBadgeKind(issue.stateType);
+      const planBadge = issue.bucket === 'ready'
+        ? '<span class="badge success"><span class="dot"></span>Ready</span>'
+        : '<span class="badge info"><span class="dot"></span>Plan pending</span>';
+      tr.innerHTML = '<td><span class="mono">' + window.esc(issue.identifier) + '</span> ' + window.esc(issue.title) + '</td>'
+        + '<td><span class="mono">' + window.esc(issue.teamKey) + '</span></td>'
+        + '<td><span class="badge ' + stateKind + '">' + window.esc(issue.stateName) + '</span></td>'
+        + '<td>' + planBadge + '</td>'
+        + '<td><a class="text-accent" href="https://linear.app/issue/' + window.esc(issue.identifier) + '" target="_blank">Open ↗</a></td>';
+      tbody.appendChild(tr);
+    }
+  }
+
+  function renderProgress(counts) {
+    const tbody = document.getElementById('issues-progress-body');
+    const emptyEl = document.getElementById('issues-progress-empty');
+    tbody.innerHTML = '';
+    const entries = Object.entries(counts).filter(function (pair) { return pair[1] > 0; });
+    entries.sort(function (a, b) { return a[0].localeCompare(b[0]); });
+    if (entries.length === 0) {
+      emptyEl.classList.remove('hidden');
+      tbody.closest('table').style.display = 'none';
+      return;
+    }
+    emptyEl.classList.add('hidden');
+    tbody.closest('table').style.display = '';
+    for (const pair of entries) {
+      const teamKey = pair[0];
+      const count = pair[1];
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td class="mono">' + window.esc(teamKey) + '</td>'
+        + '<td style="text-align:right" class="mono text-secondary">' + count + '</td>';
+      tbody.appendChild(tr);
+    }
+  }
+
+  function renderSubtitle(issues, counts) {
+    const inProgress = Object.values(counts).reduce(function (a, b) { return a + b; }, 0);
+    const el = document.getElementById('issues-subtitle');
+    if (el) el.textContent = issues.length + ' matched \xb7 ' + inProgress + ' currently implementing';
+  }
+
+  async function loadIssues() {
+    const errorEl = document.getElementById('issues-error');
+    errorEl.hidden = true;
+    const res = await window.api('/api/linear/issues');
+    if (!res.ok) {
+      let errorMsg = 'Unknown error';
+      try {
+        const errBody = await res.json();
+        errorMsg = errBody.error || errorMsg;
+      } catch (_) { /* ignore parse errors */ }
+      errorEl.innerHTML = '<div style="flex:1"><div class="alert-title">Failed to load Linear issues</div><div class="alert-desc">' + window.esc(errorMsg) + '</div></div>';
+      errorEl.hidden = false;
+      document.getElementById('issues-body').innerHTML = '';
+      document.getElementById('issues-progress-body').innerHTML = '';
+      document.getElementById('issues-count').textContent = '—';
+      document.getElementById('issues-subtitle').textContent = '—';
+      return;
+    }
+    const data = await res.json();
+    renderInbox(data.issues);
+    renderProgress(data.inProgressCountsByTeam);
+    renderSubtitle(data.issues, data.inProgressCountsByTeam);
+  }
+
+  window.loadIssues = loadIssues;
+  window.registerPage('issues', function () { loadIssues(); setInterval(loadIssues, 60000); });
+}());
+`;

--- a/src/admin-ui/pages/stubs.ts
+++ b/src/admin-ui/pages/stubs.ts
@@ -19,7 +19,6 @@ function stubPage(route: string, title: string, subtitle: string, phase: string,
 }
 
 export const stubsHtml = [
-  stubPage("issues", "Issues", "Linear issue inbox", "Plan 4", "Matched issues, plan state, dispatchable. Backed by /api/linear/issues (new endpoint)."),
   stubPage("pulls", "Pull requests", "PRs opened by the bot", "Plan 4", "Risk-scored, awaiting CI/review. Backed by /api/github/pulls (new endpoint)."),
   stubPage("blockers", "Blockers", "Why each issue isn't running", "Plan 4", "Surfaces concurrency cap, missing secrets, dedup, Linear deps, Bedrock region, Fly config — derived from poll-selection.ts."),
   stubPage("pipelines", "Pipelines & steps", "Composable step library + pipeline definitions", "Plan 5", "List + edit pipeline YAMLs, step modules registered in src/pipeline/."),

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -28,7 +28,7 @@ import { getLastSweepAt } from "./reaper.js";
 import { listLog, getInFlightJobs, updateJobStatus, getJobById } from "./log.js";
 import { getStepsByJobId } from "./step-log.js";
 import { listMachines, destroyMachine, listAppSecrets, setAppSecrets, unsetAppSecret } from "./fly-machines.js";
-import { removeAIWorkingLabel } from "./linear.js";
+import { removeAIWorkingLabel, fetchAIImplementIssueSnapshot, type LinearIssue } from "./linear.js";
 import { adminHtml } from "./admin-html.js";
 import { getOrchestratorSettings, setOrchestratorSetting } from "./orchestrator-settings.js";
 
@@ -67,6 +67,18 @@ function readBody(req: http.IncomingMessage): Promise<string> {
 function json(res: http.ServerResponse, status: number, data: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });
   res.end(JSON.stringify(data));
+}
+
+function shapeIssue(i: LinearIssue, bucket: "ready" | "needs-planning") {
+  return {
+    id: i.id,
+    identifier: i.identifier,
+    title: i.title,
+    teamKey: i.team.key,
+    stateName: i.state.name,
+    stateType: i.state.type,
+    bucket,
+  };
 }
 
 function getToken(req: http.IncomingMessage): string | undefined {
@@ -171,6 +183,11 @@ export function handleAdminRequest(
       return true;
     }
 
+    if (url === "/api/linear/issues" && method === "GET") {
+      handleListLinearIssues(res, config);
+      return true;
+    }
+
     if (url === "/api/reaper/summary" && method === "GET") {
       const summary = getReaperSummary();
       json(res, 200, { ...summary, lastSweepAt: getLastSweepAt() });
@@ -251,6 +268,25 @@ export function handleAdminRequest(
   }
 
   return false;
+}
+
+async function handleListLinearIssues(
+  res: http.ServerResponse,
+  config: AdminConfig,
+): Promise<void> {
+  try {
+    const snapshot = await fetchAIImplementIssueSnapshot(config.linearApiKey);
+    const issues = [
+      ...snapshot.readyForImplementation.map((i) => shapeIssue(i, "ready")),
+      ...snapshot.needsPlanning.map((i) => shapeIssue(i, "needs-planning")),
+    ].sort((a, b) => a.identifier.localeCompare(b.identifier));
+    json(res, 200, {
+      issues,
+      inProgressCountsByTeam: snapshot.inProgressCountsByTeam,
+    });
+  } catch (err) {
+    json(res, 502, { error: err instanceof Error ? err.message : String(err) });
+  }
 }
 
 async function handleSetRunnerMode(


### PR DESCRIPTION
## Summary

Plan 4a of 5. Replaces the `issues` route stub with a real Linear inbox.

- New auth-protected route `GET /api/linear/issues` wrapping `fetchAIImplementIssueSnapshot`. Returns `{ issues: [...{ id, identifier, title, teamKey, stateName, stateType, bucket }], inProgressCountsByTeam }`. `bucket` is `"ready"` (Plan-Complete) or `"needs-planning"`. 502 on Linear API failure.
- New page `src/admin-ui/pages/issues.ts` — Inbox table + In-progress-by-team table, error alert, 60s auto-refresh.
- Stub for `issues` removed from `stubs.ts`.
- Tests: 3 endpoint tests (401 / 502 / 200-shape), 5 structural page tests.
- 6 commits + 1 review-fix; 618 tests pass.

Plan: `docs/superpowers/plans/2026-04-29-admin-issues.md`. PR base: `admin-overhaul`.

## Test plan

- [ ] `#issues` loads and shows AI-Implement issues from Linear
- [ ] State badge has the animated dot for in-progress states
- [ ] Plan badge shows "Ready" (success) or "Plan pending" (info) per bucket
- [ ] In-progress-by-team table shows non-zero teams only
- [ ] Linear key invalid → error alert with the server's message; empty-state hidden
- [ ] 60s refresh updates without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)