### PR TITLE
feat(sync-workflow): add target_base input; preserve target-side commits on resync

### DIFF
--- a/.github/workflows/sync-workflow.yml
+++ b/.github/workflows/sync-workflow.yml
@@ -144,6 +144,30 @@ jobs:
             CHANGES_MADE=true
           }
 
+          remote_file_exists() {
+            local REMOTE="$1"
+            local REF="$2"
+            gh api "repos/$REPO/contents/$REMOTE?ref=$REF" > /dev/null 2>&1
+          }
+
+          seed_once_file() {
+            local LOCAL="$1"
+            local REMOTE="$2"
+            local MSG="$3"
+
+            if remote_file_exists "$REMOTE" "$TARGET_BASE"; then
+              echo "  Skipping $REMOTE (already exists in $REPO on $TARGET_BASE)"
+              return
+            fi
+
+            if remote_file_exists "$REMOTE" "$SYNC_BRANCH"; then
+              echo "  Skipping $REMOTE (already exists in $REPO on $SYNC_BRANCH)"
+              return
+            fi
+
+            sync_file "$LOCAL" "$REMOTE" "$MSG"
+          }
+
           echo "==> $REPO"
 
           # 1. claude-implement.yml — always sync
@@ -166,37 +190,43 @@ jobs:
 
           # 4. WORKFLOW.md — seed once only; never overwrite (each repo owns its own prompt template)
           if [ -f "workflows/WORKFLOW.md" ]; then
-            if ! gh api "repos/$REPO/contents/WORKFLOW.md?ref=$TARGET_BASE" > /dev/null 2>&1; then
-              sync_file \
-                "workflows/WORKFLOW.md" \
-                "WORKFLOW.md" \
-                "Add WORKFLOW.md prompt template (customise for this repo)"
-            else
-              echo "  Skipping WORKFLOW.md (already exists in $REPO)"
-            fi
+            seed_once_file \
+              "workflows/WORKFLOW.md" \
+              "WORKFLOW.md" \
+              "Add WORKFLOW.md prompt template (customise for this repo)"
           fi
 
           # 5. PLANNING.md — seed once only; never overwrite (each repo owns its own planning template)
           if [ -f "workflows/PLANNING.md" ]; then
-            if ! gh api "repos/$REPO/contents/PLANNING.md?ref=$TARGET_BASE" > /dev/null 2>&1; then
-              sync_file \
-                "workflows/PLANNING.md" \
-                "PLANNING.md" \
-                "Add PLANNING.md planning template (customise for this repo)"
-            else
-              echo "  Skipping PLANNING.md (already exists in $REPO)"
-            fi
-          fi
-
-          if [ "$CHANGES_MADE" = "false" ]; then
-            echo "  No changes, skipping PR"
-            exit 0
+            seed_once_file \
+              "workflows/PLANNING.md" \
+              "PLANNING.md" \
+              "Add PLANNING.md planning template (customise for this repo)"
           fi
 
           # Open a PR if one isn't already open for the sync branch
           EXISTING_PR=$(gh api "repos/$REPO/pulls?state=open" \
             --jq "[.[] | select(.head.ref == \"$SYNC_BRANCH\")] | .[0].number" \
             2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+            EXISTING_PR_BASE=$(gh api "repos/$REPO/pulls/$EXISTING_PR" \
+              --jq '.base.ref' 2>/dev/null || echo "")
+            if [ "$EXISTING_PR_BASE" != "$TARGET_BASE" ]; then
+              gh api -X PATCH "repos/$REPO/pulls/$EXISTING_PR" \
+                -f base="$TARGET_BASE" >/dev/null
+              echo "  Retargeted PR #$EXISTING_PR from ${EXISTING_PR_BASE:-unknown} to $TARGET_BASE"
+            fi
+          fi
+
+          if [ "$CHANGES_MADE" = "false" ]; then
+            if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+              echo "  No file changes; PR #$EXISTING_PR already open in $REPO"
+            else
+              echo "  No changes, skipping PR"
+            fi
+            exit 0
+          fi
 
           if [ -z "$EXISTING_PR" ] || [ "$EXISTING_PR" = "null" ]; then
             PR_BODY=$(printf 'Auto-synced from ai-implement.\n\n**Always updated:**\n- `.github/workflows/claude-implement.yml`\n- `.github/workflows/comment-trigger.yml`\n- `.github/workflows/claude-plan.yml`\n\n**Added once (never overwritten):**\n- `WORKFLOW.md` — Claude implementation prompt template; customise this for your repo\n- `PLANNING.md` — Claude planning prompt template; customise this for your repo')

--- a/.github/workflows/sync-workflow.yml
+++ b/.github/workflows/sync-workflow.yml
@@ -4,6 +4,18 @@ name: Sync workflow to target repo
 # claude-plan.yml, comment-trigger.yml) into a target repo, opening a PR.
 # WORKFLOW.md and PLANNING.md are seeded once and never overwritten.
 #
+# Branch base:
+#   - Defaults to the target repo's default branch.
+#   - Override with the `target_base` workflow input (e.g. for repos that
+#     merge into `testing` rather than `main`).
+#
+# Sync-branch policy:
+#   - If sync/ai-implement doesn't exist → create from base tip.
+#   - If it exists with zero commits ahead of base → reset to base tip.
+#   - If it exists with commits ahead of base → preserve them. Target-side
+#     customisations (e.g. edits to WORKFLOW.md after first sync) belong
+#     to the target repo and must survive subsequent sync runs.
+#
 # This workflow runs on demand (workflow_dispatch) — provide the target
 # repo each time. The orchestrator can also call this dispatch via the
 # GitHub API as part of repo onboarding.
@@ -20,6 +32,11 @@ on:
         description: 'Target repo as owner/name (e.g. acme-corp/api)'
         required: true
         type: string
+      target_base:
+        description: 'Branch to base the sync PR on (default: target repo default branch)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   sync:
@@ -51,18 +68,37 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.sync-token.outputs.token }}
           REPO: ${{ steps.target.outputs.repo }}
