### PR TITLE
Make plan workflow ticketing-agnostic

### DIFF
--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -6,7 +6,6 @@
 #   AI_IMPLEMENT_PRIVATE_KEY - GitHub App PEM private key
 #   ANTHROPIC_API_KEY        - Anthropic API key (fallback if no OAuth token)
 #   CLAUDE_CODE_OAUTH_TOKEN  - Claude Code OAuth token (preferred over API key)
-#   LINEAR_API_KEY           - Linear API key for fetching related issues and posting comments
 #
 # Optional org/repo variable:
 #   AI_IMPLEMENT_ALLOWED_BOTS - Override claude-code-action allowed_bots.
@@ -23,19 +22,19 @@ on:
   workflow_dispatch:
     inputs:
       issue_id:
-        description: "Linear issue UUID"
+        description: "Ticketing-system issue ID"
         required: true
         type: string
       issue_identifier:
-        description: "Linear issue identifier (e.g., ENG-123)"
+        description: "Ticketing-system issue identifier (e.g., ENG-123)"
         required: true
         type: string
       issue_title:
-        description: "Linear issue title"
+        description: "Ticketing-system issue title"
         required: true
         type: string
       issue_description:
-        description: "Linear issue description"
+        description: "Ticketing-system issue description"
         required: true
         type: string
       provider:
