### PR TITLE
Update Claude review workflow authentication method

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -67,7 +67,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           allowed_bots: "*"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "/claude-review"
           track_progress: true


### PR DESCRIPTION
Replaced anthropic_api_key with claude_code_oauth_token in the Claude review workflow.