### PR TITLE
Plan 4b: Pull requests page

### DIFF
--- a/docs/superpowers/plans/2026-04-29-admin-pulls.md
+++ b/docs/superpowers/plans/2026-04-29-admin-pulls.md
@@ -1,0 +1,264 @@
+# Pull Requests Page — Plan 4b
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Replace the `pulls` route stub with a list of bot-opened pull requests, derived entirely from existing `dispatch_log` entries that have a non-null `prUrl`.
+
+**Architecture:** Add `getPulls()` to `src/log.ts` (returns one row per unique PR URL, picking the latest entry per URL). Add `GET /api/pulls` route that returns these. Add `src/admin-ui/pages/pulls.ts`. Remove the `pulls` stub. **No GitHub API calls** — keep it pure log-derived. CI status / review state / risk scoring stay deferred to a later polish plan that adds GitHub fan-out.
+
+**Out of scope:**
+- CI status (would need GitHub API).
+- Review state, approval count.
+- Risk score (would need PR diff analysis).
+- Auto-merge / closed/merged state (we can infer "open" only from "we have a prUrl"; closing detection requires polling GitHub).
+- Pagination / filtering.
+
+**Branching:** `admin-overhaul-4b-pulls` off `admin-overhaul`. PR back to `admin-overhaul`.
+
+---
+
+## Endpoint contract
+
+`GET /api/pulls` (auth-protected). Response 200:
+
+```ts
+{
+  pulls: Array<{
+    prUrl: string;             // canonical
+    prNumber: number | null;   // parsed from prUrl tail
+    repo: string | null;
+    teamKey: string | null;
+    issueIdentifier: string | null;
+    issueTitle: string | null;
+    jobStatus: string;         // status of the most recent dispatch for this PR
+    dispatchNumber: number;    // iteration count
+    lastDispatchedAt: number;  // ms epoch
+    jobId: number;             // most-recent job that produced this PR
+  }>;
+}
+```
+
+Rules:
+- Iterate `listLog(500)` (we only ever store the last 500). Filter to `prUrl != null`.
+- Group by `prUrl`. For each group, keep the entry with the largest `dispatchedAt` (the latest re-dispatch wins).
+- Sort the result by `lastDispatchedAt` desc.
+- `prNumber` = parse from `prUrl.split('/').pop()`; if not numeric, leave null.
+
+---
+
+## File Structure
+
+```
+src/log.ts                                  — MODIFIED. Add getPulls().
+src/__tests__/jobs.test.ts                  — MODIFIED. Unit test for getPulls().
+src/admin.ts                                — MODIFIED. Add GET /api/pulls.
+src/__tests__/admin.test.ts                 — MODIFIED. 401 + 200 tests for /api/pulls.
+src/admin-ui/pages/pulls.ts                 — NEW.
+src/admin-ui/pages/stubs.ts                 — MODIFIED. Remove "pulls" entry.
+src/admin-ui/index.ts                       — MODIFIED. Inject pullsHtml + pullsScript.
+src/admin-ui/__tests__/pulls.test.ts        — NEW. Structural tests.
+```
+
+---
+
+## Task 1: `getPulls()` helper + tests
+
+**Files:**
+- Modify: `src/log.ts`
+- Modify: `src/__tests__/jobs.test.ts`
+
+- [ ] **Step 1: TDD** — add a test that inserts three log rows (two with the same prUrl, one without) and asserts `getPulls()` returns one entry per unique prUrl, picking the latest by `dispatchedAt`. Also assert ordering (latest first).
+
+- [ ] **Step 2: Implement**
+
+```ts
+export interface PullSummary {
+  prUrl: string;
+  prNumber: number | null;
+  repo: string | null;
+  teamKey: string | null;
+  issueIdentifier: string | null;
+  issueTitle: string | null;
+  jobStatus: string;
+  dispatchNumber: number;
+  lastDispatchedAt: number;
+  jobId: number;
+}
+
+export function getPulls(): PullSummary[] {
+  const rows = listLog(500).filter((j) => j.prUrl);
+  const byUrl = new Map<string, PullSummary>();
+  for (const j of rows) {
+    const ts = new Date(j.dispatchedAt).getTime();
+    const existing = byUrl.get(j.prUrl!);
+    if (existing && existing.lastDispatchedAt >= ts) continue;
+    const tail = j.prUrl!.split("/").pop() ?? "";
+    const prNumber = /^\d+$/.test(tail) ? Number.parseInt(tail, 10) : null;
+    byUrl.set(j.prUrl!, {
+      prUrl: j.prUrl!,
+      prNumber,
+      repo: j.repo ?? null,
+      teamKey: j.teamKey ?? null,
+      issueIdentifier: j.issueIdentifier ?? null,
+      issueTitle: j.issueTitle ?? null,
+      jobStatus: j.status ?? "unknown",
+      dispatchNumber: j.dispatchNumber ?? 1,
+      lastDispatchedAt: ts,
+      jobId: j.id,
+    });
+  }
+  return Array.from(byUrl.values()).sort((a, b) => b.lastDispatchedAt - a.lastDispatchedAt);
+}
+```
+
+The exact field names on `Job` may differ — check `listLog` output. If `dispatchedAt` is stored as ISO, the `new Date(...).getTime()` works; if it's a number, that works too (Date(number).getTime() is identity).
+
+- [ ] **Step 3: Run** `npm test -- src/__tests__/jobs.test.ts`. Pass.
+
+- [ ] **Step 4: Commit** — `feat(log): add getPulls() summary helper`.
+
+---
+
+## Task 2: `/api/pulls` endpoint
+
+**Files:**
+- Modify: `src/admin.ts`
+- Modify: `src/__tests__/admin.test.ts`
+
+- [ ] **Step 1: TDD** — two tests:
+  1. 401 without auth.
+  2. 200 with `{ pulls: [] }` shape on a fresh DB; insert two log rows with the same prUrl and verify `pulls.length === 1` with the expected `dispatchNumber`.
+
+- [ ] **Step 2: Wire the route** between `/api/log` and `/api/reaper/summary`:
+
+```ts
+if (url === "/api/pulls" && method === "GET") {
+  return json(res, 200, { pulls: getPulls() });
+}
+```
+
+Add the import `import { ..., getPulls } from "./log.js";`.
+
+- [ ] **Step 3: Run + commit** — `feat(admin): add /api/pulls endpoint`.
+
+---
+
+## Task 3: Page module
+
+**Files:**
+- Create: `src/admin-ui/pages/pulls.ts`
+
+```html
+<section data-page="pulls" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Pull requests</h1>
+      <div class="page-subtitle" id="pulls-subtitle">—</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadPulls()">↻ Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="pulls-error" class="alert fail" hidden></div>
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Bot-opened PRs</h2>
+        <div class="card-subtitle"><span id="pulls-count">—</span></div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead>
+            <tr><th>PR</th><th>Issue</th><th>Repo</th><th>Status</th><th>Iter</th><th style="text-align:right">Last dispatch</th><th></th></tr>
+          </thead>
+          <tbody id="pulls-body"></tbody>
+        </table>
+        <div id="pulls-empty" class="hidden text-tertiary" style="padding:12px">No bot-opened pull requests yet.</div>
+      </div>
+    </div>
+    <div class="alert info" style="margin-top:12px">
+      <div style="flex:1">
+        <div class="alert-title">CI / review state coming later</div>
+        <div class="alert-desc">A future plan will fan out to GitHub for CI green/red, review status, and risk scoring. For now, click a PR to inspect status on GitHub.</div>
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+Script (IIFE):
+
+- `async function loadPulls()` — fetch `/api/pulls`. On error, show `#pulls-error` and clear body. On success, render rows.
+- For each pull row:
+  - PR cell: `<a class="text-accent mono" href="${prUrl}" target="_blank">#${prNumber ?? '?'}</a>`. esc the href.
+  - Issue cell: if `issueIdentifier`, `<a class="text-accent" href="https://linear.app/issue/${id}" target="_blank"><span class="mono text-secondary">${id}</span> ${title}</a>`; else `—`.
+  - Repo: `<span class="mono">${repo ?? '—'}</span>`.
+  - Status: badge — `running`→running, `completed`→success, `failed`→fail, `timed_out`→warn, others→neutral. Use `<span class="dot"></span>` like the issues page.
+  - Iter: `<span class="mono">${dispatchNumber}</span>` with re-dispatch warn color when >1.
+  - Last dispatch: `${fmtAgo(lastDispatchedAt)}` (mono, text-tertiary).
+  - Action cell: `<a class="text-accent" href="${prUrl}" target="_blank">Open ↗</a>`.
+- `fmtAgo` local helper.
+- Subtitle: `${pulls.length} tracked`.
+- `window.loadPulls = loadPulls;`
+- `registerPage('pulls', () => { loadPulls(); setInterval(loadPulls, 30000); })`.
+- Error path also hides `#pulls-empty`.
+
+`const`/`let` only. `window.api`/`window.esc` only.
+
+Commit: `feat(admin): add pulls page module`.
+
+---
+
+## Task 4: Wire + remove stub
+
+- Modify `src/admin-ui/index.ts` to import + inject `pullsHtml` and `pullsScript`.
+- Modify `src/admin-ui/pages/stubs.ts` to remove the `pulls` entry.
+
+`npm run typecheck && npm test` — pass. Commit: `feat(admin): wire pulls page, remove its stub`.
+
+---
+
+## Task 5: Structural tests
+
+**File:** `src/admin-ui/__tests__/pulls.test.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+import { pullsHtml, pullsScript } from "../pages/pulls.js";
+
+describe("pulls page", () => {
+  it("declares the expected ids", () => {
+    for (const id of ["pulls-subtitle", "pulls-error", "pulls-count", "pulls-body", "pulls-empty"]) {
+      expect(pullsHtml).toContain(`id="${id}"`);
+    }
+  });
+  it("registers route + exposes loadPulls", () => {
+    expect(pullsScript).toContain("window.registerPage('pulls'");
+    expect(pullsScript).toContain("window.loadPulls = loadPulls");
+  });
+  it("calls /api/pulls and nothing new", () => {
+    expect(pullsScript).toContain("/api/pulls");
+    expect(pullsScript).not.toMatch(/\/api\/(github|pr|reviews)\b/);
+  });
+  it("uses window.api/window.esc only", () => {
+    const stripped = pullsScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+  it("uses const/let, not var", () => {
+    expect(pullsScript).not.toMatch(/\bvar\s+\w/);
+  });
+});
+```
+
+Final: `npm run typecheck && npm test`. Pass.
+
+Commit: `test(admin): structural tests for pulls page module`.
+
+---
+
+## Risks
+
+- **Log rotation:** we only keep the last 500 dispatches. PRs whose latest dispatch falls off the tail won't appear. Acceptable — old PRs are in the GitHub UI and Linear can show them too.
+- **`prUrl` field absence on older entries:** `j.prUrl ?? null` guard handles that; the filter step drops them before grouping.
+- **Multiple repos with the same PR number:** the prUrl is the unique key (it includes owner/repo/number), not the bare number — collisions impossible.

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1015,3 +1015,48 @@ describe("admin linear issues endpoint", () => {
     expect(body.issues[1].bucket).toBe("needs-planning");
   });
 });
