### PR TITLE
[codex] publish runner image channels

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -11,7 +11,7 @@ name: Build runner image
 
 on:
   push:
-    branches: [main]
+    branches: [main, testing]
     paths:
       - "Dockerfile.session"
       - "session/**"
@@ -19,10 +19,23 @@ on:
       - "pipelines/**"
       - ".github/workflows/build-runner.yml"
   workflow_dispatch:
+    inputs:
+      channel:
+        description: "Runner image channel to publish"
+        type: choice
+        required: true
+        default: next
+        options:
+          - next
+          - latest
 
 permissions:
   contents: read
   packages: write
+
+concurrency:
+  group: build-runner-${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -36,8 +49,36 @@ jobs:
           # GHCR namespaces must be lowercase; github.repository_owner preserves
           # the original casing, so lowercase it here.
           owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
-          echo "image=ghcr.io/${owner}/ai-implement-runner" >> "$GITHUB_OUTPUT"
-          echo "date_tag=base-v$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          case "${{ github.ref_name }}" in
+            main)
+              expected_channel="latest"
+              ;;
+            testing)
+              expected_channel="next"
+              ;;
+            *)
+              echo "Unsupported runner image source branch: ${{ github.ref_name }}" >&2
+              exit 1
+              ;;
+          esac
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            channel="${{ inputs.channel }}"
+          else
+            channel="${expected_channel}"
+          fi
+          if [[ "${channel}" != "next" && "${channel}" != "latest" ]]; then
+            echo "Unsupported runner image channel: ${channel}" >&2
+            exit 1
+          fi
+          if [[ "${channel}" != "${expected_channel}" ]]; then
+            echo "Ref ${{ github.ref_name }} maps to ${expected_channel}, but selected channel ${channel} does not match selected channel policy" >&2
+            exit 1
+          fi
+          {
+            echo "image=ghcr.io/${owner}/ai-implement-runner"
+            echo "date_tag=base-${channel}-v$(date -u +%Y%m%d)-${GITHUB_SHA::12}"
+            echo "channel=${channel}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -54,21 +95,18 @@ jobs:
           context: .
           file: Dockerfile.session
           push: true
-          # :next is the v2 cutover tag (ships the TS dist). :latest continues to
-          # point at the bash-canonical image and is promoted manually after pilot
-          # validation in Task 6. Do NOT add :latest here until that gate clears.
+          # Push only non-channel tags before smoke testing; the channel is
+          # promoted to this tested SHA after the smoke test passes.
           tags: |
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}
             ${{ steps.meta.outputs.image }}:${{ github.sha }}
-            ${{ steps.meta.outputs.image }}:next
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke-test — verify TS dist is present in :next image
+      - name: Smoke-test — verify TS dist is present in SHA image
         run: |
-          docker pull "${{ steps.meta.outputs.image }}:next"
+          docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"
           if ! output=$(docker run --rm --entrypoint node \
-            "${{ steps.meta.outputs.image }}:next" \
+            "${{ steps.meta.outputs.image }}:${{ github.sha }}" \
             -e "import('/app/dist/pipeline/runner.js').then(m => console.log(Object.keys(m)))" 2>&1); then
             echo "ERROR: docker run failed to start or import the module"
             echo "$output"
@@ -77,3 +115,16 @@ jobs:
           echo "Module exports: $output"
           echo "$output" | grep -q "PipelineRunner" || \
             { echo "ERROR: PipelineRunner not found in /app/dist/pipeline/runner.js exports"; exit 1; }
+
+      - name: Promote tested SHA image to channel and debug tags
+        run: |
+          current_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | awk '{print $1}')
+          if [ "$current_sha" != "${{ github.sha }}" ]; then
+            echo "::error::Ref ${{ github.ref_name }} now points at ${current_sha:-unknown}, not tested SHA ${{ github.sha }}. Skipping channel promotion." >&2
+            exit 1
+          fi
+          docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"
+          docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"
+          docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"
+          docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"
+          docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -24,7 +24,6 @@ on:
         description: "Runner image channel to publish. Policy: main -> latest, testing -> next."
         type: choice
         required: true
