### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -150,14 +150,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
       - name: Configure AWS credentials (Bedrock)
         if: inputs.provider == 'bedrock'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -68,13 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         id: app-token
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/claude-plan.yml
+++ b/.github/workflows/claude-plan.yml
@@ -310,14 +310,14 @@ jobs:
 
       - name: Configure AWS credentials (Bedrock)
         if: steps.auth-check.outputs.auth_method == 'bedrock'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}
 
       - name: Run Claude (Bedrock)
         if: steps.auth-check.outputs.auth_method == 'bedrock'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ed282bf5e31de156a90889428e1d6a5013b0fdf
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           ISSUE_ID: ${{ inputs.issue_id }}
@@ -330,7 +330,7 @@ jobs:
 
       - name: Run Claude (OAuth token)
         if: steps.auth-check.outputs.auth_method == 'oauth'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ed282bf5e31de156a90889428e1d6a5013b0fdf
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           ISSUE_ID: ${{ inputs.issue_id }}
@@ -343,7 +343,7 @@ jobs:
 
       - name: Run Claude (API key)
         if: steps.auth-check.outputs.auth_method == 'api_key'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ed282bf5e31de156a90889428e1d6a5013b0fdf
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           ISSUE_ID: ${{ inputs.issue_id }}

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Check trigger command
         id: trigger
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const body = context.payload.comment.body ?? "";
@@ -52,7 +52,7 @@ jobs:
 
       - name: Auth check (write, maintain, or admin)
         if: steps.trigger.outputs.matched == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -64,7 +64,7 @@ jobs:
 
       - name: Acknowledge trigger
         if: steps.trigger.outputs.matched == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -77,7 +77,7 @@ jobs:
       - name: Extract PR metadata
         if: steps.trigger.outputs.matched == 'true'
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           AI_IMPLEMENT_PROVIDER: ${{ vars.AI_IMPLEMENT_PROVIDER }}
           AI_IMPLEMENT_AWS_REGION: ${{ vars.AI_IMPLEMENT_AWS_REGION }}
@@ -171,7 +171,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
@@ -195,7 +195,7 @@ jobs:
 
       - name: Configure AWS credentials (Bedrock)
         if: needs.check-trigger.outputs.provider == 'bedrock'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: ${{ needs.check-trigger.outputs.aws_region }}

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -15,6 +15,7 @@ const PLANNING_WORKFLOWS = [
   ".github/workflows/claude-plan.yml",
 ];
 const FILES = [...IMPLEMENT_WORKFLOWS, ...COMMENT_TRIGGER_WORKFLOWS];
+const SYNCED_WORKFLOW_FILES = [...IMPLEMENT_WORKFLOWS, ...COMMENT_TRIGGER_WORKFLOWS, ...PLANNING_WORKFLOWS];
 
 describe("GHA workflow shims", () => {
   it("ships workflow templates in the orchestrator image for admin-triggered syncs", () => {
@@ -38,6 +39,17 @@ describe("GHA workflow shims", () => {
       readFileSync("workflows/claude-plan.yml", "utf-8"),
     );
   });
+
+  for (const f of SYNCED_WORKFLOW_FILES) {
+    it(`${f} pins external actions to full commit SHAs`, () => {
+      const yaml = readFileSync(f, "utf-8");
+      const actionRefs = [...yaml.matchAll(/^\s*uses:\s*([^\s#]+@[^\s#]+)/gm)].map((m) => m[1]);
+      expect(actionRefs.length).toBeGreaterThan(0);
+      for (const ref of actionRefs) {
+        expect(ref).toMatch(/@[0-9a-f]{40}$/);
+      }
+    });
+  }
 
   for (const f of FILES) {
     it(`${f} uses a resolved runner image for its container job`, () => {

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -150,14 +150,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
       - name: Configure AWS credentials (Bedrock)
         if: inputs.provider == 'bedrock'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}

--- a/workflows/claude-plan.yml
+++ b/workflows/claude-plan.yml
@@ -68,13 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         id: app-token
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/workflows/claude-plan.yml
+++ b/workflows/claude-plan.yml
@@ -310,14 +310,14 @@ jobs:
 
       - name: Configure AWS credentials (Bedrock)
         if: steps.auth-check.outputs.auth_method == 'bedrock'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: ${{ inputs.aws_region }}
 
       - name: Run Claude (Bedrock)
         if: steps.auth-check.outputs.auth_method == 'bedrock'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ed282bf5e31de156a90889428e1d6a5013b0fdf
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           ISSUE_ID: ${{ inputs.issue_id }}
@@ -330,7 +330,7 @@ jobs:
 
       - name: Run Claude (OAuth token)
         if: steps.auth-check.outputs.auth_method == 'oauth'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ed282bf5e31de156a90889428e1d6a5013b0fdf
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           ISSUE_ID: ${{ inputs.issue_id }}
@@ -343,7 +343,7 @@ jobs:
 
       - name: Run Claude (API key)
         if: steps.auth-check.outputs.auth_method == 'api_key'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@3ed282bf5e31de156a90889428e1d6a5013b0fdf
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           ISSUE_ID: ${{ inputs.issue_id }}

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Check trigger command
         id: trigger
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const body = context.payload.comment.body ?? "";
@@ -52,7 +52,7 @@ jobs:
 
       - name: Auth check (write, maintain, or admin)
         if: steps.trigger.outputs.matched == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -64,7 +64,7 @@ jobs:
 
       - name: Acknowledge trigger
         if: steps.trigger.outputs.matched == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -77,7 +77,7 @@ jobs:
       - name: Extract PR metadata
         if: steps.trigger.outputs.matched == 'true'
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           AI_IMPLEMENT_PROVIDER: ${{ vars.AI_IMPLEMENT_PROVIDER }}
           AI_IMPLEMENT_AWS_REGION: ${{ vars.AI_IMPLEMENT_AWS_REGION }}
@@ -171,7 +171,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
@@ -195,7 +195,7 @@ jobs:
 
       - name: Configure AWS credentials (Bedrock)
         if: needs.check-trigger.outputs.provider == 'bedrock'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
         with:
           role-to-assume: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
           aws-region: ${{ needs.check-trigger.outputs.aws_region }}


### PR DESCRIPTION
## Summary
- Pin the external actions used by the synced workflow templates — `configure-aws-credentials`, `claude-code-action`, `github-script`, `create-github-app-token` — to full commit SHAs.
- Add a test asserting every block-form `uses:` ref in the synced workflows is SHA-pinned.

Supply-chain hardening; no behavioral change. Independent of the ticketing-agnostic-plan PR.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — new pin assertions across the synced workflows; full suite green