### PR TITLE
[codex] structure post-push review feedback

### DIFF
--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -685,11 +685,53 @@ describe("postPushReviewStep", () => {
     expect(report).toHaveBeenCalledWith(expect.objectContaining({
       id: "post-push-review.1",
       status: "failed",
+      outputs: expect.objectContaining({
+        issues: [expect.stringContaining("claude auth temporarily unavailable")],
+        blockingIssues: [expect.objectContaining({
+          rawText: expect.stringContaining("claude auth temporarily unavailable"),
+        })],
+      }),
     }));
     expect(ghComments.some((comment) => comment.includes("review-failed"))).toBe(true);
     expect(ghComments.some((comment) => comment.includes("No actionable code feedback was produced"))).toBe(true);
     expect(ghComments.some((comment) => comment.includes("Manual review required; automated review did not complete"))).toBe(true);
     expect(ghComments.some((comment) => comment.includes("Not ready to merge until manually reviewed"))).toBe(false);
+  });
+
+  it("reports invalid non-JSON reviewer output with structured blocking issue outputs", async () => {
+    const ghComments: string[] = [];
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const report = vi.fn(async () => undefined);
+    const ctx = makeCtx(vi.fn(async () => ({
+      stdout: "this is not json",
+      exitCode: 0,
+      tokensUsed: 100,
+    })));
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn: vi.fn() },
+      { report },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(report).toHaveBeenCalledWith(expect.objectContaining({
+      id: "post-push-review.1",
+      status: "failed",
+      outputs: expect.objectContaining({
+        issues: [expect.stringContaining("Reviewer returned non-JSON output")],
+        blockingIssues: [expect.objectContaining({
+          rawText: expect.stringContaining("Reviewer returned non-JSON output"),
+        })],
+      }),
+    }));
+    expect(ghComments.some((comment) => comment.includes("review-invalid"))).toBe(true);
   });
 
   it("does not fail the job when a post-push fix-pass LLM exits non-zero", async () => {
@@ -1077,6 +1119,86 @@ describe("postPushReviewStep", () => {
     expect(fixPrompt).toContain("**First-visit detection is incomplete**");
     expect(fixPrompt).toContain(requiredFix);
     expect(fixPrompt).not.toContain(`${requiredFix.slice(0, 80)}...`);
+  });
+
+  it("renders text-only blocking issue objects like legacy string issues", async () => {
+    const issueText = "The reviewer returned a legacy text-only object that should stay flat in comments and prompts.";
+    const reviewerJson = JSON.stringify({
+      approved: false,
+      blocking_issues: [{ text: issueText }],
+      feedback: issueText,
+      score: 4,
+      progress_delta: 0,
+    });
+    const ghComments: string[] = [];
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(reviewComment).toContain(`Blocking issues:\n1. ${issueText}`);
+    expect(reviewComment).not.toContain("**Blocking issue**");
+
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain(`Issues:\n1. ${issueText}`);
+    expect(fixPrompt).not.toContain("**Blocking issue**");
+  });
+
+  it("escapes markdown control characters in structured issue fields", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: false,
+      blocking_issues: [{
+        title: "Fix **unsafe** label",
+        location: "src/app/`weird`.tsx",
+        problem: "Do not render [click me](https://example.com) as a link.",
+        required_fix: "Escape *markdown* before posting.",
+      }],
+      feedback: "Structured fields contain markdown.",
+      score: 4,
+      progress_delta: 0,
+    });
+    const ghComments: string[] = [];
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(reviewComment).toContain("**Fix \\*\\*unsafe\\*\\* label**");
+    expect(reviewComment).toContain("Location: `src/app/'weird'.tsx`");
+    expect(reviewComment).toContain("Do not render \\[click me\\]\\(https://example.com\\) as a link.");
+    expect(reviewComment).toContain("Escape \\*markdown\\* before posting.");
   });
 
   it("includes unresolved structured issues when a fix pass makes no file changes", async () => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -1069,8 +1069,8 @@ describe("postPushReviewStep", () => {
     expect(out.approved).toBe(true);
     const secondReviewPrompt = invoke.mock.calls[2][0].prompt;
     expect(secondReviewPrompt).toContain("Review 1:");
-    expect(secondReviewPrompt).toContain("1. **First-visit hydration state is unsafe**");
-    expect(secondReviewPrompt).toContain("Location: `src/app/page.tsx`");
+    expect(secondReviewPrompt).toContain("1. First-visit hydration state is unsafe");
+    expect(secondReviewPrompt).toContain("Location: src/app/page.tsx");
     expect(secondReviewPrompt).toContain("Problem: The first render can decide panel visibility before browser-only sessionStorage state is available.");
     expect(secondReviewPrompt).toContain(`Required fix: ${requiredFix}`);
   });
@@ -1116,7 +1116,8 @@ describe("postPushReviewStep", () => {
     expect(reviewComment).toContain(requiredFix);
 
     const fixPrompt = invoke.mock.calls[1][0].prompt;
-    expect(fixPrompt).toContain("**First-visit detection is incomplete**");
+    expect(fixPrompt).toContain("First-visit detection is incomplete");
+    expect(fixPrompt).not.toContain("**First-visit detection is incomplete**");
     expect(fixPrompt).toContain(requiredFix);
     expect(fixPrompt).not.toContain(`${requiredFix.slice(0, 80)}...`);
   });
@@ -1199,6 +1200,13 @@ describe("postPushReviewStep", () => {
     expect(reviewComment).toContain("Location: `src/app/'weird'.tsx`");
     expect(reviewComment).toContain("Do not render \\[click me\\]\\(https://example.com\\) as a link.");
     expect(reviewComment).toContain("Escape \\*markdown\\* before posting.");
+
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("Fix **unsafe** label");
+    expect(fixPrompt).toContain("src/app/`weird`.tsx");
+    expect(fixPrompt).toContain("Do not render [click me](https://example.com) as a link.");
+    expect(fixPrompt).toContain("Escape *markdown* before posting.");
+    expect(fixPrompt).not.toContain("\\[click me\\]\\(https://example.com\\)");
   });
 
   it("includes unresolved structured issues when a fix pass makes no file changes", async () => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -979,6 +979,60 @@ describe("postPushReviewStep", () => {
     expect(invoke.mock.calls[1][0]).toEqual(expect.objectContaining({ maxTurns: 45 }));
   });
 
+  it("includes structured issue details in follow-up review history", async () => {
+    const requiredFix = "Move the sessionStorage read into the hydrated effect and keep the dismissed flag synchronized when the first-visit panel is closed.";
+    const firstReview = JSON.stringify({
+      approved: false,
+      blocking_issues: [{
+        title: "First-visit hydration state is unsafe",
+        location: "src/app/page.tsx",
+        problem: "The first render can decide panel visibility before browser-only sessionStorage state is available.",
+        required_fix: requiredFix,
+      }],
+      feedback: "The first-visit state handling still needs one fix.",
+      score: 4,
+      progress_delta: 0,
+    });
+    const secondReview = JSON.stringify({
+      approved: true,
+      blocking_issues: [],
+      feedback: "Looks good.",
+      score: 9,
+      progress_delta: 1,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "M src/app/page.tsx\n", exitCode: 0 };
+      if (args[0] === "rev-parse" && args[1] === "--short") return { stdout: "abc1234\n", exitCode: 0 };
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "codex/structured-review-feedback\n", exitCode: 0 };
+      if (args[0] === "ls-remote") return { stdout: "beadfeed\trefs/heads/codex/structured-review-feedback\n", exitCode: 0 };
+      if (args[0] === "show") return { stdout: "M\tsrc/app/page.tsx\n", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn()
+      .mockResolvedValueOnce({ stdout: firstReview, exitCode: 0, tokensUsed: 100 })
+      .mockResolvedValueOnce({ stdout: "", exitCode: 0, tokensUsed: 100 })
+      .mockResolvedValueOnce({ stdout: secondReview, exitCode: 0, tokensUsed: 100 });
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 3, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(true);
+    const secondReviewPrompt = invoke.mock.calls[2][0].prompt;
+    expect(secondReviewPrompt).toContain("Review 1:");
+    expect(secondReviewPrompt).toContain("1. **First-visit hydration state is unsafe**");
+    expect(secondReviewPrompt).toContain("Location: `src/app/page.tsx`");
+    expect(secondReviewPrompt).toContain("Problem: The first render can decide panel visibility before browser-only sessionStorage state is available.");
+    expect(secondReviewPrompt).toContain(`Required fix: ${requiredFix}`);
+  });
+
   it("posts full structured blocking issues in PR comments and fix prompts", async () => {
     const requiredFix = "Read sessionStorage only after the component has mounted, keep the dismissed flag in sync when the user dismisses the first-visit panel, and preserve the isHydrated guard so server-rendered markup cannot diverge from client-rendered markup.";
     const reviewerJson = JSON.stringify({

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -567,14 +567,101 @@ describe("postPushReviewStep", () => {
     const secondReviewPrompt = invoke.mock.calls[2][0].prompt;
     expect(firstReviewPrompt).toContain("complete merge-readiness review");
     expect(firstReviewPrompt).toContain("Do not stop after the first issue");
-    expect(firstReviewPrompt).toContain("Every issues[] entry must be self-contained");
+    expect(firstReviewPrompt).toContain("Every blocking_issues[] entry must be self-contained");
     expect(secondReviewPrompt).toContain("Review 1:");
     expect(secondReviewPrompt).toContain("1. Fix auth flow");
     expect(secondReviewPrompt).toContain("first verify every previous issue is fixed");
     expect(invoke.mock.calls[1][0]).toEqual(expect.objectContaining({ maxTurns: 45 }));
   });
 
-  it("omits duplicate review summaries and compacts long blocking issues in PR comments", async () => {
+  it("posts full structured blocking issues in PR comments and fix prompts", async () => {
+    const requiredFix = "Read sessionStorage only after the component has mounted, keep the dismissed flag in sync when the user dismisses the first-visit panel, and preserve the isHydrated guard so server-rendered markup cannot diverge from client-rendered markup.";
+    const reviewerJson = JSON.stringify({
+      approved: false,
+      blocking_issues: [{
+        title: "First-visit detection is incomplete",
+        location: "src/app/page.tsx",
+        problem: "The implementation renders the first-visit panel from a default client value before sessionStorage has been checked, which can show the wrong state during hydration and can re-open a dismissed panel.",
+        required_fix: requiredFix,
+      }],
+      feedback: "The review found one blocker.",
+      score: 4,
+      progress_delta: 0,
+    });
+    const ghComments: string[] = [];
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(reviewComment).toContain("**First-visit detection is incomplete**");
+    expect(reviewComment).toContain("Location: `src/app/page.tsx`");
+    expect(reviewComment).toContain(requiredFix);
+
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("**First-visit detection is incomplete**");
+    expect(fixPrompt).toContain(requiredFix);
+    expect(fixPrompt).not.toContain(`${requiredFix.slice(0, 80)}...`);
+  });
+
+  it("includes unresolved structured issues when a fix pass makes no file changes", async () => {
+    const requiredFix = "Persist the dismissed state to sessionStorage before hiding the panel and ensure the initial render waits for the hydrated guard before deciding whether to show the first-visit UI.";
+    const reviewerJson = JSON.stringify({
+      approved: false,
+      blocking_issues: [{
+        title: "Dismissed first-visit state is lost",
+        location: "src/app/page.tsx",
+        problem: "The fix pass must not stop with a generic message because reviewers need the unresolved blocker in the terminal PR comment.",
+        required_fix: requiredFix,
+      }],
+      feedback: "Not ready until the first-visit state is fixed.",
+      score: 4,
+      progress_delta: 0,
+    });
+    const ghComments: string[] = [];
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    const noChangesComment = ghComments.find((comment) => comment.includes("no-changes"));
+    expect(noChangesComment).toContain("Unresolved blocking issues:");
+    expect(noChangesComment).toContain("Dismissed first-visit state is lost");
+    expect(noChangesComment).toContain(requiredFix);
+  });
+
+  it("omits duplicate review summaries without truncating legacy blocking issues in PR comments", async () => {
     const longIssue = "The parse API error path is missing user-visible error handling in app/page.tsx, so failed parse requests leave the user stuck on the input surface without feedback or a retry path. Add an error state, render it near OpenInput, and reset loading after failures.";
     const notApproved = JSON.stringify({
       approved: false,
@@ -605,9 +692,8 @@ describe("postPushReviewStep", () => {
     );
 
     const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
-    expect(reviewComment).toContain("Blocking issues:\n1. The parse API error path is missing user-visible error handling");
+    expect(reviewComment).toContain(`Blocking issues:\n1. ${longIssue}`);
     expect(reviewComment).not.toContain("Reviewer summary:");
-    expect(reviewComment!.length).toBeLessThan(longIssue.length * 2);
   });
 
   it("posts a concrete fix summary when the fixer reports one", async () => {

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -34,8 +34,16 @@ const DEFAULT_MAX_ITERATIONS = 3;
 
 interface ReviewFinding {
   iteration: number;
-  issues: string[];
+  issues: ReviewIssue[];
   feedback: string;
+}
+
+interface ReviewIssue {
+  title: string;
+  location?: string;
+  problem: string;
+  requiredFix: string;
+  rawText?: string;
 }
 
 interface FixSummary {
@@ -88,10 +96,76 @@ function compactForComment(text: string, maxLength = 260): string {
   return `${compact.slice(0, maxLength - 3).trim()}...`;
 }
 
-function formatIssueList(issues: string[], options?: { compact?: boolean }): string {
+function issueFromString(text: string): ReviewIssue {
+  const trimmed = text.trim();
+  return {
+    title: "Blocking issue",
+    problem: trimmed,
+    requiredFix: "",
+    rawText: trimmed,
+  };
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseReviewIssue(value: unknown): ReviewIssue | null {
+  if (typeof value === "string") {
+    const text = value.trim();
+    return text ? issueFromString(text) : null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const issue = value as Record<string, unknown>;
+  const title = stringValue(issue.title) || stringValue(issue.summary) || "Blocking issue";
+  const location = stringValue(issue.location) || stringValue(issue.file) || stringValue(issue.path) || undefined;
+  const problem = stringValue(issue.problem) || stringValue(issue.issue) || stringValue(issue.details) || stringValue(issue.description);
+  const requiredFix = stringValue(issue.required_fix) || stringValue(issue.requiredFix) || stringValue(issue.fix) || stringValue(issue.recommendation);
+  const rawText = stringValue(issue.text);
+  if (!problem && !requiredFix && !rawText) return null;
+
+  return {
+    title,
+    location,
+    problem: problem || rawText || title,
+    requiredFix,
+  };
+}
+
+function parseReviewIssues(parsed: Record<string, unknown>): ReviewIssue[] {
+  const source = Array.isArray(parsed.blocking_issues)
+    ? parsed.blocking_issues
+    : Array.isArray(parsed.blockingIssues)
+      ? parsed.blockingIssues
+      : Array.isArray(parsed.issues)
+        ? parsed.issues
+        : [];
+
+  return source
+    .map(parseReviewIssue)
+    .filter((issue): issue is ReviewIssue => issue !== null);
+}
+
+function plainIssueText(issue: ReviewIssue): string {
+  if (issue.rawText) return issue.rawText;
+  return [
+    issue.title,
+    issue.location ? `Location: ${issue.location}` : "",
+    issue.problem ? `Problem: ${issue.problem}` : "",
+    issue.requiredFix ? `Required fix: ${issue.requiredFix}` : "",
+  ].filter(Boolean).join("\n");
+}
+
+function formatIssueList(issues: ReviewIssue[]): string {
   return issues.map((issue, index) => {
-    const text = options?.compact ? compactForComment(issue) : issue;
-    return `${index + 1}. ${text}`;
+    if (issue.rawText) return `${index + 1}. ${issue.rawText}`;
+
+    const lines = [`${index + 1}. **${issue.title}**`];
+    if (issue.location) lines.push(`   - Location: \`${issue.location.replace(/`/g, "'")}\``);
+    if (issue.problem) lines.push(`   - Problem: ${issue.problem}`);
+    if (issue.requiredFix) lines.push(`   - Required fix: ${issue.requiredFix}`);
+    return lines.join("\n");
   }).join("\n");
 }
 
@@ -99,17 +173,19 @@ function normalizeForComparison(text: string): string {
   return text.toLowerCase().replace(/[`*_()[\]{}.,:;!?'"-]+/g, " ").replace(/\s+/g, " ").trim();
 }
 
-function blockingIssuesBlock(issues: string[], options?: { compact?: boolean }): string {
-  const issueList = formatIssueList(issues, options);
-  return issueList ? `\n\nBlocking issues:\n${issueList}` : "";
+function blockingIssuesBlock(issues: ReviewIssue[], options?: { heading?: string }): string {
+  const issueList = formatIssueList(issues);
+  const heading = options?.heading ?? "Blocking issues:";
+  return issueList ? `\n\n${heading}\n${issueList}` : "";
 }
 
-function reviewerSummaryBlock(feedback: string, issues: string[]): string {
+function reviewerSummaryBlock(feedback: string, issues: ReviewIssue[]): string {
   const summary = feedback.trim();
   if (!summary) return "";
   const normalizedSummary = normalizeForComparison(summary);
-  const repeatsIssue = issues.some((issue) => normalizeForComparison(issue) === normalizedSummary);
-  const repeatsAllIssues = normalizeForComparison(issues.join("\n")) === normalizedSummary;
+  const issueTexts = issues.map(plainIssueText);
+  const repeatsIssue = issueTexts.some((issue) => normalizeForComparison(issue) === normalizedSummary);
+  const repeatsAllIssues = normalizeForComparison(issueTexts.join("\n")) === normalizedSummary;
   if (repeatsIssue || repeatsAllIssues) return "";
   return `\n\nReviewer summary:\n${summary}`;
 }
@@ -193,8 +269,11 @@ function feedbackImpliesFixNeeded(feedback: string): boolean {
     .test(feedback);
 }
 
-function filterNonBlockingIssues(issues: string[]): string[] {
-  return issues.filter((issue) => !(isDeferredOrNonBlocking(issue) && !hasStrongActionSignal(issue)));
+function filterNonBlockingIssues(issues: ReviewIssue[]): ReviewIssue[] {
+  return issues.filter((issue) => {
+    const text = plainIssueText(issue);
+    return !(isDeferredOrNonBlocking(text) && !hasStrongActionSignal(text));
+  });
 }
 
 function parseFixSummary(stdout: string): FixSummary | null {
@@ -319,7 +398,8 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
 
 Set approved=true only when no code changes are needed. If you find any bug,
 missing requirement, unsafe behavior, test gap, or follow-up that should be
-fixed in this PR, set approved=false and put every actionable item in issues[].
+fixed in this PR, set approved=false and put every actionable item in
+blocking_issues[].
 Do not approve while listing "minor issues worth addressing" in feedback.
 Do not set approved=false for future/later-task concerns that are not required
 by this issue; mention those in feedback only.
@@ -329,20 +409,23 @@ Inspect the whole diff before deciding. Do not stop after the first issue.
 Before producing JSON, check requirements coverage, changed API/data contracts,
 error handling, security, regressions, edge cases, and test coverage.
 
-Every issues[] entry must be self-contained and immediately actionable:
-include the affected file/function when possible, the failing behavior, and
-the required fix. Keep each issue to one concise sentence. Do not put praise,
-overall status, or optional/future cleanup in issues[]. Do not write feedback
-that refers to issues "above" unless those issues are explicitly listed in
-issues[].
+Every blocking_issues[] entry must be self-contained and immediately
+actionable. Use structured objects with title, location, problem, and
+required_fix fields. Include the affected file/function when possible, the
+failing behavior, and the required fix. Do not abbreviate or truncate issue
+details; do not use ellipses. Do not put praise, overall status, or
+optional/future cleanup in blocking_issues[]. Do not write feedback that
+refers to issues "above" unless those issues are explicitly listed in
+blocking_issues[].
 
 Use feedback for a short overall review summary that adds context not already
-present in issues[]. Do not repeat the issues[] text verbatim in feedback.
+present in blocking_issues[]. Do not repeat the blocking_issues[] text
+verbatim in feedback.
 
 On follow-up reviews, first verify every previous issue is fixed, then review
 the entire updated diff again for newly introduced or newly visible blockers.
-If a previous issue remains unresolved, keep it in issues[] with the current
-reason it is still blocking.
+If a previous issue remains unresolved, keep it in blocking_issues[] with the
+current reason it is still blocking.
 
 Issue description:
 ${context.data.issueDescription}
@@ -356,7 +439,7 @@ ${DIFF_INJECTION_PREAMBLE}
 ${diffRes.stdout}
 </pr_diff>
 
-Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "progress_delta": int, "feedback": "string"}.`;
+Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string", "location": "file/function or empty string", "problem": "full failing behavior", "required_fix": "full required fix"}], "score": int, "progress_delta": int, "feedback": "string"}.`;
 
       const reviewResult = await context.llmExecutor.invoke({ prompt: reviewPrompt, model, maxTurns: REVIEW_MAX_TURNS });
       if (reviewResult.exitCode !== 0) {
@@ -384,7 +467,7 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
       }
 
       const parsed = extractFirstJsonObject(reviewResult.stdout) as
-        | { approved?: boolean; feedback?: string; issues?: string[] }
+        | { approved?: boolean; feedback?: string; issues?: unknown[]; blocking_issues?: unknown[]; blockingIssues?: unknown[] }
         | null;
       if (!parsed) {
         feedback = compactErrorMessage(`Reviewer returned non-JSON output: ${reviewResult.stdout || "(empty stdout)"}`);
@@ -410,18 +493,16 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
       }
 
       feedback = String(parsed.feedback ?? "");
-      let issues = Array.isArray(parsed.issues)
-        ? parsed.issues.filter((issue): issue is string => typeof issue === "string")
-        : [];
+      let issues = parseReviewIssues(parsed);
       issues = filterNonBlockingIssues(issues);
       if (issues.length === 0 && parsed.approved === true && feedbackImpliesFixNeeded(feedback)) {
-        issues.push(feedback);
+        issues.push(issueFromString(feedback));
       }
       if (issues.length === 0 && parsed.approved === false && !feedbackImpliesFixNeeded(feedback)) {
         approved = true;
         feedback = feedback || "Reviewer did not identify actionable blockers.";
       } else if (issues.length === 0 && parsed.approved === false) {
-        issues.push(feedback || "Reviewer marked the PR not ready but did not provide actionable issue details.");
+        issues.push(issueFromString(feedback || "Reviewer marked the PR not ready but did not provide actionable issue details."));
       }
       approved = approved || (parsed.approved === true && issues.length === 0);
       reviewHistory.push({ iteration, issues: [...issues], feedback });
@@ -434,7 +515,7 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
         ended_at: new Date().toISOString(),
         parent_step_id: "post-push-review",
         inputs: { iteration, prNumber },
-        outputs: { approved, feedback, issues },
+        outputs: { approved, feedback, issues: issues.map(plainIssueText), blockingIssues: issues },
         logs_url: null,
       });
 
@@ -454,7 +535,7 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
         postPrComment(
           ghSpawn,
           prNumber,
-          `${marker}\n⚠️ Reached review cap (${maxIterations} iterations) without approval.${blockingIssuesBlock(issues, { compact: true })}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
+          `${marker}\n⚠️ Reached review cap (${maxIterations} iterations) without approval.${blockingIssuesBlock(issues)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
           marker,
         );
         break;
@@ -464,7 +545,7 @@ Output ONLY valid JSON: {"approved": bool, "issues": [string], "score": int, "pr
       postPrComment(
         ghSpawn,
         prNumber,
-        `${feedbackMarker}\n⚠️ Reviewer found issues — starting fix pass ${fixPassLabel(iteration, maxIterations)}...${blockingIssuesBlock(issues, { compact: true })}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
+        `${feedbackMarker}\n⚠️ Reviewer found issues — starting fix pass ${fixPassLabel(iteration, maxIterations)}...${blockingIssuesBlock(issues)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
         feedbackMarker,
       );
 
@@ -528,7 +609,7 @@ ${feedback}
         postPrComment(
           ghSpawn,
           prNumber,
-          `${marker}\n⚠️ Fix pass ${fixPassLabel(iteration, maxIterations)} completed with no file changes; stopping the post-push review loop.\n\n**Merge readiness:** Not ready to merge.`,
+          `${marker}\n⚠️ Fix pass ${fixPassLabel(iteration, maxIterations)} completed with no file changes; stopping the post-push review loop.${blockingIssuesBlock(issues, { heading: "Unresolved blocking issues:" })}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
           marker,
         );
         break;

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -189,6 +189,18 @@ function formatIssueList(issues: ReviewIssue[]): string {
   }).join("\n");
 }
 
+function formatIssueListForPrompt(issues: ReviewIssue[]): string {
+  return issues.map((issue, index) => {
+    if (issue.rawText) return `${index + 1}. ${issue.rawText}`;
+
+    const lines = [`${index + 1}. ${issue.title}`];
+    if (issue.location) lines.push(`   - Location: ${issue.location}`);
+    if (issue.problem) lines.push(`   - Problem: ${issue.problem}`);
+    if (issue.requiredFix) lines.push(`   - Required fix: ${issue.requiredFix}`);
+    return lines.join("\n");
+  }).join("\n");
+}
+
 function normalizeForComparison(text: string): string {
   return text.toLowerCase().replace(/[`*_()[\]{}.,:;!?'"-]+/g, " ").replace(/\s+/g, " ").trim();
 }
@@ -220,7 +232,7 @@ function formatReviewHistory(history: ReviewFinding[]): string {
   }
 
   return history.map((finding) => {
-    const issueList = finding.issues.length > 0 ? formatIssueList(finding.issues) : "None provided.";
+    const issueList = finding.issues.length > 0 ? formatIssueListForPrompt(finding.issues) : "None provided.";
     return `Review ${finding.iteration}:
 Issues:
 ${issueList}
@@ -640,7 +652,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       );
 
       const issueList = issues.length > 0
-        ? formatIssueList(issues)
+        ? formatIssueListForPrompt(issues)
         : "None provided.";
 
       const fixPrompt = `You are fixing reviewer feedback on PR #${prNumber} for issue ${context.data.issueIdentifier}: ${context.data.issueTitle}.

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -131,6 +131,7 @@ function parseReviewIssue(value: unknown): ReviewIssue | null {
   const requiredFix = stringValue(issue.required_fix) || stringValue(issue.requiredFix) || stringValue(issue.fix) || stringValue(issue.recommendation);
   const rawText = stringValue(issue.text);
   if (!problem && !requiredFix && !rawText) return null;
+  if (rawText && !problem && !requiredFix) return issueFromString(rawText);
 
   return {
     title,
@@ -164,14 +165,26 @@ function plainIssueText(issue: ReviewIssue): string {
   ].filter(Boolean).join("\n");
 }
 
+function escapeMarkdownText(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\*/g, "\\*")
+    .replace(/_/g, "\\_")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)");
+}
+
 function formatIssueList(issues: ReviewIssue[]): string {
   return issues.map((issue, index) => {
     if (issue.rawText) return `${index + 1}. ${issue.rawText}`;
 
-    const lines = [`${index + 1}. **${issue.title}**`];
+    const lines = [`${index + 1}. **${escapeMarkdownText(issue.title)}**`];
     if (issue.location) lines.push(`   - Location: \`${issue.location.replace(/`/g, "'")}\``);
-    if (issue.problem) lines.push(`   - Problem: ${issue.problem}`);
-    if (issue.requiredFix) lines.push(`   - Required fix: ${issue.requiredFix}`);
+    if (issue.problem) lines.push(`   - Problem: ${escapeMarkdownText(issue.problem)}`);
+    if (issue.requiredFix) lines.push(`   - Required fix: ${escapeMarkdownText(issue.requiredFix)}`);
     return lines.join("\n");
   }).join("\n");
 }
@@ -395,6 +408,16 @@ function postPrComment(ghSpawn: (args: string[]) => SpawnResult, prNumber: strin
   }
 }
 
+function failedReviewOutputs(feedback: string) {
+  const issue = issueFromString(feedback);
+  return {
+    approved: false,
+    feedback,
+    issues: [plainIssueText(issue)],
+    blockingIssues: [issue],
+  };
+}
+
 async function reportInvalidStructuredReview(
   reporter: StepReporter,
   ghSpawn: (args: string[]) => SpawnResult,
@@ -410,7 +433,7 @@ async function reportInvalidStructuredReview(
     ended_at: new Date().toISOString(),
     parent_step_id: "post-push-review",
     inputs: { iteration, prNumber },
-    outputs: { approved: false, feedback, issues: [feedback] },
+    outputs: failedReviewOutputs(feedback),
     logs_url: null,
   });
   const marker = `<!-- ai-implement post-push iter=${iteration} review-invalid -->`;
@@ -504,7 +527,7 @@ ${DIFF_INJECTION_PREAMBLE}
 ${diffRes.stdout}
 </pr_diff>
 
-Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string", "location": "file/function or empty string", "problem": "full failing behavior", "required_fix": "full required fix"}], "score": int, "progress_delta": int, "feedback": "string"}.`;
+Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string", "location": "file/function; omit when unknown", "problem": "full failing behavior", "required_fix": "full required fix"}], "score": int, "progress_delta": int, "feedback": "string"}.`;
 
       const reviewResult = await context.llmExecutor.invoke({ prompt: reviewPrompt, model, maxTurns: REVIEW_MAX_TURNS });
       if (reviewResult.exitCode !== 0) {
@@ -518,7 +541,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
           ended_at: new Date().toISOString(),
           parent_step_id: "post-push-review",
           inputs: { iteration, prNumber },
-          outputs: { approved: false, feedback, issues: [feedback] },
+          outputs: failedReviewOutputs(feedback),
           logs_url: null,
         });
         const marker = `<!-- ai-implement post-push iter=${iteration} review-failed -->`;
@@ -544,7 +567,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
           ended_at: new Date().toISOString(),
           parent_step_id: "post-push-review",
           inputs: { iteration, prNumber },
-          outputs: { approved: false, feedback, issues: [feedback] },
+          outputs: failedReviewOutputs(feedback),
           logs_url: null,
         });
         const marker = `<!-- ai-implement post-push iter=${iteration} review-invalid -->`;


### PR DESCRIPTION
## Summary
- request structured post-push review blockers with title, location, problem, and required_fix fields
- normalize structured blockers and legacy string issues into one internal ReviewIssue model
- render full blocker details in review, cap, fix prompt, and no-change comments instead of compacting them away
- include unresolved blockers when a fix pass makes no file changes

## Root cause
The review loop already parsed JSON, but the downstream comment formatter compacted blockers to short strings and the no-change terminal path dropped the unresolved feedback entirely. That made PR comments ambiguous and gave the fix loop no useful visible context when it failed to change files.

## Validation
- npm test -- src/__tests__/post-push-review.test.ts
- npm run typecheck
- git diff --check
- npm test -- --exclude ".worktrees/**"

Note: plain npm test also discovers .worktrees/review-ledger-bridge-testing, where better-sqlite3 was built for a different Node ABI; that unrelated worktree was excluded for the full workspace validation.