### PR TITLE
fix(session): skip dev server in autonomous mode

### DIFF
--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -380,12 +380,7 @@ chown coder:coder /home/coder/.gitconfig 2>/dev/null || true
 
 # ── 11. Start the dev command (interactive/preview sessions only) ────────────
 # Autonomous implementation sessions do NOT start the target repo's dev server.
-# Their job is to implement the issue, not serve the app. Running the repo's
-# `dev` script and then hard-gating on a readiness check is pure downside here:
-# a dev server that never binds — slow start, an unexpected port, or a repo
-# whose `dev` script is itself a long-running daemon (e.g. this orchestrator) —
-# makes wait_for_ready call fail() and abort the whole session before Claude
-# ever runs. The dev server exists for interactive/preview modes; gate on mode.
+# Their job is to implement the issue, not serve the app. 
 if [ "$SESSION_MODE" != "autonomous" ]; then
   start_dev_server
   wait_for_ready

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -378,10 +378,18 @@ chown -R coder:coder /workspace
 cp /root/.gitconfig /home/coder/.gitconfig 2>/dev/null || true
 chown coder:coder /home/coder/.gitconfig 2>/dev/null || true
 
-# ── 11. Start the dev command ────────────────────────────────────────────────
-
-start_dev_server
-wait_for_ready
+# ── 11. Start the dev command (interactive/preview sessions only) ────────────
+# Autonomous implementation sessions do NOT start the target repo's dev server.
+# Their job is to implement the issue, not serve the app. Running the repo's
+# `dev` script and then hard-gating on a readiness check is pure downside here:
+# a dev server that never binds — slow start, an unexpected port, or a repo
+# whose `dev` script is itself a long-running daemon (e.g. this orchestrator) —
+# makes wait_for_ready call fail() and abort the whole session before Claude
+# ever runs. The dev server exists for interactive/preview modes; gate on mode.
+if [ "$SESSION_MODE" != "autonomous" ]; then
+  start_dev_server
+  wait_for_ready
+fi
 
 post_status "{\"nonce\":\"${MACHINE_NONCE}\",\"event\":\"setup_complete\"}"
 


### PR DESCRIPTION
## Summary

Autonomous implementation sessions were aborting before Claude ever ran.

`session/entrypoint.sh` unconditionally ran the target repo's `dev` script (`start_dev_server`) and then hard-gated on a readiness check (`wait_for_ready`). On timeout, `wait_for_ready` calls `fail()`, which exits the session non-zero — **before** Claude Code runs. The orchestrator then re-dispatches the issue every 60s, producing a fresh machine each cycle, which reads as "machines keep rebooting."

It triggered reliably while dogfooding (running AI-Implement issues against the AI-Implement repo itself): this repo's `dev` script is `tsx src/index.ts` — the orchestrator. The session booted a nested copy of the orchestrator as its "dev server," the readiness check curled the wrong port, timed out at 60s, and killed the session.

Root cause isn't the port mismatch — it's that an autonomous implementation session has no business gating on the target app's dev server at all. The dev server exists for interactive/preview sessions. This change gates `start_dev_server` + `wait_for_ready` behind `SESSION_MODE != autonomous`, so autonomous runs go straight to implementation. The machinery stays intact for interactive/preview modes.

## Test plan

- [x] `shellcheck session/entrypoint.sh` — clean (no new findings)
- [ ] Dispatch an autonomous Fly session and confirm it reaches Claude Code instead of aborting at the readiness gate
- [ ] Confirm interactive/preview mode (when exercised) still starts the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)