### PR TITLE
Plan 5d: Runners fleet view

### DIFF
--- a/docs/superpowers/plans/2026-04-30-admin-runners.md
+++ b/docs/superpowers/plans/2026-04-30-admin-runners.md
@@ -1,0 +1,152 @@
+# Runners Page — Plan 5d
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Replace the `runners` route stub with a fleet-view page that aggregates runner-mode, per-mapping execution modes, live Fly sessions, and reaper status. Pure derived view — no new backend.
+
+**Architecture:** Single new page module `src/admin-ui/pages/runners.ts`. Calls into 4 existing endpoints in parallel: `/api/runner-mode`, `/api/mappings`, `/api/sessions`, `/api/reaper/summary`. Shapes them into:
+- KPI strip: current runner mode badge / Live Fly sessions count / 24h reaper destructions / Capacity (running across all teams ÷ sum of caps)
+- "Fly Machines" card: live sessions table (subset reuse from Sessions page; just essentials)
+- "Per-project execution mode" card: which mapping uses which runner; cap utilization
+- Mode-override warning if runner-mode != "default" — explains the global override is in effect
+
+**Branching:** `admin-overhaul-5d-runners` off `admin-overhaul`.
+
+**Out of scope:**
+- "Warm pools" — we don't have any.
+- Per-runner profiles / image overrides — `.ai-implement/image.yml` lives in target repos, requires GitHub fan-out.
+- Action buttons (destroy machine, switch mode) — those exist on Sessions and Reaper pages already.
+
+---
+
+## File Structure
+
+```
+src/admin-ui/pages/runners.ts                — NEW.
+src/admin-ui/pages/stubs.ts                  — MODIFIED. Remove "runners" entry.
+src/admin-ui/index.ts                        — MODIFIED. Inject + script.
+src/admin-ui/__tests__/runners.test.ts       — NEW.
+```
+
+---
+
+## Task 1: Page module
+
+**File:** `src/admin-ui/pages/runners.ts`
+
+Exports: `runnersHtml`, `runnersScript`.
+
+### Markup
+
+```html
+<section data-page="runners" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Runners</h1>
+      <div class="page-subtitle" id="runners-subtitle">—</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadRunners()">↻ Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="runners-error" class="alert fail" hidden></div>
+    <div id="runners-mode-banner" class="alert warn" hidden></div>
+
+    <div class="kpi-grid">
+      <div class="kpi"><div class="kpi-label">Runner mode</div><div class="kpi-value" id="kpi-runner-mode">—</div><div class="kpi-trend" id="kpi-runner-source"></div></div>
+      <div class="kpi"><div class="kpi-label">Live Fly sessions</div><div class="kpi-value" id="kpi-live-sessions">0</div></div>
+      <div class="kpi"><div class="kpi-label">Capacity used</div><div class="kpi-value" id="kpi-capacity"><span id="kpi-capacity-used">0</span><span class="kpi-unit"> / <span id="kpi-capacity-max">0</span></span></div></div>
+      <div class="kpi"><div class="kpi-label">Reaper (24h)</div><div class="kpi-value" id="kpi-reaped">0</div><div class="kpi-trend" id="kpi-reaper-sweep"></div></div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Fly Machines — live sessions</h2>
+        <div class="card-subtitle"><a href="#sessions" class="text-accent">Manage on Sessions page →</a></div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Issue</th><th>Team</th><th>Repo</th><th>Machine</th><th>State</th></tr></thead>
+          <tbody id="runners-sessions-body"></tbody>
+        </table>
+        <div id="runners-sessions-empty" class="hidden text-tertiary" style="padding:12px">No live machines.</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Per-project execution mode</h2>
+        <div class="card-subtitle">Effective mode is the mapping value unless the runner-mode override is set.</div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Team</th><th>Repo</th><th>Mode</th><th>Effective</th><th style="width:200px">Cap utilization</th><th style="text-align:right">Cap</th></tr></thead>
+          <tbody id="runners-projects-body"></tbody>
+        </table>
+        <div id="runners-projects-empty" class="hidden text-tertiary" style="padding:12px">No projects configured.</div>
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+### Script (IIFE)
+
+- `function fmtAgo(ms)` — local.
+- `function clampPct(n)` — `Math.min(100, Math.max(0, Math.round(n)))`.
+- `async function loadRunners()`:
+  1. Hide error and mode banner.
+  2. Run 4 fetches in parallel:
+     ```js
+     const [rmRes, mapRes, sessRes, reapRes] = await Promise.all([
+       window.api('/api/runner-mode'),
+       window.api('/api/mappings'),
+       window.api('/api/sessions'),
+       window.api('/api/reaper/summary'),
+     ]);
+     ```
+  3. If any of `runner-mode` or `mappings` failed: show error alert with the worst error, clear bodies. Return.
+  4. `sessions` may legitimately 503 when Fly app isn't configured — treat as empty array, not as page-level error. Set the live-sessions count to '—' or 0 with a footnote.
+  5. `reaper-summary` is best-effort — if it fails, leave the reaper KPI as 0.
+  6. Render:
+     - `renderRunnerModeKpi(runnerMode)` — set `#kpi-runner-mode` text + colorize, set `#kpi-runner-source` to `(env)` or `(db)` or `(default)`.
+     - If `runnerMode.mode !== 'default'`, show `#runners-mode-banner` with text like `Runner mode override active: ${mode}. All projects route through ${mode} regardless of their per-project mode.` Banner classes: `default`→hide; `gha`→info; `fly`→success; `shadow`→warn.
+     - Sessions: `#kpi-live-sessions` ← length; render the live sessions subset (top 8 rows, no destroy button); empty state.
+     - Capacity: walk mappings, sum `maxInProgressAiIssues` (max). Walk sessions filtered to ones with a teamKey, count per team to get "running" — but easier: total live sessions = `sessions.length`. That's used; max is sum of caps.
+     - Reaper: set `#kpi-reaped` to `summary.total24h ?? 0`; set `#kpi-reaper-sweep` to `last sweep ${fmtAgo(summary.lastSweepAt)}` or `(no sweep yet)`.
+     - Per-project rows: one per mapping, sorted by teamKey. Mode badge from `executionMode` (gha→info, fly→success). Effective: same as mode unless override active, then show override badge in warn. Cap utilization: a tiny meter (`<div class="meter"><div class="fill" style="width:N%;background:var(--accent)"></div></div>`), running count is from sessions filtered to that team. Cap = `maxInProgressAiIssues`.
+- `renderSubtitle(...)`: `${liveSessions} live · ${runnerMode.mode} mode`.
+- `window.loadRunners = loadRunners;`
+- `window.registerPage('runners', () => { loadRunners(); setInterval(loadRunners, 30000); });`
+
+`const`/`let` only. `window.api`/`window.esc` only. No `var`.
+
+Commit: `feat(admin): add runners page module`.
+
+---
+
+## Task 2: Wire + remove stub
+
+- `src/admin-ui/index.ts`: import + inject `runnersHtml` / `runnersScript`.
+- `src/admin-ui/pages/stubs.ts`: remove the `runners` entry.
+
+`npm run typecheck && npm test` — pass.
+
+Commit: `feat(admin): wire runners page, remove its stub`.
+
+---
+
+## Task 3: Structural tests
+
+Standard 5-test pattern. Required ids: `runners-subtitle`, `runners-error`, `runners-mode-banner`, `kpi-runner-mode`, `kpi-runner-source`, `kpi-live-sessions`, `kpi-capacity-used`, `kpi-capacity-max`, `kpi-reaped`, `kpi-reaper-sweep`, `runners-sessions-body`, `runners-sessions-empty`, `runners-projects-body`, `runners-projects-empty`. Window symbol: `loadRunners`. Endpoints used (any of these substrings present): `/api/runner-mode`, `/api/mappings`, `/api/sessions`, `/api/reaper/summary`. Anti-test: no `/api/runners` or `/api/fleet` etc.
+
+Commit: `test(admin): structural tests for runners page module`.
+
+---
+
+## Risks
+
+- **Sessions 503 on unconfigured Fly app:** the existing `/api/sessions` returns 503 when no Fly app is set. Page must treat that as "0 sessions" not as a page-level error.
+- **Per-team running count from sessions:** sessions only have `teamKey` set when the dispatch row had it. A session could have a null `teamKey`; those count toward the global live count but not toward any project row's utilization. Acceptable.
+- **Capacity max:** sum of all mappings' `maxInProgressAiIssues`. If mappings are empty, division yields NaN — show '—' for the percentage.

