### PR TITLE
[codex] Ignore local client toml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 *.sqlite
 *.pem
 *.pem.txt
+clients/*.toml
+!clients/example-client.toml
 .claude/
 .conductor/
 .wrangler/


### PR DESCRIPTION
## Summary
- Ignore local client-specific TOML files under clients/
- Keep clients/example-client.toml trackable as the shared template

## Why
Local client TOML files should not be overwritten by upstream pulls, while the example config should remain versioned for onboarding and reference.

## Validation
- git check-ignore -v clients/acme.toml
- git check-ignore -v clients/example-client.toml