-        default: next
         options:
           - next
           - latest
@@ -123,7 +122,7 @@ jobs:
           set -euo pipefail
           digest_ref="${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"
 
-          if ! current_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | awk '{print $1}'); then
+          if ! current_sha=$(git ls-remote origin "refs/heads/$GITHUB_REF_NAME" | awk '{print $1}'); then
             echo "::error::Could not verify current head for ${{ github.ref_name }}. Re-run this job after the transient failure clears to re-test and promote the digest image." >&2
             exit 1
           fi

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -90,23 +90,25 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.session
           push: true
           # Push only non-channel tags before smoke testing; the channel is
-          # promoted to this tested SHA after the smoke test passes.
+          # promoted from the immutable build digest after the smoke test passes.
           tags: |
             ${{ steps.meta.outputs.image }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Smoke-test — verify TS dist is present in SHA image
+      - name: Smoke-test — verify TS dist is present in built digest
         run: |
-          docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"
+          digest_ref="${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"
+          docker pull "$digest_ref"
           if ! output=$(docker run --rm --entrypoint node \
-            "${{ steps.meta.outputs.image }}:${{ github.sha }}" \
+            "$digest_ref" \
             -e "import('/app/dist/pipeline/runner.js').then(m => console.log(Object.keys(m)))" 2>&1); then
             echo "ERROR: docker run failed to start or import the module"
             echo "$output"
@@ -116,12 +118,13 @@ jobs:
           echo "$output" | grep -q "PipelineRunner" || \
             { echo "ERROR: PipelineRunner not found in /app/dist/pipeline/runner.js exports"; exit 1; }
 
-      - name: Promote tested SHA image to channel and debug tags
+      - name: Promote tested digest to channel and debug tags
         run: |
           set -euo pipefail
+          digest_ref="${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"
 
           if ! current_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | awk '{print $1}'); then
-            echo "::error::Could not verify current head for ${{ github.ref_name }}. Re-run this job after the transient failure clears to re-test and promote the SHA image." >&2
+            echo "::error::Could not verify current head for ${{ github.ref_name }}. Re-run this job after the transient failure clears to re-test and promote the digest image." >&2
             exit 1
           fi
           if [ "$current_sha" != "${{ github.sha }}" ]; then
@@ -129,9 +132,9 @@ jobs:
             exit 1
           fi
           # Re-pull immediately before tagging so promotion fails closed if the
-          # tested SHA manifest was removed between smoke test and promotion.
-          docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"
-          docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"
-          docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"
+          # tested digest manifest was removed between smoke test and promotion.
+          docker pull "$digest_ref"
+          docker tag "$digest_ref" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"
+          docker tag "$digest_ref" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"
           docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"
           docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"

--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "Runner image channel to publish"
+        description: "Runner image channel to publish. Policy: main -> latest, testing -> next."
         type: choice
         required: true
         default: next
@@ -48,7 +48,7 @@ jobs:
         run: |
           # GHCR namespaces must be lowercase; github.repository_owner preserves
           # the original casing, so lowercase it here.
-          owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
           case "${{ github.ref_name }}" in
             main)
               expected_channel="latest"
@@ -118,11 +118,18 @@ jobs:
 
       - name: Promote tested SHA image to channel and debug tags
         run: |
-          current_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | awk '{print $1}')
+          set -euo pipefail
+
+          if ! current_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | awk '{print $1}'); then
+            echo "::error::Could not verify current head for ${{ github.ref_name }}. Re-run this job after the transient failure clears to re-test and promote the SHA image." >&2
+            exit 1
+          fi
           if [ "$current_sha" != "${{ github.sha }}" ]; then
             echo "::error::Ref ${{ github.ref_name }} now points at ${current_sha:-unknown}, not tested SHA ${{ github.sha }}. Skipping channel promotion." >&2
             exit 1
           fi
+          # Re-pull immediately before tagging so promotion fails closed if the
+          # tested SHA manifest was removed between smoke test and promotion.
           docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"
           docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"
           docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -97,7 +97,7 @@ jobs:
             runner_image="${CONFIGURED_RUNNER_IMAGE:-}"
           fi
           if [ -z "$runner_image" ]; then
