### PR TITLE
fix(provisioner): three onboarding paper-cuts in scripts/provision-client.sh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -849,9 +849,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -869,9 +866,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -889,9 +883,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -909,9 +900,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -929,9 +917,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -949,9 +934,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1853,9 +1835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1877,9 +1856,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1901,9 +1877,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1925,9 +1898,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/scripts/provision-client.sh
+++ b/scripts/provision-client.sh
@@ -216,62 +216,31 @@ echo "FLY_SESSIONS_TOKEN: Fly API token for the '${SESSIONS_ORG}' org."
 echo "  Generate one with: fly tokens create org --org ${SESSIONS_ORG}"
 read_secret "FLY_SESSIONS_TOKEN" "FLY_SESSIONS_TOKEN (Fly API token for ${SESSIONS_ORG} org)" "true"
 
-# ---------- 5. Link GitHub repos ----------
-
-SYNC_WORKFLOW=".github/workflows/sync-workflow.yml"
+# ---------- 5. Collect target repos (printed in next-steps) ----------
 
 echo ""
-echo "=== Link GitHub repos ==="
-echo "Add target repos so the workflow templates (claude-implement.yml, etc.)"
-echo "are synced to them. Enter repos as owner/repo (e.g. acme/my-app)."
-echo "Press Enter with no input when done."
+echo "=== Target repos ==="
+echo "Target repos receive the synced workflow templates via sync-workflow.yml,"
+echo "dispatched per-repo. Enter repos as owner/repo (e.g. acme/api)."
+echo "Press Enter when done. (You can also dispatch sync later with no entries here.)"
 echo ""
 
-REPOS_ADDED=false
+TARGET_REPOS=()
 while true; do
-  read -rp "GitHub repo to link (owner/repo, or Enter to skip): " REPO_INPUT
+  read -rp "Target repo (owner/repo, or Enter to skip): " REPO_INPUT
   [ -z "$REPO_INPUT" ] && break
 
-  # Validate format
   if ! echo "$REPO_INPUT" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
-    echo "  Invalid format. Use owner/repo (e.g. acme/my-app)"
+    echo "  Invalid format. Use owner/repo (e.g. acme/api)."
     continue
   fi
 
-  REPO_OWNER=$(echo "$REPO_INPUT" | cut -d/ -f1)
-
-  # Check if already in sync workflow
-  if grep -qF "$REPO_INPUT" "$SYNC_WORKFLOW" 2>/dev/null; then
-    echo "  $REPO_INPUT is already in sync-workflow.yml, skipping."
-    continue
-  fi
-
-  # Add to the matrix — insert before the closing "steps:" line
-  # Find the last matrix entry and append after it
-  sed -i.bak "/^    steps:$/i\\
-          - repo: ${REPO_INPUT}\\
-            owner: ${REPO_OWNER}" "$SYNC_WORKFLOW"
-  rm -f "${SYNC_WORKFLOW}.bak"
-
-  echo "  Added $REPO_INPUT to sync-workflow.yml"
-  REPOS_ADDED=true
+  TARGET_REPOS+=("$REPO_INPUT")
+  echo "  Added: $REPO_INPUT"
 done
 
-if [ "$REPOS_ADDED" = "true" ]; then
-  echo ""
-  echo "New repos added to sync-workflow.yml."
-  read -rp "Commit and push to trigger the sync workflow? [Y/n]: " PUSH_CONFIRM
-  PUSH_CONFIRM="${PUSH_CONFIRM:-Y}"
-  if [[ "$PUSH_CONFIRM" =~ ^[Yy] ]]; then
-    git add "$SYNC_WORKFLOW"
-    git commit -m "Add repos to workflow sync matrix for client: $SLUG"
-    git push
-    echo "  Pushed. The sync workflow will run automatically."
-    echo "  Check progress: gh run list --workflow=sync-workflow.yml --limit 1"
-  else
-    echo "  Skipped. Remember to commit and push $SYNC_WORKFLOW to trigger the sync."
-  fi
-fi
+# Detect this repo's owner/name for printing dispatch commands.
+ORCH_REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || echo "")
 
 # ---------- 6. Done ----------
 
