### PR TITLE
Stabilize Fly reruns and runner callbacks

### DIFF
--- a/src/__tests__/fly-machines.test.ts
+++ b/src/__tests__/fly-machines.test.ts
@@ -579,6 +579,16 @@ describe("buildSessionMachineConfig", () => {
     expect(result.config.env!.CUSTOM_VAR).toBe("hello");
   });
 
+  it("injects runner callback env when provided", () => {
+    const result = buildSessionMachineConfig({
+      ...baseInput,
+      runnerCallbackUrl: "https://orchestrator.example",
+      runToken: "run-token",
+    });
+    expect(result.config.env!.RUNNER_CALLBACK_URL).toBe("https://orchestrator.example");
+    expect(result.config.env!.RUN_TOKEN).toBe("run-token");
+  });
+
   it("extraEnv overrides standard env vars when keys collide", () => {
     const result = buildSessionMachineConfig({
       ...baseInput,

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runAutonomous } from "../run-autonomous.js";
@@ -50,6 +50,8 @@ describe("runAutonomous", () => {
     vi.stubEnv("LINEAR_API_KEY", "");
     vi.stubEnv("ORCHESTRATOR_URL", "");
     vi.stubEnv("MACHINE_NONCE", "");
+    vi.stubEnv("RUNNER_CALLBACK_URL", "");
+    vi.stubEnv("RUN_TOKEN", "");
     vi.stubEnv("CLAUDE_MODEL", "");
     vi.stubEnv("PR_NUMBER", "");
   });
@@ -465,6 +467,78 @@ describe("runAutonomous", () => {
     expect(extras.githubOwner).toBe("acme");
     expect(extras.githubRepo).toBe("app");
     expect(extras.prNumber).toBe("42");
+  });
+
+  it("posts implementation callback comments after successful push", async () => {
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orchestrator.example");
+    vi.stubEnv("RUN_TOKEN", "run-token");
+    mkdirSync(join(workspaceDir, "ai-output", "comments"), { recursive: true });
+    writeFileSync(join(workspaceDir, "ai-output", "comments", "02-second.md"), "second");
+    writeFileSync(join(workspaceDir, "ai-output", "comments", "01-first.md"), "first");
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+    const mod: StepModule = { run: vi.fn().mockResolvedValue({ prUrl: "https://github.com/acme/app/pull/1" }) };
+    const { pipeline, runner } = makeSingleStepPipeline("push", mod);
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://orchestrator.example/runner/result",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer run-token" }),
+      }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
+      phase: string;
+      outcome: string;
+      prUrl: string;
+      comments: Array<{ body: string }>;
+    };
+    expect(body).toMatchObject({
+      phase: "implementation",
+      outcome: "success",
+      prUrl: "https://github.com/acme/app/pull/1",
+    });
+    expect(body.comments).toEqual([{ body: "first" }, { body: "second" }]);
+  });
+
+  it("posts implementation failure callback when pipeline fails", async () => {
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orchestrator.example/");
+    vi.stubEnv("RUN_TOKEN", "run-token");
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+    const mod: StepModule = { run: vi.fn().mockRejectedValue(new Error("push failed")) };
+    const { pipeline, runner } = makeSingleStepPipeline("push", mod);
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(result.exitCode).toBe(1);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
+      phase: string;
+      outcome: string;
+      failureReason: string;
+    };
+    expect(body).toMatchObject({
+      phase: "implementation",
+      outcome: "failure",
+      failureReason: "push failed",
+    });
   });
 
   it("throws when a required env var is missing", async () => {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -541,6 +541,53 @@ describe("runAutonomous", () => {
     });
   });
 
