### PR TITLE
Add orchestrator workflow sync action

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,12 +102,11 @@ All tables live in a single SQLite file at `DEDUP_DB_PATH` (default `/data/dedup
 
 ## Adding a new target repo
 
-1. Add the repo to the matrix in `.github/workflows/sync-workflow.yml`
-2. Run the sync workflow — it opens a PR in the target repo with the workflow files and a starter `WORKFLOW.md`
-3. Merge the PR in the target repo
-4. Enable "Allow GitHub Actions to create and approve pull requests" in the target repo settings
-5. Install the GitHub App on the target repo
-6. Add the team→repo mapping in the admin UI at `/admin`
+1. Add the team→repo mapping in the admin UI at `/admin`
+2. Install the GitHub App on the target repo
+3. Click **Sync workflows** on that project row — the orchestrator opens or updates a PR in the target repo with workflow files and starter prompt templates
+4. Merge the PR in the target repo
+5. Enable "Allow GitHub Actions to create and approve pull requests" in the target repo settings
 
 ## admin-ui
 
@@ -145,7 +144,7 @@ The 14 not-yet-implemented routes (`overview`, `issues`, `pulls`, `blockers`, `p
 `workflows/claude-plan.yml` is the planning workflow synced to target repos. It runs read-only codebase analysis and posts structured planning comments to Linear when dispatched. It supports:
 - **PLANNING.md** — per-repo Claude prompt template; front matter carries `model:` (same rules as WORKFLOW.md)
 
-`sync-workflow.yml` always syncs `claude-implement.yml`, `comment-trigger.yml`, and `claude-plan.yml`. It seeds `WORKFLOW.md` and `PLANNING.md` once and never overwrites them (each repo owns its own prompt templates after initial setup).
+The Projects page **Sync workflows** action always syncs `claude-implement.yml`, `comment-trigger.yml`, and `claude-plan.yml` into the target repo. It seeds `WORKFLOW.md` and `PLANNING.md` once and never overwrites them (each repo owns its own prompt templates after initial setup). `.github/workflows/sync-workflow.yml` remains as a manual fallback, but normal distribution should happen from the orchestrator.
 
 ### Model IDs are passed through verbatim
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ All tables live in a single SQLite file at `DEDUP_DB_PATH` (default `/data/dedup
 4. Merge the PR in the target repo
 5. Enable "Allow GitHub Actions to create and approve pull requests" in the target repo settings
 
+The GitHub App must have **workflows** permission in addition to **contents** permission. GitHub rejects writes under `.github/workflows/` without it, so the Sync workflows action will fail before opening or updating the target-repo PR.
+
 ## admin-ui
 
 The admin SPA at `/admin` is composed from string-exporting modules under `src/admin-ui/`. `src/admin-html.ts` is a thin re-export of `src/admin-ui/index.ts`. There is **no client-side build step** — all client JS is concatenated into a single inline `<script>` block at module load time.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN npm ci --omit=dev
 
 COPY --from=builder /app/dist ./dist
 COPY pipelines/ ./pipelines/
+COPY workflows/ ./workflows/
 
 # Create data directory (Fly volume will mount here)
 RUN mkdir -p /data

--- a/README.md
+++ b/README.md
@@ -57,17 +57,13 @@ npm install
 npm run dev                # starts polling + HTTP server on :8080
 ```
 
-Then in your Linear workspace, create an `AI-Implement` label. In the orchestrator's admin UI at http://localhost:8080/admin (gated by `ADMIN_ACCESS_CODE`), add a team → repo mapping. Sync the workflow templates into the target repo:
-
-```bash
-gh workflow run sync-workflow.yml -f target_repo=your-org/your-repo
-```
+Then in your Linear workspace, create an `AI-Implement` label. Install the GitHub App on the target repo, then in the orchestrator's admin UI at http://localhost:8080/admin (gated by `ADMIN_ACCESS_CODE`), add a team → repo mapping. From the Projects page, click **Sync workflows** for that project; the orchestrator opens or updates a PR in the target repo with the workflow templates.
 
 The synced workflows allow the GitHub App bot that minted the workflow token by
 default. To allow a different bot or a comma-separated allow-list, set the
 `AI_IMPLEMENT_ALLOWED_BOTS` Actions variable on the target repo or org.
 
-Merge the resulting PR in the target repo, enable "Allow GitHub Actions to create and approve pull requests" in its settings, install the GitHub App on it, then label any Linear issue `AI-Implement` and watch.
+Merge the resulting PR in the target repo, enable "Allow GitHub Actions to create and approve pull requests" in its settings, then label any Linear issue `AI-Implement` and watch.
 
 The full architecture, env-var reference, SQLite schema, multi-client deploy model, and Bedrock setup live in [`CLAUDE.md`](CLAUDE.md).
 

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -9,6 +9,10 @@ const IMPLEMENT_WORKFLOWS = [
 const FILES = [...IMPLEMENT_WORKFLOWS, "workflows/comment-trigger.yml"];
 
 describe("GHA workflow shims", () => {
+  it("ships workflow templates in the orchestrator image for admin-triggered syncs", () => {
+    expect(readFileSync("Dockerfile", "utf-8")).toMatch(/COPY workflows\/ \.\/workflows\//);
+  });
+
   it("keeps the canonical and synced dispatch workflows byte-for-byte identical", () => {
     expect(readFileSync(".github/workflows/claude-implement.yml", "utf-8")).toBe(
       readFileSync("workflows/claude-implement.yml", "utf-8"),

--- a/src/__tests__/workflow-sync.test.ts
+++ b/src/__tests__/workflow-sync.test.ts
@@ -67,6 +67,7 @@ function response(status: number, body?: unknown): Response {
 function makeGithubFetch(opts?: {
   mainFiles?: Record<string, string>;
   syncFiles?: Record<string, string>;
+  syncAheadBy?: number;
   existingPr?: FakePull | null;
 }) {
   const branches: Record<string, { sha: string; aheadBy: number; files: Record<string, string> }> = {
@@ -75,17 +76,19 @@ function makeGithubFetch(opts?: {
   if (opts?.syncFiles) {
     branches["sync/ai-implement"] = {
       sha: "sync-sha",
-      aheadBy: 0,
+      aheadBy: opts.syncAheadBy ?? 0,
       files: { ...opts.syncFiles },
     };
   }
   const pulls: FakePull[] = opts?.existingPr ? [opts.existingPr] : [];
+  const calls: Array<{ path: string; method: string; headers: HeadersInit | undefined; body: unknown }> = [];
 
   const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
     const url = new URL(String(input));
     const path = url.pathname;
     const method = init?.method ?? "GET";
     const body = init?.body ? JSON.parse(String(init.body)) : {};
+    calls.push({ path, method, headers: init?.headers, body });
 
     if (method === "GET" && path === "/repos/acme/app") {
       return response(200, { default_branch: "main" });
@@ -168,7 +171,7 @@ function makeGithubFetch(opts?: {
     return response(500, { message: `Unhandled fake GitHub route: ${method} ${path}` });
   }) as typeof fetch;
 
-  return { fetchImpl, branches, pulls };
+  return { fetchImpl, branches, pulls, calls };
 }
 
 describe("syncWorkflowTemplates", () => {
@@ -196,6 +199,9 @@ describe("syncWorkflowTemplates", () => {
     ]);
     expect(fake.branches["sync/ai-implement"].files[".github/workflows/claude-implement.yml"]).toBe("implement-yml\n");
     expect(fake.branches["sync/ai-implement"].files["WORKFLOW.md"]).toBe("workflow-md\n");
+    const writeCalls = fake.calls.filter((call) => ["POST", "PUT", "PATCH"].includes(call.method));
+    expect(writeCalls.length).toBeGreaterThan(0);
+    expect(writeCalls.every((call) => (call.headers as Record<string, string>)["Content-Type"] === "application/json")).toBe(true);
   });
 
   it("does not overwrite repo-owned prompt templates when they already exist on base", async () => {
@@ -251,5 +257,106 @@ describe("syncWorkflowTemplates", () => {
     expect(result.status).toBe("up-to-date");
     expect(result.changedFiles).toEqual([]);
     expect(result.prUrl).toBeNull();
+  });
+
+  it("updates an existing sync PR when files change", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch({
+      syncFiles: {
+        ".github/workflows/claude-implement.yml": "old implement\n",
+      },
+      existingPr: {
+        number: 77,
+        html_url: "https://github.com/acme/app/pull/77",
+        head: "sync/ai-implement",
+        base: { ref: "develop" },
+      },
+    });
+
+    const result = await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.status).toBe("pr-updated");
+    expect(result.prNumber).toBe(77);
+    expect(result.prUrl).toBe("https://github.com/acme/app/pull/77");
+    expect(fake.pulls).toHaveLength(1);
+    expect(fake.pulls[0].base.ref).toBe("main");
+  });
+
+  it("returns pr-existing when no files changed and a sync PR is already open", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const syncedFiles = {
+      ".github/workflows/claude-implement.yml": "implement-yml\n",
+      ".github/workflows/comment-trigger.yml": "comment-yml\n",
+      ".github/workflows/claude-plan.yml": "plan-yml\n",
+      "WORKFLOW.md": "workflow-md\n",
+      "PLANNING.md": "planning-md\n",
+    };
+    const fake = makeGithubFetch({
+      mainFiles: syncedFiles,
+      syncFiles: syncedFiles,
+      existingPr: {
+        number: 88,
+        html_url: "https://github.com/acme/app/pull/88",
+        head: "sync/ai-implement",
+        base: { ref: "main" },
+      },
+    });
+
+    const result = await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.status).toBe("pr-existing");
+    expect(result.prNumber).toBe(88);
+    expect(result.changedFiles).toEqual([]);
+  });
+
+  it("preserves an existing sync branch that is ahead of base", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch({
+      syncFiles: {
+        "operator-note.txt": "keep me\n",
+      },
+      syncAheadBy: 2,
+    });
+
+    await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(fake.branches["sync/ai-implement"].files["operator-note.txt"]).toBe("keep me\n");
+    expect(fake.calls.some((call) => call.method === "PATCH" && call.path.includes("/git/refs/heads/"))).toBe(false);
+  });
+
+  it("throws when an always-synced workflow template is missing", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    rmSync(join(templatesRoot, "workflows/claude-plan.yml"));
+    const fake = makeGithubFetch();
+
+    await expect(syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    })).rejects.toThrow("Missing workflow template: workflows/claude-plan.yml");
   });
 });

--- a/src/__tests__/workflow-sync.test.ts
+++ b/src/__tests__/workflow-sync.test.ts
@@ -1,0 +1,255 @@
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import type { RepoMapping } from "../config.js";
+import { syncWorkflowTemplates } from "../workflow-sync.js";
+
+const mapping: RepoMapping = {
+  owner: "acme",
+  repo: "app",
+  workflowFile: "claude-implement.yml",
+  defaultBranch: "main",
+  maxInProgressAiIssues: 3,
+  executionMode: "github-actions",
+  sessionMode: "autonomous",
+  machineCpus: 2,
+  machineMemoryMb: 4096,
+  planningEnabled: true,
+  planningWorkflowFile: "claude-plan.yml",
+  autoApprovePlans: true,
+  extraEnv: {},
+  provider: "anthropic",
+  ticketingProvider: "linear",
+  ticketingConfig: { kind: "linear" },
+  awsRegion: null,
+  paused: false,
+};
+
+let tempRoot: string | null = null;
+
+afterEach(() => {
+  if (tempRoot) rmSync(tempRoot, { recursive: true, force: true });
+  tempRoot = null;
+});
+
+function makeTemplatesRoot(): string {
+  tempRoot = mkdtempSync(join(tmpdir(), "workflow-sync-"));
+  mkdirSync(join(tempRoot, "workflows"), { recursive: true });
+  writeFileSync(join(tempRoot, "workflows/claude-implement.yml"), "implement-yml\n");
+  writeFileSync(join(tempRoot, "workflows/comment-trigger.yml"), "comment-yml\n");
+  writeFileSync(join(tempRoot, "workflows/claude-plan.yml"), "plan-yml\n");
+  writeFileSync(join(tempRoot, "workflows/WORKFLOW.md"), "workflow-md\n");
+  writeFileSync(join(tempRoot, "workflows/PLANNING.md"), "planning-md\n");
+  return tempRoot;
+}
+
+interface FakePull {
+  number: number;
+  html_url: string;
+  head: string;
+  base: { ref: string };
+}
+
+function fileSha(content: string): string {
+  return `sha-${Buffer.from(content).toString("base64url")}`;
+}
+
+function response(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => typeof body === "string" ? body : JSON.stringify(body ?? {}),
+  } as Response;
+}
+
+function makeGithubFetch(opts?: {
+  mainFiles?: Record<string, string>;
+  syncFiles?: Record<string, string>;
+  existingPr?: FakePull | null;
+}) {
+  const branches: Record<string, { sha: string; aheadBy: number; files: Record<string, string> }> = {
+    main: { sha: "base-sha", aheadBy: 0, files: { ...(opts?.mainFiles ?? {}) } },
+  };
+  if (opts?.syncFiles) {
+    branches["sync/ai-implement"] = {
+      sha: "sync-sha",
+      aheadBy: 0,
+      files: { ...opts.syncFiles },
+    };
+  }
+  const pulls: FakePull[] = opts?.existingPr ? [opts.existingPr] : [];
+
+  const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const path = url.pathname;
+    const method = init?.method ?? "GET";
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+
+    if (method === "GET" && path === "/repos/acme/app") {
+      return response(200, { default_branch: "main" });
+    }
+
+    const getRefMatch = path.match(/^\/repos\/acme\/app\/git\/ref\/heads\/(.+)$/);
+    if (getRefMatch && method === "GET") {
+      const branch = decodeURIComponent(getRefMatch[1]);
+      const ref = branches[branch];
+      return ref ? response(200, { object: { sha: ref.sha } }) : response(404, { message: "Not Found" });
+    }
+    if (path === "/repos/acme/app/git/refs" && method === "POST") {
+      const branch = String(body.ref).replace(/^refs\/heads\//, "");
+      branches[branch] = {
+        sha: body.sha,
+        aheadBy: 0,
+        files: { ...branches.main.files },
+      };
+      return response(201, { ref: body.ref });
+    }
+    const patchRefMatch = path.match(/^\/repos\/acme\/app\/git\/refs\/heads\/(.+)$/);
+    if (patchRefMatch && method === "PATCH") {
+      const branch = decodeURIComponent(patchRefMatch[1]);
+      branches[branch] = {
+        sha: body.sha,
+        aheadBy: 0,
+        files: { ...branches.main.files },
+      };
+      return response(200, { object: { sha: body.sha } });
+    }
+
+    const compareMatch = path.match(/^\/repos\/acme\/app\/compare\/(.+)\.\.\.(.+)$/);
+    if (compareMatch && method === "GET") {
+      const head = decodeURIComponent(compareMatch[2]);
+      return response(200, { ahead_by: branches[head]?.aheadBy ?? 0 });
+    }
+
+    const contentsMatch = path.match(/^\/repos\/acme\/app\/contents\/(.+)$/);
+    if (contentsMatch && method === "GET") {
+      const remotePath = decodeURIComponent(contentsMatch[1]);
+      const ref = decodeURIComponent(url.searchParams.get("ref") ?? "main");
+      const content = branches[ref]?.files[remotePath];
+      if (content === undefined) return response(404, { message: "Not Found" });
+      return response(200, {
+        type: "file",
+        sha: fileSha(content),
+        encoding: "base64",
+        content: Buffer.from(content).toString("base64"),
+      });
+    }
+    if (contentsMatch && method === "PUT") {
+      const remotePath = decodeURIComponent(contentsMatch[1]);
+      const branch = body.branch;
+      branches[branch].files[remotePath] = Buffer.from(body.content, "base64").toString("utf-8");
+      branches[branch].aheadBy = 1;
+      return response(200, { content: { path: remotePath } });
+    }
+
+    if (path === "/repos/acme/app/pulls" && method === "GET") {
+      return response(200, pulls);
+    }
+    if (path === "/repos/acme/app/pulls" && method === "POST") {
+      const pr = {
+        number: 123,
+        html_url: "https://github.com/acme/app/pull/123",
+        head: body.head,
+        base: { ref: body.base },
+      };
+      pulls.push(pr);
+      return response(201, pr);
+    }
+    const prMatch = path.match(/^\/repos\/acme\/app\/pulls\/(\d+)$/);
+    if (prMatch && method === "PATCH") {
+      const pr = pulls.find((p) => p.number === Number(prMatch[1]));
+      if (!pr) return response(404, { message: "Not Found" });
+      pr.base.ref = body.base;
+      return response(200, pr);
+    }
+
+    return response(500, { message: `Unhandled fake GitHub route: ${method} ${path}` });
+  }) as typeof fetch;
+
+  return { fetchImpl, branches, pulls };
+}
+
+describe("syncWorkflowTemplates", () => {
+  it("opens a sync PR with workflow files and seed templates", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch();
+
+    const result = await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.status).toBe("pr-opened");
+    expect(result.prUrl).toBe("https://github.com/acme/app/pull/123");
+    expect(result.changedFiles).toEqual([
+      ".github/workflows/claude-implement.yml",
+      ".github/workflows/comment-trigger.yml",
+      ".github/workflows/claude-plan.yml",
+      "WORKFLOW.md",
+      "PLANNING.md",
+    ]);
+    expect(fake.branches["sync/ai-implement"].files[".github/workflows/claude-implement.yml"]).toBe("implement-yml\n");
+    expect(fake.branches["sync/ai-implement"].files["WORKFLOW.md"]).toBe("workflow-md\n");
+  });
+
+  it("does not overwrite repo-owned prompt templates when they already exist on base", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch({
+      mainFiles: {
+        "WORKFLOW.md": "custom workflow\n",
+        "PLANNING.md": "custom planning\n",
+      },
+    });
+
+    const result = await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.changedFiles).toEqual([
+      ".github/workflows/claude-implement.yml",
+      ".github/workflows/comment-trigger.yml",
+      ".github/workflows/claude-plan.yml",
+    ]);
+    expect(fake.branches["sync/ai-implement"].files["WORKFLOW.md"]).toBe("custom workflow\n");
+    expect(fake.branches["sync/ai-implement"].files["PLANNING.md"]).toBe("custom planning\n");
+  });
+
+  it("returns up-to-date when the sync branch already matches templates and no PR is open", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const syncedFiles = {
+      ".github/workflows/claude-implement.yml": "implement-yml\n",
+      ".github/workflows/comment-trigger.yml": "comment-yml\n",
+      ".github/workflows/claude-plan.yml": "plan-yml\n",
+      "WORKFLOW.md": "workflow-md\n",
+      "PLANNING.md": "planning-md\n",
+    };
+    const fake = makeGithubFetch({
+      mainFiles: syncedFiles,
+      syncFiles: syncedFiles,
+    });
+
+    const result = await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.status).toBe("up-to-date");
+    expect(result.changedFiles).toEqual([]);
+    expect(result.prUrl).toBeNull();
+  });
+});

