### PR TITLE
Fix Jira custom-field JQL references

### DIFF
--- a/src/__tests__/providers/jira.test.ts
+++ b/src/__tests__/providers/jira.test.ts
@@ -121,7 +121,12 @@ const baseMapping: Omit<RepoMapping, "ticketingProvider" | "ticketingConfig"> = 
 };
 
 const jiraMapping = (
-  overrides: Partial<{ jql: string; repoFieldValue: string }> = {},
+  overrides: Partial<{
+    jql: string;
+    repoFieldValue: string;
+    statusFieldOverride: string | null;
+    repoFieldOverride: string | null;
+  }> = {},
 ): RepoMapping => ({
   ...baseMapping,
   ticketingProvider: "jira",
@@ -129,6 +134,8 @@ const jiraMapping = (
     kind: "jira",
     jql: overrides.jql ?? "project = TEST",
     repoFieldValue: overrides.repoFieldValue ?? "acme/x",
+    statusFieldOverride: overrides.statusFieldOverride,
+    repoFieldOverride: overrides.repoFieldOverride,
   },
 });
 
@@ -346,7 +353,7 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
     expect(snap.needsPlanning[0].scopeKey).toBe("acme/x");
   });
 
-  it("references the status field by customfield id in the JQL wrapper (not a hardcoded display name)", async () => {
+  it("references custom fields with cf[n] syntax in the JQL wrapper", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(FIELDS_RESPONSE)
       .mockResolvedValueOnce(searchOk([]))
@@ -362,10 +369,35 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
     // Search calls are the 2nd and 3rd fetches; listFields is the 1st.
     const bucketBody = JSON.parse(vi.mocked(fetch).mock.calls[1][1]?.body as string);
     const capacityBody = JSON.parse(vi.mocked(fetch).mock.calls[2][1]?.body as string);
-    expect(bucketBody.jql).toContain("customfield_10100");
+    expect(bucketBody.jql).toContain("cf[10100]");
+    expect(bucketBody.jql).not.toContain("customfield_10100");
     expect(bucketBody.jql).not.toContain('"AI-Implement Status"');
-    expect(capacityBody.jql).toContain("customfield_10100");
+    expect(capacityBody.jql).toContain("cf[10100]");
+    expect(capacityBody.jql).not.toContain("customfield_10100");
     expect(capacityBody.jql).not.toContain('"AI-Implement Status"');
+  });
+
+  it("leaves non-customfield status overrides unchanged in the JQL wrapper", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(searchOk([]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-jql-passthrough" }),
+      cacheScope: "c-jql-passthrough", siteUrl: "https://x",
+      getMappings: () => ({
+        "acme/x": jiraMapping({
+          statusFieldOverride: "status",
+          repoFieldOverride: "customfield_10101",
+        }),
+      }),
+    });
+    await p.fetchAIImplementSnapshot();
+
+    const bucketBody = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    const capacityBody = JSON.parse(vi.mocked(fetch).mock.calls[1][1]?.body as string);
+    expect(bucketBody.jql).toContain("status in (Ready");
+    expect(capacityBody.jql).toContain("status in (Planning");
   });
 
   it("counts capacity from the in-flight query", async () => {

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -36,6 +36,11 @@ function adfToPlainText(adf: unknown): string {
   return out.join("").replace(/\n{3,}/g, "\n\n").trim();
 }
 
+function jqlFieldRef(fieldId: string): string {
+  const match = /^customfield_(\d+)$/.exec(fieldId);
+  return match ? `cf[${match[1]}]` : fieldId;
+}
+
 export interface JiraProviderConstructor {
   client: JiraClient;
   /** Per-instance cache scope label; typically the cloud ID. */
@@ -145,8 +150,11 @@ export class JiraProvider implements TicketingProvider {
       // Reference the status field by its resolved customfield id, not a hardcoded
       // display name. Jira instances often name the field differently than
       // "AI-Implement Status" (e.g. "ai-implement-status" or "AI-Implement-Status"),
-      // and JQL's quoted-name lookup requires an exact match.
-      const bucketJql = `(${cfg.jql}) AND ${fieldIds.statusFieldId} in (Ready, "Plan Approved")`;
+      // and JQL's quoted-name lookup requires an exact match. REST uses
+      // customfield_N ids; JQL on some instances requires cf[N], so transform
+      // before interpolating.
+      const statusJqlField = jqlFieldRef(fieldIds.statusFieldId);
+      const bucketJql = `(${cfg.jql}) AND ${statusJqlField} in (Ready, "Plan Approved")`;
       const bucketIssues = await this.client.searchJql(bucketJql, fieldsToFetch);
 
       for (const raw of bucketIssues) {
@@ -168,7 +176,7 @@ export class JiraProvider implements TicketingProvider {
         // else: orchestrator picked it up between query and our processing; skip.
       }
 
-      const capacityJql = `(${cfg.jql}) AND ${fieldIds.statusFieldId} in (Planning, Implementing)`;
+      const capacityJql = `(${cfg.jql}) AND ${statusJqlField} in (Planning, Implementing)`;
       const capacityIssues = await this.client.searchJql(capacityJql, ["summary"]);
       inProgressCountsByScope[scopeKey] = capacityIssues.length;
     }


### PR DESCRIPTION
## Summary
- Reference Jira custom fields with `cf[n]` JQL syntax instead of `customfield_n`, which Jira's JQL parser does not accept in all positions.
- Update the JQL-wrapper tests to assert the `cf[n]` form (and that `customfield_n` is absent from JQL bodies; it remains correct for REST field-update bodies).

Ported from the Cloudshare fork (originally landed there as #33). Clean cherry-pick onto `testing`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — Jira provider JQL tests green (1085 tests pass)