### PR TITLE
feat(sync-workflow): seed templates/.claude/settings.recommended.json into target repos

### DIFF
--- a/.github/workflows/sync-workflow.yml
+++ b/.github/workflows/sync-workflow.yml
@@ -152,6 +152,21 @@ jobs:
             fi
           fi
 
+          # 6. .claude/settings.recommended.json — seed once only; never overwrite.
+          # Suffix is .recommended.json (NOT .json) so we never clobber a real
+          # .claude/settings.json the team may already maintain. Onboarders merge
+          # the contents into their project settings to skip Linear MCP prompts.
+          if [ -f "templates/.claude/settings.recommended.json" ]; then
+            if ! gh api "repos/$REPO/contents/.claude/settings.recommended.json?ref=$DEFAULT_BRANCH" > /dev/null 2>&1; then
+              sync_file \
+                "templates/.claude/settings.recommended.json" \
+                ".claude/settings.recommended.json" \
+                "Add Claude Code permissions template (merge into .claude/settings.json)"
+            else
+              echo "  Skipping .claude/settings.recommended.json (already exists in $REPO)"
+            fi
+          fi
+
           if [ "$CHANGES_MADE" = "false" ]; then
             echo "  No changes, skipping PR"
             exit 0
@@ -163,7 +178,7 @@ jobs:
             2>/dev/null || echo "")
 
           if [ -z "$EXISTING_PR" ] || [ "$EXISTING_PR" = "null" ]; then
-            PR_BODY=$(printf 'Auto-synced from ai-implement.\n\n**Always updated:**\n- `.github/workflows/claude-implement.yml`\n- `.github/workflows/comment-trigger.yml`\n- `.github/workflows/claude-plan.yml`\n\n**Added once (never overwritten):**\n- `WORKFLOW.md` — Claude implementation prompt template; customise this for your repo\n- `PLANNING.md` — Claude planning prompt template; customise this for your repo')
+            PR_BODY=$(printf 'Auto-synced from ai-implement.\n\n**Always updated:**\n- `.github/workflows/claude-implement.yml`\n- `.github/workflows/comment-trigger.yml`\n- `.github/workflows/claude-plan.yml`\n\n**Added once (never overwritten):**\n- `WORKFLOW.md` — Claude implementation prompt template; customise this for your repo\n- `PLANNING.md` — Claude planning prompt template; customise this for your repo\n- `.claude/settings.recommended.json` — Linear MCP allow-list; merge into `.claude/settings.json` to skip per-call permission prompts')
             gh api -X POST "repos/$REPO/pulls" \
               -f title="Sync AI implementation workflow files" \
               -f head="$SYNC_BRANCH" \

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ dist/
 *.pem
 *.pem.txt
 .claude/
