### PR TITLE
Let pipeline own implementation branches

### DIFF
--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { buildIssueBranchName } from "../pipeline/branch-name.js";
+
+describe("buildIssueBranchName", () => {
+  it("builds issue-scoped branch names from issue metadata", () => {
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow")).toBe(
+      "ai-implement/gen-123-add-login-flow",
+    );
+  });
+
+  it("sanitizes punctuation and falls back for empty titles", () => {
+    expect(buildIssueBranchName("GEN/123", "!!!")).toBe(
+      "ai-implement/gen-123-implementation",
+    );
+  });
+});

--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -13,4 +13,10 @@ describe("buildIssueBranchName", () => {
       "ai-implement/gen-123-implementation",
     );
   });
+
+  it("handles undefined issue metadata defensively", () => {
+    expect(buildIssueBranchName(undefined, undefined)).toBe(
+      "ai-implement/issue-implementation",
+    );
+  });
 });

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -218,19 +218,19 @@ describe("loadPipelineDefinition", () => {
     expect(preflightStep.skip?.(ctxRejected)).toBe(true);
   });
 
-  it("applies push input wiring from clone outputs", () => {
+  it("applies push input wiring with an issue-scoped implementation branch", () => {
     const pipeline = loadPipelineDefinition("pipelines/autonomous.yml", {
       existsSyncImpl: () => false,
       readFileSyncImpl: (_path, _enc) => BUILTIN_PIPELINE_YAML,
     });
 
-    const ctx = makeContext();
+    const ctx = makeContext({ issueIdentifier: "ENG-42", issueTitle: "Add profile page" });
     ctx.setOutputs("clone", {
       workspaceDir: "/tmp/repo",
       repoOwner: "acme",
       repoRepo: "api",
       githubToken: "tok",
-      branch: "feature/x",
+      branch: "main",
     });
 
     const step = pipeline.steps.find((s) => s.id === "push")!;
@@ -239,7 +239,9 @@ describe("loadPipelineDefinition", () => {
     expect(inputs.repoOwner).toBe("acme");
     expect(inputs.repoRepo).toBe("api");
     expect(inputs.githubToken).toBe("tok");
-    expect(inputs.branchName).toBe("feature/x");
+    expect(inputs.branchName).toBe("ai-implement/eng-42-add-profile-page");
+    expect(inputs.baseBranch).toBe("main");
+    expect(inputs.prTitle).toBe("ENG-42: Add profile page");
   });
 
   it("applies push skip condition based on feedback-loop approval", () => {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -217,6 +217,32 @@ describe("runAutonomous", () => {
     expect(capturedPrompt).not.toContain("Pipeline-owned Git and PR handling");
   });
 
+  it("does not duplicate pipeline-owned git instructions from custom prompts", async () => {
+    writeFileSync(
+      join(workspaceDir, "WORKFLOW.md"),
+      "Do the work\n\n## Pipeline-owned Git and PR handling\n\nDo NOT create or switch branches.\n",
+    );
+
+    let capturedPrompt: string | undefined;
+    const mod: StepModule = {
+      run: vi.fn(async (ctx) => {
+        capturedPrompt = ctx.data.implementationPrompt;
+        return {};
+      }),
+    };
+    const { pipeline, runner } = makeSingleStepPipeline("check-prompt", mod);
+
+    await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+    });
+
+    expect(capturedPrompt?.match(/Pipeline-owned Git and PR handling/g)).toHaveLength(1);
+  });
+
   it("falls back to CLAUDE_MODEL env var when WORKFLOW.md has no model", async () => {
     vi.stubEnv("CLAUDE_MODEL", "claude-haiku-4-5");
     writeFileSync(join(workspaceDir, "WORKFLOW.md"), "---\n---\nNo model here\n");

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -161,7 +161,60 @@ describe("runAutonomous", () => {
       llmExecutor: makeMockExecutor(0),
     });
 
-    expect(capturedPrompt).toBe("Custom prompt for AII-1: Test issue\n");
+    expect(capturedPrompt).toContain("Custom prompt for AII-1: Test issue");
+    expect(capturedPrompt).toContain("Pipeline-owned Git and PR handling");
+  });
+
+  it("appends pipeline-owned git instructions to custom implementation prompts", async () => {
+    writeFileSync(
+      join(workspaceDir, "WORKFLOW.md"),
+      "Create a branch and open a PR for ${ISSUE_IDENTIFIER}\n",
+    );
+
+    let capturedPrompt: string | undefined;
+    const mod: StepModule = {
+      run: vi.fn(async (ctx) => {
+        capturedPrompt = ctx.data.implementationPrompt;
+        return {};
+      }),
+    };
+    const { pipeline, runner } = makeSingleStepPipeline("check-prompt", mod);
+
+    await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+    });
+
+    expect(capturedPrompt).toContain("Create a branch and open a PR for AII-1");
+    expect(capturedPrompt).toContain("Do NOT create or switch branches");
+    expect(capturedPrompt).toContain("Do NOT commit, push, or open a pull request");
+  });
+
+  it("does not append new-implementation git instructions for gap-fill runs", async () => {
+    vi.stubEnv("PR_NUMBER", "42");
+
+    let capturedPrompt: string | undefined;
+    const mod: StepModule = {
+      run: vi.fn(async (ctx) => {
+        capturedPrompt = ctx.data.implementationPrompt;
+        return {};
+      }),
+    };
+    const { pipeline, runner } = makeSingleStepPipeline("check-prompt", mod);
+
+    await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+    });
+
+    expect(capturedPrompt).toContain("Gap-fill run");
+    expect(capturedPrompt).not.toContain("Pipeline-owned Git and PR handling");
   });
 
   it("falls back to CLAUDE_MODEL env var when WORKFLOW.md has no model", async () => {

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -27,31 +27,29 @@ const BASE_INPUTS = {
   repoOwner: "acme",
   repoRepo: "app",
   githubToken: "gh-token",
-  branchName: "ENG-42/feature",
+  branchName: "ai-implement/eng-42-feature",
+  baseBranch: "main",
 };
 
-function mockPushSuccess(sha = "deadbeef") {
-  vi.mocked(spawnSync)
-    // rev-parse HEAD (commitSha)
-    .mockReturnValueOnce({
-      status: 0,
-      stdout: Buffer.from(`${sha}\n`),
-      stderr: Buffer.from(""),
-      pid: 0,
-      output: [],
-      signal: null,
-      error: undefined,
-    })
-    // git push
-    .mockReturnValueOnce({
-      status: 0,
-      stdout: Buffer.from(""),
-      stderr: Buffer.from(""),
-      pid: 0,
-      output: [],
-      signal: null,
-      error: undefined,
-    });
+function spawnResult(status: number, stdout = "", stderr = ""): ReturnType<typeof spawnSync> {
+  return {
+    status,
+    stdout: Buffer.from(stdout),
+    stderr: Buffer.from(stderr),
+    pid: 0,
+    output: [],
+    signal: null,
+    error: undefined,
+  };
+}
+
+function mockGitSuccess(sha = "deadbeef", dirty = true) {
+  vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+    const gitArgs = args as string[];
+    if (gitArgs[0] === "status") return spawnResult(0, dirty ? " M src/app.ts\n" : "");
+    if (gitArgs[0] === "rev-parse") return spawnResult(0, `${sha}\n`);
+    return spawnResult(0);
+  });
 }
 
 describe("pushStep", () => {
@@ -61,7 +59,7 @@ describe("pushStep", () => {
   });
 
   it("creates PR and returns prUrl, prNumber, commitSha on success", async () => {
-    mockPushSuccess("abc123");
+    mockGitSuccess("abc123");
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
       status: 201,
@@ -78,7 +76,7 @@ describe("pushStep", () => {
   });
 
   it("returns existing PR info on 422 (PR already open)", async () => {
-    mockPushSuccess("sha999");
+    mockGitSuccess("sha999");
     vi.mocked(fetch)
       .mockResolvedValueOnce({
         ok: false,
@@ -101,26 +99,15 @@ describe("pushStep", () => {
   });
 
   it("throws on git push failure and redacts token", async () => {
-    // rev-parse succeeds, push fails
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: Buffer.from("sha\n"),
-        stderr: Buffer.from(""),
-        pid: 0,
-        output: [],
-        signal: null,
-        error: undefined,
-      })
-      .mockReturnValueOnce({
-        status: 128,
-        stdout: Buffer.from(""),
-        stderr: Buffer.from("fatal: gh-token authentication failed"),
-        pid: 0,
-        output: [],
-        signal: null,
-        error: undefined,
-      });
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
+      if (gitArgs[0] === "rev-parse") return spawnResult(0, "sha\n");
+      if (gitArgs[0] === "push") {
+        return spawnResult(128, "", "fatal: gh-token authentication failed");
+      }
+      return spawnResult(0);
+    });
 
     await expect(
       pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
@@ -128,7 +115,7 @@ describe("pushStep", () => {
   });
 
   it("throws on non-200 non-422 PR creation", async () => {
-    mockPushSuccess();
+    mockGitSuccess();
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -141,7 +128,7 @@ describe("pushStep", () => {
   });
 
   it("throws when listing open PRs fails after 422", async () => {
-    mockPushSuccess("sha404");
+    mockGitSuccess("sha404");
     vi.mocked(fetch)
       .mockResolvedValueOnce({
         ok: false,
@@ -161,7 +148,7 @@ describe("pushStep", () => {
   });
 
   it("throws when 422 returned but no open PR found for branch", async () => {
-    mockPushSuccess("sha405");
+    mockGitSuccess("sha405");
     vi.mocked(fetch)
       .mockResolvedValueOnce({
         ok: false,
@@ -182,7 +169,7 @@ describe("pushStep", () => {
   });
 
   it("uses issueIdentifier in default PR title", async () => {
-    mockPushSuccess();
+    mockGitSuccess();
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
       status: 201,
@@ -194,5 +181,43 @@ describe("pushStep", () => {
     const fetchCall = vi.mocked(fetch).mock.calls[0];
     const body = JSON.parse(fetchCall[1]?.body as string) as { title: string };
     expect(body.title).toContain("ENG-42");
+  });
+
+  it("checks out implementation branch and commits working tree changes before pushing", async () => {
+    mockGitSuccess("abc123");
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: "https://github.com/acme/app/pull/1", number: 1 }),
+    } as Response);
+
+    await pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["checkout", "-B", "ai-implement/eng-42-feature"],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["commit", "-m", "ENG-42: Test"],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["push", expect.any(String), "HEAD:refs/heads/ai-implement/eng-42-feature"]),
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+  });
+
+  it("refuses to push over the base branch", async () => {
+    await expect(
+      pushStep.run(
+        makeContext(),
+        { ...BASE_INPUTS, branchName: "main", baseBranch: "main" },
+        new NoopStepReporter(),
+      ),
+    ).rejects.toThrow(/Refusing to push implementation branch/);
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -210,6 +210,30 @@ describe("pushStep", () => {
     );
   });
 
+  it("throws when Claude leaves no working tree changes", async () => {
+    mockGitSuccess("abc123", false);
+
+    await expect(
+      pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
+    ).rejects.toThrow(/Nothing to commit/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws when git status fails", async () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") {
+        return spawnResult(128, "", "fatal: not a git repository");
+      }
+      return spawnResult(0);
+    });
+
+    await expect(
+      pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
+    ).rejects.toThrow(/git status failed/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("refuses to push over the base branch", async () => {
     await expect(
       pushStep.run(

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -1,0 +1,17 @@
+const MAX_BRANCH_SUMMARY_LENGTH = 48;
+
+function slugify(value: string, fallback: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_BRANCH_SUMMARY_LENGTH)
+    .replace(/-+$/g, "");
+  return slug || fallback;
+}
+
+export function buildIssueBranchName(issueIdentifier: string, issueTitle: string): string {
+  const key = slugify(issueIdentifier, "issue");
+  const summary = slugify(issueTitle, "implementation");
+  return `ai-implement/${key}-${summary}`;
+}

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -1,7 +1,7 @@
 const MAX_BRANCH_SUMMARY_LENGTH = 48;
 
-function slugify(value: string, fallback: string): string {
-  const slug = value
+function slugify(value: string | undefined, fallback: string): string {
+  const slug = (value ?? "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
@@ -10,7 +10,7 @@ function slugify(value: string, fallback: string): string {
   return slug || fallback;
 }
 
-export function buildIssueBranchName(issueIdentifier: string, issueTitle: string): string {
+export function buildIssueBranchName(issueIdentifier: string | undefined, issueTitle: string | undefined): string {
   const key = slugify(issueIdentifier, "issue");
   const summary = slugify(issueTitle, "implementation");
   return `ai-implement/${key}-${summary}`;

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
 import type { PipelineContext, PipelineDefinition, StepDefinition, StepType } from "./types.js";
 import { resolveModule, type ResolveModuleOptions } from "./resolve-module.js";
+import { buildIssueBranchName } from "./branch-name.js";
 
 const VALID_STEP_TYPES = new Set<StepType>([
   "clone",
@@ -138,7 +139,9 @@ function applyWiring(step: YamlStep): StepDefinition {
           repoOwner: ctx.getOutputs("clone").repoOwner,
           repoRepo: ctx.getOutputs("clone").repoRepo,
           githubToken: ctx.getOutputs("clone").githubToken,
-          branchName: ctx.getOutputs("clone").branch,
+          branchName: buildIssueBranchName(ctx.data.issueIdentifier, ctx.data.issueTitle),
+          baseBranch: ctx.getOutputs("clone").branch,
+          prTitle: `${ctx.data.issueIdentifier}: ${ctx.data.issueTitle}`,
         }),
         skip: (ctx: PipelineContext) => ctx.getOutputs("feedback-loop").approved !== true,
       };

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -34,17 +34,18 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     }
 
     runGit(workspaceDir, ["checkout", "-B", branchName], githubToken, "git checkout");
-    if (hasWorkingTreeChanges(workspaceDir)) {
-      runGit(workspaceDir, ["config", "user.name", "ai-implement[bot]"], githubToken, "git config user.name");
-      runGit(
-        workspaceDir,
-        ["config", "user.email", "ai-implement[bot]@users.noreply.github.com"],
-        githubToken,
-        "git config user.email",
-      );
-      runGit(workspaceDir, ["add", "-A"], githubToken, "git add");
-      runGit(workspaceDir, ["commit", "-m", buildCommitMessage(issueIdentifier, issueTitle)], githubToken, "git commit");
+    if (!hasWorkingTreeChanges(workspaceDir, githubToken)) {
+      throw new Error("Nothing to commit: Claude left no file changes in the working tree");
     }
+    runGit(workspaceDir, ["config", "user.name", "ai-implement[bot]"], githubToken, "git config user.name");
+    runGit(
+      workspaceDir,
+      ["config", "user.email", "ai-implement[bot]@users.noreply.github.com"],
+      githubToken,
+      "git config user.email",
+    );
+    runGit(workspaceDir, ["add", "-A"], githubToken, "git add");
+    runGit(workspaceDir, ["commit", "-m", buildCommitMessage(issueIdentifier, issueTitle)], githubToken, "git commit");
     const commitSha = resolveCommitSha(workspaceDir);
 
     // Embed token in URL but use stdio: "pipe" so it is never printed to inherited
@@ -136,12 +137,15 @@ function runGit(
   }
 }
 
-function hasWorkingTreeChanges(workspaceDir: string): boolean {
+function hasWorkingTreeChanges(workspaceDir: string, githubToken: string): boolean {
   const result = spawnSync("git", ["status", "--porcelain"], {
     cwd: workspaceDir,
     stdio: ["ignore", "pipe", "pipe"],
   });
-  if (result.status !== 0) return false;
+  if (result.status !== 0) {
+    const stderr = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    throw new Error(`git status failed (exit ${result.status ?? "null"}): ${stderr}`);
+  }
   return result.stdout.toString().trim().length > 0;
 }
 

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -25,10 +25,26 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     _reporter: StepReporter,
   ): Promise<PushOutputs> {
     const { workspaceDir, repoOwner, repoRepo, githubToken, branchName } = inputs;
-    const { issueIdentifier } = context.data;
+    const { issueIdentifier, issueTitle } = context.data;
     const baseBranch = String(inputs.baseBranch ?? "main");
-    const prTitle = String(inputs.prTitle ?? `${issueIdentifier}: AI implementation`);
+    const prTitle = String(inputs.prTitle ?? `${issueIdentifier}: ${issueTitle || "AI implementation"}`);
 
+    if (!branchName || branchName === baseBranch) {
+      throw new Error(`Refusing to push implementation branch "${branchName}" over base branch "${baseBranch}"`);
+    }
+
+    runGit(workspaceDir, ["checkout", "-B", branchName], githubToken, "git checkout");
+    if (hasWorkingTreeChanges(workspaceDir)) {
+      runGit(workspaceDir, ["config", "user.name", "ai-implement[bot]"], githubToken, "git config user.name");
+      runGit(
+        workspaceDir,
+        ["config", "user.email", "ai-implement[bot]@users.noreply.github.com"],
+        githubToken,
+        "git config user.email",
+      );
+      runGit(workspaceDir, ["add", "-A"], githubToken, "git add");
+      runGit(workspaceDir, ["commit", "-m", buildCommitMessage(issueIdentifier, issueTitle)], githubToken, "git commit");
+    }
     const commitSha = resolveCommitSha(workspaceDir);
 
     // Embed token in URL but use stdio: "pipe" so it is never printed to inherited
@@ -98,6 +114,36 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     throw new Error(`PR creation failed with HTTP ${prRes.status}: ${body}`);
   },
 };
+
+function buildCommitMessage(issueIdentifier: string, issueTitle: string): string {
+  const title = (issueTitle || "AI implementation").replace(/\s+/g, " ").trim();
+  return `${issueIdentifier}: ${title}`.slice(0, 120);
+}
+
+function runGit(
+  workspaceDir: string,
+  args: string[],
+  githubToken: string,
+  label: string,
+): void {
+  const result = spawnSync("git", args, {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    throw new Error(`${label} failed (exit ${result.status ?? "null"}): ${stderr}`);
+  }
+}
+
+function hasWorkingTreeChanges(workspaceDir: string): boolean {
+  const result = spawnSync("git", ["status", "--porcelain"], {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) return false;
+  return result.stdout.toString().trim().length > 0;
+}
 
 function resolveCommitSha(workspaceDir: string): string | null {
   const result = spawnSync("git", ["rev-parse", "HEAD"], {

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -62,7 +62,7 @@ export interface PipelineContextData {
   githubRepo?: string;
   /** Autonomous runner: token used for clone/push. */
   githubToken?: string;
-  /** Autonomous runner: branch to clone/push. */
+  /** Autonomous runner: base branch to clone. Implementation branches are derived per issue. */
   branch?: string;
 }
 

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -52,12 +52,23 @@ ${issueDescription}`;
 
 ## New implementation
 
-Create a branch named "${issueIdentifier}/short-description" then implement the feature below and open a PR with title "${issueIdentifier}: ${issueTitle}". The PR body must include "Fixes ${issueIdentifier}" so Linear auto-closes the issue on merge.
+Implement the feature below in the current checkout. Do not create a branch, commit, push, or open a PR. Leave your file changes unstaged and uncommitted; the AI-Implement pipeline will commit, push an issue-scoped branch, and open the PR after review passes.
 
 **Issue:** ${issueIdentifier}
 **Title:** ${issueTitle}
 **Description:**
 ${issueDescription}`;
+}
+
+function appendPipelineOwnedGitInstructions(prompt: string, prNumber: string): string {
+  if (prNumber) return prompt;
+  return `${prompt.trimEnd()}
+
+## Pipeline-owned Git and PR handling
+
+Do NOT create or switch branches. Do NOT commit, push, or open a pull request.
+Modify files only in the current checkout and leave the working tree changes unstaged and uncommitted.
+The AI-Implement pipeline will create the implementation commit, push an issue-scoped branch, and open the PR after review passes.`;
 }
 
 export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<RunAutonomousResult> {
@@ -101,6 +112,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     workflowModel = parsed.frontMatter.model;
     if (parsed.body.trim()) implementationPrompt = parsed.body;
   }
+  implementationPrompt = appendPipelineOwnedGitInstructions(implementationPrompt, prNumber);
   const model = process.env.CLAUDE_MODEL || workflowModel || "claude-sonnet-4-6";
 
   const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir);

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -62,6 +62,7 @@ ${issueDescription}`;
 
 function appendPipelineOwnedGitInstructions(prompt: string, prNumber: string): string {
   if (prNumber) return prompt;
+  if (prompt.includes("Pipeline-owned Git")) return prompt;
   return `${prompt.trimEnd()}
 
 ## Pipeline-owned Git and PR handling

--- a/workflows/WORKFLOW.md
+++ b/workflows/WORKFLOW.md
@@ -119,15 +119,15 @@ Read CLAUDE.md if it exists for repo-specific context and conventions.
 
 ## New implementation
 
-Create a branch named `${ISSUE_IDENTIFIER}/short-description`, implement the
-feature described in the issue below, then open a pull request with:
+Implement the feature described in the issue below in the current checkout.
+Do NOT create or switch branches. Do NOT commit, push, or open a pull request.
+Leave your file changes unstaged and uncommitted. The AI-Implement pipeline
+will create the implementation commit, push an issue-scoped branch, and open
+the PR after review passes. The generated PR body includes
+`Fixes ${ISSUE_IDENTIFIER}` so the ticketing system automatically closes the
+issue when the PR is merged (Linear behaviour; Jira ignores it harmlessly).
 
-- **Title:** `${ISSUE_IDENTIFIER}: ${ISSUE_TITLE}`
-- **Body:** must include `Fixes ${ISSUE_IDENTIFIER}` so the ticketing system
-  automatically closes the issue when the PR is merged (Linear behaviour;
-  Jira ignores it harmlessly).
-
-After the PR is opened, write a brief implementation summary to
+After making the code changes, write a brief implementation summary to
 `ai-output/comments/01-summary.md` (e.g. a paragraph describing what
 changed plus a checklist of what was tested). The orchestrator reads this
 file and posts it back to the ticketing issue via the configured provider.


### PR DESCRIPTION
## Summary
- Move new implementation Git/PR ownership out of Claude and into the TypeScript pipeline.
- Generate deterministic issue-scoped branches like `ai-implement/gen-123-add-login-flow` instead of pushing to the cloned base branch.
- Have the push step create the local implementation branch, commit approved working-tree changes, push that branch, and open/find the PR.
- Append runtime guardrails so stale repo `WORKFLOW.md` files cannot keep telling Claude to create branches or PRs.

## Why
A Fly run successfully produced a PR, but the TS pipeline then tried to push `HEAD -> main` and failed with stale info. That happened because the pipeline wired `branchName` from the cloned default branch. This change makes `main` the PR base only, never the implementation push target.

## Verification
- npm test -- src/__tests__/steps-push.test.ts src/__tests__/pipeline-loader.test.ts src/__tests__/run-autonomous.test.ts src/__tests__/branch-name.test.ts
- npm run typecheck
- npm test