### PR TITLE
[codex] Bridge external review findings into fix passes

### DIFF
--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -269,12 +269,14 @@ describe("loadPipelineDefinition", () => {
 
     const ctx = makeContext();
     ctx.setOutputs("clone", { workspaceDir: "/tmp/repo" });
+    ctx.setOutputs("install", { reviewProviders: ["github-claude-code-review"] });
     ctx.setOutputs("push", { prNumber: 42, branchPushed: true });
 
     const step = pipeline.steps.find((s) => s.id === "post-push-review")!;
     const inputs = ctx.resolveInputs(step.inputs);
     expect(inputs.workspaceDir).toBe("/tmp/repo");
     expect(inputs.prNumber).toBe("42");
+    expect(inputs.reviewProviders).toEqual(["github-claude-code-review"]);
   });
 
   it("applies post-push-review skip condition based on push output", () => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -285,6 +285,59 @@ describe("postPushReviewStep", () => {
     ]);
   });
 
+  it("collects external findings when github-claude-code-review is configured", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Internal reviewer approves.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Configured provider blocker.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      {
+        prNumber: "42",
+        workspaceDir: "/tmp",
+        maxIterations: 2,
+        ghSpawn,
+        gitSpawn,
+        reviewProviders: ["github-claude-code-review"],
+      },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(ghSpawn).toHaveBeenCalledWith([
+      "api",
+      "--paginate",
+      "--slurp",
+      "repos/:owner/:repo/pulls/42/reviews?per_page=100",
+    ]);
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("Required external review findings");
+    expect(fixPrompt).toContain("Configured provider blocker.");
+  });
+
   it("deduplicates internal issues that repeat external review findings", async () => {
     const reviewerJson = JSON.stringify({
       approved: false,

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -628,6 +628,33 @@ describe("postPushReviewStep", () => {
     expect(gitSpawn).not.toHaveBeenCalledWith(["status", "--porcelain"]);
   });
 
+  it("does not treat resolved prior blockers in approval feedback as actionable", async () => {
+    const approvedWithResolvedBlockers = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Both Review 1 blockers are resolved. The expired-timer restart bug is fixed and the regression test covers it. Merge readiness: ready to merge.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: approvedWithResolvedBlockers, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(true);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(gitSpawn).not.toHaveBeenCalledWith(["status", "--porcelain"]);
+  });
+
   it("does not fail the job when post-push reviewer LLM exits non-zero", async () => {
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -11,6 +11,10 @@ function makeCtx(execMock: any) {
   } as any;
 }
 
+function countOccurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
 describe("postPushReviewStep", () => {
   it("approves on first iteration, posts ✅ comment, returns approved=true", async () => {
     const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
@@ -165,6 +169,7 @@ describe("postPushReviewStep", () => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
+    const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
@@ -174,6 +179,9 @@ describe("postPushReviewStep", () => {
           ]),
           exitCode: 0,
         };
+      }
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
       }
       return { stdout: "", exitCode: 0 };
     });
@@ -190,7 +198,53 @@ describe("postPushReviewStep", () => {
     expect(invoke).toHaveBeenCalledTimes(2);
     const fixPrompt = invoke.mock.calls[1][0].prompt;
     expect(fixPrompt).toContain("Required external review findings");
-    expect(fixPrompt).toContain("Missing UUID validation on path params.");
+    expect(countOccurrences(fixPrompt, "Missing UUID validation on path params.")).toBe(1);
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(reviewComment).toContain("External review findings are blocking this PR.");
+    expect(reviewComment).not.toContain("Missing UUID validation on path params.");
+  });
+
+  it("deduplicates internal issues that repeat external review findings", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: false,
+      issues: ["Missing UUID validation on path params."],
+      feedback: "External blocker is still unresolved.",
+      score: 4,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghComments: string[] = [];
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Missing UUID validation on path params.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(countOccurrences(fixPrompt, "Missing UUID validation on path params.")).toBe(1);
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(countOccurrences(reviewComment ?? "", "Missing UUID validation on path params.")).toBe(0);
   });
 
   it("runs a fix pass when approved feedback contains actionable language but issues is empty", async () => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -204,6 +204,87 @@ describe("postPushReviewStep", () => {
     expect(reviewComment).not.toContain("Missing UUID validation on path params.");
   });
 
+  it("preserves opportunistic external collection when reviewProviders is undefined", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Internal reviewer approves.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Fix UUID validation.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(ghSpawn).toHaveBeenCalledWith([
+      "api",
+      "--paginate",
+      "--slurp",
+      "repos/:owner/:repo/pulls/42/reviews?per_page=100",
+    ]);
+  });
+
+  it("skips external collection when reviewProviders is an empty array", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Internal reviewer approves.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Fix UUID validation.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn, reviewProviders: [] },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(true);
+    expect(ghSpawn).not.toHaveBeenCalledWith([
+      "api",
+      "--paginate",
+      "--slurp",
+      "repos/:owner/:repo/pulls/42/reviews?per_page=100",
+    ]);
+  });
+
   it("deduplicates internal issues that repeat external review findings", async () => {
     const reviewerJson = JSON.stringify({
       approved: false,

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -558,6 +558,51 @@ describe("postPushReviewStep", () => {
     expect(noChangesComment).not.toContain("Outstanding feedback");
   });
 
+  it("reports unresolved external findings when an externally blocked fix pass makes no changes", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Internal reviewer approves.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const ghComments: string[] = [];
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Fix UUID validation.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(out.forcePushedRevisions).toBe(0);
+    const noChangesComment = ghComments.find((comment) => comment.includes("no-changes"));
+    expect(noChangesComment).toContain("Unresolved external review findings");
+    expect(noChangesComment).toContain("Fix UUID validation.");
+    expect(noChangesComment).toContain("Not ready to merge");
+  });
+
   it("skips empty JSON preamble objects when parsing reviewer output", async () => {
     const reviewerJson = `pre-text {} ${JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "ok" })}`;
     const ghSpawn = vi.fn((args: string[]) => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -204,6 +204,65 @@ describe("postPushReviewStep", () => {
     expect(reviewComment).not.toContain("Missing UUID validation on path params.");
   });
 
+  it("runs a fix pass when a Claude issue comment has blocking findings and internal review approves", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Internal reviewer approves.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghComments: string[] = [];
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return { stdout: "[]", exitCode: 0 };
+      }
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/issues/42/comments?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            {
+              user: { login: "claude" },
+              body: "### Code Review\n\n## Blocking\n- Validate path params before database access.",
+              html_url: "https://example.com/claude-comment",
+            },
+          ]),
+          exitCode: 0,
+        };
+      }
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("Required external review findings");
+    expect(fixPrompt).toContain("Validate path params before database access.");
+    expect(ghSpawn).toHaveBeenCalledWith([
+      "api",
+      "--paginate",
+      "--slurp",
+      "repos/:owner/:repo/issues/42/comments?per_page=100",
+    ]);
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(reviewComment).toContain("External review findings are blocking this PR.");
+  });
+
   it("preserves opportunistic external collection when reviewProviders is undefined", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -485,7 +485,7 @@ describe("postPushReviewStep", () => {
     expect(countOccurrences(reviewComment ?? "", "Missing UUID validation on path params.")).toBe(0);
   });
 
-  it("runs a fix pass when approved feedback contains actionable language but issues is empty", async () => {
+  it("does not run a fix pass when approved feedback contains actionable language but issues is empty", async () => {
     const approvedWithFeedback = JSON.stringify({
       approved: true,
       issues: [],
@@ -510,9 +510,9 @@ describe("postPushReviewStep", () => {
       { report: vi.fn(async () => undefined) },
     );
 
-    expect(out.approved).toBe(false);
-    expect(invoke).toHaveBeenCalledTimes(2);
-    expect(invoke.mock.calls[1][0].prompt).toContain("Two minor issues worth addressing");
+    expect(out.approved).toBe(true);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(gitSpawn).not.toHaveBeenCalledWith(["status", "--porcelain"]);
   });
 
   it("does not run a fix pass for deferred future-task concerns", async () => {
@@ -569,11 +569,11 @@ describe("postPushReviewStep", () => {
     expect(gitSpawn).not.toHaveBeenCalledWith(["status", "--porcelain"]);
   });
 
-  it("approves malformed not-ready reviews when no actionable blocker is present", async () => {
+  it("requires structured issues when reviewer marks a PR not ready", async () => {
     const notReadyWithoutBlocker = JSON.stringify({
       approved: false,
-      issues: ["Clean resolution of the cosmetic note. All core requirements remain correctly in place. No regressions observed."],
-      feedback: "Clean resolution of the cosmetic note. All core requirements remain correctly in place. No regressions observed.",
+      issues: [],
+      feedback: "There is a bug in the timer restart flow, so this is not ready.",
       score: 9,
       progress_delta: 0,
     });
@@ -595,10 +595,11 @@ describe("postPushReviewStep", () => {
       { report: vi.fn(async () => undefined) },
     );
 
-    expect(out.approved).toBe(true);
+    expect(out.approved).toBe(false);
     expect(invoke).toHaveBeenCalledTimes(1);
-    expect(ghComments.some((comment) => comment.includes("Ready to merge"))).toBe(true);
-    expect(ghComments.some((comment) => comment.includes("Not ready to merge"))).toBe(false);
+    expect(gitSpawn).not.toHaveBeenCalledWith(["status", "--porcelain"]);
+    expect(ghComments.some((comment) => comment.includes("invalid structured review output"))).toBe(true);
+    expect(ghComments.some((comment) => comment.includes("Manual review required"))).toBe(true);
   });
 
   it("does not treat benign should-pass approval language as actionable", async () => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -247,6 +247,51 @@ describe("postPushReviewStep", () => {
     expect(countOccurrences(reviewComment ?? "", "Missing UUID validation on path params.")).toBe(0);
   });
 
+  it("suppresses duplicate feedback that repeats external review findings", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Missing UUID validation on path params.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghComments: string[] = [];
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Missing UUID validation on path params.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("Required external review findings");
+    expect(countOccurrences(fixPrompt, "Missing UUID validation on path params.")).toBe(1);
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(reviewComment).not.toContain("Reviewer summary:");
+    expect(countOccurrences(reviewComment ?? "", "Missing UUID validation on path params.")).toBe(0);
+  });
+
   it("runs a fix pass when approved feedback contains actionable language but issues is empty", async () => {
     const approvedWithFeedback = JSON.stringify({
       approved: true,

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -153,6 +153,46 @@ describe("postPushReviewStep", () => {
     expect(invoke.mock.calls[1][0].prompt).toContain("1. Escape quoted user input");
   });
 
+  it("runs a fix pass when an external changes-requested review blocks internal approval", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Internal reviewer approves.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Missing UUID validation on path params.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("Required external review findings");
+    expect(fixPrompt).toContain("Missing UUID validation on path params.");
+  });
+
   it("runs a fix pass when approved feedback contains actionable language but issues is empty", async () => {
     const approvedWithFeedback = JSON.stringify({
       approved: true,

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -137,21 +137,25 @@ describe("collectExternalReviewFindingsFromGh", () => {
         stdout: JSON.stringify([
           {
             state: "COMMENTED",
+            user: { login: "reviewer-a" },
             body: "not blocking",
             html_url: "https://example.com/commented",
           },
           {
             state: "CHANGES_REQUESTED",
+            user: { login: "reviewer-b" },
             body: "Please fix the failing validation.",
             html_url: "https://example.com/review-1",
           },
           {
             state: "CHANGES_REQUESTED",
+            user: { login: "reviewer-c" },
             body: "   ",
             html_url: "https://example.com/empty",
           },
           {
             state: "CHANGES_REQUESTED",
+            user: { login: "reviewer-d" },
             body: "Also restore the timeout handling.",
             html_url: "https://example.com/review-2",
           },
@@ -177,6 +181,39 @@ describe("collectExternalReviewFindingsFromGh", () => {
     expect(calls[1]?.slice(0, 2)).toEqual(["api", "graphql"]);
   });
 
+  it("ignores stale changes-requested reviews when the same reviewer later approves", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (args[0] === "api" && args[1] === "graphql") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+          }),
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([
+          {
+            state: "CHANGES_REQUESTED",
+            user: { login: "reviewer-a" },
+            body: "This old issue was fixed before approval.",
+            html_url: "https://example.com/stale-review",
+          },
+          {
+            state: "APPROVED",
+            user: { login: "reviewer-a" },
+            body: "Approved now.",
+            html_url: "https://example.com/approval",
+          },
+        ]),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([]);
+  });
+
   it("collects latest comments from unresolved review threads as blocking findings", () => {
     const calls: string[][] = [];
     const ghSpawn: GhSpawn = (args) => {
@@ -196,6 +233,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
                   nodes: [
                     {
                       isResolved: true,
+                      isOutdated: false,
                       path: "src/ignored.ts",
                       line: 1,
                       comments: {
@@ -209,6 +247,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
                     },
                     {
                       isResolved: false,
+                      isOutdated: false,
                       path: "src/app.ts",
                       line: 27,
                       comments: {
@@ -246,6 +285,46 @@ describe("collectExternalReviewFindingsFromGh", () => {
     expect(calls[1]?.slice(0, 2)).toEqual(["api", "graphql"]);
   });
 
+  it("ignores unresolved review threads that GitHub marks as outdated", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (args[0] === "api" && args[1] === "repos/:owner/:repo/pulls/42/reviews") {
+        return { exitCode: 0, stdout: "[]" };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      isResolved: false,
+                      isOutdated: true,
+                      path: "src/app.ts",
+                      line: 27,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "This comment belongs to an outdated diff.",
+                            url: "https://example.com/outdated-thread",
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([]);
+  });
+
   it("does not throw when GraphQL returns malformed JSON", () => {
     const ghSpawn: GhSpawn = (args) => {
       if (args[0] === "api" && args[1] === "repos/:owner/:repo/pulls/42/reviews") {
@@ -254,6 +333,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
           stdout: JSON.stringify([
             {
               state: "CHANGES_REQUESTED",
+              user: { login: "reviewer-a" },
               body: "Keep already collected review findings.",
               html_url: "https://example.com/review",
             },

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  collectExternalReviewFindingsFromGh,
   extractClaudeSummaryFindings,
   formatReviewLedgerForPrompt,
+  type GhSpawn,
   type ReviewLedgerFinding,
 } from "../pipeline/review-ledger.js";
 
@@ -112,5 +114,164 @@ describe("formatReviewLedgerForPrompt", () => {
         "Consider preserving the existing return shape.",
       ].join("\n"),
     );
+  });
+});
+
+describe("collectExternalReviewFindingsFromGh", () => {
+  it("collects non-empty changes-requested review bodies as blocking github-review findings", () => {
+    const calls: string[][] = [];
+    const ghSpawn: GhSpawn = (args) => {
+      calls.push(args);
+
+      if (args[0] === "api" && args[1] === "graphql") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+          }),
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify([
+          {
+            state: "COMMENTED",
+            body: "not blocking",
+            html_url: "https://example.com/commented",
+          },
+          {
+            state: "CHANGES_REQUESTED",
+            body: "Please fix the failing validation.",
+            html_url: "https://example.com/review-1",
+          },
+          {
+            state: "CHANGES_REQUESTED",
+            body: "   ",
+            html_url: "https://example.com/empty",
+          },
+          {
+            state: "CHANGES_REQUESTED",
+            body: "Also restore the timeout handling.",
+            html_url: "https://example.com/review-2",
+          },
+        ]),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "github-review",
+        severity: "blocking",
+        body: "Please fix the failing validation.",
+        url: "https://example.com/review-1",
+      },
+      {
+        source: "github-review",
+        severity: "blocking",
+        body: "Also restore the timeout handling.",
+        url: "https://example.com/review-2",
+      },
+    ]);
+    expect(calls[0]).toEqual(["api", "repos/:owner/:repo/pulls/42/reviews"]);
+    expect(calls[1]?.slice(0, 2)).toEqual(["api", "graphql"]);
+  });
+
+  it("collects latest comments from unresolved review threads as blocking findings", () => {
+    const calls: string[][] = [];
+    const ghSpawn: GhSpawn = (args) => {
+      calls.push(args);
+
+      if (args[0] === "api" && args[1] === "repos/:owner/:repo/pulls/42/reviews") {
+        return { exitCode: 0, stdout: "[]" };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      isResolved: true,
+                      path: "src/ignored.ts",
+                      line: 1,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "resolved comment",
+                            url: "https://example.com/resolved",
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      isResolved: false,
+                      path: "src/app.ts",
+                      line: 27,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "Original note",
+                            url: "https://example.com/thread-old",
+                          },
+                          {
+                            body: "Latest unresolved note",
+                            url: "https://example.com/thread-latest",
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "github-review-thread",
+        severity: "blocking",
+        path: "src/app.ts",
+        line: 27,
+        body: "Latest unresolved note",
+        url: "https://example.com/thread-latest",
+      },
+    ]);
+    expect(calls[1]?.slice(0, 2)).toEqual(["api", "graphql"]);
+  });
+
+  it("does not throw when GraphQL returns malformed JSON", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (args[0] === "api" && args[1] === "repos/:owner/:repo/pulls/42/reviews") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              state: "CHANGES_REQUESTED",
+              body: "Keep already collected review findings.",
+              html_url: "https://example.com/review",
+            },
+          ]),
+        };
+      }
+
+      return { exitCode: 0, stdout: "{not-json" };
+    };
+
+    expect(() => collectExternalReviewFindingsFromGh(ghSpawn, "42")).not.toThrow();
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "github-review",
+        severity: "blocking",
+        body: "Keep already collected review findings.",
+        url: "https://example.com/review",
+      },
+    ]);
   });
 });

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -34,6 +34,50 @@ describe("extractClaudeSummaryFindings", () => {
       },
     ]);
   });
+
+  it("extracts ordered bullets from blocking issues sections", () => {
+    const body = `
+## Blocking issues
+1. Missing UUID validation
+2) Fix confidence validation
+`;
+
+    expect(extractClaudeSummaryFindings(body)).toEqual([
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Missing UUID validation",
+      },
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Fix confidence validation",
+      },
+    ]);
+  });
+
+  it("folds indented continuation lines into the previous blocking bullet", () => {
+    const body = `
+## Blocking
+- Fix auth
+  because missing validation returns 500
+- Fix status
+  because it reports success too early
+`;
+
+    expect(extractClaudeSummaryFindings(body)).toEqual([
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Fix auth because missing validation returns 500",
+      },
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Fix status because it reports success too early",
+      },
+    ]);
+  });
 });
 
 describe("formatReviewLedgerForPrompt", () => {

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -177,7 +177,8 @@ describe("collectExternalReviewFindingsFromGh", () => {
         url: "https://example.com/review-2",
       },
     ]);
-    expect(calls[0]).toEqual(["api", "repos/:owner/:repo/pulls/42/reviews"]);
+    expect(calls[0]).toContain("--paginate");
+    expect(calls[0]).toContain("repos/:owner/:repo/pulls/42/reviews?per_page=100");
     expect(calls[1]?.slice(0, 2)).toEqual(["api", "graphql"]);
   });
 
@@ -219,7 +220,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
     const ghSpawn: GhSpawn = (args) => {
       calls.push(args);
 
-      if (args[0] === "api" && args[1] === "repos/:owner/:repo/pulls/42/reviews") {
+      if (isPullReviewsRequest(args)) {
         return { exitCode: 0, stdout: "[]" };
       }
 
@@ -287,7 +288,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
 
   it("ignores unresolved review threads that GitHub marks as outdated", () => {
     const ghSpawn: GhSpawn = (args) => {
-      if (args[0] === "api" && args[1] === "repos/:owner/:repo/pulls/42/reviews") {
+      if (isPullReviewsRequest(args)) {
         return { exitCode: 0, stdout: "[]" };
       }
 
@@ -325,9 +326,88 @@ describe("collectExternalReviewFindingsFromGh", () => {
     expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([]);
   });
 
+  it("collects unresolved review threads from later GraphQL pages", () => {
+    const calls: string[][] = [];
+    const ghSpawn: GhSpawn = (args) => {
+      calls.push(args);
+
+      if (isPullReviewsRequest(args)) {
+        return { exitCode: 0, stdout: "[]" };
+      }
+
+      if (args.includes("after=cursor-1")) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    nodes: [
+                      {
+                        isResolved: false,
+                        isOutdated: false,
+                        path: "src/later.ts",
+                        line: 88,
+                        comments: {
+                          nodes: [
+                            {
+                              body: "Later page unresolved finding.",
+                              url: "https://example.com/later-thread",
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                    pageInfo: {
+                      hasNextPage: false,
+                      endCursor: null,
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [],
+                  pageInfo: {
+                    hasNextPage: true,
+                    endCursor: "cursor-1",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "github-review-thread",
+        severity: "blocking",
+        path: "src/later.ts",
+        line: 88,
+        body: "Later page unresolved finding.",
+        url: "https://example.com/later-thread",
+      },
+    ]);
+    expect(calls.filter((call) => call[0] === "api" && call[1] === "graphql")).toHaveLength(2);
+    expect(calls[2]).toContain("after=cursor-1");
+  });
+
   it("does not throw when GraphQL returns malformed JSON", () => {
     const ghSpawn: GhSpawn = (args) => {
-      if (args[0] === "api" && args[1] === "repos/:owner/:repo/pulls/42/reviews") {
+      if (isPullReviewsRequest(args)) {
         return {
           exitCode: 0,
           stdout: JSON.stringify([
@@ -355,3 +435,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
     ]);
   });
 });
+
+function isPullReviewsRequest(args: string[]): boolean {
+  return args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100");
+}

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractClaudeSummaryFindings,
+  formatReviewLedgerForPrompt,
+  type ReviewLedgerFinding,
+} from "../pipeline/review-ledger.js";
+
+describe("extractClaudeSummaryFindings", () => {
+  it("extracts normalized bullets from a blocking section only", () => {
+    const body = `
+## Summary
+- ignore this summary bullet
+
+## Blocking
+- **Fix** \`src/app.ts\` before merge.
+- [Update docs](https://example.com/docs)   to explain the new flow.
+
+## Medium
+- ignore this medium bullet
+`;
+
+    expect(extractClaudeSummaryFindings(body, "https://example.com/review")).toEqual([
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Fix src/app.ts before merge.",
+        url: "https://example.com/review",
+      },
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Update docs to explain the new flow.",
+        url: "https://example.com/review",
+      },
+    ]);
+  });
+});
+
+describe("formatReviewLedgerForPrompt", () => {
+  it("returns an explicit empty-state message with no findings", () => {
+    expect(formatReviewLedgerForPrompt([])).toBe("No unresolved external review findings.");
+  });
+
+  it("formats review-ledger findings for a fix prompt", () => {
+    const findings: ReviewLedgerFinding[] = [
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        path: "src/app.ts",
+        line: 12,
+        body: "Fix the broken validation.",
+        url: "https://example.com/review",
+      },
+      {
+        source: "github-review-thread",
+        severity: "medium",
+        body: "Consider preserving the existing return shape.",
+      },
+    ];
+
+    expect(formatReviewLedgerForPrompt(findings)).toBe(
+      [
+        "[external-1] claude-review-summary blocking src/app.ts:12",
+        "Fix the broken validation.",
+        "URL: https://example.com/review",
+        "",
+        "[external-2] github-review-thread medium",
+        "Consider preserving the existing return shape.",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -179,7 +179,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
     ]);
     expect(calls[0]).toContain("--paginate");
     expect(calls[0]).toContain("repos/:owner/:repo/pulls/42/reviews?per_page=100");
-    expect(calls[1]?.slice(0, 2)).toEqual(["api", "graphql"]);
+    expect(calls.some((call) => call[0] === "api" && call[1] === "graphql")).toBe(true);
   });
 
   it("ignores stale changes-requested reviews when the same reviewer later approves", () => {
@@ -283,7 +283,131 @@ describe("collectExternalReviewFindingsFromGh", () => {
         url: "https://example.com/thread-latest",
       },
     ]);
-    expect(calls[1]?.slice(0, 2)).toEqual(["api", "graphql"]);
+    const graphqlCall = calls.find((call) => call[0] === "api" && call[1] === "graphql");
+    expect(graphqlCall?.slice(0, 2)).toEqual(["api", "graphql"]);
+    const queryArg = graphqlCall?.find((arg) => arg.startsWith("query="));
+    expect(queryArg).toContain("comments(last: 1)");
+    expect(queryArg).not.toContain("comments(first: 100)");
+  });
+
+  it("collects blocking bullets from likely Claude issue comments", () => {
+    const calls: string[][] = [];
+    const ghSpawn: GhSpawn = (args) => {
+      calls.push(args);
+
+      if (isPullReviewsRequest(args)) {
+        return { exitCode: 0, stdout: "[]" };
+      }
+
+      if (isIssueCommentsRequest(args)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            [
+              {
+                user: { login: "random-user" },
+                body: "Maybe check this before merge.",
+                html_url: "https://example.com/random",
+              },
+              {
+                user: { login: "ai-implement" },
+                body: "<!-- ai-implement post-push iter=1 review-feedback -->\n### Code Review\n\n## Blocking\n- Ignore our own marker comment.",
+                html_url: "https://example.com/self",
+              },
+              {
+                user: { login: "claude" },
+                body: "### Code Review\n\n## Blocking\n- Validate path params before database access.\n\n## Medium\n- Optional cleanup.",
+                html_url: "https://example.com/claude",
+              },
+            ],
+          ]),
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+        }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Validate path params before database access.",
+        url: "https://example.com/claude",
+      },
+    ]);
+    expect(calls[1]).toEqual([
+      "api",
+      "--paginate",
+      "--slurp",
+      "repos/:owner/:repo/issues/42/comments?per_page=100",
+    ]);
+  });
+
+  it("deduplicates external findings by body while preferring path and line context", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (isPullReviewsRequest(args)) {
+        return { exitCode: 0, stdout: "[]" };
+      }
+
+      if (isIssueCommentsRequest(args)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              user: { login: "claude" },
+              body: "### Code Review\n\n## Blocking\n- Validate path params before database access.",
+              html_url: "https://example.com/claude-summary",
+            },
+          ]),
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/app.ts",
+                      line: 27,
+                      comments: {
+                        nodes: [
+                          {
+                            body: "Validate path params before database access.",
+                            url: "https://example.com/thread",
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "github-review-thread",
+        severity: "blocking",
+        path: "src/app.ts",
+        line: 27,
+        body: "Validate path params before database access.",
+        url: "https://example.com/thread",
+      },
+    ]);
   });
 
   it("ignores unresolved review threads that GitHub marks as outdated", () => {
@@ -402,7 +526,7 @@ describe("collectExternalReviewFindingsFromGh", () => {
       },
     ]);
     expect(calls.filter((call) => call[0] === "api" && call[1] === "graphql")).toHaveLength(2);
-    expect(calls[2]).toContain("after=cursor-1");
+    expect(calls.find((call) => call.includes("after=cursor-1"))).toBeTruthy();
   });
 
   it("does not throw when GraphQL returns malformed JSON", () => {
@@ -438,4 +562,8 @@ describe("collectExternalReviewFindingsFromGh", () => {
 
 function isPullReviewsRequest(args: string[]): boolean {
   return args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100");
+}
+
+function isIssueCommentsRequest(args: string[]): boolean {
+  return args.includes("repos/:owner/:repo/issues/42/comments?per_page=100");
 }

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -348,6 +348,94 @@ describe("collectExternalReviewFindingsFromGh", () => {
     ]);
   });
 
+  it("ignores Claude-like usernames that are not trusted automation authors", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (isPullReviewsRequest(args)) {
+        return { exitCode: 0, stdout: "[]" };
+      }
+
+      if (isIssueCommentsRequest(args)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              user: { login: "claude-fan-99" },
+              body: "### Code Review\n\n## Blocking\n- Spoofed blocker should not be trusted.",
+              html_url: "https://example.com/spoofed",
+            },
+            {
+              user: { login: "aclaudeuser" },
+              body: "### Code Review\n\n## Blocking\n- Another spoofed blocker.",
+              html_url: "https://example.com/spoofed-2",
+            },
+          ]),
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+        }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([]);
+  });
+
+  it("accepts trusted automation authors only when the comment has a Claude review heading", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (isPullReviewsRequest(args)) {
+        return { exitCode: 0, stdout: "[]" };
+      }
+
+      if (isIssueCommentsRequest(args)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              user: { login: "github-actions[bot]" },
+              body: "No Changes Requested here.\n\n## Blocking\n- This plain text is not a Claude review.",
+              html_url: "https://example.com/plain-actions",
+            },
+            {
+              user: { login: "ai-implement[bot]" },
+              body: "### Code Review\n\n## Blocking\n- Trusted app review blocker.",
+              html_url: "https://example.com/app-review",
+            },
+            {
+              user: { login: "github-actions" },
+              body: "### Changes Requested\n\n## Blocking\n- Trusted GitHub Actions review blocker.",
+              html_url: "https://example.com/actions-review",
+            },
+          ]),
+        };
+      }
+
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+        }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Trusted app review blocker.",
+        url: "https://example.com/app-review",
+      },
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Trusted GitHub Actions review blocker.",
+        url: "https://example.com/actions-review",
+      },
+    ]);
+  });
+
   it("deduplicates external findings by body while preferring path and line context", () => {
     const ghSpawn: GhSpawn = (args) => {
       if (isPullReviewsRequest(args)) {
@@ -554,6 +642,36 @@ describe("collectExternalReviewFindingsFromGh", () => {
         source: "github-review",
         severity: "blocking",
         body: "Keep already collected review findings.",
+        url: "https://example.com/review",
+      },
+    ]);
+  });
+
+  it("does not throw when ghSpawn throws while collecting external findings", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (isPullReviewsRequest(args)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              state: "CHANGES_REQUESTED",
+              user: { login: "reviewer-a" },
+              body: "Keep findings collected before a later gh failure.",
+              html_url: "https://example.com/review",
+            },
+          ]),
+        };
+      }
+
+      throw new Error(`gh failed: ${args.join(" ")}`);
+    };
+
+    expect(() => collectExternalReviewFindingsFromGh(ghSpawn, "42")).not.toThrow();
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "github-review",
+        severity: "blocking",
+        body: "Keep findings collected before a later gh failure.",
         url: "https://example.com/review",
       },
     ]);