+
+describe("admin pulls endpoint", () => {
+  it("returns 401 without auth token", async () => {
+    const res = await request("/api/pulls", "GET", "secret");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 200 with empty array on a fresh DB", async () => {
+    const token = await login("secret");
+    const res = await request("/api/pulls", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body.pulls)).toBe(true);
+    expect(body.pulls).toHaveLength(0);
+  });
+
+  it("returns 200 with deduped entries — same prUrl yields one pull", async () => {
+    const token = await login("secret");
+
+    const id1 = log.appendLog({
+      issueId: "issue-pull-1",
+      issueIdentifier: "ENG-1",
+      repo: "org/repo",
+      teamKey: "ENG",
+      dispatchNumber: 1,
+    });
+    log.updateJobStatus(id1, "completed", "success", "https://github.com/org/repo/pull/55");
+
+    const id2 = log.appendLog({
+      issueId: "issue-pull-1",
+      issueIdentifier: "ENG-1",
+      repo: "org/repo",
+      teamKey: "ENG",
+      dispatchNumber: 2,
+    });
+    log.updateJobStatus(id2, "completed", "success", "https://github.com/org/repo/pull/55");
+
+    const res = await request("/api/pulls", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.pulls).toHaveLength(1);
+    expect(body.pulls[0].prUrl).toBe("https://github.com/org/repo/pull/55");
+    expect(body.pulls[0].prNumber).toBe(55);
+  });
+});

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -327,3 +327,52 @@ describe("getJobById", () => {
     expect(log.getJobById(99999999)).toBeNull();
   });
 });