+  it("skips success callback when push produces no PR URL", async () => {
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orchestrator.example");
+    vi.stubEnv("RUN_TOKEN", "run-token");
+
+    const mockFetch = vi.fn();
+    const mod: StepModule = { run: vi.fn().mockResolvedValue({}) };
+    const { pipeline, runner } = makeSingleStepPipeline("push", mod);
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("continues callback with empty comments when comment collection fails", async () => {
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orchestrator.example");
+    vi.stubEnv("RUN_TOKEN", "run-token");
+    mkdirSync(join(workspaceDir, "ai-output"), { recursive: true });
+    writeFileSync(join(workspaceDir, "ai-output", "comments"), "not a directory");
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+    const mod: StepModule = { run: vi.fn().mockResolvedValue({ prUrl: "https://github.com/acme/app/pull/1" }) };
+    const { pipeline, runner } = makeSingleStepPipeline("push", mod);
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
+      comments: Array<{ body: string }>;
+    };
+    expect(body.comments).toEqual([]);
+  });
+
   it("throws when a required env var is missing", async () => {
     vi.stubEnv("ISSUE_ID", "");
 

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -48,6 +48,9 @@ function mockGitSuccess(sha = "deadbeef", dirty = true) {
     const gitArgs = args as string[];
     if (gitArgs[0] === "status") return spawnResult(0, dirty ? " M src/app.ts\n" : "");
     if (gitArgs[0] === "rev-parse") return spawnResult(0, `${sha}\n`);
+    if (gitArgs[0] === "ls-remote") {
+      return spawnResult(0, "beadfeed\trefs/heads/ai-implement/eng-42-feature\n");
+    }
     return spawnResult(0);
   });
 }
@@ -103,6 +106,9 @@ describe("pushStep", () => {
       const gitArgs = args as string[];
       if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
       if (gitArgs[0] === "rev-parse") return spawnResult(0, "sha\n");
+      if (gitArgs[0] === "ls-remote") {
+        return spawnResult(0, "beadfeed\trefs/heads/ai-implement/eng-42-feature\n");
+      }
       if (gitArgs[0] === "push") {
         return spawnResult(128, "", "fatal: gh-token authentication failed");
       }
@@ -205,9 +211,56 @@ describe("pushStep", () => {
     );
     expect(spawnSync).toHaveBeenCalledWith(
       "git",
-      expect.arrayContaining(["push", expect.any(String), "HEAD:refs/heads/ai-implement/eng-42-feature"]),
+      expect.arrayContaining([
+        "push",
+        expect.any(String),
+        "HEAD:refs/heads/ai-implement/eng-42-feature",
+        "--force-with-lease=refs/heads/ai-implement/eng-42-feature:beadfeed",
+      ]),
       expect.objectContaining({ cwd: "/tmp/workspace" }),
     );
+  });
+
+  it("uses an empty explicit lease when the remote implementation branch does not exist", async () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
+      if (gitArgs[0] === "rev-parse") return spawnResult(0, "sha\n");
+      if (gitArgs[0] === "ls-remote") return spawnResult(0, "");
+      return spawnResult(0);
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: "https://github.com/acme/app/pull/1", number: 1 }),
+    } as Response);
+
+    await pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining([
+        "push",
+        expect.any(String),
+        "HEAD:refs/heads/ai-implement/eng-42-feature",
+        "--force-with-lease=refs/heads/ai-implement/eng-42-feature:",
+      ]),
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+  });
+
+  it("throws when remote lease lookup fails", async () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
+      if (gitArgs[0] === "rev-parse") return spawnResult(0, "sha\n");
+      if (gitArgs[0] === "ls-remote") return spawnResult(128, "", "fatal: gh-token auth failed");
+      return spawnResult(0);
+    });
+
+    await expect(
+      pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
+    ).rejects.toThrow(/git ls-remote failed/);
   });
 
   it("throws when Claude leaves no working tree changes", async () => {

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -260,7 +260,62 @@ describe("pushStep", () => {
 
     await expect(
       pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
-    ).rejects.toThrow(/git ls-remote failed/);
+    ).rejects.toThrow(/git ls-remote failed after 3 attempts/);
+    const lsRemoteCalls = vi.mocked(spawnSync).mock.calls.filter(
+      (call) => (call[1] as string[])[0] === "ls-remote",
+    );
+    expect(lsRemoteCalls).toHaveLength(3);
+  });
+
+  it("retries transient remote lease lookup failures", async () => {
+    let lsRemoteAttempts = 0;
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
+      if (gitArgs[0] === "rev-parse") return spawnResult(0, "sha\n");
+      if (gitArgs[0] === "ls-remote") {
+        lsRemoteAttempts++;
+        if (lsRemoteAttempts < 3) return spawnResult(128, "", "temporary DNS failure");
+        return spawnResult(0, "beadfeed\trefs/heads/ai-implement/eng-42-feature\n");
+      }
+      return spawnResult(0);
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: "https://github.com/acme/app/pull/1", number: 1 }),
+    } as Response);
+
+    await pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    expect(lsRemoteAttempts).toBe(3);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining([
+        "push",
+        expect.any(String),
+        "HEAD:refs/heads/ai-implement/eng-42-feature",
+        "--force-with-lease=refs/heads/ai-implement/eng-42-feature:beadfeed",
+      ]),
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+  });
+
+  it("looks up the exact implementation branch ref for the remote lease", async () => {
+    mockGitSuccess();
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: "https://github.com/acme/app/pull/1", number: 1 }),
+    } as Response);
+
+    await pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["ls-remote", expect.any(String), "refs/heads/ai-implement/eng-42-feature"],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
   });
 
   it("throws when Claude leaves no working tree changes", async () => {

--- a/src/fly-machines.ts
+++ b/src/fly-machines.ts
@@ -350,6 +350,8 @@ export interface SessionMachineInput {
   teamSecretNames?: string[]; // full prefixed secret names from the Fly app (e.g. ["ENG_DATABASE_URL"])
   minSecretsVersion?: number;
   orchestratorUrl?: string;
+  runnerCallbackUrl?: string;
+  runToken?: string;
   orchestratorApp?: string; // Fly app name of this orchestrator, stamped into machine metadata
   tenantId?: string; // client slug (e.g. "acme-corp"), stamped as tenant_id in metadata
   expectedTtlSeconds?: number; // expected machine lifetime in seconds, stamped in metadata for reaper
@@ -383,6 +385,12 @@ export function buildSessionMachineConfig(input: SessionMachineInput): CreateMac
   }
   if (input.orchestratorUrl) {
     env.ORCHESTRATOR_URL = input.orchestratorUrl;
+  }
+  if (input.runnerCallbackUrl) {
+    env.RUNNER_CALLBACK_URL = input.runnerCallbackUrl;
+  }
+  if (input.runToken) {
+    env.RUN_TOKEN = input.runToken;
   }
   if (input.extraEnv) {
     Object.assign(env, input.extraEnv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -504,6 +504,20 @@ async function dispatchFlyMachine(
 
   const ghToken = await getInstallationToken(config.githubAppId, config.githubAppPrivateKey, mapping.owner);
 
+  let runnerCallbackUrl = "";
+  let runToken = "";
+  if (config.runnerCallbackBaseUrl && config.runnerTokenSecret) {
+    const minted = mintRunToken({
+      issueId: issue.id,
+      mappingTeamKey: issue.scopeKey,
+      phase: "implementation",
+      ttlSeconds: IMPLEMENTATION_TTL_SECONDS,
+      secret: config.runnerTokenSecret,
+    });
+    runnerCallbackUrl = config.runnerCallbackBaseUrl;
+    runToken = minted.token;
+  }
+
   const { image: resolvedImage, source: imageSource } = await resolveSessionImage({
     owner: mapping.owner,
     repo: mapping.repo,
@@ -535,6 +549,8 @@ async function dispatchFlyMachine(
     teamSecretNames: allSecretNames,
     minSecretsVersion: minSecretsVersion ?? undefined,
     orchestratorUrl: config.orchestratorUrl ?? undefined,
+    runnerCallbackUrl: runnerCallbackUrl || undefined,
+    runToken: runToken || undefined,
     orchestratorApp: config.flyOrchestratorApp ?? undefined,
     tenantId: config.tenantId ?? undefined,
     expectedTtlSeconds: Math.round(SWEEP_MACHINE_MAX_AGE_MS / 1000),

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -1,6 +1,9 @@
 import { spawnSync } from "node:child_process";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 
+const LS_REMOTE_MAX_ATTEMPTS = 3;
+const LS_REMOTE_RETRY_DELAYS_MS = [250, 1000];
+
 interface PushInputs extends Record<string, unknown> {
   workspaceDir: string;
   repoOwner: string;
@@ -171,15 +174,32 @@ function resolveRemoteBranchSha(
   branchName: string,
   githubToken: string,
 ): string | null {
-  const result = spawnSync("git", ["ls-remote", "--heads", remote, branchName], {
-    cwd: workspaceDir,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result.status !== 0) {
-    const stderr = (result.stderr?.toString() ?? "").replace(githubToken, "***");
-    throw new Error(`git ls-remote failed (exit ${result.status ?? "null"}): ${stderr}`);
+  const remoteRef = `refs/heads/${branchName}`;
+  let lastError = "";
+  for (let attempt = 1; attempt <= LS_REMOTE_MAX_ATTEMPTS; attempt++) {
+    const result = spawnSync("git", ["ls-remote", remote, remoteRef], {
+      cwd: workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (result.status === 0) {
+      const line = result.stdout
+        .toString()
+        .trim()
+        .split("\n")
+        .find((entry) => entry.endsWith(`\t${remoteRef}`));
+      if (!line) return null;
+      return line.split("\t")[0] || null;
+    }
+
+    lastError = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    if (attempt < LS_REMOTE_MAX_ATTEMPTS) {
+      sleepSync(LS_REMOTE_RETRY_DELAYS_MS[attempt - 1] ?? 1000);
+    }
   }
-  const line = result.stdout.toString().trim();
-  if (!line) return null;
-  return line.split(/\s+/)[0] || null;
+  throw new Error(`git ls-remote failed after ${LS_REMOTE_MAX_ATTEMPTS} attempts: ${lastError}`);
+}
+
+function sleepSync(ms: number): void {
+  if (process.env.NODE_ENV === "test") return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -51,9 +51,16 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     // Embed token in URL but use stdio: "pipe" so it is never printed to inherited
     // stdout/stderr. Token is redacted from any error messages.
     const remote = `https://x-access-token:${githubToken}@github.com/${repoOwner}/${repoRepo}.git`;
+    const remoteRef = `refs/heads/${branchName}`;
+    const expectedRemoteSha = resolveRemoteBranchSha(workspaceDir, remote, branchName, githubToken);
     const pushResult = spawnSync(
       "git",
-      ["push", remote, `HEAD:refs/heads/${branchName}`, "--force-with-lease"],
+      [
+        "push",
+        remote,
+        `HEAD:${remoteRef}`,
+        `--force-with-lease=${remoteRef}:${expectedRemoteSha ?? ""}`,
+      ],
       { cwd: workspaceDir, stdio: ["ignore", "pipe", "pipe"] },
     );
     if (pushResult.status !== 0) {
@@ -156,4 +163,23 @@ function resolveCommitSha(workspaceDir: string): string | null {
   });
   if (result.status !== 0) return null;
   return result.stdout.toString().trim() || null;
+}
+
+function resolveRemoteBranchSha(
+  workspaceDir: string,
+  remote: string,
+  branchName: string,
+  githubToken: string,
+): string | null {
+  const result = spawnSync("git", ["ls-remote", "--heads", remote, branchName], {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    throw new Error(`git ls-remote failed (exit ${result.status ?? "null"}): ${stderr}`);
+  }
+  const line = result.stdout.toString().trim();
+  if (!line) return null;
+  return line.split(/\s+/)[0] || null;
 }

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -92,18 +92,25 @@ async function postRunnerResult(params: {
   const runToken = process.env.RUN_TOKEN;
   if (!callbackUrl || !runToken) return;
 
-  const body: Record<string, unknown> = {
-    phase: "implementation",
-    outcome: params.outcome,
-    comments: collectRunnerComments(params.workspaceDir),
-  };
-  if (params.prUrl) body.prUrl = params.prUrl;
-  if (params.failureReason) body.failureReason = params.failureReason;
-
   if (params.outcome === "success" && !params.prUrl) {
     console.warn("RUNNER_CALLBACK_URL is set but no PR URL was produced; skipping runner result callback.");
     return;
   }
+
+  let comments: Array<{ body: string }> = [];
+  try {
+    comments = collectRunnerComments(params.workspaceDir);
+  } catch (err) {
+    console.warn("[runner-callback] Failed to collect runner comments; continuing with no comments:", err);
+  }
+
+  const body: Record<string, unknown> = {
+    phase: "implementation",
+    outcome: params.outcome,
+    comments,
+  };
+  if (params.prUrl) body.prUrl = params.prUrl;
+  if (params.failureReason) body.failureReason = params.failureReason;
 
   const fetchFn = params.fetchImpl ?? fetch;
   try {

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { ClaudeCliExecutor } from "./pipeline/executor.js";
 import { DefaultPipelineContext } from "./pipeline/context.js";
@@ -70,6 +70,58 @@ function appendPipelineOwnedGitInstructions(prompt: string, prNumber: string): s
 Do NOT create or switch branches. Do NOT commit, push, or open a pull request.
 Modify files only in the current checkout and leave the working tree changes unstaged and uncommitted.
 The AI-Implement pipeline will create the implementation commit, push an issue-scoped branch, and open the PR after review passes.`;
+}
+
+function collectRunnerComments(workspaceDir: string): Array<{ body: string }> {
+  const commentsDir = join(workspaceDir, "ai-output", "comments");
+  if (!existsSync(commentsDir)) return [];
+  return readdirSync(commentsDir)
+    .filter((name) => name.endsWith(".md"))
+    .sort()
+    .map((name) => ({ body: readFileSync(join(commentsDir, name), "utf-8") }));
+}
+
+async function postRunnerResult(params: {
+  workspaceDir: string;
+  outcome: "success" | "failure";
+  prUrl?: string;
+  failureReason?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const callbackUrl = process.env.RUNNER_CALLBACK_URL;
+  const runToken = process.env.RUN_TOKEN;
+  if (!callbackUrl || !runToken) return;
+
+  const body: Record<string, unknown> = {
+    phase: "implementation",
+    outcome: params.outcome,
+    comments: collectRunnerComments(params.workspaceDir),
+  };
+  if (params.prUrl) body.prUrl = params.prUrl;
+  if (params.failureReason) body.failureReason = params.failureReason;
+
+  if (params.outcome === "success" && !params.prUrl) {
+    console.warn("RUNNER_CALLBACK_URL is set but no PR URL was produced; skipping runner result callback.");
+    return;
+  }
+
+  const fetchFn = params.fetchImpl ?? fetch;
+  try {
+    const res = await fetchFn(`${callbackUrl.replace(/\/$/, "")}/runner/result`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${runToken}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`[runner-callback] POST /runner/result failed with HTTP ${res.status}: ${text}`);
+    }
+  } catch (err) {
+    console.error("[runner-callback] POST /runner/result failed:", err);
+  }
 }
 
 export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<RunAutonomousResult> {
@@ -155,9 +207,22 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     const pipeline = opts.pipeline ?? DEFAULT_PIPELINE;
     const runner = opts.runner ?? (await createDefaultRunner());
     await runner.run(pipeline, context, reporter);
+    const pushOutputs = context.getOutputs("push");
+    await postRunnerResult({
+      workspaceDir,
+      outcome: "success",
+      prUrl: typeof pushOutputs.prUrl === "string" ? pushOutputs.prUrl : undefined,
+      fetchImpl: opts.fetchImpl,
+    });
     return { exitCode: 0 };
   } catch (err) {
     console.error(`Pipeline failed: ${err}`);
+    await postRunnerResult({
+      workspaceDir,
+      outcome: "failure",
+      failureReason: err instanceof Error ? err.message : String(err),
+      fetchImpl: opts.fetchImpl,
+    });
     return { exitCode: 1 };
   }
 }


### PR DESCRIPTION
## Summary
- Fix Fly rerun pushes to existing `ai-implement/...` branches by leasing against the remote branch SHA from `git ls-remote` instead of relying on fresh-clone tracking state.
- Use an empty explicit lease when the implementation branch does not exist yet.
- Pass runner callback URL/token into Fly machines when callback config is enabled.
- Have the TypeScript autonomous runner POST implementation success/failure results and sorted `ai-output/comments/*.md` files to `/runner/result`.

## Why
GEN-64 got into a re-dispatch loop after PR #60 was created because each fresh Fly clone pushed with implicit `--force-with-lease`, but had no local tracking ref for the existing implementation branch, producing `(stale info)`. Also, Fly sessions were not wired into the existing runner callback path, so output comments had no route back to the orchestrator.

## Verification
- npm test -- src/__tests__/steps-push.test.ts src/__tests__/run-autonomous.test.ts src/__tests__/fly-machines.test.ts
- npm run typecheck
- npm test