--- a/src/__tests__/steps-install.test.ts
+++ b/src/__tests__/steps-install.test.ts
@@ -154,6 +154,36 @@ describe("installStep", () => {
     expect(outputs.packageManager).toBe("npm");
   });
 
+  it("parses known reviewProviders from .ai-implement/config.yml", async () => {
+    mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      "reviewProviders:\n  - github-claude-code-review\n",
+    );
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.reviewProviders).toEqual(["github-claude-code-review"]);
+  });
+
+  it("ignores unknown reviewProviders from .ai-implement/config.yml", async () => {
+    mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      "reviewProviders:\n  - unsupported-reviewer\n  - github-claude-code-review\n",
+    );
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.reviewProviders).toEqual(["github-claude-code-review"]);
+  });
+
   it("returns empty repoModels when config.yml has no models section", async () => {
     mockRootPackageJson();
 

--- a/src/__tests__/steps-install.test.ts
+++ b/src/__tests__/steps-install.test.ts
@@ -230,7 +230,7 @@ describe("installStep", () => {
     expect(outputs.reviewProviders).toEqual([]);
   });
 
-  it("treats unknown-only reviewProviders as absent", async () => {
+  it("treats unknown-only reviewProviders as explicit empty config", async () => {
     mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
     vi.mocked(fs.readFileSync).mockReturnValue(
       "reviewProviders:\n  - unsupported-reviewer\n",
@@ -242,7 +242,7 @@ describe("installStep", () => {
       new NoopStepReporter(),
     );
 
-    expect(outputs.reviewProviders).toBeUndefined();
+    expect(outputs.reviewProviders).toEqual([]);
   });
 
   it("treats malformed reviewProviders config as absent", async () => {

--- a/src/__tests__/steps-install.test.ts
+++ b/src/__tests__/steps-install.test.ts
@@ -184,6 +184,80 @@ describe("installStep", () => {
     expect(outputs.reviewProviders).toEqual(["github-claude-code-review"]);
   });
 
+  it("parses quoted reviewProviders with trailing comments from .ai-implement/config.yml", async () => {
+    mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      "reviewProviders:\n  - \"github-claude-code-review\" # enabled by repo config\n  - 'github-claude-code-review'\n",
+    );
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.reviewProviders).toEqual([
+      "github-claude-code-review",
+      "github-claude-code-review",
+    ]);
+  });
+
+  it("parses inline reviewProviders arrays from .ai-implement/config.yml", async () => {
+    mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      "reviewProviders: [\"github-claude-code-review\"]\n",
+    );
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.reviewProviders).toEqual(["github-claude-code-review"]);
+  });
+
+  it("preserves explicit empty reviewProviders arrays from .ai-implement/config.yml", async () => {
+    mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
+    vi.mocked(fs.readFileSync).mockReturnValue("reviewProviders: []\n");
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.reviewProviders).toEqual([]);
+  });
+
+  it("treats unknown-only reviewProviders as absent", async () => {
+    mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      "reviewProviders:\n  - unsupported-reviewer\n",
+    );
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.reviewProviders).toBeUndefined();
+  });
+
+  it("treats malformed reviewProviders config as absent", async () => {
+    mockRootPackageJson((p) => p.includes(".ai-implement/config.yml"));
+    vi.mocked(fs.readFileSync).mockReturnValue("reviewProviders: github-claude-code-review\n");
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.reviewProviders).toBeUndefined();
+  });
+
   it("returns empty repoModels when config.yml has no models section", async () => {
     mockRootPackageJson();
 

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -152,6 +152,7 @@ function applyWiring(step: YamlStep): StepDefinition {
         inputs: (ctx: PipelineContext) => ({
           prNumber: String(ctx.getOutputs("push").prNumber ?? ""),
           workspaceDir: ctx.getOutputs("clone").workspaceDir,
+          reviewProviders: ctx.getOutputs("install").reviewProviders,
         }),
         skip: (ctx: PipelineContext) => {
           const pushOutputs = ctx.getOutputs("push");

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -27,9 +27,10 @@ export function collectExternalReviewFindingsFromGh(ghSpawn: GhSpawn, prNumber: 
   const findings: ReviewLedgerFinding[] = [];
 
   collectChangesRequestedReviews(ghSpawn, prNumber, findings);
+  collectClaudeIssueComments(ghSpawn, prNumber, findings);
   collectUnresolvedReviewThreads(ghSpawn, prNumber, findings);
 
-  return findings;
+  return dedupeReviewFindings(findings);
 }
 
 export function extractClaudeSummaryFindings(body: string, url?: string): ReviewLedgerFinding[] {
@@ -135,6 +136,29 @@ function collectChangesRequestedReviews(ghSpawn: GhSpawn, prNumber: string, find
   }
 }
 
+function collectClaudeIssueComments(ghSpawn: GhSpawn, prNumber: string, findings: ReviewLedgerFinding[]): void {
+  const result = safeGhSpawn(ghSpawn, [
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/:owner/:repo/issues/${prNumber}/comments?per_page=100`,
+  ]);
+  if (!result || result.exitCode !== 0) return;
+
+  const comments = parseReviewPages(result.stdout);
+
+  for (const comment of comments) {
+    if (!isRecord(comment) || !isLikelyClaudeReviewComment(comment)) continue;
+
+    findings.push(
+      ...extractClaudeSummaryFindings(
+        comment.body,
+        typeof comment.html_url === "string" ? comment.html_url : undefined,
+      ),
+    );
+  }
+}
+
 function collectUnresolvedReviewThreads(ghSpawn: GhSpawn, prNumber: string, findings: ReviewLedgerFinding[]): void {
   let after: string | undefined;
 
@@ -153,6 +177,30 @@ function collectUnresolvedReviewThreads(ghSpawn: GhSpawn, prNumber: string, find
 
     after = reviewThreads.pageInfo.endCursor;
   }
+}
+
+function dedupeReviewFindings(findings: ReviewLedgerFinding[]): ReviewLedgerFinding[] {
+  const deduped: ReviewLedgerFinding[] = [];
+  const indexByNormalizedBody = new Map<string, number>();
+
+  for (const finding of findings) {
+    const key = normalizeText(finding.body).toLowerCase();
+    if (!key) continue;
+
+    const existingIndex = indexByNormalizedBody.get(key);
+    if (existingIndex === undefined) {
+      indexByNormalizedBody.set(key, deduped.length);
+      deduped.push(finding);
+      continue;
+    }
+
+    const existing = deduped[existingIndex];
+    if (!hasLineLocation(existing) && hasLineLocation(finding)) {
+      deduped[existingIndex] = finding;
+    }
+  }
+
+  return deduped;
 }
 
 function buildReviewThreadsArgs(prNumber: string, after?: string): string[] {
@@ -244,6 +292,30 @@ function getCommentNodes(thread: Record<string, unknown>): unknown[] | undefined
   return Array.isArray(comments.nodes) ? comments.nodes : undefined;
 }
 
+function isLikelyClaudeReviewComment(comment: Record<string, unknown>): comment is Record<string, unknown> & { body: string } {
+  if (typeof comment.body !== "string" || isAiImplementComment(comment.body)) return false;
+  return isClaudeAuthor(comment) || hasClaudeReviewHeading(comment.body);
+}
+
+function isAiImplementComment(body: string): boolean {
+  return body.includes("<!-- ai-implement");
+}
+
+function isClaudeAuthor(comment: Record<string, unknown>): boolean {
+  const user = comment.user;
+  if (!isRecord(user) || typeof user.login !== "string") return false;
+  return user.login.toLowerCase().includes("claude");
+}
+
+function hasClaudeReviewHeading(body: string): boolean {
+  return /(?:^|\n)\s{0,3}#{1,6}\s+(?:Code Review|Follow-up Review|Code Review Complete|Changes Requested)\b/i.test(body)
+    || /(?:^|\n)\s*Changes Requested\b/i.test(body);
+}
+
+function hasLineLocation(finding: ReviewLedgerFinding): boolean {
+  return typeof finding.path === "string" && typeof finding.line === "number";
+}
+
 function isActionableReviewState(value: unknown): value is "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED" {
   return value === "APPROVED" || value === "CHANGES_REQUESTED" || value === "DISMISSED";
 }
@@ -279,7 +351,7 @@ query($owner: String!, $repo: String!, $number: Int!, $after: String) {
           isOutdated
           path
           line
-          comments(first: 100) {
+          comments(last: 1) {
             nodes {
               body
               url

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -16,33 +16,52 @@ export interface ReviewLedgerFinding {
 }
 
 export function extractClaudeSummaryFindings(body: string, url?: string): ReviewLedgerFinding[] {
-  const findings: ReviewLedgerFinding[] = [];
+  const items: string[] = [];
   let inBlockingSection = false;
+  let currentItem: string | undefined;
+
+  const flushCurrentItem = () => {
+    if (!currentItem) return;
+
+    const normalizedBody = normalizeText(currentItem);
+    if (normalizedBody) {
+      items.push(normalizedBody);
+    }
+
+    currentItem = undefined;
+  };
 
   for (const line of body.split(/\r?\n/)) {
     const heading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
     if (heading) {
+      flushCurrentItem();
       inBlockingSection = /^blocking\b/i.test(normalizeText(heading[1]));
       continue;
     }
 
     if (!inBlockingSection) continue;
 
-    const bullet = line.match(/^\s*[-*+]\s+(.+)$/);
-    if (!bullet) continue;
+    const bullet = line.match(/^\s*(?:[-*+]|\d+[\.)])\s+(.+)$/);
+    if (bullet) {
+      flushCurrentItem();
+      currentItem = bullet[1];
+      continue;
+    }
 
-    const normalizedBody = normalizeText(bullet[1]);
-    if (!normalizedBody) continue;
-
-    findings.push({
-      source: "claude-review-summary",
-      severity: "blocking",
-      body: normalizedBody,
-      ...(url ? { url } : {}),
-    });
+    const continuation = line.match(/^\s{2,}(\S.*)$/);
+    if (continuation && currentItem) {
+      currentItem = `${currentItem} ${continuation[1]}`;
+    }
   }
 
-  return findings;
+  flushCurrentItem();
+
+  return items.map((item) => ({
+    source: "claude-review-summary",
+    severity: "blocking",
+    body: item,
+    ...(url ? { url } : {}),
+  }));
 }
 
 export function formatReviewLedgerForPrompt(findings: ReviewLedgerFinding[]): string {

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -23,6 +23,16 @@ export interface GhResult {
 
 export type GhSpawn = (args: string[]) => GhResult;
 
+const TRUSTED_REVIEW_COMMENT_AUTHORS = new Set([
+  "ai-implement",
+  "ai-implement[bot]",
+  "claude",
+  "claude[bot]",
+  "claude-code[bot]",
+  "github-actions",
+  "github-actions[bot]",
+]);
+
 export function collectExternalReviewFindingsFromGh(ghSpawn: GhSpawn, prNumber: string): ReviewLedgerFinding[] {
   const findings: ReviewLedgerFinding[] = [];
 
@@ -294,7 +304,7 @@ function getCommentNodes(thread: Record<string, unknown>): unknown[] | undefined
 
 function isLikelyClaudeReviewComment(comment: Record<string, unknown>): comment is Record<string, unknown> & { body: string } {
   if (typeof comment.body !== "string" || isAiImplementComment(comment.body)) return false;
-  return isClaudeAuthor(comment) || hasClaudeReviewHeading(comment.body);
+  return isClaudeAuthor(comment) && hasClaudeReviewHeading(comment.body);
 }
 
 function isAiImplementComment(body: string): boolean {
@@ -304,12 +314,11 @@ function isAiImplementComment(body: string): boolean {
 function isClaudeAuthor(comment: Record<string, unknown>): boolean {
   const user = comment.user;
   if (!isRecord(user) || typeof user.login !== "string") return false;
-  return user.login.toLowerCase().includes("claude");
+  return TRUSTED_REVIEW_COMMENT_AUTHORS.has(user.login.toLowerCase());
 }
 
 function hasClaudeReviewHeading(body: string): boolean {
-  return /(?:^|\n)\s{0,3}#{1,6}\s+(?:Code Review|Follow-up Review|Code Review Complete|Changes Requested)\b/i.test(body)
-    || /(?:^|\n)\s*Changes Requested\b/i.test(body);
+  return /(?:^|\n)\s{0,3}#{1,6}\s+(?:Code Review|Follow-up Review|Code Review Complete|Changes Requested)\b/i.test(body);
 }
 
 function hasLineLocation(finding: ReviewLedgerFinding): boolean {

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -103,11 +103,15 @@ function formatLocation(finding: ReviewLedgerFinding): string | undefined {
 }
 
 function collectChangesRequestedReviews(ghSpawn: GhSpawn, prNumber: string, findings: ReviewLedgerFinding[]): void {
-  const result = safeGhSpawn(ghSpawn, ["api", `repos/:owner/:repo/pulls/${prNumber}/reviews`]);
+  const result = safeGhSpawn(ghSpawn, [
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/:owner/:repo/pulls/${prNumber}/reviews?per_page=100`,
+  ]);
   if (!result || result.exitCode !== 0) return;
 
-  const reviews = parseJson(result.stdout);
-  if (!Array.isArray(reviews)) return;
+  const reviews = parseReviewPages(result.stdout);
 
   const latestActionableReviewsByReviewer = new Map<string, Record<string, unknown>>();
 
@@ -132,7 +136,27 @@ function collectChangesRequestedReviews(ghSpawn: GhSpawn, prNumber: string, find
 }
 
 function collectUnresolvedReviewThreads(ghSpawn: GhSpawn, prNumber: string, findings: ReviewLedgerFinding[]): void {
-  const result = safeGhSpawn(ghSpawn, [
+  let after: string | undefined;
+
+  for (;;) {
+    const result = safeGhSpawn(ghSpawn, buildReviewThreadsArgs(prNumber, after));
+    if (!result || result.exitCode !== 0) return;
+
+    const payload = parseJson(result.stdout);
+    const reviewThreads = getReviewThreadsConnection(payload);
+    if (!reviewThreads) return;
+
+    collectReviewThreadFindings(reviewThreads.nodes, findings);
+
+    if (reviewThreads.pageInfo?.hasNextPage !== true) return;
+    if (typeof reviewThreads.pageInfo.endCursor !== "string" || !reviewThreads.pageInfo.endCursor) return;
+
+    after = reviewThreads.pageInfo.endCursor;
+  }
+}
+
+function buildReviewThreadsArgs(prNumber: string, after?: string): string[] {
+  const args = [
     "api",
     "graphql",
     "-F",
@@ -143,13 +167,16 @@ function collectUnresolvedReviewThreads(ghSpawn: GhSpawn, prNumber: string, find
     `number=${prNumber}`,
     "-f",
     `query=${reviewThreadsQuery}`,
-  ]);
-  if (!result || result.exitCode !== 0) return;
+  ];
 
-  const payload = parseJson(result.stdout);
-  const nodes = getReviewThreadNodes(payload);
-  if (!nodes) return;
+  if (after) {
+    args.push("-F", `after=${after}`);
+  }
 
+  return args;
+}
+
+function collectReviewThreadFindings(nodes: unknown[], findings: ReviewLedgerFinding[]): void {
   for (const thread of nodes) {
     if (!isRecord(thread) || thread.isResolved !== false || thread.isOutdated === true) continue;
 
@@ -187,7 +214,14 @@ function parseJson(value: string): unknown {
   }
 }
 
-function getReviewThreadNodes(payload: unknown): unknown[] | undefined {
+function parseReviewPages(stdout: string): unknown[] {
+  const payload = parseJson(stdout);
+  if (!Array.isArray(payload)) return [];
+  if (payload.every(Array.isArray)) return payload.flat();
+  return payload;
+}
+
+function getReviewThreadsConnection(payload: unknown): { nodes: unknown[]; pageInfo?: Record<string, unknown> } | undefined {
   if (!isRecord(payload)) return undefined;
   const data = payload.data;
   if (!isRecord(data)) return undefined;
@@ -197,7 +231,11 @@ function getReviewThreadNodes(payload: unknown): unknown[] | undefined {
   if (!isRecord(pullRequest)) return undefined;
   const reviewThreads = pullRequest.reviewThreads;
   if (!isRecord(reviewThreads)) return undefined;
-  return Array.isArray(reviewThreads.nodes) ? reviewThreads.nodes : undefined;
+  if (!Array.isArray(reviewThreads.nodes)) return undefined;
+  return {
+    nodes: reviewThreads.nodes,
+    ...(isRecord(reviewThreads.pageInfo) ? { pageInfo: reviewThreads.pageInfo } : {}),
+  };
 }
 
 function getCommentNodes(thread: Record<string, unknown>): unknown[] | undefined {
@@ -232,10 +270,10 @@ function normalizeText(value: string): string {
 }
 
 const reviewThreadsQuery = `
-query($owner: String!, $repo: String!, $number: Int!) {
+query($owner: String!, $repo: String!, $number: Int!, $after: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $after) {
         nodes {
           isResolved
           isOutdated
@@ -247,6 +285,10 @@ query($owner: String!, $repo: String!, $number: Int!) {
               url
             }
           }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
         }
       }
     }

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -15,6 +15,23 @@ export interface ReviewLedgerFinding {
   url?: string;
 }
 
+export interface GhResult {
+  stdout: string;
+  stderr?: string;
+  exitCode: number;
+}
+
+export type GhSpawn = (args: string[]) => GhResult;
+
+export function collectExternalReviewFindingsFromGh(ghSpawn: GhSpawn, prNumber: string): ReviewLedgerFinding[] {
+  const findings: ReviewLedgerFinding[] = [];
+
+  collectChangesRequestedReviews(ghSpawn, prNumber, findings);
+  collectUnresolvedReviewThreads(ghSpawn, prNumber, findings);
+
+  return findings;
+}
+
 export function extractClaudeSummaryFindings(body: string, url?: string): ReviewLedgerFinding[] {
   const items: string[] = [];
   let inBlockingSection = false;
@@ -85,6 +102,109 @@ function formatLocation(finding: ReviewLedgerFinding): string | undefined {
   return typeof finding.line === "number" ? `${finding.path}:${finding.line}` : finding.path;
 }
 
+function collectChangesRequestedReviews(ghSpawn: GhSpawn, prNumber: string, findings: ReviewLedgerFinding[]): void {
+  const result = safeGhSpawn(ghSpawn, ["api", `repos/:owner/:repo/pulls/${prNumber}/reviews`]);
+  if (!result || result.exitCode !== 0) return;
+
+  const reviews = parseJson(result.stdout);
+  if (!Array.isArray(reviews)) return;
+
+  for (const review of reviews) {
+    if (!isRecord(review) || review.state !== "CHANGES_REQUESTED" || typeof review.body !== "string") {
+      continue;
+    }
+
+    const body = review.body.trim();
+    if (!body) continue;
+
+    findings.push({
+      source: "github-review",
+      severity: "blocking",
+      body,
+      ...(typeof review.html_url === "string" ? { url: review.html_url } : {}),
+    });
+  }
+}
+
+function collectUnresolvedReviewThreads(ghSpawn: GhSpawn, prNumber: string, findings: ReviewLedgerFinding[]): void {
+  const result = safeGhSpawn(ghSpawn, [
+    "api",
+    "graphql",
+    "-F",
+    "owner={owner}",
+    "-F",
+    "repo={repo}",
+    "-F",
+    `number=${prNumber}`,
+    "-f",
+    `query=${reviewThreadsQuery}`,
+  ]);
+  if (!result || result.exitCode !== 0) return;
+
+  const payload = parseJson(result.stdout);
+  const nodes = getReviewThreadNodes(payload);
+  if (!nodes) return;
+
+  for (const thread of nodes) {
+    if (!isRecord(thread) || thread.isResolved !== false) continue;
+
+    const comments = getCommentNodes(thread);
+    const latestComment = comments?.at(-1);
+    if (!isRecord(latestComment) || typeof latestComment.body !== "string") continue;
+
+    const body = latestComment.body.trim();
+    if (!body) continue;
+
+    findings.push({
+      source: "github-review-thread",
+      severity: "blocking",
+      body,
+      ...(typeof thread.path === "string" ? { path: thread.path } : {}),
+      ...(typeof thread.line === "number" ? { line: thread.line } : {}),
+      ...(typeof latestComment.url === "string" ? { url: latestComment.url } : {}),
+    });
+  }
+}
+
+function safeGhSpawn(ghSpawn: GhSpawn, args: string[]): GhResult | undefined {
+  try {
+    return ghSpawn(args);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function getReviewThreadNodes(payload: unknown): unknown[] | undefined {
+  if (!isRecord(payload)) return undefined;
+  const data = payload.data;
+  if (!isRecord(data)) return undefined;
+  const repository = data.repository;
+  if (!isRecord(repository)) return undefined;
+  const pullRequest = repository.pullRequest;
+  if (!isRecord(pullRequest)) return undefined;
+  const reviewThreads = pullRequest.reviewThreads;
+  if (!isRecord(reviewThreads)) return undefined;
+  return Array.isArray(reviewThreads.nodes) ? reviewThreads.nodes : undefined;
+}
+
+function getCommentNodes(thread: Record<string, unknown>): unknown[] | undefined {
+  const comments = thread.comments;
+  if (!isRecord(comments)) return undefined;
+  return Array.isArray(comments.nodes) ? comments.nodes : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function normalizeText(value: string): string {
   return value
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
@@ -93,3 +213,25 @@ function normalizeText(value: string): string {
     .replace(/\s+/g, " ")
     .trim();
 }
+
+const reviewThreadsQuery = `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          path
+          line
+          comments(first: 100) {
+            nodes {
+              body
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`;

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -1,0 +1,76 @@
+export type ReviewLedgerSource =
+  | "claude-review-summary"
+  | "github-review"
+  | "github-review-thread"
+  | "ai-implement-internal";
+
+export type ReviewLedgerSeverity = "blocking" | "medium" | "minor";
+
+export interface ReviewLedgerFinding {
+  source: ReviewLedgerSource;
+  severity: ReviewLedgerSeverity;
+  body: string;
+  path?: string;
+  line?: number;
+  url?: string;
+}
+
+export function extractClaudeSummaryFindings(body: string, url?: string): ReviewLedgerFinding[] {
+  const findings: ReviewLedgerFinding[] = [];
+  let inBlockingSection = false;
+
+  for (const line of body.split(/\r?\n/)) {
+    const heading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (heading) {
+      inBlockingSection = /^blocking\b/i.test(normalizeText(heading[1]));
+      continue;
+    }
+
+    if (!inBlockingSection) continue;
+
+    const bullet = line.match(/^\s*[-*+]\s+(.+)$/);
+    if (!bullet) continue;
+
+    const normalizedBody = normalizeText(bullet[1]);
+    if (!normalizedBody) continue;
+
+    findings.push({
+      source: "claude-review-summary",
+      severity: "blocking",
+      body: normalizedBody,
+      ...(url ? { url } : {}),
+    });
+  }
+
+  return findings;
+}
+
+export function formatReviewLedgerForPrompt(findings: ReviewLedgerFinding[]): string {
+  if (findings.length === 0) {
+    return "No unresolved external review findings.";
+  }
+
+  return findings
+    .map((finding, index) => {
+      const location = formatLocation(finding);
+      const header = [`[external-${index + 1}]`, finding.source, finding.severity, location]
+        .filter(Boolean)
+        .join(" ");
+      return [header, finding.body, finding.url ? `URL: ${finding.url}` : undefined].filter(Boolean).join("\n");
+    })
+    .join("\n\n");
+}
+
+function formatLocation(finding: ReviewLedgerFinding): string | undefined {
+  if (!finding.path) return undefined;
+  return typeof finding.line === "number" ? `${finding.path}:${finding.line}` : finding.path;
+}
+
+function normalizeText(value: string): string {
+  return value
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -109,11 +109,16 @@ function collectChangesRequestedReviews(ghSpawn: GhSpawn, prNumber: string, find
   const reviews = parseJson(result.stdout);
   if (!Array.isArray(reviews)) return;
 
-  for (const review of reviews) {
-    if (!isRecord(review) || review.state !== "CHANGES_REQUESTED" || typeof review.body !== "string") {
-      continue;
-    }
+  const latestActionableReviewsByReviewer = new Map<string, Record<string, unknown>>();
 
+  reviews.forEach((review, index) => {
+    if (!isRecord(review) || !isActionableReviewState(review.state)) return;
+
+    latestActionableReviewsByReviewer.set(getReviewReviewerKey(review, index), review);
+  });
+
+  for (const review of latestActionableReviewsByReviewer.values()) {
+    if (review.state !== "CHANGES_REQUESTED" || typeof review.body !== "string") continue;
     const body = review.body.trim();
     if (!body) continue;
 
@@ -146,7 +151,7 @@ function collectUnresolvedReviewThreads(ghSpawn: GhSpawn, prNumber: string, find
   if (!nodes) return;
 
   for (const thread of nodes) {
-    if (!isRecord(thread) || thread.isResolved !== false) continue;
+    if (!isRecord(thread) || thread.isResolved !== false || thread.isOutdated === true) continue;
 
     const comments = getCommentNodes(thread);
     const latestComment = comments?.at(-1);
@@ -201,6 +206,18 @@ function getCommentNodes(thread: Record<string, unknown>): unknown[] | undefined
   return Array.isArray(comments.nodes) ? comments.nodes : undefined;
 }
 
+function isActionableReviewState(value: unknown): value is "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED" {
+  return value === "APPROVED" || value === "CHANGES_REQUESTED" || value === "DISMISSED";
+}
+
+function getReviewReviewerKey(review: Record<string, unknown>, fallbackIndex: number): string {
+  const user = review.user;
+  if (!isRecord(user)) return `review:${fallbackIndex}`;
+  if (typeof user.id === "number" || typeof user.id === "string") return `user-id:${user.id}`;
+  if (typeof user.login === "string") return `user-login:${user.login}`;
+  return `review:${fallbackIndex}`;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -221,6 +238,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
       reviewThreads(first: 100) {
         nodes {
           isResolved
+          isOutdated
           path
           line
           comments(first: 100) {

--- a/src/pipeline/steps/install.ts
+++ b/src/pipeline/steps/install.ts
@@ -28,6 +28,56 @@ interface InstallOutputs extends Record<string, unknown> {
 
 const KNOWN_REVIEW_PROVIDERS = new Set(["github-claude-code-review"]);
 
+function stripYamlComment(value: string): string {
+  let quote: "'" | "\"" | null = null;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if ((char === "'" || char === "\"") && quote === null) {
+      quote = char;
+    } else if (char === quote) {
+      quote = null;
+    } else if (char === "#" && quote === null) {
+      return value.slice(0, i).trim();
+    }
+  }
+  return value.trim();
+}
+
+function normalizeYamlScalar(value: string): string | undefined {
+  const trimmed = stripYamlComment(value);
+  if (!trimmed) return undefined;
+  const quote = trimmed[0];
+  if ((quote === "'" || quote === "\"") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function splitInlineYamlArrayItems(value: string): string[] | null {
+  const trimmed = stripYamlComment(value);
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
+  const inner = trimmed.slice(1, -1).trim();
+  if (!inner) return [];
+
+  const items: string[] = [];
+  let quote: "'" | "\"" | null = null;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const char = inner[i];
+    if ((char === "'" || char === "\"") && quote === null) {
+      quote = char;
+    } else if (char === quote) {
+      quote = null;
+    } else if (char === "," && quote === null) {
+      items.push(inner.slice(start, i));
+      start = i + 1;
+    }
+  }
+  if (quote !== null) return null;
+  items.push(inner.slice(start));
+  return items;
+}
+
 function parseModelsSection(raw: string): RepoModels {
   const result: RepoModels = {};
   const lines = raw.split(/\r?\n/);
@@ -59,9 +109,23 @@ function parseReviewProvidersSection(raw: string): string[] | undefined {
   let inReviewProviders = false;
   const providers: string[] = [];
   let sawReviewProviders = false;
+  let sawListItem = false;
 
   for (const line of lines) {
-    if (/^reviewProviders:/.test(line)) {
+    const topLevelMatch = /^reviewProviders:\s*(.*)$/.exec(line);
+    if (topLevelMatch) {
+      const inlineValue = stripYamlComment(topLevelMatch[1] ?? "");
+      if (inlineValue) {
+        const inlineItems = splitInlineYamlArrayItems(inlineValue);
+        if (inlineItems === null) return undefined;
+        if (inlineItems.length === 0) return [];
+        const knownProviders = inlineItems
+          .map((item) => normalizeYamlScalar(item))
+          .filter((provider): provider is string =>
+            provider !== undefined && KNOWN_REVIEW_PROVIDERS.has(provider),
+          );
+        return knownProviders.length > 0 ? knownProviders : undefined;
+      }
       inReviewProviders = true;
       sawReviewProviders = true;
       continue;
@@ -71,15 +135,17 @@ function parseReviewProvidersSection(raw: string): string[] | undefined {
         inReviewProviders = false;
         continue;
       }
-      const providerMatch = /^\s+-\s*(\S+)/.exec(line);
-      const provider = providerMatch?.[1];
+      const providerMatch = /^\s+-\s*(.+?)\s*$/.exec(line);
+      if (providerMatch) sawListItem = true;
+      const provider = providerMatch ? normalizeYamlScalar(providerMatch[1]) : undefined;
       if (provider && KNOWN_REVIEW_PROVIDERS.has(provider)) {
         providers.push(provider);
       }
     }
   }
 
-  return sawReviewProviders ? providers : undefined;
+  if (!sawReviewProviders || !sawListItem) return undefined;
+  return providers.length > 0 ? providers : undefined;
 }
 
 function readAiImplementConfig(workspaceDir: string): AiImplementConfig {

--- a/src/pipeline/steps/install.ts
+++ b/src/pipeline/steps/install.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { parse as parseYaml } from "yaml";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 
 interface RepoModels {
@@ -28,123 +29,25 @@ interface InstallOutputs extends Record<string, unknown> {
 
 const KNOWN_REVIEW_PROVIDERS = new Set(["github-claude-code-review"]);
 
-function stripYamlComment(value: string): string {
-  let quote: "'" | "\"" | null = null;
-  for (let i = 0; i < value.length; i++) {
-    const char = value[i];
-    if ((char === "'" || char === "\"") && quote === null) {
-      quote = char;
-    } else if (char === quote) {
-      quote = null;
-    } else if (char === "#" && quote === null) {
-      return value.slice(0, i).trim();
-    }
-  }
-  return value.trim();
-}
-
-function normalizeYamlScalar(value: string): string | undefined {
-  const trimmed = stripYamlComment(value);
-  if (!trimmed) return undefined;
-  const quote = trimmed[0];
-  if ((quote === "'" || quote === "\"") && trimmed.endsWith(quote)) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-}
-
-function splitInlineYamlArrayItems(value: string): string[] | null {
-  const trimmed = stripYamlComment(value);
-  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
-  const inner = trimmed.slice(1, -1).trim();
-  if (!inner) return [];
-
-  const items: string[] = [];
-  let quote: "'" | "\"" | null = null;
-  let start = 0;
-  for (let i = 0; i < inner.length; i++) {
-    const char = inner[i];
-    if ((char === "'" || char === "\"") && quote === null) {
-      quote = char;
-    } else if (char === quote) {
-      quote = null;
-    } else if (char === "," && quote === null) {
-      items.push(inner.slice(start, i));
-      start = i + 1;
-    }
-  }
-  if (quote !== null) return null;
-  items.push(inner.slice(start));
-  return items;
-}
-
-function parseModelsSection(raw: string): RepoModels {
+function parseModelsConfig(value: unknown): RepoModels {
   const result: RepoModels = {};
-  const lines = raw.split(/\r?\n/);
-  let inModels = false;
-  for (const line of lines) {
-    if (/^models:/.test(line)) {
-      inModels = true;
-      continue;
-    }
-    if (inModels) {
-      // A non-empty line starting without indentation means a new top-level key
-      if (/^\S/.test(line) && line.trim() !== "") {
-        inModels = false;
-        continue;
-      }
-      // Note: quoted YAML values (e.g. implement: "model-name") are not stripped —
-      // users should write unquoted values to avoid silently including quote characters.
-      const implMatch = /^\s+implement:\s*(\S+)/.exec(line);
-      if (implMatch) result.implement = implMatch[1];
-      const reviewMatch = /^\s+review:\s*(\S+)/.exec(line);
-      if (reviewMatch) result.review = reviewMatch[1];
-    }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return result;
+  const models = value as Record<string, unknown>;
+  if (typeof models.implement === "string" && models.implement.trim()) {
+    result.implement = models.implement.trim();
+  }
+  if (typeof models.review === "string" && models.review.trim()) {
+    result.review = models.review.trim();
   }
   return result;
 }
 
-function parseReviewProvidersSection(raw: string): string[] | undefined {
-  const lines = raw.split(/\r?\n/);
-  let inReviewProviders = false;
-  const providers: string[] = [];
-  let sawReviewProviders = false;
-  let sawListItem = false;
-
-  for (const line of lines) {
-    const topLevelMatch = /^reviewProviders:\s*(.*)$/.exec(line);
-    if (topLevelMatch) {
-      const inlineValue = stripYamlComment(topLevelMatch[1] ?? "");
-      if (inlineValue) {
-        const inlineItems = splitInlineYamlArrayItems(inlineValue);
-        if (inlineItems === null) return undefined;
-        if (inlineItems.length === 0) return [];
-        const knownProviders = inlineItems
-          .map((item) => normalizeYamlScalar(item))
-          .filter((provider): provider is string =>
-            provider !== undefined && KNOWN_REVIEW_PROVIDERS.has(provider),
-          );
-        return knownProviders.length > 0 ? knownProviders : undefined;
-      }
-      inReviewProviders = true;
-      sawReviewProviders = true;
-      continue;
-    }
-    if (inReviewProviders) {
-      if (/^\S/.test(line) && line.trim() !== "") {
-        inReviewProviders = false;
-        continue;
-      }
-      const providerMatch = /^\s+-\s*(.+?)\s*$/.exec(line);
-      if (providerMatch) sawListItem = true;
-      const provider = providerMatch ? normalizeYamlScalar(providerMatch[1]) : undefined;
-      if (provider && KNOWN_REVIEW_PROVIDERS.has(provider)) {
-        providers.push(provider);
-      }
-    }
-  }
-
-  if (!sawReviewProviders || !sawListItem) return undefined;
+function parseReviewProvidersConfig(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  if (value.length === 0) return [];
+  const providers = value.filter((provider): provider is string =>
+    typeof provider === "string" && KNOWN_REVIEW_PROVIDERS.has(provider),
+  );
   return providers.length > 0 ? providers : undefined;
 }
 
@@ -153,12 +56,15 @@ function readAiImplementConfig(workspaceDir: string): AiImplementConfig {
   if (!fs.existsSync(configPath)) return {};
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
-    // Minimal YAML key: value parsing — avoids pulling in a yaml dep
-    const pkgMatch = /^packageManager:\s*(\S+)/m.exec(raw);
-    const models = parseModelsSection(raw);
-    const reviewProviders = parseReviewProvidersSection(raw);
+    const parsed = parseYaml(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const doc = parsed as Record<string, unknown>;
+    const models = parseModelsConfig(doc.models);
+    const reviewProviders = parseReviewProvidersConfig(doc.reviewProviders);
     const config: AiImplementConfig = {};
-    if (pkgMatch) config.packageManager = pkgMatch[1];
+    if (typeof doc.packageManager === "string" && doc.packageManager.trim()) {
+      config.packageManager = doc.packageManager.trim();
+    }
     if (models.implement || models.review) config.models = models;
     if (reviewProviders !== undefined) config.reviewProviders = reviewProviders;
     return config;

--- a/src/pipeline/steps/install.ts
+++ b/src/pipeline/steps/install.ts
@@ -48,7 +48,7 @@ function parseReviewProvidersConfig(value: unknown): string[] | undefined {
   const providers = value.filter((provider): provider is string =>
     typeof provider === "string" && KNOWN_REVIEW_PROVIDERS.has(provider),
   );
-  return providers.length > 0 ? providers : undefined;
+  return providers;
 }
 
 function readAiImplementConfig(workspaceDir: string): AiImplementConfig {

--- a/src/pipeline/steps/install.ts
+++ b/src/pipeline/steps/install.ts
@@ -11,6 +11,7 @@ interface RepoModels {
 interface AiImplementConfig {
   packageManager?: string;
   models?: RepoModels;
+  reviewProviders?: string[];
 }
 
 interface InstallInputs extends Record<string, unknown> {
@@ -22,7 +23,10 @@ interface InstallOutputs extends Record<string, unknown> {
   installMethod: string;
   durationMs: number;
   repoModels: RepoModels;
+  reviewProviders?: string[];
 }
+
+const KNOWN_REVIEW_PROVIDERS = new Set(["github-claude-code-review"]);
 
 function parseModelsSection(raw: string): RepoModels {
   const result: RepoModels = {};
@@ -50,6 +54,34 @@ function parseModelsSection(raw: string): RepoModels {
   return result;
 }
 
+function parseReviewProvidersSection(raw: string): string[] | undefined {
+  const lines = raw.split(/\r?\n/);
+  let inReviewProviders = false;
+  const providers: string[] = [];
+  let sawReviewProviders = false;
+
+  for (const line of lines) {
+    if (/^reviewProviders:/.test(line)) {
+      inReviewProviders = true;
+      sawReviewProviders = true;
+      continue;
+    }
+    if (inReviewProviders) {
+      if (/^\S/.test(line) && line.trim() !== "") {
+        inReviewProviders = false;
+        continue;
+      }
+      const providerMatch = /^\s+-\s*(\S+)/.exec(line);
+      const provider = providerMatch?.[1];
+      if (provider && KNOWN_REVIEW_PROVIDERS.has(provider)) {
+        providers.push(provider);
+      }
+    }
+  }
+
+  return sawReviewProviders ? providers : undefined;
+}
+
 function readAiImplementConfig(workspaceDir: string): AiImplementConfig {
   const configPath = path.join(workspaceDir, ".ai-implement", "config.yml");
   if (!fs.existsSync(configPath)) return {};
@@ -58,9 +90,11 @@ function readAiImplementConfig(workspaceDir: string): AiImplementConfig {
     // Minimal YAML key: value parsing — avoids pulling in a yaml dep
     const pkgMatch = /^packageManager:\s*(\S+)/m.exec(raw);
     const models = parseModelsSection(raw);
+    const reviewProviders = parseReviewProvidersSection(raw);
     const config: AiImplementConfig = {};
     if (pkgMatch) config.packageManager = pkgMatch[1];
     if (models.implement || models.review) config.models = models;
+    if (reviewProviders !== undefined) config.reviewProviders = reviewProviders;
     return config;
   } catch {
     return {};
@@ -99,6 +133,7 @@ export const installStep: StepModule<InstallInputs, InstallOutputs> = {
         installMethod: "skipped: no package.json",
         durationMs: 0,
         repoModels: config.models ?? {},
+        reviewProviders: config.reviewProviders,
       };
     }
 
@@ -121,6 +156,12 @@ export const installStep: StepModule<InstallInputs, InstallOutputs> = {
     });
     const durationMs = Date.now() - start;
 
-    return { packageManager, installMethod, durationMs, repoModels: config.models ?? {} };
+    return {
+      packageManager,
+      installMethod,
+      durationMs,
+      repoModels: config.models ?? {},
+      reviewProviders: config.reviewProviders,
+    };
   },
 };

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import type { StepModule } from "../types.js";
+import type { StepModule, StepReporter } from "../types.js";
 import { formatGitNameStatusSummary } from "../step-utils.js";
 import {
   collectExternalReviewFindingsFromGh,
@@ -200,26 +200,6 @@ function extractCommentIdWithMarker(stdout: string, marker: string): number | nu
   return null;
 }
 
-function isDeferredOrNonBlocking(text: string): boolean {
-  return /\b(later tasks?|future tasks?|future work|later cleanup|cleanup pass|cosmetic note|minor cosmetic|nice[- ]to[- ]have|at some point|not required|not required by this task|not blocking|non[- ]blocking|optional|consider)\b/i
-    .test(text);
-}
-
-function hasStrongActionSignal(text: string): boolean {
-  return /\b(must|needs?|required fix|fix required|blocking|blocker|not ready|bug|missing|incomplete|incorrect|unsafe|regression|breaks?|fails?|failure)\b/i
-    .test(text);
-}
-
-function feedbackImpliesFixNeeded(feedback: string): boolean {
-  if (isDeferredOrNonBlocking(feedback)) return false;
-  return /\b(worth addressing|should\s+(?:be\s+)?(?:fix(?:ed)?|address(?:ed)?|handle(?:d)?|include(?:d)?|add(?:ed)?|remove(?:d)?|update(?:d)?|change(?:d)?)|must|needs?|required fix|fix required|fix(?:es|ing)?\s+(?:the\s+)?(?:bug|issue|problem|failure|regression|breakage)|there\s+is\s+(?:a\s+)?bug|bug\s+(?:found|remain(?:s|ing)?|causes?|in|where|when|with|because|that\s+(?:causes|breaks?|fails?))|regression\s+(?:found|remain(?:s|ing)?|causes?|in|where|when|with|because)|blocking issue|issue(?:s)?\s+(?:found|to fix|remain|remaining|required)|missing|incomplete|at minimum|incorrect|unsafe|breaks?|fails?)\b/i
-    .test(feedback);
-}
-
-function filterNonBlockingIssues(issues: string[]): string[] {
-  return issues.filter((issue) => !(isDeferredOrNonBlocking(issue) && !hasStrongActionSignal(issue)));
-}
-
 function dedupeIssuesAgainstExternalFindings(
   issues: string[],
   externalFindings: ReviewLedgerFinding[],
@@ -339,6 +319,33 @@ function postPrComment(ghSpawn: (args: string[]) => SpawnResult, prNumber: strin
   }
 }
 
+async function reportInvalidStructuredReview(
+  reporter: StepReporter,
+  ghSpawn: (args: string[]) => SpawnResult,
+  prNumber: string,
+  iteration: number,
+  feedback: string,
+) {
+  await reporter.report({
+    id: `post-push-review.${iteration}`,
+    type: "custom",
+    status: "failed",
+    started_at: new Date().toISOString(),
+    ended_at: new Date().toISOString(),
+    parent_step_id: "post-push-review",
+    inputs: { iteration, prNumber },
+    outputs: { approved: false, feedback, issues: [feedback] },
+    logs_url: null,
+  });
+  const marker = `<!-- ai-implement post-push iter=${iteration} review-invalid -->`;
+  postPrComment(
+    ghSpawn,
+    prNumber,
+    `${marker}\n⚠️ Post-push review returned invalid output.\n\n${feedback}\n\nThe implementation PR is still available, but this automated review pass did not finish. No actionable code feedback was produced by this review attempt.\n\n**Merge readiness:** Manual review required; automated review did not complete.`,
+    marker,
+  );
+}
+
 export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReviewOutputs> = {
   async run(context, inputs, reporter) {
     const ghSpawn = inputs.ghSpawn ?? makeDefaultGhSpawn(inputs.workspaceDir);
@@ -378,7 +385,9 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
 Set approved=true only when no code changes are needed. If you find any bug,
 missing requirement, unsafe behavior, test gap, or follow-up that should be
 fixed in this PR, set approved=false and put every actionable item in issues[].
-Do not approve while listing "minor issues worth addressing" in feedback.
+The orchestrator treats issues[] as the only blocking finding list; it will not
+infer blockers from feedback prose. If something must be fixed before merge, it
+must be present in issues[].
 Do not set approved=false for future/later-task concerns that are not required
 by this issue; mention those in feedback only.
 
@@ -467,23 +476,23 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
         break;
       }
 
-      feedback = suppressDuplicateExternalFeedback(String(parsed.feedback ?? ""), externalFindings);
-      let issues = Array.isArray(parsed.issues)
-        ? parsed.issues.filter((issue): issue is string => typeof issue === "string")
-        : [];
-      issues = filterNonBlockingIssues(issues);
-      if (issues.length === 0 && parsed.approved === true && feedbackImpliesFixNeeded(feedback)) {
-        issues.push(feedback);
+      if (
+        typeof parsed.approved !== "boolean"
+        || !Array.isArray(parsed.issues)
+        || parsed.issues.some((issue) => typeof issue !== "string")
+      ) {
+        feedback = "Reviewer returned invalid structured review output: expected approved:boolean and issues:string[].";
+        await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
+        break;
       }
+
+      feedback = suppressDuplicateExternalFeedback(String(parsed.feedback ?? ""), externalFindings);
+      let issues = parsed.issues.map((issue) => issue.trim()).filter((issue) => issue.length > 0);
       issues = dedupeIssuesAgainstExternalFindings(issues, externalFindings);
-      if (issues.length === 0 && parsed.approved === false && !feedbackImpliesFixNeeded(feedback) && !hasExternalBlockers) {
-        approved = true;
-        feedback = feedback || "Reviewer did not identify actionable blockers.";
-      } else if (issues.length === 0 && parsed.approved === false && feedbackImpliesFixNeeded(feedback)) {
-        issues.push(feedback || "Reviewer marked the PR not ready but did not provide actionable issue details.");
-        issues = dedupeIssuesAgainstExternalFindings(issues, externalFindings);
-      } else if (issues.length === 0 && parsed.approved === false && !hasExternalBlockers) {
-        issues.push("Reviewer marked the PR not ready but did not provide actionable issue details.");
+      if (issues.length === 0 && parsed.approved === false && !hasExternalBlockers) {
+        feedback = "Reviewer returned invalid structured review output: approved=false requires at least one issues[] entry.";
+        await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
+        break;
       }
       approved = approved || (parsed.approved === true && issues.length === 0 && !hasExternalBlockers);
       reviewHistory.push({ iteration, issues: [...issues], feedback });

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -207,6 +207,24 @@ function filterNonBlockingIssues(issues: string[]): string[] {
   return issues.filter((issue) => !(isDeferredOrNonBlocking(issue) && !hasStrongActionSignal(issue)));
 }
 
+function dedupeIssuesAgainstExternalFindings(
+  issues: string[],
+  externalFindings: ReviewLedgerFinding[],
+): string[] {
+  const externalBodies = new Set(externalFindings.map((finding) => normalizeForComparison(finding.body)));
+  const seen = new Set<string>();
+  return issues.filter((issue) => {
+    const normalized = normalizeForComparison(issue);
+    if (!normalized || externalBodies.has(normalized) || seen.has(normalized)) return false;
+    seen.add(normalized);
+    return true;
+  });
+}
+
+function externalBlockingCommentBlock(hasExternalBlockers: boolean): string {
+  return hasExternalBlockers ? "\n\nExternal review findings are blocking this PR." : "";
+}
+
 function parseFixSummary(stdout: string): FixSummary | null {
   const parsed = extractFirstJsonObject(stdout);
   if (!parsed) return null;
@@ -324,6 +342,7 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
       const diffRes = ghSpawn(["pr", "diff", prNumber]);
       if (diffRes.exitCode !== 0) throw new Error(`gh pr diff failed: ${resultMessage(diffRes)}`);
       const externalFindings: ReviewLedgerFinding[] = collectExternalReviewFindingsFromGh(ghSpawn, prNumber);
+      const hasExternalBlockers = externalFindings.some((finding) => finding.severity === "blocking");
 
       const previousFindings = formatReviewHistory(reviewHistory);
       const reviewPrompt = `You are reviewing the diff for PR #${prNumber} against issue ${context.data.issueIdentifier}: ${context.data.issueTitle}.
@@ -428,15 +447,17 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
       if (issues.length === 0 && parsed.approved === true && feedbackImpliesFixNeeded(feedback)) {
         issues.push(feedback);
       }
-      const externalBlockingFindings = externalFindings.filter((finding) => finding.severity === "blocking");
-      issues.push(...externalBlockingFindings.map((finding) => finding.body));
-      if (issues.length === 0 && parsed.approved === false && !feedbackImpliesFixNeeded(feedback)) {
+      issues = dedupeIssuesAgainstExternalFindings(issues, externalFindings);
+      if (issues.length === 0 && parsed.approved === false && !feedbackImpliesFixNeeded(feedback) && !hasExternalBlockers) {
         approved = true;
         feedback = feedback || "Reviewer did not identify actionable blockers.";
-      } else if (issues.length === 0 && parsed.approved === false) {
+      } else if (issues.length === 0 && parsed.approved === false && feedbackImpliesFixNeeded(feedback)) {
         issues.push(feedback || "Reviewer marked the PR not ready but did not provide actionable issue details.");
+        issues = dedupeIssuesAgainstExternalFindings(issues, externalFindings);
+      } else if (issues.length === 0 && parsed.approved === false && !hasExternalBlockers) {
+        issues.push("Reviewer marked the PR not ready but did not provide actionable issue details.");
       }
-      approved = approved || (parsed.approved === true && issues.length === 0);
+      approved = approved || (parsed.approved === true && issues.length === 0 && !hasExternalBlockers);
       reviewHistory.push({ iteration, issues: [...issues], feedback });
 
       await reporter.report({
@@ -467,7 +488,7 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
         postPrComment(
           ghSpawn,
           prNumber,
-          `${marker}\n⚠️ Reached review cap (${maxIterations} iterations) without approval.${blockingIssuesBlock(issues, { compact: true })}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
+          `${marker}\n⚠️ Reached review cap (${maxIterations} iterations) without approval.${blockingIssuesBlock(issues, { compact: true })}${externalBlockingCommentBlock(hasExternalBlockers)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
           marker,
         );
         break;
@@ -477,7 +498,7 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
       postPrComment(
         ghSpawn,
         prNumber,
-        `${feedbackMarker}\n⚠️ Reviewer found issues — starting fix pass ${fixPassLabel(iteration, maxIterations)}...${blockingIssuesBlock(issues, { compact: true })}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
+        `${feedbackMarker}\n⚠️ Reviewer found issues — starting fix pass ${fixPassLabel(iteration, maxIterations)}...${blockingIssuesBlock(issues, { compact: true })}${externalBlockingCommentBlock(hasExternalBlockers)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
         feedbackMarker,
       );
 

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -143,6 +143,17 @@ function externalReviewFindingsBlock(findings: ReviewLedgerFinding[]): string {
   return `\n\nRequired external review findings:\n${formatReviewLedgerForPrompt(findings)}`;
 }
 
+function externalReviewFindingsCommentBlock(findings: ReviewLedgerFinding[]): string {
+  if (findings.length === 0) return "";
+  const issues = findings.map((finding) => {
+    const location = finding.path
+      ? `${finding.path}${typeof finding.line === "number" ? `:${finding.line}` : ""}: `
+      : "";
+    return `${location}${finding.body}`;
+  });
+  return `\n\nUnresolved external review findings:\n${formatIssueList(issues, { compact: true })}`;
+}
+
 function extractFirstJsonObject(text: string): Record<string, unknown> | null {
   let depth = 0;
   let start = -1;
@@ -572,7 +583,7 @@ ${externalReviewFindingsBlock(externalFindings)}
         postPrComment(
           ghSpawn,
           prNumber,
-          `${marker}\n⚠️ Fix pass ${fixPassLabel(iteration, maxIterations)} completed with no file changes; stopping the post-push review loop.\n\n**Merge readiness:** Not ready to merge.`,
+          `${marker}\n⚠️ Fix pass ${fixPassLabel(iteration, maxIterations)} completed with no file changes; stopping the post-push review loop.${externalReviewFindingsCommentBlock(externalFindings)}\n\n**Merge readiness:** Not ready to merge.`,
           marker,
         );
         break;

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -212,7 +212,7 @@ function hasStrongActionSignal(text: string): boolean {
 
 function feedbackImpliesFixNeeded(feedback: string): boolean {
   if (isDeferredOrNonBlocking(feedback)) return false;
-  return /\b(worth addressing|should\s+(?:be\s+)?(?:fix(?:ed)?|address(?:ed)?|handle(?:d)?|include(?:d)?|add(?:ed)?|remove(?:d)?|update(?:d)?|change(?:d)?)|must|needs?|fix|bug|blocking issue|issue(?:s)?\s+(?:found|to fix|remain|remaining|required)|missing|incomplete|at minimum|incorrect|unsafe|regression|breaks?|fails?)\b/i
+  return /\b(worth addressing|should\s+(?:be\s+)?(?:fix(?:ed)?|address(?:ed)?|handle(?:d)?|include(?:d)?|add(?:ed)?|remove(?:d)?|update(?:d)?|change(?:d)?)|must|needs?|required fix|fix required|fix(?:es|ing)?\s+(?:the\s+)?(?:bug|issue|problem|failure|regression|breakage)|there\s+is\s+(?:a\s+)?bug|bug\s+(?:found|remain(?:s|ing)?|causes?|in|where|when|with|because|that\s+(?:causes|breaks?|fails?))|regression\s+(?:found|remain(?:s|ing)?|causes?|in|where|when|with|because)|blocking issue|issue(?:s)?\s+(?:found|to fix|remain|remaining|required)|missing|incomplete|at minimum|incorrect|unsafe|breaks?|fails?)\b/i
     .test(feedback);
 }
 

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -12,6 +12,7 @@ interface PostPushReviewInputs extends Record<string, unknown> {
   workspaceDir: string;
   model?: string;
   maxIterations?: number;
+  reviewProviders?: string[];
   ghSpawn?: (args: string[]) => SpawnResult;
   gitSpawn?: (args: string[]) => SpawnResult;
 }
@@ -36,6 +37,7 @@ const FEEDBACK_INJECTION_PREAMBLE =
 const REVIEW_MAX_TURNS = 12;
 const FIX_MAX_TURNS = 45;
 const DEFAULT_MAX_ITERATIONS = 3;
+const GITHUB_CLAUDE_CODE_REVIEW_PROVIDER = "github-claude-code-review";
 
 interface ReviewFinding {
   iteration: number;
@@ -245,6 +247,10 @@ function externalBlockingCommentBlock(hasExternalBlockers: boolean): string {
   return hasExternalBlockers ? "\n\nExternal review findings are blocking this PR." : "";
 }
 
+function shouldCollectExternalReviewFindings(reviewProviders: string[] | undefined): boolean {
+  return reviewProviders === undefined || reviewProviders.includes(GITHUB_CLAUDE_CODE_REVIEW_PROVIDER);
+}
+
 function parseFixSummary(stdout: string): FixSummary | null {
   const parsed = extractFirstJsonObject(stdout);
   if (!parsed) return null;
@@ -361,7 +367,9 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
 
       const diffRes = ghSpawn(["pr", "diff", prNumber]);
       if (diffRes.exitCode !== 0) throw new Error(`gh pr diff failed: ${resultMessage(diffRes)}`);
-      const externalFindings: ReviewLedgerFinding[] = collectExternalReviewFindingsFromGh(ghSpawn, prNumber);
+      const externalFindings: ReviewLedgerFinding[] = shouldCollectExternalReviewFindings(inputs.reviewProviders)
+        ? collectExternalReviewFindingsFromGh(ghSpawn, prNumber)
+        : [];
       const hasExternalBlockers = externalFindings.some((finding) => finding.severity === "blocking");
 
       const previousFindings = formatReviewHistory(reviewHistory);

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -374,6 +374,7 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
 
       const diffRes = ghSpawn(["pr", "diff", prNumber]);
       if (diffRes.exitCode !== 0) throw new Error(`gh pr diff failed: ${resultMessage(diffRes)}`);
+      // Re-fetch each iteration so review comments posted during a fix pass can still gate merge readiness.
       const externalFindings: ReviewLedgerFinding[] = shouldCollectExternalReviewFindings(inputs.reviewProviders)
         ? collectExternalReviewFindingsFromGh(ghSpawn, prNumber)
         : [];

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -1,6 +1,11 @@
 import { spawnSync } from "node:child_process";
 import type { StepModule } from "../types.js";
 import { formatGitNameStatusSummary } from "../step-utils.js";
+import {
+  collectExternalReviewFindingsFromGh,
+  formatReviewLedgerForPrompt,
+  type ReviewLedgerFinding,
+} from "../review-ledger.js";
 
 interface PostPushReviewInputs extends Record<string, unknown> {
   prNumber: string;
@@ -131,6 +136,11 @@ ${issueList}
 Summary:
 ${finding.feedback || "(none)"}`;
   }).join("\n\n");
+}
+
+function externalReviewFindingsBlock(findings: ReviewLedgerFinding[]): string {
+  if (findings.length === 0) return "";
+  return `\n\nRequired external review findings:\n${formatReviewLedgerForPrompt(findings)}`;
 }
 
 function extractFirstJsonObject(text: string): Record<string, unknown> | null {
@@ -313,6 +323,7 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
 
       const diffRes = ghSpawn(["pr", "diff", prNumber]);
       if (diffRes.exitCode !== 0) throw new Error(`gh pr diff failed: ${resultMessage(diffRes)}`);
+      const externalFindings: ReviewLedgerFinding[] = collectExternalReviewFindingsFromGh(ghSpawn, prNumber);
 
       const previousFindings = formatReviewHistory(reviewHistory);
       const reviewPrompt = `You are reviewing the diff for PR #${prNumber} against issue ${context.data.issueIdentifier}: ${context.data.issueTitle}.
@@ -417,6 +428,8 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
       if (issues.length === 0 && parsed.approved === true && feedbackImpliesFixNeeded(feedback)) {
         issues.push(feedback);
       }
+      const externalBlockingFindings = externalFindings.filter((finding) => finding.severity === "blocking");
+      issues.push(...externalBlockingFindings.map((finding) => finding.body));
       if (issues.length === 0 && parsed.approved === false && !feedbackImpliesFixNeeded(feedback)) {
         approved = true;
         feedback = feedback || "Reviewer did not identify actionable blockers.";
@@ -502,6 +515,7 @@ ${issueList}
 
 Summary:
 ${feedback}
+${externalReviewFindingsBlock(externalFindings)}
 </reviewer_feedback>`;
 
       const fixResult = await context.llmExecutor.invoke({ prompt: fixPrompt, model, maxTurns: FIX_MAX_TURNS });

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -221,6 +221,15 @@ function dedupeIssuesAgainstExternalFindings(
   });
 }
 
+function suppressDuplicateExternalFeedback(feedback: string, externalFindings: ReviewLedgerFinding[]): string {
+  const normalizedFeedback = normalizeForComparison(feedback);
+  if (!normalizedFeedback) return "";
+  const duplicatesExternalFinding = externalFindings.some((finding) => {
+    return normalizeForComparison(finding.body) === normalizedFeedback;
+  });
+  return duplicatesExternalFinding ? "" : feedback;
+}
+
 function externalBlockingCommentBlock(hasExternalBlockers: boolean): string {
   return hasExternalBlockers ? "\n\nExternal review findings are blocking this PR." : "";
 }
@@ -439,7 +448,7 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
         break;
       }
 
-      feedback = String(parsed.feedback ?? "");
+      feedback = suppressDuplicateExternalFeedback(String(parsed.feedback ?? ""), externalFindings);
       let issues = Array.isArray(parsed.issues)
         ? parsed.issues.filter((issue): issue is string => typeof issue === "string")
         : [];


### PR DESCRIPTION
## Summary
- add a review ledger that ingests external GitHub/Claude review findings from PR reviews, top-level Claude review comments, and unresolved review threads
- feed external blockers into post-push fix passes while avoiding stale, outdated, or duplicate findings
- add review provider config parsing with backwards-compatible opportunistic collection by default
- surface unresolved external blockers when a fix pass makes no file changes

## Why
AI-Implement previously only fixed issues found by its internal review loop. If the Claude Code Review workflow found additional blockers, the fix pass could miss them or stop with no changes. This bridges those review artifacts into the repair loop so external review systems can drive fixes too.

## Validation
- npm test -- src/__tests__/review-ledger.test.ts src/__tests__/post-push-review.test.ts src/__tests__/steps-install.test.ts src/__tests__/pipeline-loader.test.ts: 73 passed
- npm run typecheck: passed
- npm run build: passed
- npm test: 93 files, 1123 tests passed