### PR TITLE
Plan 4c: Blockers page

### DIFF
--- a/docs/superpowers/plans/2026-04-29-admin-blockers.md
+++ b/docs/superpowers/plans/2026-04-29-admin-blockers.md
@@ -1,0 +1,322 @@
+# Blockers Page — Plan 4c
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Replace the `blockers` route stub with a page that explains, per matched Linear issue, why it isn't being dispatched. Blockers fall into three categories the orchestrator can determine today: `no-mapping`, `dedup`, `concurrency`.
+
+**Architecture:** Add `selectBlockers()` to `src/poll-selection.ts` mirroring the existing `selectIssuesToDispatch` logic but returning blocker reasons instead of dispatchable issues. Add `GET /api/blockers` route that calls into the same Linear/mappings/dedup primitives the poller uses, then runs `selectBlockers`. Add `src/admin-ui/pages/blockers.ts`. Remove the `blockers` stub.
+
+**Out of scope (future polish):**
+- `secret`, `app-install`, `bedrock-region`, `linear-dep` blocker reasons — each requires inspecting state we don't currently surface (Fly secrets, GitHub App install status, mapping config, Linear graph). Each is one or more new helpers; defer.
+- Live "claim and dispatch this now" actions on a blocked row.
+- Filtering / search.
+
+**Branching:** `admin-overhaul-4c-blockers` off `admin-overhaul`. PR back to `admin-overhaul`.
+
+---
+
+## Endpoint contract
+
+`GET /api/blockers` (auth-protected). Response 200:
+
+```ts
+{
+  blockers: Array<{
+    issueId: string;
+    issueIdentifier: string;
+    issueTitle: string;
+    teamKey: string;
+    reason: 'no-mapping' | 'dedup' | 'concurrency';
+    detail: string;        // human-friendly: e.g. "DATA at concurrency cap (2/2). Waiting for a slot."
+  }>;
+  totals: {
+    teams: number;         // distinct teamKeys with blockers
+    issues: number;        // blockers.length
+    byReason: Record<string, number>;
+  };
+}
+```
+
+Server-side derivation:
+1. Call `fetchAIImplementIssueSnapshot(linearApiKey)` → all currently matched issues + `inProgressCountsByTeam`.
+2. Read `getMappings()` → `teamRepoMap`.
+3. Read `getDispatchedIds()` from dedup → `Set<string>`.
+4. For each issue:
+   - If `!teamRepoMap[issue.team.key]` → `no-mapping` blocker, detail `"No mapping for team {teamKey}. Add one in Projects."`.
+   - Else if `dispatched.has(issue.id)` → `dedup` blocker, detail `"Already dispatched recently. Waiting for the in-flight job."`.
+   - Else if `mapping.maxInProgressAiIssues - (inProgress[teamKey] ?? 0) <= 0` → `concurrency` blocker, detail `"{teamKey} at concurrency cap ({inProgress}/{maxAi}). Waiting for a slot."`.
+   - Else → not a blocker (skip).
+5. On Linear failure → 502.
+
+Sort blockers by reason then teamKey then identifier for stable presentation.
+
+---
+
+## File Structure
+
+```
+src/poll-selection.ts                     — MODIFIED. Add selectBlockers().
+src/__tests__/poll-selection.test.ts      — MODIFIED. Tests for selectBlockers (no-mapping, dedup, concurrency, mixed).
+src/admin.ts                              — MODIFIED. Add GET /api/blockers.
+src/__tests__/admin.test.ts               — MODIFIED. 401 + 502 + 200-shape tests.
+src/admin-ui/pages/blockers.ts            — NEW.
+src/admin-ui/pages/stubs.ts               — MODIFIED. Remove "blockers" entry.
+src/admin-ui/index.ts                     — MODIFIED. Inject blockersHtml + blockersScript.
+src/admin-ui/__tests__/blockers.test.ts   — NEW. Structural tests.
+```
+
+---
+
+## Task 1: `selectBlockers` helper
+
+**Files:**
+- Modify: `src/poll-selection.ts`
+- Modify: `src/__tests__/poll-selection.test.ts`
+
+- [ ] **Step 1: TDD**
+
+Look at existing tests in `poll-selection.test.ts` for shape. Add tests:
+
+1. `selectBlockers` returns `no-mapping` when team isn't in mappings.
+2. Returns `dedup` when issue is in dispatched set, regardless of capacity.
+3. Returns `concurrency` when team is at cap and not deduped.
+4. Returns nothing for an issue that would dispatch (has slot, not deduped, has mapping).
+5. Returns multiple blockers across teams sorted by reason+teamKey+identifier.
+
+- [ ] **Step 2: Implement**
+
+```ts
+export interface Blocker {
+  issueId: string;
+  issueIdentifier: string;
+  issueTitle: string;
+  teamKey: string;
+  reason: "no-mapping" | "dedup" | "concurrency";
+  detail: string;
+}
+
+export function selectBlockers(
+  issues: LinearIssue[],
+  teamRepoMap: Record<string, RepoMapping>,
+  inProgressCountsByTeam: Record<string, number>,
+  isAlreadyDispatched: (issueId: string) => boolean,
+): Blocker[] {
+  const blockers: Blocker[] = [];
+  for (const issue of issues) {
+    const teamKey = issue.team.key;
+    const mapping = teamRepoMap[teamKey];
+    if (!mapping) {
+      blockers.push({
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        issueTitle: issue.title,
+        teamKey,
+        reason: "no-mapping",
+        detail: `No mapping for team ${teamKey}. Add one in Projects.`,
+      });
+      continue;
+    }
+    if (isAlreadyDispatched(issue.id)) {
+      blockers.push({
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        issueTitle: issue.title,
+        teamKey,
+        reason: "dedup",
+        detail: `Already dispatched recently. Waiting for the in-flight job.`,
+      });
+      continue;
+    }
+    const inProgress = inProgressCountsByTeam[teamKey] ?? 0;
+    const cap = mapping.maxInProgressAiIssues;
+    if (cap - inProgress <= 0) {
+      blockers.push({
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        issueTitle: issue.title,
+        teamKey,
+        reason: "concurrency",
+        detail: `${teamKey} at concurrency cap (${inProgress}/${cap}). Waiting for a slot.`,
+      });
+    }
+  }
+  blockers.sort((a, b) =>
+    a.reason.localeCompare(b.reason) ||
+    a.teamKey.localeCompare(b.teamKey) ||
+    a.issueIdentifier.localeCompare(b.issueIdentifier),
+  );
+  return blockers;
+}
+```
+
+- [ ] **Step 3: Run + commit** — `feat(poll-selection): add selectBlockers helper`.
+
+---
+
+## Task 2: `/api/blockers` endpoint
+
+**Files:**
+- Modify: `src/admin.ts`
+- Modify: `src/__tests__/admin.test.ts`
+
+- [ ] **Step 1: TDD** — three tests:
+  1. 401 without auth.
+  2. 502 when Linear throws (use `vi.spyOn` on `fetchAIImplementIssueSnapshot` like the issues endpoint test in Plan 4a).
+  3. 200 with shape on success: stub the linear snapshot to return one issue whose team has no mapping; assert the response has `blockers[0].reason === 'no-mapping'`.
+
+- [ ] **Step 2: Wire**
+
+```ts
+if (url === "/api/blockers" && method === "GET") {
+  try {
+    const snapshot = await fetchAIImplementIssueSnapshot(config.linearApiKey);
+    const allIssues = [...snapshot.readyForImplementation, ...snapshot.needsPlanning];
+    const teamRepoMap = getMappings();
+    const dispatchedSet = new Set(getDispatchedIds());
+    const blockers = selectBlockers(
+      allIssues,
+      teamRepoMap,
+      snapshot.inProgressCountsByTeam,
+      (id) => dispatchedSet.has(id),
+    );
+    const teams = new Set(blockers.map((b) => b.teamKey));
+    const byReason: Record<string, number> = {};
+    for (const b of blockers) byReason[b.reason] = (byReason[b.reason] ?? 0) + 1;
+    return json(res, 200, {
+      blockers,
+      totals: { teams: teams.size, issues: blockers.length, byReason },
+    });
+  } catch (err) {
+    return json(res, 502, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+```
+
+Imports needed (group with existing):
+```ts
+import { selectBlockers } from "./poll-selection.js";
+import { getMappings } from "./config.js";
+import { getDispatchedIds } from "./dedup.js";
+```
+
+- [ ] **Step 3: Run + commit** — `feat(admin): add /api/blockers endpoint`.
+
+---
+
+## Task 3: Page module
+
+**Files:**
+- Create: `src/admin-ui/pages/blockers.ts`
+
+```html
+<section data-page="blockers" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Blockers</h1>
+      <div class="page-subtitle" id="blockers-subtitle">—</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadBlockers()">↻ Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="blockers-error" class="alert fail" hidden></div>
+
+    <div class="kpi-grid" id="blockers-kpis" hidden>
+      <div class="kpi"><div class="kpi-label">Total blocked</div><div class="kpi-value" id="kpi-blocked-total">0</div></div>
+      <div class="kpi"><div class="kpi-label">Teams affected</div><div class="kpi-value" id="kpi-blocked-teams">0</div></div>
+      <div class="kpi"><div class="kpi-label">By concurrency cap</div><div class="kpi-value" id="kpi-blocked-concurrency">0</div></div>
+      <div class="kpi"><div class="kpi-label">By dedup</div><div class="kpi-value" id="kpi-blocked-dedup">0</div></div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Blocked issues</h2>
+        <div class="card-subtitle">grouped by reason</div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Issue</th><th>Team</th><th>Reason</th><th>Detail</th><th></th></tr></thead>
+          <tbody id="blockers-body"></tbody>
+        </table>
+        <div id="blockers-empty" class="hidden text-tertiary" style="padding:12px">Nothing's blocked. All matched issues either have capacity or are already dispatched.</div>
+      </div>
+    </div>
+
+    <div class="alert info" style="margin-top:12px">
+      <div style="flex:1">
+        <div class="alert-title">More blocker types coming</div>
+        <div class="alert-desc">Today this page surfaces three blocker reasons: no mapping, deduplication, concurrency cap. Future plans will add missing-secret, GitHub App install, Bedrock region, and Linear-dependency blockers.</div>
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+Script (IIFE):
+- `async function loadBlockers()`. On error: show error, hide kpi grid, clear body.
+- On success: populate KPIs (`hidden=false`), render rows, set subtitle `"{N} blocked across {T} teams"`.
+- Reason badge mapping: `no-mapping`→`fail`, `dedup`→`info`, `concurrency`→`warn`. Label text: capitalize and humanize (`No mapping`, `Dedup`, `Concurrency cap`).
+- Last cell: `<a class="text-accent" href="https://linear.app/issue/{id}" target="_blank">Open ↗</a>`.
+- Subtitle empty state: `"Nothing's blocked"` if zero.
+- 60s auto-refresh.
+- Window: `window.loadBlockers`.
+
+`const`/`let` only. `window.api`/`window.esc` only.
+
+Commit: `feat(admin): add blockers page module`.
+
+---
+
+## Task 4: Wire + remove stub
+
+- Modify `src/admin-ui/index.ts` to import + inject.
+- Modify `src/admin-ui/pages/stubs.ts` to remove the `blockers` entry.
+
+`npm run typecheck && npm test` — pass. Commit: `feat(admin): wire blockers page, remove its stub`.
+
+---
+
+## Task 5: Structural tests
+
+**File:** `src/admin-ui/__tests__/blockers.test.ts`
+
+```ts
+import { describe, expect, it } from "vitest";
+import { blockersHtml, blockersScript } from "../pages/blockers.js";
+
+describe("blockers page", () => {
+  it("declares the expected ids", () => {
+    for (const id of ["blockers-subtitle", "blockers-error", "blockers-kpis", "blockers-body", "blockers-empty", "kpi-blocked-total", "kpi-blocked-teams", "kpi-blocked-concurrency", "kpi-blocked-dedup"]) {
+      expect(blockersHtml).toContain(`id="${id}"`);
+    }
+  });
+  it("registers route + exposes loadBlockers", () => {
+    expect(blockersScript).toContain("window.registerPage('blockers'");
+    expect(blockersScript).toContain("window.loadBlockers = loadBlockers");
+  });
+  it("calls /api/blockers", () => {
+    expect(blockersScript).toContain("/api/blockers");
+  });
+  it("uses window.api/window.esc only", () => {
+    const stripped = blockersScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+  it("uses const/let, not var", () => {
+    expect(blockersScript).not.toMatch(/\bvar\s+\w/);
+  });
+});
+```
+
+Final: `npm run typecheck && npm test`. Pass.
+
+Commit: `test(admin): structural tests for blockers page module`.
+
+---
+
+## Risks
+
+- **Empty install (no mappings):** an `AI-Implement`-labeled issue with no matching mapping will appear as a blocker on first load. That's the right behavior — the user added the label but hasn't created the project yet.
+- **Race with dispatch loop:** the poller dispatches every 60s; the blockers endpoint reads the same state at request time. A blocker may flip to "now dispatched" between two consecutive Refresh clicks. Acceptable.
+- **Scale:** for installs with hundreds of matched issues, the blockers list could be large. Single-page render is fine up to a few hundred rows; bigger lists need pagination — defer.

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1060,3 +1060,51 @@ describe("admin pulls endpoint", () => {
     expect(body.pulls[0].prNumber).toBe(55);
   });
 });
+
+describe("admin blockers endpoint", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without auth token", async () => {
+    const res = await request("/api/blockers", "GET", "secret");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 502 on Linear failure", async () => {
+    vi.spyOn(linear, "fetchAIImplementIssueSnapshot").mockRejectedValueOnce(
+      new Error("boom"),
+    );
+    const token = await login("secret");
+    const res = await request("/api/blockers", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body).error).toContain("boom");
+  });
+
+  it("returns 200 with shape — no-mapping blocker when issue team has no mapping", async () => {
+    const stubSnapshot = {
+      readyForImplementation: [
+        {
+          id: "issue-1",
+          identifier: "CORE-100",
+          title: "Implement feature X",
+          team: { id: "team-1", key: "CORE" },
+          state: { id: "state-1", name: "Todo", type: "unstarted" },
+        },
+      ],
+      needsPlanning: [],
+      inProgressCountsByTeam: {},
+    };
+    vi.spyOn(linear, "fetchAIImplementIssueSnapshot").mockResolvedValueOnce(stubSnapshot);
+    const token = await login("secret");
+    // No mapping for CORE team → should produce a no-mapping blocker
+    const res = await request("/api/blockers", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body.blockers)).toBe(true);
+    expect(body.blockers).toHaveLength(1);
+    expect(body.blockers[0].reason).toBe("no-mapping");
+    expect(body.totals.byReason["no-mapping"]).toBe(1);
+    expect(body.totals.issues).toBe(1);
+  });
+});

--- a/src/__tests__/poll-selection.test.ts
+++ b/src/__tests__/poll-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { selectIssuesToDispatch } from "../poll-selection.js";
+import { selectIssuesToDispatch, selectBlockers } from "../poll-selection.js";
 import type { RepoMapping } from "../config.js";
 import type { LinearIssue } from "../linear.js";
 
@@ -95,5 +95,74 @@ describe("selectIssuesToDispatch", () => {
     );
     expect(selected).toHaveLength(2);
     expect(selected.map((i) => i.identifier)).toEqual(["APP-1", "APP-2"]);
+  });
+});
+
+describe("selectBlockers", () => {
+  it("returns no-mapping when teamRepoMap lacks the issue's team", () => {
+    const blockers = selectBlockers(
+      [makeIssue("1", "UNK-1", "UNK")],
+      { APP: makeMapping(3) },
+      {},
+      () => false,
+    );
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].reason).toBe("no-mapping");
+    expect(blockers[0].issueId).toBe("1");
+    expect(blockers[0].teamKey).toBe("UNK");
+  });
+
+  it("returns dedup when isAlreadyDispatched is true, NOT concurrency even if at cap", () => {
+    const blockers = selectBlockers(
+      [makeIssue("1", "APP-1", "APP")],
+      { APP: makeMapping(1) },
+      { APP: 1 }, // at cap
+      (id) => id === "1",
+    );
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].reason).toBe("dedup");
+  });
+
+  it("returns concurrency when team is at cap and not deduped", () => {
+    const blockers = selectBlockers(
+      [makeIssue("1", "APP-1", "APP")],
+      { APP: makeMapping(2) },
+      { APP: 2 },
+      () => false,
+    );
+    expect(blockers).toHaveLength(1);
+    expect(blockers[0].reason).toBe("concurrency");
+    expect(blockers[0].teamKey).toBe("APP");
+  });
+
+  it("returns nothing for a dispatchable issue", () => {
+    const blockers = selectBlockers(
+      [makeIssue("1", "APP-1", "APP")],
+      { APP: makeMapping(3) },
+      { APP: 1 },
+      () => false,
+    );
+    expect(blockers).toHaveLength(0);
+  });
+
+  it("returns multiple blockers from mixed input, sorted by reason+teamKey+identifier", () => {
+    const blockers = selectBlockers(
+      [
+        makeIssue("1", "APP-2", "APP"), // concurrency (APP at cap)
+        makeIssue("2", "APP-1", "APP"), // dedup
+        makeIssue("3", "API-1", "API"), // no-mapping
+        makeIssue("4", "APP-3", "APP"), // concurrency (APP at cap)
+      ],
+      { APP: makeMapping(1) },
+      { APP: 1 }, // APP at cap
+      (id) => id === "2",
+    );
+    // issue "2" (APP-1) → dedup; issue "3" (API-1) → no-mapping; issues "1","4" → concurrency
+    // sorted: concurrency/APP/APP-2, concurrency/APP/APP-3, dedup/APP/APP-1, no-mapping/API/API-1
+    expect(blockers).toHaveLength(4);
+    expect(blockers[0]).toMatchObject({ reason: "concurrency", issueIdentifier: "APP-2" });
+    expect(blockers[1]).toMatchObject({ reason: "concurrency", issueIdentifier: "APP-3" });
+    expect(blockers[2]).toMatchObject({ reason: "dedup", issueIdentifier: "APP-1" });
+    expect(blockers[3]).toMatchObject({ reason: "no-mapping", issueIdentifier: "API-1" });
   });
 });

--- a/src/admin-ui/__tests__/blockers.test.ts
+++ b/src/admin-ui/__tests__/blockers.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { blockersHtml, blockersScript } from "../pages/blockers.js";
+
+describe("blockers page", () => {
+  it("declares the expected ids", () => {
+    for (const id of ["blockers-subtitle", "blockers-error", "blockers-kpis", "blockers-body", "blockers-empty", "kpi-blocked-total", "kpi-blocked-teams", "kpi-blocked-concurrency", "kpi-blocked-dedup"]) {
+      expect(blockersHtml).toContain(`id="${id}"`);
+    }
+  });
+  it("registers route + exposes loadBlockers", () => {
+    expect(blockersScript).toContain("window.registerPage('blockers'");
+    expect(blockersScript).toContain("window.loadBlockers = loadBlockers");
+  });
+  it("calls /api/blockers", () => {
+    expect(blockersScript).toContain("/api/blockers");
+  });
+  it("uses window.api/window.esc only", () => {
+    const stripped = blockersScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+  it("uses const/let, not var", () => {
+    expect(blockersScript).not.toMatch(/\bvar\s+\w/);
+  });
+});

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -13,6 +13,7 @@ import { sessionsHtml, sessionsScript } from "./pages/sessions.js";
 import { auditHtml, auditScript } from "./pages/audit.js";
 import { issuesHtml, issuesScript } from "./pages/issues.js";
 import { pullsHtml, pullsScript } from "./pages/pulls.js";
+import { blockersHtml, blockersScript } from "./pages/blockers.js";
 import { stubsHtml } from "./pages/stubs.js";
 import { drawerHtml, drawerScript } from "./drawer.js";
 import { stepperHtml, stepperScript } from "./stepper.js";
@@ -41,6 +42,7 @@ const shell = `<div id="admin-page" class="app-shell hidden">
     ${auditHtml}
     ${issuesHtml}
     ${pullsHtml}
+    ${blockersHtml}
     ${stubsHtml}
   </main>
 </div>`;
@@ -57,7 +59,7 @@ const body = `<body>
 ${shell}
 ${drawerHtml}
 ${stepperHtml}
-<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${drawerScript}${stepperScript}</script>
+<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${blockersScript}${drawerScript}${stepperScript}</script>
 </body></html>`;
 
 export const adminHtml = head + body;

--- a/src/admin-ui/pages/blockers.ts
+++ b/src/admin-ui/pages/blockers.ts
@@ -1,0 +1,122 @@
+export const blockersHtml = `
+<section data-page="blockers" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Blockers</h1>
+      <div class="page-subtitle" id="blockers-subtitle">—</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadBlockers()">↻ Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="blockers-error" class="alert fail" hidden></div>
+
+    <div class="kpi-grid" id="blockers-kpis" hidden>
+      <div class="kpi"><div class="kpi-label">Total blocked</div><div class="kpi-value" id="kpi-blocked-total">0</div></div>
+      <div class="kpi"><div class="kpi-label">Teams affected</div><div class="kpi-value" id="kpi-blocked-teams">0</div></div>
+      <div class="kpi"><div class="kpi-label">By concurrency cap</div><div class="kpi-value" id="kpi-blocked-concurrency">0</div></div>
+      <div class="kpi"><div class="kpi-label">By dedup</div><div class="kpi-value" id="kpi-blocked-dedup">0</div></div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Blocked issues</h2>
+        <div class="card-subtitle">grouped by reason</div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Issue</th><th>Team</th><th>Reason</th><th>Detail</th><th></th></tr></thead>
+          <tbody id="blockers-body"></tbody>
+        </table>
+        <div id="blockers-empty" class="hidden text-tertiary" style="padding:12px">Nothing's blocked. All matched issues either have capacity or are already dispatched.</div>
+      </div>
+    </div>
+
+    <div class="alert info" style="margin-top:12px">
+      <div style="flex:1">
+        <div class="alert-title">More blocker types coming</div>
+        <div class="alert-desc">Today this page surfaces three blocker reasons: no mapping, deduplication, concurrency cap. Future plans will add missing-secret, GitHub App install, Bedrock region, and Linear-dependency blockers.</div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+export const blockersScript = `
+(function () {
+  function reasonBadge(reason) {
+    if (reason === 'no-mapping') return '<span class="badge fail"><span class="dot"></span>No mapping</span>';
+    if (reason === 'dedup') return '<span class="badge info"><span class="dot"></span>Dedup</span>';
+    if (reason === 'concurrency') return '<span class="badge warn"><span class="dot"></span>Concurrency cap</span>';
+    return '<span class="badge neutral"><span class="dot"></span>' + window.esc(reason) + '</span>';
+  }
+
+  function renderRows(blockers) {
+    const tbody = document.getElementById('blockers-body');
+    const emptyEl = document.getElementById('blockers-empty');
+    tbody.innerHTML = '';
+    if (blockers.length === 0) {
+      emptyEl.classList.remove('hidden');
+      tbody.closest('table').style.display = 'none';
+      return;
+    }
+    emptyEl.classList.add('hidden');
+    tbody.closest('table').style.display = '';
+    for (const b of blockers) {
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td><span class="mono text-secondary">' + window.esc(b.issueIdentifier) + '</span> <span>' + window.esc(b.issueTitle || '') + '</span></td>'
+        + '<td><span class="mono">' + window.esc(b.teamKey) + '</span></td>'
+        + '<td>' + reasonBadge(b.reason) + '</td>'
+        + '<td class="col-grow"><span class="text-secondary">' + window.esc(b.detail) + '</span></td>'
+        + '<td><a class="text-accent" href="https://linear.app/issue/' + window.esc(b.issueIdentifier) + '" target="_blank">Open ↗</a></td>';
+      tbody.appendChild(tr);
+    }
+  }
+
+  function renderKpis(totals) {
+    document.getElementById('kpi-blocked-total').textContent = totals.issues;
+    document.getElementById('kpi-blocked-teams').textContent = totals.teams;
+    document.getElementById('kpi-blocked-concurrency').textContent = totals.byReason.concurrency ?? 0;
+    document.getElementById('kpi-blocked-dedup').textContent = totals.byReason.dedup ?? 0;
+    document.getElementById('blockers-kpis').hidden = false;
+  }
+
+  function renderSubtitle(blockers, totals) {
+    const el = document.getElementById('blockers-subtitle');
+    if (!el) return;
+    if (blockers.length === 0) {
+      el.textContent = "Nothing's blocked";
+    } else {
+      el.textContent = blockers.length + ' blocked across ' + totals.teams + ' team(s)';
+    }
+  }
+
+  async function loadBlockers() {
+    const errorEl = document.getElementById('blockers-error');
+    errorEl.hidden = true;
+    const res = await window.api('/api/blockers');
+    if (!res.ok) {
+      let errorMsg = 'Unknown error';
+      try {
+        const errBody = await res.json();
+        errorMsg = errBody.error || errorMsg;
+      } catch (_) { /* ignore parse errors */ }
+      errorEl.innerHTML = '<div style="flex:1"><div class="alert-title">Failed to load blockers</div><div class="alert-desc">' + window.esc(errorMsg) + '</div></div>';
+      errorEl.hidden = false;
+      document.getElementById('blockers-kpis').hidden = true;
+      document.getElementById('blockers-body').innerHTML = '';
+      document.getElementById('blockers-empty').classList.add('hidden');
+      document.getElementById('blockers-subtitle').textContent = '—';
+      return;
+    }
+    const data = await res.json();
+    renderKpis(data.totals);
+    renderRows(data.blockers);
+    renderSubtitle(data.blockers, data.totals);
+  }
+
+  window.loadBlockers = loadBlockers;
+  window.registerPage('blockers', function () { loadBlockers(); setInterval(loadBlockers, 60000); });
+}());
+`;

--- a/src/admin-ui/pages/stubs.ts
+++ b/src/admin-ui/pages/stubs.ts
@@ -19,7 +19,6 @@ function stubPage(route: string, title: string, subtitle: string, phase: string,
 }
 
 export const stubsHtml = [
-  stubPage("blockers", "Blockers", "Why each issue isn't running", "Plan 4", "Surfaces concurrency cap, missing secrets, dedup, Linear deps, Bedrock region, Fly config — derived from poll-selection.ts."),
   stubPage("pipelines", "Pipelines & steps", "Composable step library + pipeline definitions", "Plan 5", "List + edit pipeline YAMLs, step modules registered in src/pipeline/."),
   stubPage("models", "Models & providers", "Per-step models, provider failover, runner profiles", "Plan 5", "Configure provider chains and per-step model IDs."),
   stubPage("channels", "Triggers & channels", "Input triggers + output notifications", "Plan 5", "Linear, webhook, MCP triggers; Slack, Teams, GitHub PR comment channels."),

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -23,12 +23,13 @@ import {
   isRunnerMode,
   setFlySecretsMinVersion,
 } from "./runner-mode.js";
-import { getDb, listDispatched, deleteDispatched, getReaperSummary, listReaperActions } from "./dedup.js";
+import { getDb, listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
 import { getLastSweepAt } from "./reaper.js";
 import { listLog, getInFlightJobs, updateJobStatus, getJobById, getPulls } from "./log.js";
 import { getStepsByJobId } from "./step-log.js";
 import { listMachines, destroyMachine, listAppSecrets, setAppSecrets, unsetAppSecret } from "./fly-machines.js";
 import { removeAIWorkingLabel, fetchAIImplementIssueSnapshot, type LinearIssue } from "./linear.js";
+import { selectBlockers } from "./poll-selection.js";
 import { adminHtml } from "./admin-html.js";
 import { getOrchestratorSettings, setOrchestratorSetting } from "./orchestrator-settings.js";
 
@@ -193,6 +194,11 @@ export function handleAdminRequest(
       return true;
     }
 
+    if (url === "/api/blockers" && method === "GET") {
+      handleListBlockers(res, config);
+      return true;
+    }
+
     if (url === "/api/reaper/summary" && method === "GET") {
       const summary = getReaperSummary();
       json(res, 200, { ...summary, lastSweepAt: getLastSweepAt() });
@@ -273,6 +279,33 @@ export function handleAdminRequest(
   }
 
   return false;
+}
+
+async function handleListBlockers(
+  res: http.ServerResponse,
+  config: AdminConfig,
+): Promise<void> {
+  try {
+    const snapshot = await fetchAIImplementIssueSnapshot(config.linearApiKey);
+    const allIssues = [...snapshot.readyForImplementation, ...snapshot.needsPlanning];
+    const teamRepoMap = getMappings();
+    const dispatchedSet = new Set(getDispatchedIds());
+    const blockers = selectBlockers(
+      allIssues,
+      teamRepoMap,
+      snapshot.inProgressCountsByTeam,
+      (id) => dispatchedSet.has(id),
+    );
+    const teams = new Set(blockers.map((b) => b.teamKey));
+    const byReason: Record<string, number> = {};
+    for (const b of blockers) byReason[b.reason] = (byReason[b.reason] ?? 0) + 1;
+    json(res, 200, {
+      blockers,
+      totals: { teams: teams.size, issues: blockers.length, byReason },
+    });
+  } catch (err) {
+    json(res, 502, { error: err instanceof Error ? err.message : String(err) });
+  }
 }
 
 async function handleListLinearIssues(

--- a/src/poll-selection.ts
+++ b/src/poll-selection.ts
@@ -1,6 +1,68 @@
 import type { RepoMapping } from "./config.js";
 import type { LinearIssue } from "./linear.js";
 
+export interface Blocker {
+  issueId: string;
+  issueIdentifier: string;
+  issueTitle: string;
+  teamKey: string;
+  reason: "no-mapping" | "dedup" | "concurrency";
+  detail: string;
+}
+
+export function selectBlockers(
+  issues: LinearIssue[],
+  teamRepoMap: Record<string, RepoMapping>,
+  inProgressCountsByTeam: Record<string, number>,
+  isAlreadyDispatched: (issueId: string) => boolean,
+): Blocker[] {
+  const blockers: Blocker[] = [];
+  for (const issue of issues) {
+    const teamKey = issue.team.key;
+    const mapping = teamRepoMap[teamKey];
+    if (!mapping) {
+      blockers.push({
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        issueTitle: issue.title,
+        teamKey,
+        reason: "no-mapping",
+        detail: `No mapping for team ${teamKey}. Add one in Projects.`,
+      });
+      continue;
+    }
+    if (isAlreadyDispatched(issue.id)) {
+      blockers.push({
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        issueTitle: issue.title,
+        teamKey,
+        reason: "dedup",
+        detail: `Already dispatched recently. Waiting for the in-flight job.`,
+      });
+      continue;
+    }
+    const inProgress = inProgressCountsByTeam[teamKey] ?? 0;
+    const cap = mapping.maxInProgressAiIssues;
+    if (cap - inProgress <= 0) {
+      blockers.push({
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        issueTitle: issue.title,
+        teamKey,
+        reason: "concurrency",
+        detail: `${teamKey} at concurrency cap (${inProgress}/${cap}). Waiting for a slot.`,
+      });
+    }
+  }
+  blockers.sort((a, b) =>
+    a.reason.localeCompare(b.reason) ||
+    a.teamKey.localeCompare(b.teamKey) ||
+    a.issueIdentifier.localeCompare(b.issueIdentifier),
+  );
+  return blockers;
+}
+
 export function selectIssuesToDispatch(
   issues: LinearIssue[],
   teamRepoMap: Record<string, RepoMapping>,


### PR DESCRIPTION
## Summary

Plan 4c of 5. Replaces the `blockers` route stub with a real page that explains, per matched Linear issue, why it isn't being dispatched. Three blocker reasons surfaced today: `no-mapping`, `dedup`, `concurrency`. Other reasons (secret, app-install, bedrock-region, linear-dep) deferred — each needs new state inspection.

- New `selectBlockers()` helper in `src/poll-selection.ts` mirrors `selectIssuesToDispatch` but returns blockers. Dedup wins over concurrency. Sorted by reason+teamKey+identifier.
- New auth-protected `GET /api/blockers` returns `{ blockers, totals: { teams, issues, byReason } }`. 502 on Linear failure.
- New page `src/admin-ui/pages/blockers.ts` — KPI strip + per-issue table grouped by reason + info banner about deferred blocker types.
- Stub removed.
- 5 helper tests + 3 endpoint tests + 5 structural page tests.
- 5 commits; 642 tests pass.

Plan: `docs/superpowers/plans/2026-04-29-admin-blockers.md`. PR base: `admin-overhaul`.

## Test plan

- [ ] `#blockers` shows blocked issues with the right reason badges
- [ ] When a Linear issue has a team with no mapping → "No mapping" reason
- [ ] When an issue is in dedup ledger → "Dedup" reason (not concurrency, even if team is at cap)
- [ ] When team is at cap and not deduped → "Concurrency cap" reason
- [ ] KPI tiles match the per-reason totals
- [ ] Empty state when nothing blocked
- [ ] 60s refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)