### PR TITLE
[codex] honor configured default branch

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -166,6 +166,7 @@ jobs:
       - name: Run pipeline
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.ref_name }}
           ISSUE_ID: ${{ inputs.issue_id }}
           ISSUE_IDENTIFIER: ${{ inputs.issue_identifier }}
           ISSUE_TITLE: ${{ inputs.issue_title }}

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -99,6 +99,7 @@ jobs:
             );
             core.setOutput("pr_number", String(context.payload.issue.number));
             core.setOutput("issue_meta", JSON.stringify(meta));
+            // The workflow runs in the target repo, so repository.default_branch is the target fallback.
             core.setOutput("default_branch", pr.data.base.ref || context.payload.repository.default_branch || "");
             core.setOutput("provider", process.env.AI_IMPLEMENT_PROVIDER || "anthropic");
             core.setOutput("aws_region", process.env.AI_IMPLEMENT_AWS_REGION || "");

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -34,6 +34,7 @@ jobs:
       matched: ${{ steps.trigger.outputs.matched }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
       issue_meta: ${{ steps.pr.outputs.issue_meta }}
+      default_branch: ${{ steps.pr.outputs.default_branch }}
       provider: ${{ steps.pr.outputs.provider }}
       aws_region: ${{ steps.pr.outputs.aws_region }}
       runner_image: ${{ steps.runner-image.outputs.runner_image }}
@@ -98,6 +99,7 @@ jobs:
             );
             core.setOutput("pr_number", String(context.payload.issue.number));
             core.setOutput("issue_meta", JSON.stringify(meta));
+            core.setOutput("default_branch", pr.data.base.ref || context.payload.repository.default_branch || "");
             core.setOutput("provider", process.env.AI_IMPLEMENT_PROVIDER || "anthropic");
             core.setOutput("aws_region", process.env.AI_IMPLEMENT_AWS_REGION || "");
 
@@ -204,6 +206,7 @@ jobs:
       - name: Run pipeline (gap-fill)
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_DEFAULT_BRANCH: ${{ needs.check-trigger.outputs.default_branch }}
           PR_NUMBER: ${{ needs.check-trigger.outputs.pr_number }}
           ISSUE_META: ${{ needs.check-trigger.outputs.issue_meta }}
           PROVIDER: ${{ needs.check-trigger.outputs.provider }}

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -46,7 +46,13 @@ else
 fi
 
 # ── 4. Git config + clone ────────────────────────────────────────────────────