+
+describe("getPulls", () => {
+  it("returns one entry per unique prUrl, latest wins", () => {
+    const id1 = log.appendLog({
+      issueId: "issue-pr-1",
+      issueIdentifier: "ENG-10",
+      repo: "org/repo",
+      teamKey: "ENG",
+      dispatchNumber: 1,
+    });
+    log.updateJobStatus(id1, "completed", "success", "https://github.com/org/repo/pull/100");
+
+    // Insert a second row with the same prUrl but later timestamp (by manipulating dispatched_at directly)
+    const db = dedup.getDb();
+    db.prepare(
+      "INSERT INTO dispatch_log (issue_id, issue_identifier, repo, team_key, dispatched_at, dispatch_number, status, pr_url) VALUES (?, ?, ?, ?, ?, ?, 'completed', ?)",
+    ).run("issue-pr-1", "ENG-10", "org/repo", "ENG", Date.now() + 5000, 2, "https://github.com/org/repo/pull/100");
+
+    const pulls = log.getPulls();
+    expect(pulls.length).toBe(1);
+    expect(pulls[0].dispatchNumber).toBe(2);
+  });
+
+  it("filters out null prUrl", () => {
+    log.appendLog({
+      issueId: "issue-no-pr",
+      issueIdentifier: "ENG-20",
+      repo: "org/repo",
+      teamKey: "ENG",
+    });
+    // No prUrl set — should not appear in getPulls
+    const pulls = log.getPulls();
+    expect(pulls.length).toBe(0);
+  });
+
+  it("prNumber parsing extracts the numeric segment from the prUrl", () => {
+    const id = log.appendLog({
+      issueId: "issue-pr-num",
+      issueIdentifier: "ENG-30",
+      repo: "org/repo",
+      teamKey: "ENG",
+    });
+    log.updateJobStatus(id, "completed", "success", "https://github.com/acme/repo/pull/123");
+
+    const pulls = log.getPulls();
+    expect(pulls.length).toBe(1);
+    expect(pulls[0].prNumber).toBe(123);
+  });
+});