--- a/src/admin-ui/__tests__/runners.test.ts
+++ b/src/admin-ui/__tests__/runners.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { runnersHtml, runnersScript } from "../pages/runners.js";
+
+describe("runners page", () => {
+  it("declares the expected ids", () => {
+    for (const id of ["runners-subtitle", "runners-error", "runners-mode-banner", "kpi-runner-mode", "kpi-runner-source", "kpi-live-sessions", "kpi-capacity-used", "kpi-capacity-max", "kpi-reaped", "kpi-reaper-sweep", "runners-sessions-body", "runners-sessions-empty", "runners-projects-body", "runners-projects-empty"]) {
+      expect(runnersHtml).toContain(`id="${id}"`);
+    }
+  });
+  it("registers route + exposes loadRunners", () => {
+    expect(runnersScript).toContain("window.registerPage('runners'");
+    expect(runnersScript).toContain("window.loadRunners = loadRunners");
+  });
+  it("calls the four expected endpoints", () => {
+    for (const ep of ["/api/runner-mode", "/api/mappings", "/api/sessions", "/api/reaper/summary"]) {
+      expect(runnersScript).toContain(ep);
+    }
+  });
+  it("does not invent new endpoints", () => {
+    expect(runnersScript).not.toMatch(/\/api\/(runners|fleet|machines)\b/);
+  });
+  it("uses window.api/window.esc only", () => {
+    const stripped = runnersScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+  it("uses const/let, not var", () => {
+    expect(runnersScript).not.toMatch(/\bvar\s+\w/);
+  });
+});

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -17,6 +17,7 @@ import { blockersHtml, blockersScript } from "./pages/blockers.js";
 import { customizationsHtml, customizationsScript } from "./pages/customizations.js";
 import { pipelinesAndStepsHtml, pipelinesAndStepsScript } from "./pages/pipelines-and-steps.js";
 import { modelsAndProvidersHtml, modelsAndProvidersScript } from "./pages/models-and-providers.js";
+import { runnersHtml, runnersScript } from "./pages/runners.js";
 import { stubsHtml } from "./pages/stubs.js";
 import { drawerHtml, drawerScript } from "./drawer.js";
 import { stepperHtml, stepperScript } from "./stepper.js";
@@ -49,6 +50,7 @@ const shell = `<div id="admin-page" class="app-shell hidden">
     ${customizationsHtml}
     ${pipelinesAndStepsHtml}
     ${modelsAndProvidersHtml}
+    ${runnersHtml}
     ${stubsHtml}
   </main>
 </div>`;
@@ -65,7 +67,7 @@ const body = `<body>
 ${shell}
 ${drawerHtml}
 ${stepperHtml}
-<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${blockersScript}${customizationsScript}${pipelinesAndStepsScript}${modelsAndProvidersScript}${drawerScript}${stepperScript}</script>
+<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${blockersScript}${customizationsScript}${pipelinesAndStepsScript}${modelsAndProvidersScript}${runnersScript}${drawerScript}${stepperScript}</script>
 </body></html>`;
 
 export const adminHtml = head + body;

--- a/src/admin-ui/pages/runners.ts
+++ b/src/admin-ui/pages/runners.ts
@@ -1,0 +1,220 @@
+export const runnersHtml = `
+<section data-page="runners" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Runners</h1>
+      <div class="page-subtitle" id="runners-subtitle">—</div>
+    </div>
+    <div class="page-header-actions">
+      <button class="btn btn-sm" onclick="loadRunners()">↻ Refresh</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="runners-error" class="alert fail" hidden></div>
+    <div id="runners-mode-banner" class="alert warn" hidden></div>
+
+    <div class="kpi-grid">
+      <div class="kpi"><div class="kpi-label">Runner mode</div><div class="kpi-value" id="kpi-runner-mode">—</div><div class="kpi-trend" id="kpi-runner-source"></div></div>
+      <div class="kpi"><div class="kpi-label">Live Fly sessions</div><div class="kpi-value" id="kpi-live-sessions">0</div></div>
+      <div class="kpi"><div class="kpi-label">Capacity used</div><div class="kpi-value"><span id="kpi-capacity-used">0</span><span class="kpi-unit"> / <span id="kpi-capacity-max">0</span></span></div></div>
+      <div class="kpi"><div class="kpi-label">Reaper (24h)</div><div class="kpi-value" id="kpi-reaped">0</div><div class="kpi-trend" id="kpi-reaper-sweep"></div></div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Fly Machines — live sessions</h2>
+        <div class="card-subtitle"><a href="#sessions" class="text-accent">Manage on Sessions page →</a></div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Issue</th><th>Team</th><th>Repo</th><th>Machine</th><th>State</th></tr></thead>
+          <tbody id="runners-sessions-body"></tbody>
+        </table>
+        <div id="runners-sessions-empty" class="hidden text-tertiary" style="padding:12px">No live machines.</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Per-project execution mode</h2>
+        <div class="card-subtitle">Effective mode is the mapping value unless the runner-mode override is set.</div>
+      </div>
+      <div class="card-body tight">
+        <table class="tbl">
+          <thead><tr><th>Team</th><th>Repo</th><th>Mode</th><th>Effective</th><th style="width:200px">Cap utilization</th><th style="text-align:right">Cap</th></tr></thead>
+          <tbody id="runners-projects-body"></tbody>
+        </table>
+        <div id="runners-projects-empty" class="hidden text-tertiary" style="padding:12px">No projects configured.</div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+export const runnersScript = `
+(function () {
+  function fmtAgo(ms) {
+    const s = Math.floor((Date.now() - ms) / 1000);
+    if (s < 60) return s + 's ago';
+    const m = Math.floor(s / 60);
+    if (m < 60) return m + 'm ago';
+    const h = Math.floor(m / 60);
+    return h + 'h ago';
+  }
+
+  async function fetchOk(url, fallback) {
+    try {
+      const res = await window.api(url);
+      if (res.ok) return await res.json();
+      return fallback;
+    } catch (e) {
+      return fallback;
+    }
+  }
+
+  function kindForMode(mode) {
+    if (mode === 'gha') return 'info';
+    if (mode === 'fly') return 'success';
+    if (mode === 'shadow') return 'warn';
+    return 'neutral';
+  }
+
+  async function loadRunners() {
+    const errEl = document.getElementById('runners-error');
+    const bannerEl = document.getElementById('runners-mode-banner');
+    errEl.hidden = true;
+    bannerEl.hidden = true;
+
+    const [runnerModeRes, mappingsRes, sessions, reaper] = await Promise.all([
+      window.api('/api/runner-mode'),
+      window.api('/api/mappings'),
+      fetchOk('/api/sessions', null),
+      fetchOk('/api/reaper/summary', null),
+    ]);
+
+    if (!runnerModeRes.ok || !mappingsRes.ok) {
+      let message = 'Unknown error';
+      try {
+        const body = await (!runnerModeRes.ok ? runnerModeRes : mappingsRes).json();
+        message = body.error || message;
+      } catch (e) { /* ignore */ }
+      errEl.innerHTML = '<div style="flex:1"><div class="alert-title">Failed to load runners data</div><div class="alert-desc">' + window.esc(message) + '</div></div>';
+      errEl.hidden = false;
+      document.getElementById('kpi-runner-mode').textContent = '—';
+      document.getElementById('kpi-live-sessions').textContent = '0';
+      document.getElementById('kpi-capacity-used').textContent = '0';
+      document.getElementById('kpi-capacity-max').textContent = '0';
+      document.getElementById('kpi-reaped').textContent = '0';
+      document.getElementById('runners-sessions-body').innerHTML = '';
+      document.getElementById('runners-projects-body').innerHTML = '';
+      document.getElementById('runners-subtitle').textContent = '—';
+      return;
+    }
+
+    const runnerMode = await runnerModeRes.json();
+    const mappings = await mappingsRes.json();
+
+    const liveSessions = Array.isArray(sessions) ? sessions : [];
+    const mapEntries = Object.entries(mappings).sort((a, b) => a[0].localeCompare(b[0]));
+    const capMax = mapEntries.reduce((s, entry) => s + (entry[1].maxInProgressAiIssues ?? 0), 0);
+    const capUsed = liveSessions.length;
+
+    const runningByTeam = {};
+    for (const s of liveSessions) {
+      if (s.teamKey) runningByTeam[s.teamKey] = (runningByTeam[s.teamKey] ?? 0) + 1;
+    }
+
+    // Runner mode KPI
+    const modeBadgeKind = kindForMode(runnerMode.mode);
+    document.getElementById('kpi-runner-mode').innerHTML = '<span class="badge ' + modeBadgeKind + '"><span class="dot"></span>' + window.esc(runnerMode.mode) + '</span>';
+    document.getElementById('kpi-runner-source').textContent = '(' + runnerMode.source + ')';
+
+    if (runnerMode.mode !== 'default') {
+      const bannerKind = runnerMode.mode === 'shadow' ? 'warn' : 'info';
+      bannerEl.className = 'alert ' + bannerKind;
+      bannerEl.innerHTML = '<div style="flex:1"><div class="alert-title">Runner mode override active: ' + window.esc(runnerMode.mode) + '</div><div class="alert-desc">All projects route through ' + window.esc(runnerMode.mode) + ' regardless of their per-project mode.</div></div>';
+      bannerEl.hidden = false;
+    }
+
+    // Live sessions KPI
+    document.getElementById('kpi-live-sessions').textContent = String(liveSessions.length);
+
+    // Capacity KPI
+    document.getElementById('kpi-capacity-used').textContent = String(capUsed);
+    document.getElementById('kpi-capacity-max').textContent = String(capMax || '—');
+
+    // Reaper KPI
+    document.getElementById('kpi-reaped').textContent = String(reaper ? (reaper.total24h ?? 0) : 0);
+    document.getElementById('kpi-reaper-sweep').textContent = reaper && reaper.lastSweepAt ? ('last sweep ' + fmtAgo(reaper.lastSweepAt)) : 'no sweep yet';
+
+    // Sessions table
+    const sessionsBody = document.getElementById('runners-sessions-body');
+    const sessionsEmpty = document.getElementById('runners-sessions-empty');
+    sessionsBody.innerHTML = '';
+    const topSessions = liveSessions.slice(0, 8);
+    if (topSessions.length === 0) {
+      sessionsEmpty.classList.remove('hidden');
+    } else {
+      sessionsEmpty.classList.add('hidden');
+      for (const s of topSessions) {
+        const stateBadgeKind = s.state === 'started' ? 'success' : s.state === 'stopped' ? 'neutral' : 'info';
+        const machineId = s.machineId || '';
+        const machineTrunc = machineId.length > 12 ? machineId.slice(0, 12) : machineId;
+        const tr = document.createElement('tr');
+        tr.innerHTML = '<td class="mono" title="' + window.esc(s.issueTitle || '') + '">' + window.esc(s.issueIdentifier || '—') + '</td>'
+          + '<td class="mono">' + window.esc(s.teamKey || '—') + '</td>'
+          + '<td class="mono">' + window.esc(s.repo || '—') + '</td>'
+          + '<td class="mono" title="' + window.esc(machineId) + '">' + window.esc(machineTrunc) + '</td>'
+          + '<td><span class="badge ' + stateBadgeKind + '">' + window.esc(s.state || '—') + '</span></td>';
+        sessionsBody.appendChild(tr);
+      }
+    }
+
+    // Projects table
+    const projectsBody = document.getElementById('runners-projects-body');
+    const projectsEmpty = document.getElementById('runners-projects-empty');
+    projectsBody.innerHTML = '';
+    if (mapEntries.length === 0) {
+      projectsEmpty.classList.remove('hidden');
+    } else {
+      projectsEmpty.classList.add('hidden');
+      for (const entry of mapEntries) {
+        const teamKey = entry[0];
+        const m = entry[1];
+        const execMode = m.executionMode || 'gha';
+        const modeKind = execMode === 'fly' || execMode === 'fly-machines' ? 'success' : 'info';
+        const effectiveBadge = runnerMode.mode === 'default'
+          ? '<span class="badge ' + modeKind + '">' + window.esc(execMode) + '</span>'
+          : '<span class="badge warn">' + window.esc(runnerMode.mode) + '</span>';
+        const cap = m.maxInProgressAiIssues ?? 0;
+        const running = runningByTeam[teamKey] ?? 0;
+        let capCell;
+        if (cap === 0) {
+          capCell = '<td style="text-align:right"><span class="mono text-secondary">— / 0</span></td>';
+        } else {
+          const rawPct = (running / cap) * 100;
+          const pct = Math.min(100, Math.max(0, rawPct));
+          const fillColor = pct >= 100 ? 'var(--st-fail-dot)' : pct >= 75 ? 'var(--st-warn-dot)' : 'var(--accent)';
+          capCell = '<td><div class="meter"><div class="fill" style="width:' + pct + '%;background:' + fillColor + '"></div></div></td>'
+            + '<td style="text-align:right"><span class="mono text-secondary">' + running + ' / ' + cap + '</span></td>';
+        }
+        const owner = m.owner || '';
+        const repo = m.repo || '';
+        const tr = document.createElement('tr');
+        tr.innerHTML = '<td class="mono">' + window.esc(teamKey) + '</td>'
+          + '<td class="mono">' + window.esc(owner) + '/' + window.esc(repo) + '</td>'
+          + '<td><span class="badge ' + modeKind + '">' + window.esc(execMode) + '</span></td>'
+          + '<td>' + effectiveBadge + '</td>'
+          + (cap === 0 ? capCell : capCell);
+        projectsBody.appendChild(tr);
+      }
+    }
+
+    // Subtitle
+    document.getElementById('runners-subtitle').textContent = liveSessions.length + ' live · ' + runnerMode.mode + ' mode';
+  }
+
+  window.loadRunners = loadRunners;
+  window.registerPage('runners', function () { loadRunners(); setInterval(loadRunners, 30000); });
+})();
+`;

--- a/src/admin-ui/pages/stubs.ts
+++ b/src/admin-ui/pages/stubs.ts
@@ -21,7 +21,6 @@ function stubPage(route: string, title: string, subtitle: string, phase: string,
 export const stubsHtml = [
   stubPage("channels", "Triggers & channels", "Input triggers + output notifications", "Plan 5", "Linear, webhook, MCP triggers; Slack, Teams, GitHub PR comment channels."),
   stubPage("policies", "Policies & risk", "Auto-merge thresholds, risk rubric, CI gates", "Plan 5", "Edge vs stable channels, risk dimensions."),
-  stubPage("runners", "Runners", "Fly Machines, GitHub Actions, warm pools", "Plan 5", "Per-runner profiles, image overrides, health metrics."),
   stubPage("secrets", "Secrets", "Encrypted store, scoped per project", "Plan 5", "Rotation tracking; complements global secrets on Settings."),
   stubPage("mcp", "MCP server", "Claude as the primary interface", "Plan 5", "Phase 1 read-only → Phase 3 orchestration."),
   stubPage("webhooks", "Webhooks", "Inbound endpoints + outbound delivery log", "Plan 5", "Signed payloads, retry counters."),


### PR DESCRIPTION
## Summary

Plan 5d. Replaces the `runners` route stub with a fleet view that aggregates four existing endpoints. **No new backend.**

- KPI strip: current Runner mode (with badge + source), Live Fly sessions, Capacity used / max (sum of caps), Reaper 24h count + last sweep ago.
- Override banner appears when `runner-mode !== 'default'` explaining all projects route through the override regardless of their per-project mode.
- Live Fly sessions table (top 8) — read-only here; manage on Sessions page.
- Per-project execution mode table with mode badge, effective mode (matches per-project unless override active), and a colored capacity-utilization meter (green / amber ≥75% / red ≥100%).
- Tolerates `/api/sessions` 503 (Fly app not configured) and `/api/reaper/summary` failure as best-effort — neither shows a page-level error.
- 6 structural tests; 679 tests pass.

Plan: `docs/superpowers/plans/2026-04-30-admin-runners.md`. PR base: `admin-overhaul`.

## Test plan

- [ ] `#runners` shows mode + sessions + capacity + reaper KPIs
- [ ] Switching runner mode on the Reaper page (then refreshing here) updates the badge and toggles the override banner
- [ ] When Fly sessions app is unset, sessions count shows 0 and the table is empty (no error)
- [ ] Per-project meter turns amber at 75% and red at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)