@@ -285,11 +254,26 @@ echo ""
 echo "  Next steps:"
 echo "    1. Commit clients/${SLUG}.toml and push to main to deploy:"
 echo "       git add clients/${SLUG}.toml && git commit -m 'Add client: $SLUG' && git push"
-echo "    2. Merge the sync PR in each target repo (opens automatically)"
-echo "    3. Enable 'Allow GitHub Actions to create and approve pull requests'"
+echo "    2. Set GitHub Actions secrets on the orchestrator + target repos:"
+if [ "${#TARGET_REPOS[@]}" -gt 0 ] && [ -n "$ORCH_REPO" ]; then
+  echo "       ./scripts/set-github-secrets.sh $ORCH_REPO ${TARGET_REPOS[*]}"
+elif [ -n "$ORCH_REPO" ]; then
+  echo "       ./scripts/set-github-secrets.sh $ORCH_REPO <target-repo> [<target-repo>...]"
+else
+  echo "       ./scripts/set-github-secrets.sh <orchestrator-repo> <target-repo> [<target-repo>...]"
+fi
+echo "    3. Install the GitHub App on each target repo"
+echo "    4. Enable 'Allow GitHub Actions to create and approve pull requests'"
 echo "       in each target repo: Settings → Actions → General"
-echo "    4. Install the GitHub App on each target repo"
-echo "    5. Add team→repo mappings via the admin UI at /admin"
+echo "    5. Dispatch sync-workflow.yml per target repo:"
+if [ "${#TARGET_REPOS[@]}" -gt 0 ] && [ -n "$ORCH_REPO" ]; then
+  for repo in "${TARGET_REPOS[@]}"; do
+    echo "       gh workflow run sync-workflow.yml --repo $ORCH_REPO -f target_repo=$repo"
+  done
+else
+  echo "       gh workflow run sync-workflow.yml --repo <orchestrator-repo> -f target_repo=<target-repo>"
+fi
+echo "    6. Add team→repo mappings via the admin UI at /admin"
 echo ""
 echo "  To re-run this script (update secrets, add more repos):"
 echo "    ./scripts/provision-client.sh $SLUG"

--- a/scripts/provision-client.sh
+++ b/scripts/provision-client.sh
@@ -74,13 +74,13 @@ TOML
 fi
 
 # Read values from config (section-aware parsing)
-APP_NAME=$(awk '/^\[fly\]/,/^\[/' "$CONFIG_FILE" | grep 'app_name' | head -1 | sed 's/.*= *//' | tr -d '"')
-FLY_ORG=$(awk '/^\[fly\]/,/^\[/' "$CONFIG_FILE" | grep 'org ' | head -1 | sed 's/.*= *//' | tr -d '"')
-REGION=$(awk '/^\[fly\]/,/^\[/' "$CONFIG_FILE" | grep 'region' | head -1 | sed 's/.*= *//' | tr -d '"')
+APP_NAME=$(awk '/^\[fly\]/{f=1;next}/^\[/{f=0}f' "$CONFIG_FILE" | grep 'app_name' | head -1 | sed 's/.*= *//' | tr -d '"')
+FLY_ORG=$(awk '/^\[fly\]/{f=1;next}/^\[/{f=0}f' "$CONFIG_FILE" | grep 'org ' | head -1 | sed 's/.*= *//' | tr -d '"')
+REGION=$(awk '/^\[fly\]/{f=1;next}/^\[/{f=0}f' "$CONFIG_FILE" | grep 'region' | head -1 | sed 's/.*= *//' | tr -d '"')
 