-            runner_image="ghcr.io/builddownai/ai-implement-runner:next"
+            runner_image="ghcr.io/builddownai/ai-implement-runner:latest"
           fi
 
           case "$runner_image" in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ Runner image channels:
 - `ghcr.io/builddownai/ai-implement-runner:next` is published from `testing` and is intended for staging/testing orchestrators. Set `SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:next` in that orchestrator environment to keep it paired with the testing runner.
 - Commit SHA tags are pushed first and smoke-tested before any mutable channel is promoted. They are immutable and are the safest rollback target.
 - Channel-scoped date/debug tags are promoted only after the SHA image passes smoke testing. They use `base-<channel>-vYYYYMMDD-<12-char-sha>` (for example, `base-next-v20260526-abc123def456`) so `latest` and `next` builds do not collide and same-day builds do not overwrite each other.
+- Cancelled or failed runs can leave SHA-only images with no channel pointer. That is intentional fail-closed behavior; clean old SHA-only images through GHCR retention/cleanup rather than relying on mutable channel tags for retention.
 
 Typical custom-image use: your repo needs a language runtime or tool that isn't in the base image (e.g. terraform, ruby, go). Build an image `FROM` the channel that matches your orchestrator (`latest` for production, `next` for testing), add your tools, push, and point `image.yml` at it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,8 +227,8 @@ Runner image channels:
 
 - `ghcr.io/builddownai/ai-implement-runner:latest` is published from `main` and is the stable default for production orchestrators and synced target-repo workflows.
 - `ghcr.io/builddownai/ai-implement-runner:next` is published from `testing` and is intended for staging/testing orchestrators. Set `SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:next` in that orchestrator environment to keep it paired with the testing runner.
-- Commit SHA tags are pushed first and smoke-tested before any mutable channel is promoted. They are immutable and are the safest rollback target.
-- Channel-scoped date/debug tags are promoted only after the SHA image passes smoke testing. They use `base-<channel>-vYYYYMMDD-<12-char-sha>` (for example, `base-next-v20260526-abc123def456`) so `latest` and `next` builds do not collide and same-day builds do not overwrite each other.
+- Commit SHA tags are pushed first, then the build digest is smoke-tested before any mutable channel is promoted. Use the immutable digest for the strongest rollback pin; the SHA tag is a convenient lookup tag for the same build.
+- Channel-scoped date/debug tags are promoted only after the digest image passes smoke testing. They use `base-<channel>-vYYYYMMDD-<12-char-sha>` (for example, `base-next-v20260526-abc123def456`) so `latest` and `next` builds do not collide and same-day builds do not overwrite each other.
 - Cancelled or failed runs can leave SHA-only images with no channel pointer. That is intentional fail-closed behavior; clean old SHA-only images through GHCR retention/cleanup rather than relying on mutable channel tags for retention.
 
 Typical custom-image use: your repo needs a language runtime or tool that isn't in the base image (e.g. terraform, ruby, go). Build an image `FROM` the channel that matches your orchestrator (`latest` for production, `next` for testing), add your tools, push, and point `image.yml` at it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,14 @@ The image must be publicly pullable. The customer owns building and publishing i
 
 The default runner image itself must also be public on GHCR — Fly pulls anonymously, so a private package surfaces as `failed to get manifest ... unauthorized` at machine-create time. New GHCR packages default to Private and the org must allow public container packages first (Org Settings → Packages). See the comment at the top of `.github/workflows/build-runner.yml`.
 