--- a/src/admin-ui/__tests__/pages-render.test.ts
+++ b/src/admin-ui/__tests__/pages-render.test.ts
@@ -19,4 +19,10 @@ describe("admin HTML", () => {
     expect(adminHtml).toContain('id="access-code"');
     expect(adminHtml).toContain('id="login-error"');
   });
+
+  it("exposes the per-project workflow sync action", () => {
+    expect(adminHtml).toContain("Sync workflows");
+    expect(adminHtml).toContain("/sync-workflows");
+    expect(adminHtml).toContain("window.syncWorkflows");
+  });
 });

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -665,6 +665,7 @@ export const projectsScript = `
       };
       button.textContent = labels[data.status] || 'Synced';
       if (data.prUrl) {
+        button.dataset.prUrl = data.prUrl;
         button.title = data.prUrl;
         window.open(data.prUrl, '_blank', 'noopener,noreferrer');
       }

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -236,6 +236,7 @@ export const projectsScript = `
           + '<button class="btn btn-sm" data-key="' + ek + '" data-paused="' + (m.paused ? '1' : '0') + '" onclick="togglePause(this.dataset.key, this.dataset.paused === \\'1\\')">' + pauseLabel + '</button> '
           + '<button class="btn btn-sm" data-key="' + ek + '" onclick="openMappingDialog(this.dataset.key)">Edit</button> '
           + '<button class="btn btn-sm btn-danger" data-key="' + ek + '" onclick="delMapping(this.dataset.key)">Del</button> '