-SESSIONS_APP=$(awk '/^\[sessions\]/,/^\[/' "$CONFIG_FILE" | grep 'app_name' | head -1 | sed 's/.*= *//' | tr -d '"')
-SESSIONS_ORG=$(awk '/^\[sessions\]/,/^\[/' "$CONFIG_FILE" | grep 'org ' | head -1 | sed 's/.*= *//' | tr -d '"')
-SESSIONS_REGION=$(awk '/^\[sessions\]/,/^\[/' "$CONFIG_FILE" | grep 'region' | head -1 | sed 's/.*= *//' | tr -d '"')
+SESSIONS_APP=$(awk '/^\[sessions\]/{f=1;next}/^\[/{f=0}f' "$CONFIG_FILE" | grep 'app_name' | head -1 | sed 's/.*= *//' | tr -d '"')
+SESSIONS_ORG=$(awk '/^\[sessions\]/{f=1;next}/^\[/{f=0}f' "$CONFIG_FILE" | grep 'org ' | head -1 | sed 's/.*= *//' | tr -d '"')
+SESSIONS_REGION=$(awk '/^\[sessions\]/{f=1;next}/^\[/{f=0}f' "$CONFIG_FILE" | grep 'region' | head -1 | sed 's/.*= *//' | tr -d '"')
 
 # Fallback defaults if [sessions] section is missing
 SESSIONS_APP="${SESSIONS_APP:-ai-implement-sessions-${SLUG}}"