+          TARGET_BASE_INPUT: ${{ inputs.target_base }}
         run: |
           SYNC_BRANCH="sync/ai-implement"
           CHANGES_MADE=false
 
-          # Get default branch name and its HEAD SHA
-          DEFAULT_BRANCH=$(gh api "repos/$REPO" --jq '.default_branch')
-          BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')
+          # Resolve target base: explicit input wins, otherwise the repo's default branch.
+          if [ -n "$TARGET_BASE_INPUT" ]; then
+            TARGET_BASE="$TARGET_BASE_INPUT"
+          else
+            TARGET_BASE=$(gh api "repos/$REPO" --jq '.default_branch')
+          fi
+          echo "  Base branch: $TARGET_BASE"
+          BASE_SHA=$(gh api "repos/$REPO/git/ref/heads/$TARGET_BASE" --jq '.object.sha')
 
-          # Create or reset the sync branch to the current default branch tip
+          # Manage the sync branch.
+          # - Doesn't exist → create from base tip.
+          # - Exists with zero commits ahead of base → safe to reset to current base tip.
+          # - Exists with commits ahead of base → preserve them. Target-side customisation
+          #   commits (e.g. edits to WORKFLOW.md after the first sync) belong to the target
+          #   repo and must survive subsequent sync runs. The sync_file PUT calls below
+          #   commit on top of whatever the branch contains.
           if gh api "repos/$REPO/git/ref/heads/$SYNC_BRANCH" --silent 2>/dev/null; then
-            gh api -X PATCH "repos/$REPO/git/refs/heads/$SYNC_BRANCH" \
-              -f sha="$BASE_SHA" -F force=true
+            AHEAD_BY=$(gh api "repos/$REPO/compare/$TARGET_BASE...$SYNC_BRANCH" \
+              --jq '.ahead_by' 2>/dev/null || echo "0")
+            if [ "${AHEAD_BY:-0}" -eq 0 ]; then
+              echo "  Sync branch exists, no commits ahead of $TARGET_BASE → resetting to base tip"
+              gh api -X PATCH "repos/$REPO/git/refs/heads/$SYNC_BRANCH" \
+                -f sha="$BASE_SHA" -F force=true
+            else
+              echo "  Sync branch ahead of $TARGET_BASE by $AHEAD_BY commit(s) → preserving customisations"
+            fi
           else
             gh api -X POST "repos/$REPO/git/refs" \
               -f ref="refs/heads/$SYNC_BRANCH" \
@@ -130,7 +166,7 @@ jobs:
 
           # 4. WORKFLOW.md — seed once only; never overwrite (each repo owns its own prompt template)
           if [ -f "workflows/WORKFLOW.md" ]; then
-            if ! gh api "repos/$REPO/contents/WORKFLOW.md?ref=$DEFAULT_BRANCH" > /dev/null 2>&1; then
+            if ! gh api "repos/$REPO/contents/WORKFLOW.md?ref=$TARGET_BASE" > /dev/null 2>&1; then
               sync_file \
                 "workflows/WORKFLOW.md" \
                 "WORKFLOW.md" \
