### PR TITLE
[codex] default allowed_bots to GitHub App slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Then in your Linear workspace, create an `AI-Implement` label. In the orchestrat
 gh workflow run sync-workflow.yml -f target_repo=your-org/your-repo
 ```
 
+The synced workflows allow the GitHub App bot that minted the workflow token by
+default. To allow a different bot or a comma-separated allow-list, set the
+`AI_IMPLEMENT_ALLOWED_BOTS` Actions variable on the target repo or org.
+
 Merge the resulting PR in the target repo, enable "Allow GitHub Actions to create and approve pull requests" in its settings, install the GitHub App on it, then label any Linear issue `AI-Implement` and watch.
 
 The full architecture, env-var reference, SQLite schema, multi-client deploy model, and Bedrock setup live in [`CLAUDE.md`](CLAUDE.md).

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -8,6 +8,10 @@
 #   CLAUDE_CODE_OAUTH_TOKEN  - Claude Code OAuth token (preferred over API key)
 #   LINEAR_API_KEY           - Linear API key for status updates
 #
+# Optional org/repo variable:
+#   AI_IMPLEMENT_ALLOWED_BOTS - Override claude-code-action allowed_bots.
+#                               Defaults to this workflow's GitHub App slug.
+#
 # Additional secret (Bedrock provider, when orchestrator sets provider=bedrock):
 #   AWS_BEDROCK_ROLE_ARN     - IAM role ARN that the GitHub OIDC provider can assume;
 #                              role must grant bedrock:InvokeModel on the relevant
@@ -469,7 +473,7 @@ jobs:
           use_bedrock: "true"
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 100 --allowedTools 'Bash(*)' --allowedTools 'Write' --allowedTools 'Edit' --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep' --allowedTools 'WebFetch' --allowedTools 'Agent'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
 
@@ -480,7 +484,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 100 --allowedTools 'Bash(*)' --allowedTools 'Write' --allowedTools 'Edit' --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep' --allowedTools 'WebFetch' --allowedTools 'Agent'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
 
@@ -491,7 +495,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 100 --allowedTools 'Bash(*)' --allowedTools 'Write' --allowedTools 'Edit' --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep' --allowedTools 'WebFetch' --allowedTools 'Agent'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
 
@@ -617,7 +621,7 @@ jobs:
           use_bedrock: "true"
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.gap_analysis_model }} --max-turns 20 --allowedTools 'Bash(gh *)'"
           prompt: |
             You are doing a gap analysis on an AI-generated PR. Do NOT make any code changes. Complete this in exactly 4 tool calls — no exploring, no follow-up lookups.
@@ -670,7 +674,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.gap_analysis_model }} --max-turns 20 --allowedTools 'Bash(gh *)'"
           prompt: |
             You are doing a gap analysis on an AI-generated PR. Do NOT make any code changes. Complete this in exactly 4 tool calls — no exploring, no follow-up lookups.
@@ -723,7 +727,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.gap_analysis_model }} --max-turns 20 --allowedTools 'Bash(gh *)'"
           prompt: |
             You are doing a gap analysis on an AI-generated PR. Do NOT make any code changes. Complete this in exactly 4 tool calls — no exploring, no follow-up lookups.
@@ -855,4 +859,3 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $RUN_TOKEN" \
             --data-raw "$PAYLOAD"
-

--- a/workflows/claude-plan.yml
+++ b/workflows/claude-plan.yml
@@ -8,6 +8,10 @@
 #   CLAUDE_CODE_OAUTH_TOKEN  - Claude Code OAuth token (preferred over API key)
 #   LINEAR_API_KEY           - Linear API key for fetching related issues and posting comments
 #
+# Optional org/repo variable:
+#   AI_IMPLEMENT_ALLOWED_BOTS - Override claude-code-action allowed_bots.
+#                               Defaults to this workflow's GitHub App slug.
+#
 # Additional secret (Bedrock provider, when orchestrator sets provider=bedrock):
 #   AWS_BEDROCK_ROLE_ARN     - IAM role ARN that the GitHub OIDC provider can assume;
 #                              role must grant bedrock:InvokeModel on the relevant
@@ -320,7 +324,7 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 50 --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep' --allowedTools 'Bash(curl*api.linear.app/graphql*)'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
 
@@ -333,7 +337,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 50 --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep' --allowedTools 'Bash(curl*api.linear.app/graphql*)'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
 
@@ -346,7 +350,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
-          allowed_bots: "ai-implement-bot"
+          allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 50 --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep' --allowedTools 'Bash(curl*api.linear.app/graphql*)'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded Claude `allowed_bots` value with a workflow-native default: the GitHub App slug from `actions/create-github-app-token`.

## Changes

- Use `${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}` for all `allowed_bots` entries in `claude-plan.yml` and `claude-implement.yml`.
- Document `AI_IMPLEMENT_ALLOWED_BOTS` as an optional org/repo Actions variable for overrides.
- Add a README note that normal installs need no extra sync input or secret.

## Why

This keeps the secure default narrow without sync-time templating. The default follows the actual GitHub App that minted the token, while operators can still set `AI_IMPLEMENT_ALLOWED_BOTS` to a different bot, a comma-separated allow-list, or `*` when they explicitly want that behavior.

## Validation

- `git diff --cached --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' workflows/claude-plan.yml workflows/claude-implement.yml`\n- `actionlint -ignore 'SC2016|SC2129' workflows/claude-plan.yml workflows/claude-implement.yml`\n\n`actionlint` without ignores only reports pre-existing shellcheck warnings in embedded scripts, not this change.