-Typical use: your repo needs a language runtime or tool that isn't in the base image (e.g. terraform, ruby, go). Build an image `FROM` the published base `ghcr.io/builddownai/ai-implement-runner:latest`, add your tools, push, and point `image.yml` at it.
+Runner image channels:
+
+- `ghcr.io/builddownai/ai-implement-runner:latest` is published from `main` and is the stable default for production orchestrators and synced target-repo workflows.
+- `ghcr.io/builddownai/ai-implement-runner:next` is published from `testing` and is intended for staging/testing orchestrators. Set `SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:next` in that orchestrator environment to keep it paired with the testing runner.
+- Commit SHA tags are pushed first and smoke-tested before any mutable channel is promoted. They are immutable and are the safest rollback target.
+- Channel-scoped date/debug tags are promoted only after the SHA image passes smoke testing. They use `base-<channel>-vYYYYMMDD-<12-char-sha>` (for example, `base-next-v20260526-abc123def456`) so `latest` and `next` builds do not collide and same-day builds do not overwrite each other.
+
+Typical custom-image use: your repo needs a language runtime or tool that isn't in the base image (e.g. terraform, ruby, go). Build an image `FROM` the channel that matches your orchestrator (`latest` for production, `next` for testing), add your tools, push, and point `image.yml` at it.
 
 ## Multi-client deploy
 

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -33,6 +33,7 @@ describe("GHA workflow shims", () => {
     expect(doc.on.push.branches).toEqual(["main", "testing"]);
     expect(doc.on.workflow_dispatch.inputs.channel.type).toBe("choice");
     expect(doc.on.workflow_dispatch.inputs.channel.description).toContain("main -> latest, testing -> next");
+    expect(doc.on.workflow_dispatch.inputs.channel.default).toBeUndefined();
     expect(doc.on.workflow_dispatch.inputs.channel.options).toEqual(["next", "latest"]);
     expect(doc.concurrency.group).toBe("build-runner-${{ github.ref_name }}");
     expect(doc.concurrency["cancel-in-progress"]).toBe(true);
@@ -60,7 +61,8 @@ describe("GHA workflow shims", () => {
     expect(promoteStep.name).toContain("tested digest");
     expect(promoteStep.run).toContain("set -euo pipefail");
     expect(promoteStep.run).toContain('digest_ref="${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"');
-    expect(promoteStep.run).toContain('git ls-remote origin "refs/heads/${{ github.ref_name }}"');
+    expect(promoteStep.run).toContain('git ls-remote origin "refs/heads/$GITHUB_REF_NAME"');
+    expect(promoteStep.run).not.toContain('refs/heads/${{ github.ref_name }}');
     expect(promoteStep.run).toContain("Could not verify current head");
     expect(promoteStep.run).toContain("re-test and promote the digest image");
     expect(promoteStep.run).toContain('if [ "$current_sha" != "${{ github.sha }}" ]; then');

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -43,29 +43,35 @@ describe("GHA workflow shims", () => {
     expect(yaml).toMatch(/date_tag=base-\$\{channel\}-v\$\(date -u \+%Y%m%d\)-\$\{GITHUB_SHA::12\}/);
 
     expect(buildStep).toBeDefined();
+    expect(buildStep.id).toBe("build");
     expect(buildStep.with.tags.trim()).toBe("${{ steps.meta.outputs.image }}:${{ github.sha }}");
     expect(buildStep.with.tags).not.toContain("${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}");
     expect(buildStep.with.tags).not.toContain("${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}");
 
     expect(smokeStep).toBeDefined();
-    expect(smokeStep.run).toContain('docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"');
-    expect(smokeStep.run).toContain('"${{ steps.meta.outputs.image }}:${{ github.sha }}"');
+    expect(smokeStep.name).toContain("built digest");
+    expect(smokeStep.run).toContain('digest_ref="${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"');
+    expect(smokeStep.run).toContain('docker pull "$digest_ref"');
+    expect(smokeStep.run).toContain('"$digest_ref"');
+    expect(smokeStep.run).not.toContain("steps.meta.outputs.image }}:${{ github.sha");
     expect(smokeStep.run).not.toContain("steps.meta.outputs.channel");
 
     expect(promoteStep).toBeDefined();
+    expect(promoteStep.name).toContain("tested digest");
     expect(promoteStep.run).toContain("set -euo pipefail");
+    expect(promoteStep.run).toContain('digest_ref="${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"');
     expect(promoteStep.run).toContain('git ls-remote origin "refs/heads/${{ github.ref_name }}"');
     expect(promoteStep.run).toContain("Could not verify current head");
-    expect(promoteStep.run).toContain("re-test and promote the SHA image");
+    expect(promoteStep.run).toContain("re-test and promote the digest image");
     expect(promoteStep.run).toContain('if [ "$current_sha" != "${{ github.sha }}" ]; then');
     expect(promoteStep.run).toContain("Skipping channel promotion");
     expect(promoteStep.run).toContain("Re-pull immediately before tagging");
-    expect(promoteStep.run).toContain('docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"');
+    expect(promoteStep.run).toContain('docker pull "$digest_ref"');
     expect(promoteStep.run).toContain(
-      'docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"',
+      'docker tag "$digest_ref" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"',
     );
     expect(promoteStep.run).toContain(
-      'docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"',
+      'docker tag "$digest_ref" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"',
     );
     expect(promoteStep.run).toContain('docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"');
     expect(promoteStep.run).toContain('docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"');

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -32,9 +32,11 @@ describe("GHA workflow shims", () => {
 
     expect(doc.on.push.branches).toEqual(["main", "testing"]);
     expect(doc.on.workflow_dispatch.inputs.channel.type).toBe("choice");
+    expect(doc.on.workflow_dispatch.inputs.channel.description).toContain("main -> latest, testing -> next");
     expect(doc.on.workflow_dispatch.inputs.channel.options).toEqual(["next", "latest"]);
     expect(doc.concurrency.group).toBe("build-runner-${{ github.ref_name }}");
     expect(doc.concurrency["cancel-in-progress"]).toBe(true);
+    expect(yaml).toContain('owner="${GITHUB_REPOSITORY_OWNER,,}"');
     expect(yaml).toMatch(/main\)\s+expected_channel="latest"/);
     expect(yaml).toMatch(/testing\)\s+expected_channel="next"/);
     expect(yaml).toMatch(/does not match selected channel/);
@@ -51,9 +53,13 @@ describe("GHA workflow shims", () => {
     expect(smokeStep.run).not.toContain("steps.meta.outputs.channel");
 
     expect(promoteStep).toBeDefined();
+    expect(promoteStep.run).toContain("set -euo pipefail");
     expect(promoteStep.run).toContain('git ls-remote origin "refs/heads/${{ github.ref_name }}"');
+    expect(promoteStep.run).toContain("Could not verify current head");
+    expect(promoteStep.run).toContain("re-test and promote the SHA image");
     expect(promoteStep.run).toContain('if [ "$current_sha" != "${{ github.sha }}" ]; then');
     expect(promoteStep.run).toContain("Skipping channel promotion");
+    expect(promoteStep.run).toContain("Re-pull immediately before tagging");
     expect(promoteStep.run).toContain('docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"');
     expect(promoteStep.run).toContain(
       'docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"',

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -22,6 +22,49 @@ describe("GHA workflow shims", () => {
     expect(readFileSync("Dockerfile", "utf-8")).toMatch(/COPY workflows\/ \.\/workflows\//);
   });
 
+  it("publishes runner image channels from the correct source branches", () => {
+    const yaml = readFileSync(".github/workflows/build-runner.yml", "utf-8");
+    const doc = parse(yaml) as any;
+    const steps = doc.jobs.build.steps as any[];
+    const buildStep = steps.find((step) => step.name === "Build and push");
+    const smokeStep = steps.find((step) => String(step.name).startsWith("Smoke-test"));
+    const promoteStep = steps.find((step) => String(step.name).startsWith("Promote"));
+
+    expect(doc.on.push.branches).toEqual(["main", "testing"]);
+    expect(doc.on.workflow_dispatch.inputs.channel.type).toBe("choice");
+    expect(doc.on.workflow_dispatch.inputs.channel.options).toEqual(["next", "latest"]);
+    expect(doc.concurrency.group).toBe("build-runner-${{ github.ref_name }}");
+    expect(doc.concurrency["cancel-in-progress"]).toBe(true);
+    expect(yaml).toMatch(/main\)\s+expected_channel="latest"/);
+    expect(yaml).toMatch(/testing\)\s+expected_channel="next"/);
+    expect(yaml).toMatch(/does not match selected channel/);
+    expect(yaml).toMatch(/date_tag=base-\$\{channel\}-v\$\(date -u \+%Y%m%d\)-\$\{GITHUB_SHA::12\}/);
+
+    expect(buildStep).toBeDefined();
+    expect(buildStep.with.tags.trim()).toBe("${{ steps.meta.outputs.image }}:${{ github.sha }}");
+    expect(buildStep.with.tags).not.toContain("${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}");
+    expect(buildStep.with.tags).not.toContain("${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}");
+
+    expect(smokeStep).toBeDefined();
+    expect(smokeStep.run).toContain('docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"');
+    expect(smokeStep.run).toContain('"${{ steps.meta.outputs.image }}:${{ github.sha }}"');
+    expect(smokeStep.run).not.toContain("steps.meta.outputs.channel");
+
+    expect(promoteStep).toBeDefined();
+    expect(promoteStep.run).toContain('git ls-remote origin "refs/heads/${{ github.ref_name }}"');
+    expect(promoteStep.run).toContain('if [ "$current_sha" != "${{ github.sha }}" ]; then');
+    expect(promoteStep.run).toContain("Skipping channel promotion");
+    expect(promoteStep.run).toContain('docker pull "${{ steps.meta.outputs.image }}:${{ github.sha }}"');
+    expect(promoteStep.run).toContain(
+      'docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"',
+    );
+    expect(promoteStep.run).toContain(
+      'docker tag "${{ steps.meta.outputs.image }}:${{ github.sha }}" "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"',
+    );
+    expect(promoteStep.run).toContain('docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.channel }}"');
+    expect(promoteStep.run).toContain('docker push "${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.date_tag }}"');
+  });
+
   it("keeps the canonical and synced dispatch workflows byte-for-byte identical", () => {
     expect(readFileSync(".github/workflows/claude-implement.yml", "utf-8")).toBe(
       readFileSync("workflows/claude-implement.yml", "utf-8"),
@@ -92,7 +135,7 @@ describe("GHA workflow shims", () => {
       expect(yaml).toMatch(/validate-runner-image:/);
       expect(yaml).toMatch(/needs:\s*validate-runner-image/);
       expect(yaml).toMatch(/image:\s*\$\{\{\s*needs\.validate-runner-image\.outputs\.runner_image\s*\}\}/);
-      expect(yaml).toMatch(/ghcr\.io\/builddownai\/ai-implement-runner:next/);
+      expect(yaml).toMatch(/ghcr\.io\/builddownai\/ai-implement-runner:latest/);
       expect(yaml).toMatch(/invalid characters for a container image reference/);
       expect(yaml).toMatch(/AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES=<prefix>/);
     });

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -97,7 +97,7 @@ jobs:
             runner_image="${CONFIGURED_RUNNER_IMAGE:-}"
           fi
           if [ -z "$runner_image" ]; then
-            runner_image="ghcr.io/builddownai/ai-implement-runner:next"
+            runner_image="ghcr.io/builddownai/ai-implement-runner:latest"
           fi
 
           case "$runner_image" in


### PR DESCRIPTION
## Summary
- Publish runner image channels from branch policy: main -> latest, testing -> next.
- Smoke-test the SHA image before promoting mutable channel and channel-scoped date/debug tags.
- Default synced implementation workflows back to the stable latest runner and document staging via SESSION_IMAGE=:next.

## Test Plan
- npm test -- src/__tests__/workflow-shim-structure.test.ts
- actionlint .github/workflows/build-runner.yml .github/workflows/claude-implement.yml workflows/claude-implement.yml
- git diff --check origin/testing
- npm test

## Operational Notes
- Manual dispatch still has a channel selector, but the description now states the branch policy and the workflow rejects mismatched ref/channel pairs.
- Promotion intentionally re-pulls the tested SHA before tagging so the job fails closed if the registry manifest disappears between smoke test and promotion.
- If remote-head verification fails because of a transient GitHub/network issue, re-running the job re-tests the SHA and promotes it; no new push is required.
- Cancelled or failed runs can leave SHA-only images with no channel pointer. That is intentional fail-closed behavior and should be handled by GHCR retention/cleanup.
- Repository owner normalization now uses the Actions-provided env var instead of interpolating context into shell.

## Notes
- PR targets testing as requested.
- Channel promotion has both GitHub Actions concurrency and a remote-head check before pushing latest/next.