@@ -78,56 +77,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Fetch related issues from Linear
-        id: fetch-related
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
-        run: |
-          FETCH_LOG=/tmp/related-fetch.log
-          : > "$FETCH_LOG"
-          # curl -fsS: fail on HTTP errors, suppress progress, keep error messages.
-          if ! RESPONSE=$(curl -fsS --max-time 30 -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            --data-raw "$(jq -n --arg id "$ISSUE_ID" \
-              '{query: "query($id: String!) { issue(id: $id) { parent { id identifier title children { nodes { id identifier title } } } relations { nodes { type relatedIssue { id identifier title } } } } }", variables: {id: $id}}')" \
-            2>"$FETCH_LOG"); then
-            echo "::warning::Failed to fetch related issues from Linear — proceeding without them."
-            if [ -s "$FETCH_LOG" ]; then
-              echo "Linear fetch error details:"
-              sed 's/^/  /' "$FETCH_LOG"
-            fi
-            RESPONSE='{"data":{"issue":{"parent":null,"relations":{"nodes":[]}}}}'
-          fi
-
-          PARENT=$(echo "$RESPONSE" | jq -r \
-            'if .data.issue.parent then "- \(.data.issue.parent.identifier): \(.data.issue.parent.title)" else "" end' \
-            2>/dev/null || echo "")
-
-          SIBLINGS=$(echo "$RESPONSE" | jq -r \
-            --arg issueId "$ISSUE_ID" \
-            '[.data.issue.parent.children.nodes[]? | select(.id != $issueId) | "- \(.identifier): \(.title)"] | join("\n")' \
-            2>/dev/null || echo "")
-
-          DEPENDENCIES=$(echo "$RESPONSE" | jq -r \
-            '[.data.issue.relations.nodes[]? | "- [\(.type)] \(.relatedIssue.identifier): \(.relatedIssue.title)"] | join("\n")' \
-            2>/dev/null || echo "")
-
-          # Unique delimiter guards against Linear content that happens to contain a fixed token.
-          EOF_TOKEN=$(openssl rand -hex 8)
-          {
-            echo "parent<<RELATED_${EOF_TOKEN}"
-            echo "$PARENT"
-            echo "RELATED_${EOF_TOKEN}"
-            echo "siblings<<RELATED_${EOF_TOKEN}"
-            echo "$SIBLINGS"
-            echo "RELATED_${EOF_TOKEN}"
-            echo "dependencies<<RELATED_${EOF_TOKEN}"
-            echo "$DEPENDENCIES"
-            echo "RELATED_${EOF_TOKEN}"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Prepare planning prompt
         id: prepare-prompt
         env:
@@ -136,9 +85,9 @@ jobs:
           ISSUE_TITLE: ${{ inputs.issue_title }}
           ISSUE_DESCRIPTION: ${{ inputs.issue_description }}
           PROVIDER: ${{ inputs.provider }}
-          PARENT: ${{ steps.fetch-related.outputs.parent }}
-          SIBLINGS: ${{ steps.fetch-related.outputs.siblings }}
-          DEPENDENCIES: ${{ steps.fetch-related.outputs.dependencies }}
+          PARENT: None
+          SIBLINGS: None
+          DEPENDENCIES: None
         run: |
           FRONTMATTER=""
 
@@ -318,9 +267,6 @@ jobs:
       - name: Run Claude (Bedrock)
         if: steps.auth-check.outputs.auth_method == 'bedrock'
         uses: anthropics/claude-code-action@v1
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -331,9 +277,6 @@ jobs:
       - name: Run Claude (OAuth token)
         if: steps.auth-check.outputs.auth_method == 'oauth'
         uses: anthropics/claude-code-action@v1
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -344,62 +287,12 @@ jobs:
       - name: Run Claude (API key)
         if: steps.auth-check.outputs.auth_method == 'api_key'
         uses: anthropics/claude-code-action@v1
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 50 --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
-
-      - name: Update Linear labels
-        if: always()
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
-          ISSUE_IDENTIFIER: ${{ inputs.issue_identifier }}
-          JOB_STATUS: ${{ job.status }}
-        run: |
-          # Fetch current labels
-          RESPONSE=$(curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            -d "{\"query\":\"{ issue(id: \\\"$ISSUE_ID\\\") { labels { nodes { id name } } } }\"}")
-
-          # Remove AI-Planning from label set
-          LABEL_IDS=$(echo "$RESPONSE" | jq -c '[.data.issue.labels.nodes[] | select(.name != "AI-Planning") | .id]')
-
-          # On success, find or create Plan-Complete and add it
-          if [ "$JOB_STATUS" = "success" ]; then
-            PLAN_COMPLETE_ID=$(curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d '{"query":"{ issueLabels(filter: { name: { eq: \"Plan-Complete\" } }) { nodes { id } } }"}' \
-              | jq -r '.data.issueLabels.nodes[0].id')
-
-            if [ "$PLAN_COMPLETE_ID" = "null" ] || [ -z "$PLAN_COMPLETE_ID" ]; then
-              PLAN_COMPLETE_ID=$(curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-                -H "Content-Type: application/json" \
-                -H "Authorization: $LINEAR_API_KEY" \
-                -d '{"query":"mutation { issueLabelCreate(input: { name: \"Plan-Complete\", color: \"#7c3aed\" }) { issueLabel { id } } }"}' \
-                | jq -r '.data.issueLabelCreate.issueLabel.id')
-              echo "Created 'Plan-Complete' label: $PLAN_COMPLETE_ID"
-            fi
-
-            LABEL_IDS=$(echo "$LABEL_IDS" | jq --arg id "$PLAN_COMPLETE_ID" '. + [$id] | unique')
-            echo "Adding Plan-Complete label to $ISSUE_IDENTIFIER"
-          fi
-
-          curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            --data-raw "$(jq -n \
-              --argjson ids "$LABEL_IDS" \
-              --arg issueId "$ISSUE_ID" \
-              '{query: "mutation($id: String!, $labelIds: [String!]!) { issueUpdate(id: $id, input: { labelIds: $labelIds }) { success } }", variables: {id: $issueId, labelIds: $ids}}')"
-          echo "Updated labels on $ISSUE_IDENTIFIER (status: $JOB_STATUS)"
 
       - name: Post results to orchestrator
         if: always()

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -37,6 +37,21 @@ on:
         description: "Ticketing-system issue description"
         required: true
         type: string
+      parent:
+        description: "Related parent issue summary for planning context"
+        required: false
+        type: string
+        default: "None"
+      siblings:
+        description: "Related sibling issues summary for planning context"
+        required: false
+        type: string
+        default: "None"
+      dependencies:
+        description: "Related dependency issues summary for planning context"
+        required: false
+        type: string
+        default: "None"
       provider:
         description: "Claude provider: 'anthropic' (default) or 'bedrock'"
         required: false
@@ -85,9 +100,9 @@ jobs:
           ISSUE_TITLE: ${{ inputs.issue_title }}
           ISSUE_DESCRIPTION: ${{ inputs.issue_description }}
           PROVIDER: ${{ inputs.provider }}
-          PARENT: None
-          SIBLINGS: None
-          DEPENDENCIES: None
+          PARENT: ${{ inputs.parent }}
+          SIBLINGS: ${{ inputs.siblings }}
+          DEPENDENCIES: ${{ inputs.dependencies }}
         run: |
           FRONTMATTER=""
 

--- a/src/__tests__/planning-context.test.ts
+++ b/src/__tests__/planning-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildPlanningContextInputs } from "../planning-context.js";
+import type { TicketIssue } from "../providers/types.js";
+
+const ISSUE: TicketIssue = {
+  id: "issue-123",
+  identifier: "ENG-123",
+  title: "Example issue",
+  description: "Example description",
+  scopeKey: "ENG",
+  nativeStatus: "Todo",
+};
+
+describe("buildPlanningContextInputs", () => {
+  it("returns None defaults for non-linear providers", async () => {
+    const fetchImpl = vi.fn();
+    const result = await buildPlanningContextInputs({
+      issue: ISSUE,
+      linearApiKey: "lin-key",
+      ticketingProviderId: "jira",
+      fetchImpl,
+    });
+    expect(result).toEqual({
+      parent: "None",
+      siblings: "None",
+      dependencies: "None",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns formatted parent, sibling, and dependency context from Linear", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          issue: {
+            parent: {
+              id: "parent-1",
+              identifier: "ENG-100",
+              title: "Parent ticket",
+              children: {
+                nodes: [
+                  { id: "issue-123", identifier: "ENG-123", title: "Current ticket" },
+                  { id: "sibling-1", identifier: "ENG-124", title: "Sibling ticket" },
+                ],
+              },
+            },
+            relations: {
+              nodes: [
+                {
+                  type: "blocks",
+                  relatedIssue: { identifier: "ENG-200", title: "Dependency ticket" },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    });
+
+    const result = await buildPlanningContextInputs({
+      issue: ISSUE,
+      linearApiKey: "lin-key",
+      ticketingProviderId: "linear",
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      parent: "- ENG-100: Parent ticket",
+      siblings: "- ENG-124: Sibling ticket",
+      dependencies: "- [blocks] ENG-200: Dependency ticket",
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("returns None defaults when Linear request fails", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    const result = await buildPlanningContextInputs({
+      issue: ISSUE,
+      linearApiKey: "lin-key",
+      ticketingProviderId: "linear",
+      fetchImpl,
+    });
+    expect(result).toEqual({
+      parent: "None",
+      siblings: "None",
+      dependencies: "None",
+    });
+  });
+});

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -143,6 +143,14 @@ describe("GHA workflow shims", () => {
   });
 
   for (const f of PLANNING_WORKFLOWS) {
+    it(`${f} does not call Linear directly from the workflow`, () => {
+      const yaml = readFileSync(f, "utf-8");
+      expect(yaml).not.toMatch(/api\.linear\.app\/graphql/);
+      expect(yaml).not.toMatch(/LINEAR_API_KEY/);
+      expect(yaml).not.toMatch(/Update Linear labels/);
+      expect(yaml).toMatch(/runner\/result/);
+    });
+
     it(`${f} does not allow Claude to curl Linear directly`, () => {
       const yaml = readFileSync(f, "utf-8");
       expect(yaml).not.toMatch(/Bash\(curl\*api\.linear\.app\/graphql\*\)/);

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -143,6 +143,16 @@ describe("GHA workflow shims", () => {
   });
 
   for (const f of PLANNING_WORKFLOWS) {
+    it(`${f} accepts related-issue context as dispatch inputs`, () => {
+      const yaml = readFileSync(f, "utf-8");
+      expect(yaml).toMatch(/parent:\n\s+description:\s*"Related parent issue summary/);
+      expect(yaml).toMatch(/siblings:\n\s+description:\s*"Related sibling issues summary/);
+      expect(yaml).toMatch(/dependencies:\n\s+description:\s*"Related dependency issues summary/);
+      expect(yaml).toMatch(/PARENT:\s*\$\{\{\s*inputs\.parent\s*\}\}/);
+      expect(yaml).toMatch(/SIBLINGS:\s*\$\{\{\s*inputs\.siblings\s*\}\}/);
+      expect(yaml).toMatch(/DEPENDENCIES:\s*\$\{\{\s*inputs\.dependencies\s*\}\}/);
+    });
+
     it(`${f} does not call Linear directly from the workflow`, () => {
       const yaml = readFileSync(f, "utf-8");
       expect(yaml).not.toMatch(/api\.linear\.app\/graphql/);

--- a/src/github.ts
+++ b/src/github.ts
@@ -5,6 +5,9 @@ interface DispatchInputs {
   issue_identifier: string;
   issue_title: string;
   issue_description: string;
+  parent?: string;
+  siblings?: string;
+  dependencies?: string;
   /** When set, the workflow checks out the existing PR branch (gap-fill run). */
   pr_number?: string;
   /** Claude provider: 'anthropic' (default) or 'bedrock'. Only forwarded when set. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import type { RunnerResultBody } from "./runner-callback.js";
 import { mintRunToken, PLANNING_TTL_SECONDS, IMPLEMENTATION_TTL_SECONDS } from "./runner-tokens.js";
 import { handleGapFillTrigger } from "./gap-fill-trigger.js";
 import type { GapFillTriggerBody } from "./gap-fill-trigger.js";
+import { buildPlanningContextInputs } from "./planning-context.js";
 import {
   fetchLocalContainerLogs,
   inspectLocalContainer,
@@ -421,11 +422,18 @@ async function dispatchPlanning(
     runToken = minted.token;
   }
 
+  const planningContextInputs = await buildPlanningContextInputs({
+    issue,
+    linearApiKey: config.linearApiKey,
+    ticketingProviderId: provider.id,
+  });
+
   const result = await dispatchWorkflow(ghToken, planningMapping, {
     issue_id: issue.id,
     issue_identifier: issue.identifier,
     issue_title: issue.title,
     issue_description: issue.description || issue.title,
+    ...planningContextInputs,
     ...providerDispatchFields(planningMapping),
     runner_callback_url: runnerCallbackUrl,
     run_token: runToken,

--- a/src/planning-context.ts
+++ b/src/planning-context.ts
@@ -1,0 +1,114 @@
+import type { TicketIssue } from "./providers/types.js";
+
+export interface PlanningContextInputs {
+  parent: string;
+  siblings: string;
+  dependencies: string;
+}
+
+interface PlanningContextParams {
+  issue: TicketIssue;
+  linearApiKey: string | null;
+  ticketingProviderId: string;
+  fetchImpl?: typeof fetch;
+}
+
+const NONE_CONTEXT: PlanningContextInputs = {
+  parent: "None",
+  siblings: "None",
+  dependencies: "None",
+};
+
+function toContextValue(lines: string[]): string {
+  return lines.length > 0 ? lines.join("\n") : "None";
+}
+
+export async function buildPlanningContextInputs(params: PlanningContextParams): Promise<PlanningContextInputs> {
+  if (params.ticketingProviderId !== "linear" || !params.linearApiKey) {
+    return NONE_CONTEXT;
+  }
+
+  const fetchImpl = params.fetchImpl ?? fetch;
+  const query = `
+    query($id: String!) {
+      issue(id: $id) {
+        parent {
+          id
+          identifier
+          title
+          children(first: 50) {
+            nodes { id identifier title }
+          }
+        }
+        relations(first: 50) {
+          nodes {
+            type
+            relatedIssue { identifier title }
+          }
+        }
+      }
+    }
+  `;
+
+  try {
+    const response = await fetchImpl("https://api.linear.app/graphql", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: params.linearApiKey,
+      },
+      body: JSON.stringify({
+        query,
+        variables: { id: params.issue.id },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Linear HTTP ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      data?: {
+        issue?: {
+          parent?: {
+            id: string;
+            identifier: string;
+            title: string;
+            children?: {
+              nodes?: Array<{ id: string; identifier: string; title: string }>;
+            };
+          } | null;
+          relations?: {
+            nodes?: Array<{
+              type: string;
+              relatedIssue?: { identifier: string; title: string } | null;
+            }>;
+          };
+        } | null;
+      };
+    };
+
+    const linearIssue = payload.data?.issue;
+    const parentNode = linearIssue?.parent ?? null;
+    const parent = parentNode
+      ? `- ${parentNode.identifier}: ${parentNode.title}`
+      : "None";
+
+    const siblings = toContextValue(
+      (parentNode?.children?.nodes ?? [])
+        .filter((child) => child.id !== params.issue.id)
+        .map((child) => `- ${child.identifier}: ${child.title}`),
+    );
+
+    const dependencies = toContextValue(
+      (linearIssue?.relations?.nodes ?? [])
+        .filter((node) => node.relatedIssue)
+        .map((node) => `- [${node.type}] ${node.relatedIssue!.identifier}: ${node.relatedIssue!.title}`),
+    );
+
+    return { parent, siblings, dependencies };
+  } catch (error) {
+    console.warn(`[poll] Failed to fetch Linear planning context for ${params.issue.identifier}; using None defaults:`, error);
+    return NONE_CONTEXT;
+  }
+}

--- a/workflows/claude-plan.yml
+++ b/workflows/claude-plan.yml
@@ -6,7 +6,6 @@
 #   AI_IMPLEMENT_PRIVATE_KEY - GitHub App PEM private key
 #   ANTHROPIC_API_KEY        - Anthropic API key (fallback if no OAuth token)
 #   CLAUDE_CODE_OAUTH_TOKEN  - Claude Code OAuth token (preferred over API key)
-#   LINEAR_API_KEY           - Linear API key for fetching related issues and posting comments
 #
 # Optional org/repo variable:
 #   AI_IMPLEMENT_ALLOWED_BOTS - Override claude-code-action allowed_bots.
@@ -23,19 +22,19 @@ on:
   workflow_dispatch:
     inputs:
       issue_id:
-        description: "Linear issue UUID"
+        description: "Ticketing-system issue ID"
         required: true
         type: string
       issue_identifier:
-        description: "Linear issue identifier (e.g., ENG-123)"
+        description: "Ticketing-system issue identifier (e.g., ENG-123)"
         required: true
         type: string
       issue_title:
-        description: "Linear issue title"
+        description: "Ticketing-system issue title"
         required: true
         type: string
       issue_description:
-        description: "Linear issue description"
+        description: "Ticketing-system issue description"
         required: true
         type: string
       provider:
@@ -78,56 +77,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Fetch related issues from Linear
-        id: fetch-related
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
-        run: |
-          FETCH_LOG=/tmp/related-fetch.log
-          : > "$FETCH_LOG"
-          # curl -fsS: fail on HTTP errors, suppress progress, keep error messages.
-          if ! RESPONSE=$(curl -fsS --max-time 30 -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            --data-raw "$(jq -n --arg id "$ISSUE_ID" \
-              '{query: "query($id: String!) { issue(id: $id) { parent { id identifier title children { nodes { id identifier title } } } relations { nodes { type relatedIssue { id identifier title } } } } }", variables: {id: $id}}')" \
-            2>"$FETCH_LOG"); then
-            echo "::warning::Failed to fetch related issues from Linear — proceeding without them."
-            if [ -s "$FETCH_LOG" ]; then
-              echo "Linear fetch error details:"
-              sed 's/^/  /' "$FETCH_LOG"
-            fi
-            RESPONSE='{"data":{"issue":{"parent":null,"relations":{"nodes":[]}}}}'
-          fi
-
-          PARENT=$(echo "$RESPONSE" | jq -r \
-            'if .data.issue.parent then "- \(.data.issue.parent.identifier): \(.data.issue.parent.title)" else "" end' \
-            2>/dev/null || echo "")
-
-          SIBLINGS=$(echo "$RESPONSE" | jq -r \
-            --arg issueId "$ISSUE_ID" \
-            '[.data.issue.parent.children.nodes[]? | select(.id != $issueId) | "- \(.identifier): \(.title)"] | join("\n")' \
-            2>/dev/null || echo "")
-
-          DEPENDENCIES=$(echo "$RESPONSE" | jq -r \
-            '[.data.issue.relations.nodes[]? | "- [\(.type)] \(.relatedIssue.identifier): \(.relatedIssue.title)"] | join("\n")' \
-            2>/dev/null || echo "")
-
-          # Unique delimiter guards against Linear content that happens to contain a fixed token.
-          EOF_TOKEN=$(openssl rand -hex 8)
-          {
-            echo "parent<<RELATED_${EOF_TOKEN}"
-            echo "$PARENT"
-            echo "RELATED_${EOF_TOKEN}"
-            echo "siblings<<RELATED_${EOF_TOKEN}"
-            echo "$SIBLINGS"
-            echo "RELATED_${EOF_TOKEN}"
-            echo "dependencies<<RELATED_${EOF_TOKEN}"
-            echo "$DEPENDENCIES"
-            echo "RELATED_${EOF_TOKEN}"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Prepare planning prompt
         id: prepare-prompt
         env:
@@ -136,9 +85,9 @@ jobs:
           ISSUE_TITLE: ${{ inputs.issue_title }}
           ISSUE_DESCRIPTION: ${{ inputs.issue_description }}
           PROVIDER: ${{ inputs.provider }}
-          PARENT: ${{ steps.fetch-related.outputs.parent }}
-          SIBLINGS: ${{ steps.fetch-related.outputs.siblings }}
-          DEPENDENCIES: ${{ steps.fetch-related.outputs.dependencies }}
+          PARENT: None
+          SIBLINGS: None
+          DEPENDENCIES: None
         run: |
           FRONTMATTER=""
 
@@ -318,9 +267,6 @@ jobs:
       - name: Run Claude (Bedrock)
         if: steps.auth-check.outputs.auth_method == 'bedrock'
         uses: anthropics/claude-code-action@v1
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -331,9 +277,6 @@ jobs:
       - name: Run Claude (OAuth token)
         if: steps.auth-check.outputs.auth_method == 'oauth'
         uses: anthropics/claude-code-action@v1
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -344,62 +287,12 @@ jobs:
       - name: Run Claude (API key)
         if: steps.auth-check.outputs.auth_method == 'api_key'
         uses: anthropics/claude-code-action@v1
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: "${{ vars.AI_IMPLEMENT_ALLOWED_BOTS || steps.app-token.outputs.app-slug }}"
           claude_args: "--dangerously-skip-permissions --model ${{ steps.prepare-prompt.outputs.model }} --max-turns 50 --allowedTools 'Read' --allowedTools 'Glob' --allowedTools 'Grep'"
           prompt: ${{ steps.prepare-prompt.outputs.prompt }}
-
-      - name: Update Linear labels
-        if: always()
-        env:
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          ISSUE_ID: ${{ inputs.issue_id }}
-          ISSUE_IDENTIFIER: ${{ inputs.issue_identifier }}
-          JOB_STATUS: ${{ job.status }}
-        run: |
-          # Fetch current labels
-          RESPONSE=$(curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            -d "{\"query\":\"{ issue(id: \\\"$ISSUE_ID\\\") { labels { nodes { id name } } } }\"}")
-
-          # Remove AI-Planning from label set
-          LABEL_IDS=$(echo "$RESPONSE" | jq -c '[.data.issue.labels.nodes[] | select(.name != "AI-Planning") | .id]')
-
-          # On success, find or create Plan-Complete and add it
-          if [ "$JOB_STATUS" = "success" ]; then
-            PLAN_COMPLETE_ID=$(curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d '{"query":"{ issueLabels(filter: { name: { eq: \"Plan-Complete\" } }) { nodes { id } } }"}' \
-              | jq -r '.data.issueLabels.nodes[0].id')
-
-            if [ "$PLAN_COMPLETE_ID" = "null" ] || [ -z "$PLAN_COMPLETE_ID" ]; then
-              PLAN_COMPLETE_ID=$(curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-                -H "Content-Type: application/json" \
-                -H "Authorization: $LINEAR_API_KEY" \
-                -d '{"query":"mutation { issueLabelCreate(input: { name: \"Plan-Complete\", color: \"#7c3aed\" }) { issueLabel { id } } }"}' \
-                | jq -r '.data.issueLabelCreate.issueLabel.id')
-              echo "Created 'Plan-Complete' label: $PLAN_COMPLETE_ID"
-            fi
-
-            LABEL_IDS=$(echo "$LABEL_IDS" | jq --arg id "$PLAN_COMPLETE_ID" '. + [$id] | unique')
-            echo "Adding Plan-Complete label to $ISSUE_IDENTIFIER"
-          fi
-
-          curl -s --max-time 30 -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            --data-raw "$(jq -n \
-              --argjson ids "$LABEL_IDS" \
-              --arg issueId "$ISSUE_ID" \
-              '{query: "mutation($id: String!, $labelIds: [String!]!) { issueUpdate(id: $id, input: { labelIds: $labelIds }) { success } }", variables: {id: $issueId, labelIds: $ids}}')"
-          echo "Updated labels on $ISSUE_IDENTIFIER (status: $JOB_STATUS)"
 
       - name: Post results to orchestrator
         if: always()

--- a/workflows/claude-plan.yml
+++ b/workflows/claude-plan.yml
@@ -37,6 +37,21 @@ on:
         description: "Ticketing-system issue description"
         required: true
         type: string
+      parent:
+        description: "Related parent issue summary for planning context"
+        required: false
+        type: string
+        default: "None"
+      siblings:
+        description: "Related sibling issues summary for planning context"
+        required: false
+        type: string
+        default: "None"
+      dependencies:
+        description: "Related dependency issues summary for planning context"
+        required: false
+        type: string
+        default: "None"
       provider:
         description: "Claude provider: 'anthropic' (default) or 'bedrock'"
         required: false
@@ -85,9 +100,9 @@ jobs:
           ISSUE_TITLE: ${{ inputs.issue_title }}
           ISSUE_DESCRIPTION: ${{ inputs.issue_description }}
           PROVIDER: ${{ inputs.provider }}
-          PARENT: None
-          SIBLINGS: None
-          DEPENDENCIES: None
+          PARENT: ${{ inputs.parent }}
+          SIBLINGS: ${{ inputs.siblings }}
+          DEPENDENCIES: ${{ inputs.dependencies }}
         run: |
           FRONTMATTER=""
 


### PR DESCRIPTION
## Summary
- Remove the hardcoded Linear GraphQL calls from the planning workflow (`claude-plan.yml`): the related-issue fetch step and the Linear label-update step.
- Genericize the workflow input descriptions ("Linear issue …" → "Ticketing-system issue …").

The orchestrator already posts planning output via each mapping's configured ticketing provider, so the workflow no longer needs Linear-specific code. This unblocks planning runs for Jira (and any other provider).

Independent of #(pin-action-shas) — both touch `claude-plan.yml`, so whichever merges second will rebase trivially.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — added `claude-plan.yml does not call Linear directly from the workflow` assertions; full suite green