-GITHUB_DEFAULT_BRANCH="${GITHUB_DEFAULT_BRANCH:-main}"
+if [ -z "${GITHUB_DEFAULT_BRANCH:-}" ]; then
+  if [ -n "${GITHUB_REF_NAME:-}" ]; then
+    GITHUB_DEFAULT_BRANCH="${GITHUB_REF_NAME}"
+  else
+    GITHUB_DEFAULT_BRANCH="$(gh api "repos/${GITHUB_OWNER}/${GITHUB_REPO}" --jq ".default_branch")"
+  fi
+fi
 export GITHUB_DEFAULT_BRANCH
 git config --global user.name "ai-implement-bot"
 git config --global user.email "ai-implement-bot@users.noreply.github.com"

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -101,7 +101,21 @@ function adminConfig(accessCode: string): Parameters<typeof admin.handleAdminReq
 }
 
 async function request(url: string, method: string, accessCode: string, body?: unknown, token?: string): Promise<{ statusCode: number; body: string }> {
-  const req = new MockRequest(url, method, token ? { authorization: `Bearer ${token}` } : {}, body === undefined ? undefined : JSON.stringify(body));
+  let requestBody = body;
+  if (
+    url === "/api/mappings" &&
+    method === "POST" &&
+    requestBody &&
+    typeof requestBody === "object" &&
+    !Array.isArray(requestBody) &&
+    "teamKey" in requestBody &&
+    "owner" in requestBody &&
+    "repo" in requestBody &&
+    !("defaultBranch" in requestBody)
+  ) {
+    requestBody = { defaultBranch: "main", ...requestBody };
+  }
+  const req = new MockRequest(url, method, token ? { authorization: `Bearer ${token}` } : {}, requestBody === undefined ? undefined : JSON.stringify(requestBody));
   const res = new MockResponse();
   admin.handleAdminRequest(req as never, res as never, adminConfig(accessCode), makeFakeRegistry(provider));
   await res.done;
@@ -203,6 +217,19 @@ describe("admin mappings", () => {
     const token = await login("secret");
     const res = await request("/api/mappings", "POST", "secret", { teamKey: "APP" }, token);
     expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects mapping creation without a default branch", async () => {
+    const token = await login("secret");
+    const res = await request(
+      "/api/mappings",
+      "POST",
+      "secret",
+      { teamKey: "APP", owner: "org", repo: "app", defaultBranch: "" },
+      token,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("defaultBranch");
   });
 
   it("updates the cap via PATCH", async () => {

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -113,9 +113,14 @@ async function request(url: string, method: string, accessCode: string, body?: u
     "repo" in requestBody &&
     !("defaultBranch" in requestBody)
   ) {
+    // Existing mapping tests pre-date the required defaultBranch field; keep them focused on their original assertions.
     requestBody = { defaultBranch: "main", ...requestBody };
   }
-  const req = new MockRequest(url, method, token ? { authorization: `Bearer ${token}` } : {}, requestBody === undefined ? undefined : JSON.stringify(requestBody));
+  return requestRaw(url, method, accessCode, requestBody, token);
+}
+
+async function requestRaw(url: string, method: string, accessCode: string, body?: unknown, token?: string): Promise<{ statusCode: number; body: string }> {
+  const req = new MockRequest(url, method, token ? { authorization: `Bearer ${token}` } : {}, body === undefined ? undefined : JSON.stringify(body));
   const res = new MockResponse();
   admin.handleAdminRequest(req as never, res as never, adminConfig(accessCode), makeFakeRegistry(provider));
   await res.done;
@@ -230,6 +235,30 @@ describe("admin mappings", () => {
     );
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toContain("defaultBranch");
+  });
+
+  it("preserves an existing mapping defaultBranch when an upsert omits it", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "DEV",
+      owner: "org",
+      repo: "app",
+      defaultBranch: "development",
+    }, token);
+    expect(create.statusCode).toBe(200);
+
+    const update = await requestRaw("/api/mappings", "POST", "secret", {
+      teamKey: "DEV",
+      owner: "org",
+      repo: "app-renamed",
+    }, token);
+    expect(update.statusCode).toBe(200);
+
+    const list = await request("/api/mappings", "GET", "secret", undefined, token);
+    expect(JSON.parse(list.body).DEV).toMatchObject({
+      repo: "app-renamed",
+      defaultBranch: "development",
+    });
   });
 
   it("updates the cap via PATCH", async () => {

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -26,8 +26,10 @@ describe("session/entrypoint.sh", () => {
 
   it("exports GITHUB_DEFAULT_BRANCH for the TS runner", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
-    expect(content).toMatch(/GITHUB_DEFAULT_BRANCH="\$\{GITHUB_DEFAULT_BRANCH:-main\}"/);
+    expect(content).toMatch(/GITHUB_DEFAULT_BRANCH="\$\{GITHUB_REF_NAME\}"/);
+    expect(content).toMatch(/gh api "repos\/\$\{GITHUB_OWNER\}\/\$\{GITHUB_REPO\}"/);
     expect(content).toMatch(/export GITHUB_DEFAULT_BRANCH/);
+    expect(content).not.toContain("GITHUB_DEFAULT_BRANCH:-main");
   });
 
   it("preserves the checked-out gap-fill PR branch for the TS clone step", () => {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runAutonomous } from "../run-autonomous.js";
@@ -39,6 +40,13 @@ function makeSingleStepPipeline(stepId: string, mod: StepModule): {
   };
   const runner = new PipelineRunner().register(stepId, mod);
   return { pipeline, runner };
+}
+
+function git(args: string[], cwd: string): void {
+  const result = spawnSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr.toString()}`);
+  }
 }
 
 describe("runAutonomous", () => {
@@ -95,9 +103,11 @@ describe("runAutonomous", () => {
     expect(result.exitCode).toBe(1);
   });
 
-  it("uses GITHUB_REF_NAME as the branch when GITHUB_DEFAULT_BRANCH is not set", async () => {
+  it("uses the checked-out branch when GITHUB_DEFAULT_BRANCH is not set", async () => {
     vi.stubEnv("GITHUB_DEFAULT_BRANCH", "");
-    vi.stubEnv("GITHUB_REF_NAME", "development");
+    vi.stubEnv("GITHUB_REF_NAME", "orchestrator-branch");
+    git(["init"], workspaceDir);
+    git(["checkout", "-b", "development"], workspaceDir);
 
     let capturedBranch: string | undefined;
     const mod: StepModule = {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -53,6 +53,8 @@ describe("runAutonomous", () => {
     vi.stubEnv("RUNNER_CALLBACK_URL", "");
     vi.stubEnv("RUN_TOKEN", "");
     vi.stubEnv("CLAUDE_MODEL", "");
+    vi.stubEnv("GITHUB_DEFAULT_BRANCH", "main");
+    vi.stubEnv("GITHUB_REF_NAME", "");
     vi.stubEnv("PR_NUMBER", "");
   });
 
@@ -91,6 +93,30 @@ describe("runAutonomous", () => {
     });
 
     expect(result.exitCode).toBe(1);
+  });
+
+  it("uses GITHUB_REF_NAME as the branch when GITHUB_DEFAULT_BRANCH is not set", async () => {
+    vi.stubEnv("GITHUB_DEFAULT_BRANCH", "");
+    vi.stubEnv("GITHUB_REF_NAME", "development");
+
+    let capturedBranch: string | undefined;
+    const mod: StepModule = {
+      run: vi.fn(async (ctx) => {
+        capturedBranch = ctx.data.branch;
+        return {};
+      }),
+    };
+    const { pipeline, runner } = makeSingleStepPipeline("check-branch", mod);
+
+    await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+    });
+
+    expect(capturedBranch).toBe("development");
   });
 
   it("reads model from WORKFLOW.md front matter and passes it through context", async () => {

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -9,7 +9,7 @@ vi.mock("node:child_process", () => ({
 
 import { spawnSync } from "node:child_process";
 
-function makeContext(): DefaultPipelineContext {
+function makeContext(overrides: Record<string, unknown> = {}): DefaultPipelineContext {
   return new DefaultPipelineContext({
     jobId: 1,
     issueId: "issue-1",
@@ -19,6 +19,7 @@ function makeContext(): DefaultPipelineContext {
     nonce: "nonce",
     orchestratorUrl: "http://localhost:8080",
     ticketingProvider: "linear",
+    ...overrides,
   });
 }
 
@@ -77,6 +78,26 @@ describe("pushStep", () => {
     expect(outputs.prNumber).toBe(7);
     expect(outputs.branchPushed).toBe(true);
     expect(outputs.commitSha).toBe("abc123");
+  });
+
+  it("uses the context branch as the PR base when baseBranch input is omitted", async () => {
+    mockGitSuccess("abc123");
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: "https://github.com/acme/app/pull/7", number: 7 }),
+      text: async () => "",
+    } as Response);
+
+    await pushStep.run(
+      makeContext({ branch: "development" }),
+      { ...BASE_INPUTS, baseBranch: undefined },
+      new NoopStepReporter(),
+    );
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const body = JSON.parse(fetchCall[1]?.body as string) as { base: string };
+    expect(body.base).toBe("development");
   });
 
   it("returns existing PR info on 422 (PR already open)", async () => {

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -153,6 +153,11 @@ describe("GHA workflow shims", () => {
       expect(yaml).toMatch(/invalid characters for a container image reference/);
       expect(yaml).toMatch(/AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES=<prefix>/);
     });
+
+    it(`${f} passes the dispatched ref to the runner as GITHUB_DEFAULT_BRANCH`, () => {
+      const yaml = readFileSync(f, "utf-8");
+      expect(yaml).toMatch(/GITHUB_DEFAULT_BRANCH:\s*\$\{\{\s*github\.ref_name\s*\}\}/);
+    });
   }
 
   it("comment trigger only runs implementation for an exact trimmed /ai-implement command", () => {
@@ -176,6 +181,13 @@ describe("GHA workflow shims", () => {
     expect(yaml).toMatch(/ghcr\.io\/builddownai\/ai-implement-runner:latest/);
     expect(yaml).toMatch(/invalid characters for a container image reference/);
     expect(yaml).toMatch(/AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES=<prefix>/);
+  });
+
+  it("comment trigger passes the PR base branch to the runner as GITHUB_DEFAULT_BRANCH", () => {
+    const yaml = readFileSync("workflows/comment-trigger.yml", "utf-8");
+    expect(yaml).toMatch(/default_branch:\s*\$\{\{\s*steps\.pr\.outputs\.default_branch\s*\}\}/);
+    expect(yaml).toMatch(/core\.setOutput\("default_branch", pr\.data\.base\.ref/);
+    expect(yaml).toMatch(/GITHUB_DEFAULT_BRANCH:\s*\$\{\{\s*needs\.check-trigger\.outputs\.default_branch\s*\}\}/);
   });
 
   it("documents and constrains the ISSUE_META eval trust boundary", () => {

--- a/src/admin-ui/__tests__/stepper.test.ts
+++ b/src/admin-ui/__tests__/stepper.test.ts
@@ -30,9 +30,15 @@ describe("new-project stepper", () => {
   });
 
   it("declares the input ids the script reads", () => {
-    for (const id of ["np-teamKey", "np-owner", "np-repo", "np-sessionMode", "np-awsRegion", "np-maxAi"]) {
+    for (const id of ["np-teamKey", "np-owner", "np-repo", "np-defaultBranch", "np-sessionMode", "np-awsRegion", "np-maxAi"]) {
       expect(stepperHtml).toContain(`id="${id}"`);
     }
+  });
+
+  it("collects and submits the configured default branch", () => {
+    expect(stepperScript).toContain("defaultBranch:");
+    expect(stepperScript).toContain("np-defaultBranch");
+    expect(stepperScript).toContain("defaultBranch: data.defaultBranch");
   });
 
   it("exposes navigation handlers on window", () => {

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -120,7 +120,7 @@ export const projectsHtml = `
           <div class="md-field"><label>Owner</label><input id="md-owner" placeholder="acme-corp"></div>
           <div class="md-field"><label>Repo</label><input id="md-repo" placeholder="backend"></div>
           <div class="md-field"><label>Workflow File</label><input id="md-wf" value="claude-implement.yml"></div>
-          <div class="md-field"><label>Default Branch</label><input id="md-branch" value="main"></div>
+          <div class="md-field"><label>Default Branch</label><input id="md-branch" placeholder="development"></div>
           <div class="md-field"><label>Max AI Issues</label><input id="md-max-ai" type="number" min="1" value="3"></div>
         </fieldset>
         <fieldset>
@@ -255,7 +255,7 @@ export const projectsScript = `
     document.getElementById('md-owner').value = m.owner || '';
     document.getElementById('md-repo').value = m.repo || '';
     document.getElementById('md-wf').value = m.workflowFile || 'claude-implement.yml';
-    document.getElementById('md-branch').value = m.defaultBranch || 'main';
+    document.getElementById('md-branch').value = m.defaultBranch || '';
     document.getElementById('md-max-ai').value = String(m.maxInProgressAiIssues ?? 3);
     document.getElementById('md-exec-mode').value = m.executionMode || 'github-actions';
     document.getElementById('md-session-mode').value = m.sessionMode || 'autonomous';
@@ -540,13 +540,19 @@ export const projectsScript = `
     const origKey = document.getElementById('md-team-key-orig').value;
     const isNew = !origKey;
     const teamKey = isNew ? document.getElementById('md-team-key').value.trim() : origKey;
+    const defaultBranch = document.getElementById('md-branch').value.trim();
+    if (!defaultBranch) {
+      errEl.textContent = 'Default Branch is required.';
+      errEl.classList.remove('hidden');
+      return;
+    }
 
     const body = {
       teamKey,
       owner: document.getElementById('md-owner').value.trim(),
       repo: document.getElementById('md-repo').value.trim(),
       workflowFile: document.getElementById('md-wf').value.trim(),
-      defaultBranch: document.getElementById('md-branch').value.trim(),
+      defaultBranch,
       maxInProgressAiIssues: parseInt(document.getElementById('md-max-ai').value, 10),
       executionMode: document.getElementById('md-exec-mode').value,
       sessionMode: document.getElementById('md-session-mode').value,

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -94,6 +94,11 @@ export const stepperHtml = `
             <input class="input mono" id="np-repo" placeholder="backend" autocomplete="off" oninput="updateStepperNextButton()">
             <div class="field-hint">Repository name only (no owner prefix).</div>
           </div>
+          <div class="field" style="grid-column:1 / -1">
+            <label class="field-label">Default Branch</label>
+            <input class="input mono" id="np-defaultBranch" placeholder="development" autocomplete="off" oninput="updateStepperNextButton()">
+            <div class="field-hint">Branch used for workflow dispatches, runner clones, and implementation PR bases.</div>
+          </div>
         </div>
       </div>
 
@@ -224,6 +229,10 @@ export const stepperHtml = `
             <div data-review="repo" class="mono"></div>
           </div>
           <div class="np-review-row">
+            <div class="np-review-label">Default branch</div>
+            <div data-review="defaultBranch" class="mono"></div>
+          </div>
+          <div class="np-review-row">
             <div class="np-review-label">Runner</div>
             <div data-review="runner"></div>
           </div>
@@ -276,7 +285,7 @@ export const stepperScript = `
     jiraRepoFieldValue: '',
     jiraStatusFieldOverride: '',
     jiraRepoFieldOverride: '',
-    teamKey: '', owner: '', repo: '',
+    teamKey: '', owner: '', repo: '', defaultBranch: '',
     executionMode: 'github-actions', machineCpus: 2, machineMemoryMb: 4096, sessionMode: 'autonomous',
     provider: 'anthropic', awsRegion: '',
     planningEnabled: true, autoApprovePlans: true,
@@ -296,6 +305,7 @@ export const stepperScript = `
     data.teamKey = '';
     data.owner = '';
     data.repo = '';
+    data.defaultBranch = '';
     data.executionMode = 'github-actions';
     data.machineCpus = 2;
     data.machineMemoryMb = 4096;
@@ -308,7 +318,7 @@ export const stepperScript = `
     data.secrets = [];
 
     // Clear inputs
-    const toClear = ['np-teamKey', 'np-owner', 'np-repo', 'np-awsRegion'];
+    const toClear = ['np-teamKey', 'np-owner', 'np-repo', 'np-defaultBranch', 'np-awsRegion'];
     for (const id of toClear) {
       const el = document.getElementById(id);
       if (el) el.value = '';
@@ -514,8 +524,10 @@ export const stepperScript = `
     } else if (n === 2) {
       const owEl = document.getElementById('np-owner');
       const reEl = document.getElementById('np-repo');
+      const brEl = document.getElementById('np-defaultBranch');
       if (owEl) data.owner = owEl.value.trim();
       if (reEl) data.repo = reEl.value.trim();
+      if (brEl) data.defaultBranch = brEl.value.trim();
     } else if (n === 3) {
       const smEl = document.getElementById('np-sessionMode');
       const cpEl = document.getElementById('np-cpus');
@@ -575,6 +587,7 @@ export const stepperScript = `
     } else if (n === 2) {
       if (!data.owner) { showError('GitHub Owner is required.'); return false; }
       if (!data.repo) { showError('Repository Name is required.'); return false; }
+      if (!data.defaultBranch) { showError('Default Branch is required.'); return false; }
     } else if (n === 3) {
       // executionMode is set via card selection — always valid
     } else if (n === 4) {
@@ -623,6 +636,7 @@ export const stepperScript = `
 
     set('teamKey', window.esc(effectiveTeamKey()) || '&mdash;');
     set('repo', window.esc(data.owner) + '/' + window.esc(data.repo));
+    set('defaultBranch', window.esc(data.defaultBranch) || '&mdash;');
 
     let runnerText = window.esc(data.executionMode);
     if (data.executionMode === 'fly-machines') {
@@ -926,7 +940,7 @@ export const stepperScript = `
       owner: data.owner,
       repo: data.repo,
       workflowFile: 'claude-implement.yml',
-      defaultBranch: 'main',
+      defaultBranch: data.defaultBranch,
       maxInProgressAiIssues: data.maxInProgressAiIssues,
       executionMode: data.executionMode,
       sessionMode: data.sessionMode,

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -970,6 +970,15 @@ async function handleUpsertMapping(
       return;
     }
 
+    const existingMapping = getMappings()[body.teamKey];
+    const defaultBranch = typeof body.defaultBranch === "string"
+      ? body.defaultBranch.trim()
+      : (existingMapping?.defaultBranch ?? "");
+    if (!defaultBranch) {
+      json(res, 400, { error: "defaultBranch is required" });
+      return;
+    }
+
     const maxInProgressAiIssues =
       body.maxInProgressAiIssues ?? DEFAULT_MAX_IN_PROGRESS_AI_ISSUES;
     if (!Number.isInteger(maxInProgressAiIssues) || maxInProgressAiIssues < 1) {
@@ -1057,7 +1066,7 @@ async function handleUpsertMapping(
       owner: body.owner,
       repo: body.repo,
       workflowFile: body.workflowFile || "claude-implement.yml",
-      defaultBranch: body.defaultBranch || "main",
+      defaultBranch,
       maxInProgressAiIssues,
       executionMode,
       sessionMode,
@@ -1075,7 +1084,7 @@ async function handleUpsertMapping(
       // so an Edit form that omits `paused` doesn't silently resume the project.
       paused: body.paused !== undefined
         ? body.paused === true
-        : (getMappings()[body.teamKey]?.paused ?? false),
+        : (existingMapping?.paused ?? false),
     };
 
     upsertMapping(body.teamKey, mapping);

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -32,7 +32,10 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
   ): Promise<PushOutputs> {
     const { workspaceDir, repoOwner, repoRepo, githubToken, branchName } = inputs;
     const { issueIdentifier, issueTitle } = context.data;
-    const baseBranch = String(inputs.baseBranch ?? "main");
+    const baseBranch = String(inputs.baseBranch ?? context.data.branch ?? "").trim();
+    if (!baseBranch) {
+      throw new Error("Missing base branch for PR creation");
+    }
     const prTitle = String(inputs.prTitle ?? `${issueIdentifier}: ${issueTitle || "AI implementation"}`);
 
     if (!branchName || branchName === baseBranch) {

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { ClaudeCliExecutor } from "./pipeline/executor.js";
 import { DefaultPipelineContext } from "./pipeline/context.js";
@@ -26,6 +27,32 @@ function requireEnv(n: string): string {
   const v = process.env[n];
   if (!v) throw new Error(`Missing required env var: ${n}`);
   return v;
+}
+
+function optionalEnv(n: string): string | null {
+  const v = process.env[n]?.trim();
+  return v ? v : null;
+}
+
+function currentGitBranch(workspaceDir: string): string | null {
+  const result = spawnSync("git", ["branch", "--show-current"], {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0) return null;
+  const branch = result.stdout.toString().trim();
+  return branch || null;
+}
+
+function resolveBranch(workspaceDir: string): string {
+  const branch =
+    optionalEnv("GITHUB_DEFAULT_BRANCH") ??
+    optionalEnv("GITHUB_REF_NAME") ??
+    currentGitBranch(workspaceDir);
+  if (!branch) {
+    throw new Error("Missing GITHUB_DEFAULT_BRANCH and unable to resolve the checked-out branch");
+  }
+  return branch;
 }
 
 function buildDefaultImplementationPrompt(params: {
@@ -141,7 +168,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   const githubRepo = requireEnv("GITHUB_REPO");
   const githubToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
   if (!githubToken) throw new Error("Missing required env var: GITHUB_TOKEN");
-  const branch = process.env.GITHUB_DEFAULT_BRANCH || "main";
+  const branch = resolveBranch(workspaceDir);
   const prNumber = process.env.PR_NUMBER ?? "";
 
   const planningContext = process.env.LINEAR_API_KEY

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -47,7 +47,6 @@ function currentGitBranch(workspaceDir: string): string | null {
 function resolveBranch(workspaceDir: string): string {
   const branch =
     optionalEnv("GITHUB_DEFAULT_BRANCH") ??
-    optionalEnv("GITHUB_REF_NAME") ??
     currentGitBranch(workspaceDir);
   if (!branch) {
     throw new Error("Missing GITHUB_DEFAULT_BRANCH and unable to resolve the checked-out branch");

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -166,6 +166,7 @@ jobs:
       - name: Run pipeline
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.ref_name }}
           ISSUE_ID: ${{ inputs.issue_id }}
           ISSUE_IDENTIFIER: ${{ inputs.issue_identifier }}
           ISSUE_TITLE: ${{ inputs.issue_title }}

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -99,6 +99,7 @@ jobs:
             );
             core.setOutput("pr_number", String(context.payload.issue.number));
             core.setOutput("issue_meta", JSON.stringify(meta));
+            // The workflow runs in the target repo, so repository.default_branch is the target fallback.
             core.setOutput("default_branch", pr.data.base.ref || context.payload.repository.default_branch || "");
             core.setOutput("provider", process.env.AI_IMPLEMENT_PROVIDER || "anthropic");
             core.setOutput("aws_region", process.env.AI_IMPLEMENT_AWS_REGION || "");

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -34,6 +34,7 @@ jobs:
       matched: ${{ steps.trigger.outputs.matched }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
       issue_meta: ${{ steps.pr.outputs.issue_meta }}
+      default_branch: ${{ steps.pr.outputs.default_branch }}
       provider: ${{ steps.pr.outputs.provider }}
       aws_region: ${{ steps.pr.outputs.aws_region }}
       runner_image: ${{ steps.runner-image.outputs.runner_image }}
@@ -98,6 +99,7 @@ jobs:
             );
             core.setOutput("pr_number", String(context.payload.issue.number));
             core.setOutput("issue_meta", JSON.stringify(meta));
+            core.setOutput("default_branch", pr.data.base.ref || context.payload.repository.default_branch || "");
             core.setOutput("provider", process.env.AI_IMPLEMENT_PROVIDER || "anthropic");
             core.setOutput("aws_region", process.env.AI_IMPLEMENT_AWS_REGION || "");
 
@@ -204,6 +206,7 @@ jobs:
       - name: Run pipeline (gap-fill)
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_DEFAULT_BRANCH: ${{ needs.check-trigger.outputs.default_branch }}
           PR_NUMBER: ${{ needs.check-trigger.outputs.pr_number }}
           ISSUE_META: ${{ needs.check-trigger.outputs.issue_meta }}
           PROVIDER: ${{ needs.check-trigger.outputs.provider }}


### PR DESCRIPTION
## Summary
- Pass the dispatched workflow ref into the runner as `GITHUB_DEFAULT_BRANCH` so GitHub Actions runs clone the configured branch instead of falling back to `main`.
- Pass comment-trigger gap-fill runs the PR base branch.
- Remove `main` fallbacks from session bootstrap, TS runner branch resolution, push-step PR base selection, and admin project creation UI/API.

## Root Cause
The orchestrator dispatched workflows on `mapping.defaultBranch`, but the target workflow did not export that ref into the runner container. `session/entrypoint.sh` then fell back to `main`, which fails for repos whose configured branch is `development` or another non-main branch.

## Validation
- `npm test -- --exclude '.worktrees/**' src/__tests__/admin.test.ts src/__tests__/workflow-shim-structure.test.ts src/__tests__/entrypoint-shellcheck.test.ts src/__tests__/run-autonomous.test.ts src/__tests__/steps-push.test.ts src/admin-ui/__tests__/stepper.test.ts`
- `pnpm typecheck`
- `npm test -- --exclude '.worktrees/**'`