@@ -142,7 +178,7 @@ jobs:
 
           # 5. PLANNING.md — seed once only; never overwrite (each repo owns its own planning template)
           if [ -f "workflows/PLANNING.md" ]; then
-            if ! gh api "repos/$REPO/contents/PLANNING.md?ref=$DEFAULT_BRANCH" > /dev/null 2>&1; then
+            if ! gh api "repos/$REPO/contents/PLANNING.md?ref=$TARGET_BASE" > /dev/null 2>&1; then
               sync_file \
                 "workflows/PLANNING.md" \
                 "PLANNING.md" \
@@ -167,7 +203,7 @@ jobs:
             gh api -X POST "repos/$REPO/pulls" \
               -f title="Sync AI implementation workflow files" \
               -f head="$SYNC_BRANCH" \
-              -f base="$DEFAULT_BRANCH" \
+              -f base="$TARGET_BASE" \
               -f body="$PR_BODY"
             echo "  Opened PR in $REPO"
           else


### PR DESCRIPTION
Two related paper-cuts in `.github/workflows/sync-workflow.yml`. Both surfaced on the very first re-sync against a real target repo and contradict the documented intent of the workflow.

## Bug 1 — PR base is hard-coded to the target's default branch

```yaml
gh api -X POST "repos/$REPO/pulls" \
  -f title="Sync AI implementation workflow files" \
  -f head="$SYNC_BRANCH" \
  -f base="$DEFAULT_BRANCH" \    # ← always default
  -f body="$PR_BODY"
```

Some target repos use a permanent integration branch (e.g. `testing`, `develop`, `staging`) and want sync PRs to land there rather than on `main`. The current workflow always opens the PR against the default branch; a manual retarget after each sync is wiped on the next sync run.

**Fix:** add a `target_base` workflow_dispatch input. Empty (default) preserves prior behaviour (use the target's default branch). Set explicitly to override:

```bash
gh workflow run sync-workflow.yml \
  -f target_repo=acme/api \
  -f target_base=testing
```

Both the branch-from SHA and the PR `base=` use the resolved `TARGET_BASE`. The "seed once" existence checks for `WORKFLOW.md` / `PLANNING.md` also use it (otherwise they'd check the default branch even when the PR targets a different one).

## Bug 2 — sync branch reset wipes target-side commits

```yaml
# Create or reset the sync branch to the current default branch tip
if gh api "repos/$REPO/git/ref/heads/$SYNC_BRANCH" --silent 2>/dev/null; then
  gh api -X PATCH "repos/$REPO/git/refs/heads/$SYNC_BRANCH" \
    -f sha="$BASE_SHA" -F force=true     # ← unconditional force-reset
fi
```

Every run force-resets `sync/ai-implement` to the current base-branch tip, destroying any commits appended on top. The synced `WORKFLOW.md` stub explicitly tells operators _"It is YOURS to customise — future syncs will never overwrite it."_ That contract is broken: the **file** content isn't re-pushed (the SHA-comparison guard in `sync_file()` works), but the **branch** reset wipes every commit that hasn't yet been merged back to the base branch.

In practice: operators landed customisations directly on `sync/ai-implement` (rather than on a branch off it) → next sync deleted them. Easy to do because the natural mental model is "the sync branch is mine to edit until I merge it."

**Fix:** three-way logic for the branch state:

| Condition | Action |
|---|---|
| Branch absent | Create from base tip (unchanged) |
| Branch present, **0 commits ahead** of base | Force-reset to base tip (no work to lose) |
| Branch present, **N>0 commits ahead** of base | **Preserve** — file PUTs commit on top of the existing tip |

Implementation uses `gh api repos/$REPO/compare/$TARGET_BASE...$SYNC_BRANCH --jq .ahead_by` to decide. Output now includes a clear log line so operators can see which path was taken:

```
Sync branch ahead of testing by 2 commit(s) → preserving customisations
```

## Combined diff

```
.github/workflows/sync-workflow.yml | 56 ++++++++++++++++++++++++++++++-------
1 file changed, 46 insertions(+), 10 deletions(-)
```

Header comment updated to document both behaviours.

## Notes

- Pre-existing SC2016 finding on the `printf '... \n ...'` PR-body line is unrelated to this PR (verified against `upstream/main`); not touching it here.
- Independent of #21 (provisioner cleanup) and #22 (App auth user accounts) — touches a different file.
- Tested by re-running sync against a real target repo: PR opens against `testing` (not default `main`), customisation commits added on top of `sync/ai-implement` survive the next sync run.