--- a/scripts/set-github-secrets.sh
+++ b/scripts/set-github-secrets.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# set-github-secrets.sh — set GitHub Actions secrets for an AI-Implement deployment.
+#
+# Sets the secrets that the synced workflows (claude-implement.yml, claude-plan.yml,
+# comment-trigger.yml, sync-workflow.yml) need at run time:
+#
+#   On the ORCHESTRATOR repo (this fork of AI-Implement):
+#     AI_IMPLEMENT_APP_ID         — sync-workflow.yml authenticates the GitHub App
+#     AI_IMPLEMENT_PRIVATE_KEY    — same
+#
+#   On each TARGET repo (e.g. acme/api):
+#     AI_IMPLEMENT_APP_ID         — claude-implement.yml authenticates as the App
+#     AI_IMPLEMENT_PRIVATE_KEY    — same
+#     LINEAR_API_KEY              — runner posts status back to Linear
+#     CLAUDE_CODE_OAUTH_TOKEN     — runner authenticates Claude Code (preferred)
+#
+# Usage:
+#   ./scripts/set-github-secrets.sh <orchestrator-repo> <target-repo> [<target-repo>...]
+#
+# Example:
+#   ./scripts/set-github-secrets.sh acme/ai-implement acme/api acme/web
+#
+# Sensitive values are read from stdin (-rsp / file path). Nothing is passed
+# via argv, so values never appear in shell history or process listings.
+#
+# Requires: gh CLI (authenticated against an account that can write secrets
+# on each repo).
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  cat >&2 <<USAGE
+Usage: $0 <orchestrator-repo> <target-repo> [<target-repo>...]
+
+Example:
+  $0 acme/ai-implement acme/api acme/web
+
+The orchestrator repo is the fork of AI-Implement. Each target repo
+receives the synced workflow templates and runner secrets.
+USAGE
+  exit 1
+fi
+
+ORCH_REPO="$1"
+shift
+TARGET_REPOS=("$@")
+
+# Validate owner/repo format.
+for repo in "$ORCH_REPO" "${TARGET_REPOS[@]}"; do
+  if ! echo "$repo" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
+    echo "Error: repo must be in 'owner/name' form (got: $repo)" >&2
+    exit 1
+  fi
+done
+
+echo
+echo "Will set secrets on:"
+echo "  Orchestrator: $ORCH_REPO  (AI_IMPLEMENT_APP_ID, AI_IMPLEMENT_PRIVATE_KEY)"
+for repo in "${TARGET_REPOS[@]}"; do
+  echo "  Target:       $repo  (AI_IMPLEMENT_APP_ID, AI_IMPLEMENT_PRIVATE_KEY, LINEAR_API_KEY, CLAUDE_CODE_OAUTH_TOKEN)"
+done
+echo
+
+read -rp  "GitHub App ID (numeric, from https://github.com/settings/apps): " APP_ID
+if ! [[ "$APP_ID" =~ ^[0-9]+$ ]]; then
+  echo "Error: App ID must be numeric." >&2
+  exit 1
+fi
+
+read -rp  "Path to GitHub App .pem private key file: " PEM_PATH
+if [ ! -f "$PEM_PATH" ]; then
+  echo "Error: .pem file not found: $PEM_PATH" >&2
+  exit 1
+fi
+
+read -rsp "LINEAR_API_KEY (lin_api_...): " LINEAR_KEY
+echo
+read -rsp "CLAUDE_CODE_OAUTH_TOKEN: " OAUTH_TOKEN
+echo
+
+if [ -z "$LINEAR_KEY" ] || [ -z "$OAUTH_TOKEN" ]; then
+  echo "Error: empty value for LINEAR_API_KEY or CLAUDE_CODE_OAUTH_TOKEN." >&2
+  exit 1
+fi
+
+# `gh secret set NAME --repo R` reads stdin when no -b/-f flag is passed.
+# Using stdin keeps the value out of argv across all gh versions.
+set_secret() {
+  local repo="$1" name="$2" value="$3"
+  printf '%s' "$value" | gh secret set "$name" --repo "$repo" >/dev/null
+  echo "  ✓ $repo / $name"
+}
+
+set_secret_file() {
+  local repo="$1" name="$2" file="$3"
+  gh secret set "$name" --repo "$repo" < "$file" >/dev/null
+  echo "  ✓ $repo / $name (from $file)"
+}
+
+echo
+echo "=== Setting secrets on $ORCH_REPO (sync-workflow.yml auth) ==="
+set_secret      "$ORCH_REPO" AI_IMPLEMENT_APP_ID      "$APP_ID"
+set_secret_file "$ORCH_REPO" AI_IMPLEMENT_PRIVATE_KEY "$PEM_PATH"
+
+for target in "${TARGET_REPOS[@]}"; do
+  echo
+  echo "=== Setting secrets on $target (runner auth + Linear + Claude) ==="
+  set_secret      "$target" AI_IMPLEMENT_APP_ID      "$APP_ID"
+  set_secret_file "$target" AI_IMPLEMENT_PRIVATE_KEY "$PEM_PATH"
+  set_secret      "$target" LINEAR_API_KEY           "$LINEAR_KEY"
+  set_secret      "$target" CLAUDE_CODE_OAUTH_TOKEN  "$OAUTH_TOKEN"
+done
+
+unset LINEAR_KEY OAUTH_TOKEN
+
+echo
+echo "Done. Verify with:"
+echo "  gh secret list --repo $ORCH_REPO"
+for target in "${TARGET_REPOS[@]}"; do
+  echo "  gh secret list --repo $target"
+done
+echo
+echo "Now dispatch the sync workflow per target repo:"
+for target in "${TARGET_REPOS[@]}"; do
+  echo "  gh workflow run sync-workflow.yml --repo $ORCH_REPO -f target_repo=$target"
+done


### PR DESCRIPTION
Three bugs surfaced while onboarding a new client (jodwyer/alpacaWheel) using `scripts/provision-client.sh`. Each is independent but they share the same file, so bundling them keeps the diff to a single review surface.

## Bug 1 — awk range matches its own end pattern

`scripts/provision-client.sh:77-83` extracts values from `clients/<slug>.toml` with:

\`\`\`bash
APP_NAME=\$(awk '/^\[fly\]/,/^\[/' \"\$CONFIG_FILE\" | grep 'app_name' | head -1 | ...)
\`\`\`

The start pattern \`/^\[fly\]/\` also matches the end pattern \`/^\[/\` on the same line, so the awk range emits only the section header. Subsequent \`grep 'app_name'\` returns 1, and with \`set -euo pipefail\` the whole script exits silently after \`Created clients/<slug>.toml\` — operator sees no Fly app, no secrets, no error. Same issue in the \`[sessions]\` extractor.

**Fix:** flag-based extractor that excludes the section header:

\`\`\`bash
awk '/^\[fly\]/{f=1;next}/^\[/{f=0}f'
\`\`\`

(commit \`6c1f26c\` — originally surfaced as fork PR #2)

## Bug 2 — sed-edit of \`sync-workflow.yml\` produces invalid YAML

\`scripts/provision-client.sh:251-253\` tries to mutate \`sync-workflow.yml\` to add new repos:

\`\`\`bash
sed -i.bak \"/^    steps:\$/i\\\\
        - repo: \${REPO_INPUT}\\\\
          owner: \${REPO_OWNER}\" \"\$SYNC_WORKFLOW\"
\`\`\`

This assumes \`sync-workflow.yml\` has a \`strategy.matrix.include:\` block. Upstream's \`sync-workflow.yml\` is \`workflow_dispatch\`-only with a single \`target_repo\` input — no matrix exists. The sed insertion produces invalid YAML (orphan list items between \`runs-on:\` and \`steps:\`). The provisioner's \"Link GitHub repos\" feature is dead code against the current workflow shape.

**Fix:** drop the broken sed-edit entirely. Replace with a simple loop that collects target repos into an array and prints the correct \`gh workflow run sync-workflow.yml -f target_repo=...\` invocations in the final \"Next steps\" block. The actual workflow dispatch is documented and works; the matrix mutation was the only broken part.

## Bug 3 — secrets only land on Fly, not on GitHub repos

The provisioner captures \`LINEAR_API_KEY\`, \`GITHUB_APP_ID\`, \`GITHUB_APP_PRIVATE_KEY\`, and \`CLAUDE_CODE_OAUTH_TOKEN\` interactively and writes them to Fly secrets via \`flyctl secrets set\`. But the synced workflows (\`claude-implement.yml\`, \`claude-plan.yml\`) on the **target repo** also need them as GitHub Actions secrets, and \`sync-workflow.yml\` itself needs \`AI_IMPLEMENT_APP_ID\` + \`AI_IMPLEMENT_PRIVATE_KEY\` on the **orchestrator repo** to authenticate the App. The provisioner doesn't propagate any of these to GitHub — first sync attempt fails with:

\`\`\`
[@octokit/auth-app] appId option is required
\`\`\`

**Fix:** add a standalone helper \`scripts/set-github-secrets.sh\` (called explicitly by the operator, not auto-invoked by the provisioner — keeps the provisioner's scope tight). It:

- Takes \`<orchestrator-repo>\` + one or more \`<target-repo>\` as positional args
- Prompts interactively for the four sensitive values (App ID, .pem path, Linear key, Claude OAuth token) — values read via \`read -rsp\` and piped to \`gh secret set --repo R\` over stdin so they never appear in argv or shell history
- Sets:
  - On orchestrator: \`AI_IMPLEMENT_APP_ID\`, \`AI_IMPLEMENT_PRIVATE_KEY\`
  - On each target: those two plus \`LINEAR_API_KEY\` and \`CLAUDE_CODE_OAUTH_TOKEN\`

\`provision-client.sh\`'s \"Next steps\" block now prints the exact invocation, populated with the orchestrator and target repos collected during the run.

## Notes

- All three changes are in \`scripts/\` — no orchestrator code, no workflow YAMLs, no template changes.
- Both scripts pass \`shellcheck\` clean.
- The renamed \"Link GitHub repos\" section keeps prompting for repos and printing dispatch commands, so the operator workflow shape doesn't change — just the broken sed mutation goes away.
- \`package-lock.json\` change in commit \`6c1f26c\` is incidental (npm install touched it); happy to drop it from the PR if upstream prefers.

Filing as a single PR rather than three because the three changes are tightly coupled: bug 2 removes the section that bug 3 then reuses for collecting target repos, and bug 1 is a pre-existing fix on the same file. Splitting would create rebase pain across reviews.

Tested against a fresh deploy of \`ai-implement-oolidata\` on Fly.io.