### PR TITLE
[codex] fix GitHub secret helper auth fallback

### DIFF
--- a/scripts/set-github-secrets.sh
+++ b/scripts/set-github-secrets.sh
@@ -13,6 +13,7 @@
 #     AI_IMPLEMENT_PRIVATE_KEY    — same
 #     LINEAR_API_KEY              — runner posts status back to Linear
 #     CLAUDE_CODE_OAUTH_TOKEN     — runner authenticates Claude Code (preferred)
+#       or ANTHROPIC_API_KEY      — fallback Claude auth if no OAuth token
 #
 # Usage:
 #   ./scripts/set-github-secrets.sh <orchestrator-repo> <target-repo> [<target-repo>...]
@@ -57,7 +58,7 @@ echo
 echo "Will set secrets on:"
 echo "  Orchestrator: $ORCH_REPO  (AI_IMPLEMENT_APP_ID, AI_IMPLEMENT_PRIVATE_KEY)"
 for repo in "${TARGET_REPOS[@]}"; do
-  echo "  Target:       $repo  (AI_IMPLEMENT_APP_ID, AI_IMPLEMENT_PRIVATE_KEY, LINEAR_API_KEY, CLAUDE_CODE_OAUTH_TOKEN)"
+  echo "  Target:       $repo  (AI_IMPLEMENT_APP_ID, AI_IMPLEMENT_PRIVATE_KEY, LINEAR_API_KEY, CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY)"
 done
 echo
 
@@ -75,11 +76,21 @@ fi
 
 read -rsp "LINEAR_API_KEY (lin_api_...): " LINEAR_KEY
 echo
-read -rsp "CLAUDE_CODE_OAUTH_TOKEN: " OAUTH_TOKEN
+read -rsp "CLAUDE_CODE_OAUTH_TOKEN (preferred; leave blank to use ANTHROPIC_API_KEY): " OAUTH_TOKEN
 echo
+API_KEY=""
+if [ -z "$OAUTH_TOKEN" ]; then
+  read -rsp "ANTHROPIC_API_KEY (fallback Claude auth): " API_KEY
+  echo
+fi
 
-if [ -z "$LINEAR_KEY" ] || [ -z "$OAUTH_TOKEN" ]; then
-  echo "Error: empty value for LINEAR_API_KEY or CLAUDE_CODE_OAUTH_TOKEN." >&2
+if [ -z "$LINEAR_KEY" ]; then
+  echo "Error: empty value for LINEAR_API_KEY." >&2
+  exit 1
+fi
+
+if [ -z "$OAUTH_TOKEN" ] && [ -z "$API_KEY" ]; then
+  echo "Error: set either CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY." >&2
   exit 1
 fi
 
@@ -108,10 +119,14 @@ for target in "${TARGET_REPOS[@]}"; do
   set_secret      "$target" AI_IMPLEMENT_APP_ID      "$APP_ID"
   set_secret_file "$target" AI_IMPLEMENT_PRIVATE_KEY "$PEM_PATH"
   set_secret      "$target" LINEAR_API_KEY           "$LINEAR_KEY"
-  set_secret      "$target" CLAUDE_CODE_OAUTH_TOKEN  "$OAUTH_TOKEN"
+  if [ -n "$OAUTH_TOKEN" ]; then
+    set_secret    "$target" CLAUDE_CODE_OAUTH_TOKEN  "$OAUTH_TOKEN"
+  else
+    set_secret    "$target" ANTHROPIC_API_KEY        "$API_KEY"
+  fi
 done
 
-unset LINEAR_KEY OAUTH_TOKEN
+unset LINEAR_KEY OAUTH_TOKEN API_KEY
 
 echo
 echo "Done. Verify with:"


### PR DESCRIPTION
## Summary

Fixes the GitHub secret helper added in PR #21 so deployments can use either Claude auth method.

## Changes

- Prompt for `CLAUDE_CODE_OAUTH_TOKEN` first and treat it as preferred.
- If OAuth is blank, prompt for `ANTHROPIC_API_KEY` and set that target repo secret instead.
- Require `LINEAR_API_KEY` plus at least one Claude auth method.

## Validation

- `bash -n scripts/set-github-secrets.sh`
- `shellcheck scripts/set-github-secrets.sh`
- `git diff --check`