--- a/src/admin-ui/__tests__/pulls.test.ts
+++ b/src/admin-ui/__tests__/pulls.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { pullsHtml, pullsScript } from "../pages/pulls.js";
+
+describe("pulls page", () => {
+  it("declares the expected ids", () => {
+    for (const id of ["pulls-subtitle", "pulls-error", "pulls-count", "pulls-body", "pulls-empty"]) {
+      expect(pullsHtml).toContain(`id="${id}"`);
+    }
+  });
+  it("registers the route and exposes loadPulls", () => {
+    expect(pullsScript).toContain("window.registerPage('pulls'");
+    expect(pullsScript).toContain("window.loadPulls = loadPulls");
+  });
+  it("calls /api/pulls and nothing new", () => {
+    expect(pullsScript).toContain("/api/pulls");
+    expect(pullsScript).not.toMatch(/\/api\/(github|pr|reviews)\b/);
+  });
+  it("uses window.api/window.esc only", () => {
+    const stripped = pullsScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+  it("uses const/let, not var", () => {
+    expect(pullsScript).not.toMatch(/\bvar\s+\w/);
+  });
+});

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -12,6 +12,7 @@ import { reaperHtml, reaperScript } from "./pages/reaper.js";
 import { sessionsHtml, sessionsScript } from "./pages/sessions.js";
 import { auditHtml, auditScript } from "./pages/audit.js";
 import { issuesHtml, issuesScript } from "./pages/issues.js";
+import { pullsHtml, pullsScript } from "./pages/pulls.js";
 import { stubsHtml } from "./pages/stubs.js";
 import { drawerHtml, drawerScript } from "./drawer.js";
 import { stepperHtml, stepperScript } from "./stepper.js";
@@ -39,6 +40,7 @@ const shell = `<div id="admin-page" class="app-shell hidden">
     ${sessionsHtml}
     ${auditHtml}
     ${issuesHtml}
+    ${pullsHtml}
     ${stubsHtml}
   </main>
 </div>`;
@@ -55,7 +57,7 @@ const body = `<body>
 ${shell}
 ${drawerHtml}
 ${stepperHtml}
-<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${drawerScript}${stepperScript}</script>
+<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${drawerScript}${stepperScript}</script>
 </body></html>`;
 
 export const adminHtml = head + body;

--- a/src/admin-ui/pages/pulls.ts
+++ b/src/admin-ui/pages/pulls.ts
@@ -1,0 +1,135 @@
+export const pullsHtml = `
+<section data-page="pulls" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Pull requests</h1>
+      <div class="page-subtitle" id="pulls-subtitle">&mdash;</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadPulls()">&#8635; Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="pulls-error" class="alert fail" hidden></div>
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Bot-opened PRs</h2>
+        <div class="card-subtitle"><span id="pulls-count">&mdash;</span></div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead>
+            <tr><th>PR</th><th>Issue</th><th>Repo</th><th>Status</th><th>Iter</th><th style="text-align:right">Last dispatch</th><th></th></tr>
+          </thead>
+          <tbody id="pulls-body"></tbody>
+        </table>
+        <div id="pulls-empty" class="hidden text-tertiary" style="padding:12px">No bot-opened pull requests yet.</div>
+      </div>
+    </div>
+    <div class="alert info" style="margin-top:12px">
+      <div style="flex:1">
+        <div class="alert-title">CI / review state coming later</div>
+        <div class="alert-desc">A future plan will fan out to GitHub for CI green/red, review status, and risk scoring. For now, click a PR to inspect status on GitHub.</div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+export const pullsScript = `
+(function () {
+  function fmtAgo(ts) {
+    const diff = Date.now() - ts;
+    const s = Math.floor(diff / 1000);
+    if (s < 60) return s + 's ago';
+    const m = Math.floor(s / 60);
+    if (m < 60) return m + 'm ago';
+    const h = Math.floor(m / 60);
+    if (h < 24) return h + 'h ago';
+    const d = Math.floor(h / 24);
+    return d + 'd ago';
+  }
+
+  function statusBadgeKind(s) {
+    if (s === 'running') return 'running';
+    if (s === 'completed') return 'success';
+    if (s === 'failed') return 'fail';
+    if (s === 'timed_out') return 'warn';
+    return 'neutral';
+  }
+
+  function renderRows(pulls) {
+    const countEl = document.getElementById('pulls-count');
+    const emptyEl = document.getElementById('pulls-empty');
+    const tbody = document.getElementById('pulls-body');
+    if (countEl) countEl.textContent = pulls.length + ' tracked';
+    if (emptyEl) {
+      if (pulls.length === 0) {
+        emptyEl.classList.remove('hidden');
+      } else {
+        emptyEl.classList.add('hidden');
+      }
+    }
+    tbody.innerHTML = '';
+    for (const pull of pulls) {
+      const { prUrl, prNumber, issueIdentifier, issueTitle, repo, jobStatus, dispatchNumber, lastDispatchedAt } = pull;
+      const kind = statusBadgeKind(jobStatus);
+      const prCell = '<a class="text-accent mono" href="' + window.esc(prUrl) + '" target="_blank">#' + (prNumber != null ? prNumber : '?') + '</a>';
+      let issueCell;
+      if (issueIdentifier) {
+        issueCell = '<a class="text-accent" href="https://linear.app/issue/' + window.esc(issueIdentifier) + '" target="_blank"><span class="mono text-secondary">' + window.esc(issueIdentifier) + '</span> <span>' + window.esc(issueTitle || '') + '</span></a>';
+      } else {
+        issueCell = '<span class="text-tertiary">&mdash;</span>';
+      }
+      const repoCell = '<span class="mono">' + (repo ? window.esc(repo) : '&mdash;') + '</span>';
+      const statusCell = '<span class="badge ' + kind + '"><span class="dot"></span>' + window.esc(jobStatus) + '</span>';
+      const iterCell = '<span class="mono' + (dispatchNumber > 1 ? ' text-secondary' : '') + '">' + dispatchNumber + '</span>';
+      const lastCell = '<td style="text-align:right" class="mono text-tertiary">' + fmtAgo(lastDispatchedAt) + '</td>';
+      const actionCell = '<a class="text-accent" href="' + window.esc(prUrl) + '" target="_blank">Open &#8599;</a>';
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td>' + prCell + '</td>'
+        + '<td>' + issueCell + '</td>'
+        + '<td>' + repoCell + '</td>'
+        + '<td>' + statusCell + '</td>'
+        + '<td>' + iterCell + '</td>'
+        + lastCell
+        + '<td>' + actionCell + '</td>';
+      tbody.appendChild(tr);
+    }
+  }
+
+  async function loadPulls() {
+    const errorEl = document.getElementById('pulls-error');
+    const subtitleEl = document.getElementById('pulls-subtitle');
+    const countEl = document.getElementById('pulls-count');
+    const tbody = document.getElementById('pulls-body');
+    if (errorEl) errorEl.hidden = true;
+    const res = await window.api('/api/pulls');
+    if (!res.ok) {
+      let msg = 'HTTP ' + res.status;
+      try {
+        const errBody = await res.json();
+        if (errBody && errBody.error) msg = errBody.error;
+      } catch (_) { /* ignore */ }
+      if (errorEl) {
+        errorEl.innerHTML = '<div style="flex:1"><div class="alert-title">Failed to load pull requests</div><div class="alert-desc">' + window.esc(msg) + '</div></div>';
+        errorEl.hidden = false;
+      }
+      if (tbody) tbody.innerHTML = '';
+      const emptyEl = document.getElementById('pulls-empty');
+      if (emptyEl) emptyEl.classList.add('hidden');
+      if (countEl) countEl.textContent = '\\u2014';
+      if (subtitleEl) subtitleEl.textContent = '\\u2014';
+      return;
+    }
+    const data = await res.json();
+    const pulls = data.pulls || [];
+    renderRows(pulls);
+    if (subtitleEl) subtitleEl.textContent = pulls.length + ' tracked';
+  }
+
+  window.loadPulls = loadPulls;
+
+  window.registerPage('pulls', function () { loadPulls(); setInterval(loadPulls, 30000); });
+})();
+`;

--- a/src/admin-ui/pages/stubs.ts
+++ b/src/admin-ui/pages/stubs.ts
@@ -19,7 +19,6 @@ function stubPage(route: string, title: string, subtitle: string, phase: string,
 }
 
 export const stubsHtml = [
-  stubPage("pulls", "Pull requests", "PRs opened by the bot", "Plan 4", "Risk-scored, awaiting CI/review. Backed by /api/github/pulls (new endpoint)."),
   stubPage("blockers", "Blockers", "Why each issue isn't running", "Plan 4", "Surfaces concurrency cap, missing secrets, dedup, Linear deps, Bedrock region, Fly config — derived from poll-selection.ts."),
   stubPage("pipelines", "Pipelines & steps", "Composable step library + pipeline definitions", "Plan 5", "List + edit pipeline YAMLs, step modules registered in src/pipeline/."),
   stubPage("models", "Models & providers", "Per-step models, provider failover, runner profiles", "Plan 5", "Configure provider chains and per-step model IDs."),

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -25,7 +25,7 @@ import {
 } from "./runner-mode.js";
 import { getDb, listDispatched, deleteDispatched, getReaperSummary, listReaperActions } from "./dedup.js";
 import { getLastSweepAt } from "./reaper.js";
-import { listLog, getInFlightJobs, updateJobStatus, getJobById } from "./log.js";
+import { listLog, getInFlightJobs, updateJobStatus, getJobById, getPulls } from "./log.js";
 import { getStepsByJobId } from "./step-log.js";
 import { listMachines, destroyMachine, listAppSecrets, setAppSecrets, unsetAppSecret } from "./fly-machines.js";
 import { removeAIWorkingLabel, fetchAIImplementIssueSnapshot, type LinearIssue } from "./linear.js";
@@ -171,6 +171,11 @@ export function handleAdminRequest(
 
     if (url === "/api/log" && method === "GET") {
       json(res, 200, listLog());
+      return true;
+    }
+
+    if (url === "/api/pulls" && method === "GET") {
+      json(res, 200, { pulls: getPulls() });
       return true;
     }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -294,6 +294,45 @@ function mapRows(rows: RawRow[]): Job[] {
   }));
 }
 
+export interface PullSummary {
+  prUrl: string;
+  prNumber: number | null;
+  repo: string | null;
+  teamKey: string | null;
+  issueIdentifier: string | null;
+  issueTitle: string | null;
+  jobStatus: string;
+  dispatchNumber: number;
+  lastDispatchedAt: number;
+  jobId: number;
+}
+
+export function getPulls(): PullSummary[] {
+  const rows = listLog(500).filter((j) => j.prUrl);
+  const byUrl = new Map<string, PullSummary>();
+  for (const j of rows) {
+    const ts = j.dispatchedAt;
+    const prUrl = j.prUrl as string;
+    const existing = byUrl.get(prUrl);
+    if (existing && existing.lastDispatchedAt >= ts) continue;
+    const tail = prUrl.split("/").pop() ?? "";
+    const prNumber = /^\d+$/.test(tail) ? Number.parseInt(tail, 10) : null;
+    byUrl.set(prUrl, {
+      prUrl,
+      prNumber,
+      repo: j.repo ?? null,
+      teamKey: j.teamKey ?? null,
+      issueIdentifier: j.issueIdentifier ?? null,
+      issueTitle: j.issueTitle ?? null,
+      jobStatus: j.status ?? "unknown",
+      dispatchNumber: j.dispatchNumber ?? 1,
+      lastDispatchedAt: ts,
+      jobId: j.id,
+    });
+  }
+  return Array.from(byUrl.values()).sort((a, b) => b.lastDispatchedAt - a.lastDispatchedAt);
+}
+
 /** Returns the job with the given id, or null if not found. */
 export function getJobById(id: number): Job | null {
   const row = getDb()


### PR DESCRIPTION
## Summary

Plan 4b of 5. Replaces the `pulls` route stub with a list of bot-opened pull requests, derived entirely from `dispatch_log` rows that have a non-null `prUrl`. **No GitHub API calls** — pure log-derived. CI / review state / risk scoring stay deferred for a later polish plan.

- New `getPulls(): PullSummary[]` helper in `src/log.ts` — filters log to prUrl-bearing rows, dedupes by URL keeping the latest dispatch, parses `prNumber` from the URL tail, sorts desc.
- New auth-protected route `GET /api/pulls`.
- New page `src/admin-ui/pages/pulls.ts` — table with PR / Issue / Repo / Status / Iter / Last dispatch + an info banner explaining what's deferred.
- Stub for `pulls` removed from `stubs.ts`.
- 3 helper tests + 3 endpoint tests + 5 structural page tests.
- 5 commits; 629 tests pass.

Plan: `docs/superpowers/plans/2026-04-29-admin-pulls.md`. PR base: `admin-overhaul`.

## Test plan

- [ ] `#pulls` shows recent bot-opened PRs from the local dispatch log
- [ ] PR number and Linear issue both link to their respective external sites
- [ ] Iteration column visually flags `dispatchNumber > 1`
- [ ] Status badge animates on `running` (the dot pulse)
- [ ] Empty install (no PRs yet) renders the empty state
- [ ] 30s auto-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)