+          + '<button class="btn btn-sm btn-ghost" data-key="' + ek + '" onclick="syncWorkflows(this)">Sync workflows</button> '
           + '<button class="btn btn-sm btn-ghost" data-key="' + ek + '" onclick="showSecrets(this.dataset.key)">Secrets</button>'
         + '</td>';
       tbody.appendChild(tr);
@@ -641,6 +642,44 @@ export const projectsScript = `
     await loadMappings();
   }
   window.togglePause = togglePause;
+
+  async function syncWorkflows(button) {
+    const key = button.dataset.key;
+    const original = button.textContent;
+    button.disabled = true;
+    button.textContent = 'Syncing...';
+    try {
+      const res = await window.api('/api/mappings/' + encodeURIComponent(key) + '/sync-workflows', {
+        method: 'POST',
+      });
+      let data = {};
+      try { data = await res.json(); } catch (_) {}
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to sync workflows');
+      }
+      const labels = {
+        'up-to-date': 'Up to date',
+        'pr-existing': 'PR exists',
+        'pr-opened': 'PR opened',
+        'pr-updated': 'PR updated',
+      };
+      button.textContent = labels[data.status] || 'Synced';
+      if (data.prUrl) {
+        button.title = data.prUrl;
+        window.open(data.prUrl, '_blank', 'noopener,noreferrer');
+      }
+      setTimeout(function () {
+        button.textContent = original;
+        button.disabled = false;
+      }, 4000);
+    } catch (err) {
+      button.textContent = 'Sync failed';
+      button.disabled = false;
+      alert(err && err.message ? err.message : String(err));
+      setTimeout(function () { button.textContent = original; }, 4000);
+    }
+  }
+  window.syncWorkflows = syncWorkflows;
 
   async function showSecrets(teamKey) {
     currentSecretsTeam = teamKey;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -39,6 +39,7 @@ import { listCustomizations } from "./customizations.js";
 import { inspectPipelinesAndSteps } from "./inspect-pipeline-graph.js";
 import { validateTicketingConfig, type TicketingMappingConfig } from "./providers/ticketing-config.js";
 import { JiraClient, JiraFieldNotSelectError } from "./providers/jira-client.js";
+import { syncWorkflowTemplates } from "./workflow-sync.js";
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -165,6 +166,18 @@ export function handleAdminRequest(
 
     if (url === "/api/mappings" && method === "POST") {
       handleUpsertMapping(req, res, registry);
+      return true;
+    }
+
+    const workflowSyncMatch = url.match(/^\/api\/mappings\/([^/]+)\/sync-workflows$/);
+    if (workflowSyncMatch && method === "POST") {
+      const teamKey = decodeURIComponent(workflowSyncMatch[1]);
+      handleSyncWorkflows(res, config, teamKey).catch((err) => {
+        console.error(`[admin] workflow sync failed for ${teamKey}:`, err);
+        if (!res.headersSent) {
+          json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+        }
+      });
       return true;
     }
 
@@ -602,6 +615,25 @@ async function handlePatchMapping(
   } catch {
     json(res, 400, { error: "Invalid request body" });
   }
+}
+
+async function handleSyncWorkflows(
+  res: http.ServerResponse,
+  config: AdminConfig,
+  teamKey: string,
+): Promise<void> {
+  const mappings = getMappings();
+  const mapping = mappings[teamKey];
+  if (!mapping) {
+    json(res, 404, { error: "Team not found" });
+    return;
+  }
+  const result = await syncWorkflowTemplates({
+    mapping,
+    githubAppId: config.githubAppId,
+    githubAppPrivateKey: config.githubAppPrivateKey,
+  });
+  json(res, 200, result);
 }
 
 async function handleListSecrets(

--- a/src/workflow-sync.ts
+++ b/src/workflow-sync.ts
@@ -33,11 +33,13 @@ const SEED_ONCE_FILES = [
     local: "workflows/WORKFLOW.md",
     remote: "WORKFLOW.md",
     message: "Add WORKFLOW.md prompt template (customise for this repo)",
+    description: "Claude implementation prompt template; customise this for your repo",
   },
   {
     local: "workflows/PLANNING.md",
     remote: "PLANNING.md",
     message: "Add PLANNING.md planning template (customise for this repo)",
+    description: "Claude planning prompt template; customise this for your repo",
   },
 ] as const;
 
@@ -80,13 +82,17 @@ class GitHubClient {
   ) {}
 
   async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const headers: Record<string, string> = {
+      ...GH_HEADERS,
+      Authorization: `Bearer ${this.token}`,
+      ...(init.headers as Record<string, string> | undefined ?? {}),
+    };
+    if (init.body !== undefined && !Object.keys(headers).some((key) => key.toLowerCase() === "content-type")) {
+      headers["Content-Type"] = "application/json";
+    }
     const res = await this.fetchImpl(`https://api.github.com${path}`, {
       ...init,