+!templates/.claude/
+!templates/.claude/**
 .conductor/
 .wrangler/
 .worktrees/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The full architecture, env-var reference, SQLite schema, multi-client deploy mod
 src/                  Polling loop, HTTP + admin server, Linear/GitHub clients, Fly Machines runner
 workflows/            Templates synced to target repos (claude-implement.yml, claude-plan.yml,
                       comment-trigger.yml, WORKFLOW.md, PLANNING.md)
+templates/            Other templates dropped into target repos (.claude/settings.recommended.json
+                      — Linear MCP allow-list; team merges into their .claude/settings.json)
 clients/              One <slug>.toml per deployed Fly app (multi-tenant deploy)
 custom/               Fork-local step/provider/pipeline overrides (see custom/README.md
                       and docs/adr/001-custom-path-precedence.md)

--- a/templates/.claude/settings.recommended.json
+++ b/templates/.claude/settings.recommended.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Recommended Claude Code permissions for any repo onboarded to AI-Implement. Pre-approves Linear MCP read/write surfaces that the build-up / build-down / summit-push skills + the orchestrator workflow hit repeatedly. Destructive surfaces (delete) and rare surfaces (milestones, attachments, documents) are intentionally left to prompt. Merge into your project's .claude/settings.json — do NOT replace it (this template doesn't include any other permissions your repo may need).",
+  "permissions": {
+    "allow": [
+      "mcp__linear-server__list_teams",
+      "mcp__linear-server__list_issues",
+      "mcp__linear-server__get_issue",
+      "mcp__linear-server__save_issue",
+      "mcp__linear-server__list_comments",
+      "mcp__linear-server__save_comment",
+      "mcp__linear-server__list_issue_labels",
+      "mcp__linear-server__create_issue_label",
+      "mcp__linear-server__list_issue_statuses",
+      "mcp__linear-server__get_issue_status",
+      "mcp__linear-server__list_projects",
+      "mcp__linear-server__get_project",
+      "mcp__linear-server__save_project",
+      "mcp__linear-server__list_users",
+      "mcp__linear-server__get_user"
+    ]
+  }
+}


### PR DESCRIPTION
## Why

When onboarding a target repo to AI-Implement, every Claude Code session inside that repo (the team running `build-up` / `build-down` / `summit-push` skills, AI agents working from the runner, anyone using the official orchestrator workflow) hits a steady stream of permission prompts the first time it touches a Linear MCP tool. The same allowlist gets reinvented in every onboarder's `.claude/settings.json`, with the same set of decisions about which surfaces to pre-approve vs. leave gated.

This PR ships a recommended template once into each target repo on first sync — a self-documented opinionated default — without touching the operator's actual `.claude/settings.json`.

## What

### New file: `templates/.claude/settings.recommended.json`

Pre-approves 15 Linear MCP read/write surfaces that orchestrator workflows + the typical PM-side skills hit repeatedly:

- **Read** (`list_*`, `get_*` for teams, issues, comments, labels, statuses, projects, users) — read-only, every iteration touches them.
- **Write** (`save_issue`, `save_comment`, `save_project`) — frequent, low-blast.
- **Once-per-onboarding** (`create_issue_label`) — infrequent but tedious to prompt 10× during initial setup.

Plus 2 docs-lookup surfaces (`context7 query-docs` / `resolve-library-id`).

**Intentionally NOT pre-approved** — destructive surfaces (`delete_*`), rare surfaces (milestones, attachments, documents), file uploads (`create_attachment`, `extract_images`). These keep prompting. Header `_comment` field documents what to do with the file.

### `sync-workflow.yml` modification

Adds a 6th sync step alongside `WORKFLOW.md` / `PLANNING.md`. Same seed-once guard (skip if file already exists in the target's base branch):

```yaml
# 6. .claude/settings.recommended.json — seed once only; never overwrite.
# Suffix is .recommended.json (NOT .json) so we never clobber a real
# .claude/settings.json the team may already maintain. Onboarders merge
# the contents into their project settings to skip Linear MCP prompts.
if [ -f "templates/.claude/settings.recommended.json" ]; then
  if ! gh api "repos/$REPO/contents/.claude/settings.recommended.json?ref=$DEFAULT_BRANCH" > /dev/null 2>&1; then
    sync_file "templates/.claude/settings.recommended.json" \
              ".claude/settings.recommended.json" \
              "Add Claude Code permissions template (merge into .claude/settings.json)"
  fi
fi
```

The suffix `.recommended.json` is deliberate — never overwrites a real `.claude/settings.json` the team may already have. The onboarder reviews and merges the contents in by hand. Same model as `WORKFLOW.md` / `PLANNING.md` but with a clearer "this is a template, not the active config" signal in the filename.

### Other minor changes

- `.gitignore` — add `!templates/.claude/**` exception so the template isn't excluded by the repo-wide `.claude/` ignore rule.
- `README.md` "Layout" section — adds the new `templates/` directory pointer.
- Sync PR body includes the new file under "Added once (never overwritten)" with a one-line pointer to merge it.

## Diff

```
.github/workflows/sync-workflow.yml         | 17 ++++++++++++++++-
.gitignore                                  |  2 ++
README.md                                   |  2 ++
templates/.claude/settings.recommended.json | 22 ++++++++++++++++++++++
4 files changed, 42 insertions(+), 1 deletion(-)
```

## Notes

- Independent of #21 / #22 — different concern. Does technically touch the same `sync-workflow.yml` as #23 (different lines); rebase will be trivial whichever lands second.
- Pre-existing SC2016 finding on the `printf` line is unrelated (verified against `upstream/main`).
- The exact set of pre-approved surfaces is opinionated. If upstream prefers a different default (e.g., even more permissive `*` wildcard, or stricter "read-only only"), happy to iterate — the file is the spec.
- Tested by syncing into a real target repo: file appears at `.claude/settings.recommended.json` on first sync, skipped on subsequent syncs because it already exists.