-      headers: {
-        ...GH_HEADERS,
-        Authorization: `Bearer ${this.token}`,
-        ...(init.headers ?? {}),
-      },
+      headers,
     });
     if (!res.ok) {
       const text = await res.text();
@@ -177,9 +183,12 @@ async function syncFile(params: {
   localContent: string;
   remotePath: string;
   message: string;
+  remote?: RemoteFile | null;
 }): Promise<boolean> {
   const { gh, repo, branch, localContent, remotePath, message } = params;
-  const remote = await getRemoteFile(gh, repo, remotePath, branch);
+  const remote = params.remote !== undefined
+    ? params.remote
+    : await getRemoteFile(gh, repo, remotePath, branch);
   if (remote?.content === localContent) return false;
 
   await gh.request(`/repos/${repo}/contents/${encodeRepoPath(remotePath)}`, {
@@ -205,8 +214,9 @@ async function syncMaybeSeedFile(params: {
 }): Promise<boolean> {
   const { gh, repo, baseBranch, syncBranch, localContent, remotePath, message } = params;
   if (await remoteFileExists(gh, repo, remotePath, baseBranch)) return false;
-  if (await remoteFileExists(gh, repo, remotePath, syncBranch)) return false;
-  return await syncFile({ gh, repo, branch: syncBranch, localContent, remotePath, message });
+  const remote = await getRemoteFile(gh, repo, remotePath, syncBranch);
+  if (remote) return false;
+  return await syncFile({ gh, repo, branch: syncBranch, localContent, remotePath, message, remote });
 }
 
 async function ensureSyncBranch(params: {
@@ -250,7 +260,19 @@ async function findSyncPr(
   const prs = await gh.request<PullRequest[]>(
     `/repos/${repo}/pulls?state=open&head=${encodeURIComponent(`${repo.split("/")[0]}:${syncBranch}`)}`,
   );
-  return prs.find((pr) => pr.base && pr.number) ?? null;
+  return prs[0] ?? null;
+}
+
+function syncPrBody(): string {
+  return [
+    "Auto-synced from ai-implement.",
+    "",
+    "**Always updated:**",
+    ...ALWAYS_SYNC_FILES.map((file) => `- \`${file.remote}\``),
+    "",
+    "**Added once (never overwritten):**",
+    ...SEED_ONCE_FILES.map((file) => `- \`${file.remote}\` — ${file.description}`),
+  ].join("\n");
 }
 
 async function createSyncPr(params: {
@@ -260,25 +282,13 @@ async function createSyncPr(params: {
   syncBranch: string;
 }): Promise<PullRequest> {
   const { gh, repo, baseBranch, syncBranch } = params;
-  const body = [
-    "Auto-synced from ai-implement.",
-    "",
-    "**Always updated:**",
-    "- `.github/workflows/claude-implement.yml`",
-    "- `.github/workflows/comment-trigger.yml`",
-    "- `.github/workflows/claude-plan.yml`",
-    "",
-    "**Added once (never overwritten):**",
-    "- `WORKFLOW.md` — Claude implementation prompt template; customise this for your repo",
-    "- `PLANNING.md` — Claude planning prompt template; customise this for your repo",
-  ].join("\n");
   return await gh.request<PullRequest>(`/repos/${repo}/pulls`, {
     method: "POST",
     body: JSON.stringify({
       title: "Sync AI implementation workflow files",
       head: syncBranch,
       base: baseBranch,
-      body,
+      body: syncPrBody(),
     }),
   });
 }

--- a/src/workflow-sync.ts
+++ b/src/workflow-sync.ts
@@ -1,0 +1,370 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { RepoMapping } from "./config.js";
+import { getInstallationToken } from "./github-app-auth.js";
+
+const GH_HEADERS = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28",
+  "User-Agent": "ai-implement-orchestrator",
+} as const;
+
+const ALWAYS_SYNC_FILES = [
+  {
+    local: "workflows/claude-implement.yml",
+    remote: ".github/workflows/claude-implement.yml",
+    message: "Sync claude-implement.yml from ai-implement",
+  },
+  {
+    local: "workflows/comment-trigger.yml",
+    remote: ".github/workflows/comment-trigger.yml",
+    message: "Sync comment-trigger.yml from ai-implement",
+  },
+  {
+    local: "workflows/claude-plan.yml",
+    remote: ".github/workflows/claude-plan.yml",
+    message: "Sync claude-plan.yml from ai-implement",
+  },
+] as const;
+
+const SEED_ONCE_FILES = [
+  {
+    local: "workflows/WORKFLOW.md",
+    remote: "WORKFLOW.md",
+    message: "Add WORKFLOW.md prompt template (customise for this repo)",
+  },
+  {
+    local: "workflows/PLANNING.md",
+    remote: "PLANNING.md",
+    message: "Add PLANNING.md planning template (customise for this repo)",
+  },
+] as const;
+
+export interface WorkflowSyncOptions {
+  mapping: RepoMapping;
+  githubAppId: string;
+  githubAppPrivateKey: string;
+  targetBase?: string;
+  syncBranch?: string;
+  templatesRoot?: string;
+  fetchImpl?: typeof fetch;
+  getInstallationTokenImpl?: typeof getInstallationToken;
+}
+
+export interface WorkflowSyncResult {
+  status: "up-to-date" | "pr-opened" | "pr-updated" | "pr-existing";
+  targetRepo: string;
+  baseBranch: string;
+  syncBranch: string;
+  changedFiles: string[];
+  prNumber: number | null;
+  prUrl: string | null;
+}
+
+interface RemoteFile {
+  sha: string;
+  content: string;
+}
+
+interface PullRequest {
+  number: number;
+  html_url: string;
+  base: { ref: string };
+}
+
+class GitHubClient {
+  constructor(
+    private readonly token: string,
+    private readonly fetchImpl: typeof fetch,
+  ) {}
+
+  async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const res = await this.fetchImpl(`https://api.github.com${path}`, {
+      ...init,
+      headers: {
+        ...GH_HEADERS,
+        Authorization: `Bearer ${this.token}`,
+        ...(init.headers ?? {}),
+      },
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GitHub ${res.status} ${path}: ${text.slice(0, 500)}`);
+    }
+    if (res.status === 204) return undefined as T;
+    return await res.json() as T;
+  }
+
+  async maybeRequest<T>(path: string, init: RequestInit = {}): Promise<T | null> {
+    const res = await this.fetchImpl(`https://api.github.com${path}`, {
+      ...init,
+      headers: {
+        ...GH_HEADERS,
+        Authorization: `Bearer ${this.token}`,
+        ...(init.headers ?? {}),
+      },
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GitHub ${res.status} ${path}: ${text.slice(0, 500)}`);
+    }
+    if (res.status === 204) return undefined as T;
+    return await res.json() as T;
+  }
+}
+
+function repoPath(mapping: RepoMapping): string {
+  return `${mapping.owner}/${mapping.repo}`;
+}
+
+function encodeRepoPath(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+function encodeRefPath(ref: string): string {
+  return ref.split("/").map(encodeURIComponent).join("/");
+}
+
+function packageRoot(): string {
+  return dirname(dirname(fileURLToPath(import.meta.url)));
+}
+
+function readTemplate(root: string, relativePath: string): string | null {
+  const path = join(root, relativePath);
+  if (!existsSync(path)) return null;
+  return readFileSync(path, "utf-8");
+}
+
+function decodeContent(content: string): string {
+  return Buffer.from(content.replace(/\s+/g, ""), "base64").toString("utf-8");
+}
+
+async function getRemoteFile(
+  gh: GitHubClient,
+  repo: string,
+  path: string,
+  ref: string,
+): Promise<RemoteFile | null> {
+  const encoded = encodeRepoPath(path);
+  const data = await gh.maybeRequest<{
+    type: string;
+    sha: string;
+    content?: string;
+    encoding?: string;
+  }>(`/repos/${repo}/contents/${encoded}?ref=${encodeURIComponent(ref)}`);
+  if (!data) return null;
+  if (data.type !== "file" || data.encoding !== "base64" || data.content === undefined) {
+    throw new Error(`GitHub content ${path} in ${repo}@${ref} is not a base64 file`);
+  }
+  return { sha: data.sha, content: decodeContent(data.content) };
+}
+
+async function remoteFileExists(
+  gh: GitHubClient,
+  repo: string,
+  path: string,
+  ref: string,
+): Promise<boolean> {
+  return (await getRemoteFile(gh, repo, path, ref)) !== null;
+}
+
+async function syncFile(params: {
+  gh: GitHubClient;
+  repo: string;
+  branch: string;
+  localContent: string;
+  remotePath: string;
+  message: string;
+}): Promise<boolean> {
+  const { gh, repo, branch, localContent, remotePath, message } = params;
+  const remote = await getRemoteFile(gh, repo, remotePath, branch);
+  if (remote?.content === localContent) return false;
+
+  await gh.request(`/repos/${repo}/contents/${encodeRepoPath(remotePath)}`, {
+    method: "PUT",
+    body: JSON.stringify({
+      message,
+      content: Buffer.from(localContent, "utf-8").toString("base64"),
+      branch,
+      ...(remote ? { sha: remote.sha } : {}),
+    }),
+  });
+  return true;
+}
+
+async function syncMaybeSeedFile(params: {
+  gh: GitHubClient;
+  repo: string;
+  baseBranch: string;
+  syncBranch: string;
+  localContent: string;
+  remotePath: string;
+  message: string;
+}): Promise<boolean> {
+  const { gh, repo, baseBranch, syncBranch, localContent, remotePath, message } = params;
+  if (await remoteFileExists(gh, repo, remotePath, baseBranch)) return false;
+  if (await remoteFileExists(gh, repo, remotePath, syncBranch)) return false;
+  return await syncFile({ gh, repo, branch: syncBranch, localContent, remotePath, message });
+}
+
+async function ensureSyncBranch(params: {
+  gh: GitHubClient;
+  repo: string;
+  baseBranch: string;
+  syncBranch: string;
+}): Promise<void> {
+  const { gh, repo, baseBranch, syncBranch } = params;
+  const base = await gh.request<{ object: { sha: string } }>(
+    `/repos/${repo}/git/ref/heads/${encodeRefPath(baseBranch)}`,
+  );
+  const syncRef = await gh.maybeRequest<{ object: { sha: string } }>(
+    `/repos/${repo}/git/ref/heads/${encodeRefPath(syncBranch)}`,
+  );
+
+  if (!syncRef) {
+    await gh.request(`/repos/${repo}/git/refs`, {
+      method: "POST",
+      body: JSON.stringify({ ref: `refs/heads/${syncBranch}`, sha: base.object.sha }),
+    });
+    return;
+  }
+
+  const compare = await gh.maybeRequest<{ ahead_by: number }>(
+    `/repos/${repo}/compare/${encodeRefPath(baseBranch)}...${encodeRefPath(syncBranch)}`,
+  );
+  if ((compare?.ahead_by ?? 0) === 0) {
+    await gh.request(`/repos/${repo}/git/refs/heads/${encodeRefPath(syncBranch)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ sha: base.object.sha, force: true }),
+    });
+  }
+}
+
+async function findSyncPr(
+  gh: GitHubClient,
+  repo: string,
+  syncBranch: string,
+): Promise<PullRequest | null> {
+  const prs = await gh.request<PullRequest[]>(
+    `/repos/${repo}/pulls?state=open&head=${encodeURIComponent(`${repo.split("/")[0]}:${syncBranch}`)}`,
+  );
+  return prs.find((pr) => pr.base && pr.number) ?? null;
+}
+
+async function createSyncPr(params: {
+  gh: GitHubClient;
+  repo: string;
+  baseBranch: string;
+  syncBranch: string;
+}): Promise<PullRequest> {
+  const { gh, repo, baseBranch, syncBranch } = params;
+  const body = [
+    "Auto-synced from ai-implement.",
+    "",
+    "**Always updated:**",
+    "- `.github/workflows/claude-implement.yml`",
+    "- `.github/workflows/comment-trigger.yml`",
+    "- `.github/workflows/claude-plan.yml`",
+    "",
+    "**Added once (never overwritten):**",
+    "- `WORKFLOW.md` — Claude implementation prompt template; customise this for your repo",
+    "- `PLANNING.md` — Claude planning prompt template; customise this for your repo",
+  ].join("\n");
+  return await gh.request<PullRequest>(`/repos/${repo}/pulls`, {
+    method: "POST",
+    body: JSON.stringify({
+      title: "Sync AI implementation workflow files",
+      head: syncBranch,
+      base: baseBranch,
+      body,
+    }),
+  });
+}
+
+async function retargetPrIfNeeded(
+  gh: GitHubClient,
+  repo: string,
+  pr: PullRequest,
+  baseBranch: string,
+): Promise<PullRequest> {
+  if (pr.base.ref === baseBranch) return pr;
+  return await gh.request<PullRequest>(`/repos/${repo}/pulls/${pr.number}`, {
+    method: "PATCH",
+    body: JSON.stringify({ base: baseBranch }),
+  });
+}
+
+export async function syncWorkflowTemplates(
+  options: WorkflowSyncOptions,
+): Promise<WorkflowSyncResult> {
+  const mapping = options.mapping;
+  const targetRepo = repoPath(mapping);
+  const syncBranch = options.syncBranch ?? "sync/ai-implement";
+  const templatesRoot = options.templatesRoot ?? packageRoot();
+  const getToken = options.getInstallationTokenImpl ?? getInstallationToken;
+  const token = await getToken(options.githubAppId, options.githubAppPrivateKey, mapping.owner);
+  const gh = new GitHubClient(token, options.fetchImpl ?? fetch);
+
+  const repo = await gh.request<{ default_branch: string }>(`/repos/${targetRepo}`);
+  const baseBranch = options.targetBase || mapping.defaultBranch || repo.default_branch;
+  await ensureSyncBranch({ gh, repo: targetRepo, baseBranch, syncBranch });
+
+  const changedFiles: string[] = [];
+  for (const file of ALWAYS_SYNC_FILES) {
+    const content = readTemplate(templatesRoot, file.local);
+    if (content === null) {
+      throw new Error(`Missing workflow template: ${file.local}`);
+    }
+    const changed = await syncFile({
+      gh,
+      repo: targetRepo,
+      branch: syncBranch,
+      localContent: content,
+      remotePath: file.remote,
+      message: file.message,
+    });
+    if (changed) changedFiles.push(file.remote);
+  }
+
+  for (const file of SEED_ONCE_FILES) {
+    const content = readTemplate(templatesRoot, file.local);
+    if (content === null) continue;
+    const changed = await syncMaybeSeedFile({
+      gh,
+      repo: targetRepo,
+      baseBranch,
+      syncBranch,
+      localContent: content,
+      remotePath: file.remote,
+      message: file.message,
+    });
+    if (changed) changedFiles.push(file.remote);
+  }
+
+  const existingPr = await findSyncPr(gh, targetRepo, syncBranch);
+  const pr = existingPr ? await retargetPrIfNeeded(gh, targetRepo, existingPr, baseBranch) : null;
+  if (changedFiles.length === 0) {
+    return {
+      status: pr ? "pr-existing" : "up-to-date",
+      targetRepo,
+      baseBranch,
+      syncBranch,
+      changedFiles,
+      prNumber: pr?.number ?? null,
+      prUrl: pr?.html_url ?? null,
+    };
+  }
+
+  const finalPr = pr ?? await createSyncPr({ gh, repo: targetRepo, baseBranch, syncBranch });
+  return {
+    status: pr ? "pr-updated" : "pr-opened",
+    targetRepo,
+    baseBranch,
+    syncBranch,
+    changedFiles,
+    prNumber: finalPr.number,
+    prUrl: finalPr.html_url,
+  };
+}


### PR DESCRIPTION
## Summary
- add a TypeScript workflow sync service that opens/updates target-repo sync PRs from the orchestrator
- add a per-project Projects page "Sync workflows" action and admin API endpoint
- ship workflow templates in the orchestrator Docker image and update onboarding docs

## Verification
- npm test
- npm run typecheck