### PR TITLE
Forward runner image to GitHub Actions dispatches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,13 +213,15 @@ Both check `custom/<path>` (relative to `process.cwd()`) first, then fall back t
 
 ## Per-repo runner image override
 
-A target repo can boot its Fly Machine session on a custom runner image by committing `.ai-implement/image.yml` at the default branch:
+A target repo can boot its runner on a custom image by committing `.ai-implement/image.yml` at the default branch:
 
 ```yaml
 image: ghcr.io/your-org/your-runner:v1
 ```
 
 The image must be publicly pullable. The customer owns building and publishing it. If the file is absent, malformed, or points at an unreachable reference, the orchestrator falls back to the default runner (`SESSION_IMAGE` env var, or `ghcr.io/builddownai/ai-implement-runner:latest`).
+
+This resolution applies to **both** execution modes. On the Fly Machines path the orchestrator boots the session machine on the resolved image directly. On the GitHub Actions path the orchestrator forwards the resolved image as the `runner_image` workflow_dispatch input to `claude-implement.yml` (which runs it as the job's `container.image`) — but only when the choice is explicit: a per-repo `.ai-implement/image.yml` override, or an explicitly-set `SESSION_IMAGE`. When neither is set the orchestrator sends no `runner_image`, so the workflow keeps its own resolution order (the `AI_IMPLEMENT_RUNNER_IMAGE` repo/org variable, then its built-in `:latest` default) and repos that pin via that variable are not overridden. Planning runs (`claude-plan.yml`) have no runner container and are unaffected.
 
 The default runner image itself must also be public on GHCR — Fly pulls anonymously, so a private package surfaces as `failed to get manifest ... unauthorized` at machine-create time. New GHCR packages default to Private and the org must allow public container packages first (Org Settings → Packages). See the comment at the top of `.github/workflows/build-runner.yml`.
 

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -90,6 +90,23 @@ describe("dispatchWorkflow", () => {
     expect(body.inputs.aws_region).toBeUndefined();
   });
 
+  it("forwards runner_image when present in inputs", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ status: 204, ok: true } as Response);
+    await dispatchWorkflow("gh-token", mockMapping, {
+      ...mockInputs,
+      runner_image: "ghcr.io/builddownai/ai-implement-runner:next",
+    });
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.inputs.runner_image).toBe("ghcr.io/builddownai/ai-implement-runner:next");
+  });
+
+  it("omits runner_image when not provided", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ status: 204, ok: true } as Response);
+    await dispatchWorkflow("gh-token", mockMapping, mockInputs);
+    const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+    expect(body.inputs.runner_image).toBeUndefined();
+  });
+
   it("forwards provider and aws_region in inputs for bedrock mappings", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({ status: 204, ok: true } as Response);
     const bedrockMapping = makeMapping({ provider: "bedrock", awsRegion: "us-west-2" });

--- a/src/__tests__/repo-image.test.ts
+++ b/src/__tests__/repo-image.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveSessionImage, __clearRepoImageCacheForTests } from "../repo-image.js";
+import { resolveSessionImage, selectRunnerImageInput, __clearRepoImageCacheForTests } from "../repo-image.js";
 
 const DEFAULT_IMAGE = "ghcr.io/builddownai/ai-implement-runner:latest";
 
@@ -169,5 +169,32 @@ describe("resolveSessionImage", () => {
       fetchImpl,
     });
     expect(result).toEqual({ image: DEFAULT_IMAGE, source: "default" });
+  });
+});
+
+describe("selectRunnerImageInput", () => {
+  it("forwards a per-repo override regardless of whether SESSION_IMAGE is set", () => {
+    const resolved = { image: "ghcr.io/acme/my-runner:v3", source: "override" as const };
+    expect(selectRunnerImageInput({ resolved, sessionImageExplicit: false })).toBe(
+      "ghcr.io/acme/my-runner:v3",
+    );
+    expect(selectRunnerImageInput({ resolved, sessionImageExplicit: true })).toBe(
+      "ghcr.io/acme/my-runner:v3",
+    );
+  });
+
+  it("forwards the orchestrator default when SESSION_IMAGE is explicitly set", () => {
+    const resolved = { image: "ghcr.io/builddownai/ai-implement-runner:next", source: "default" as const };
+    expect(selectRunnerImageInput({ resolved, sessionImageExplicit: true })).toBe(
+      "ghcr.io/builddownai/ai-implement-runner:next",
+    );
+  });
+
+  it("forwards nothing when the image is the implicit default (SESSION_IMAGE unset, no override)", () => {
+    // Leaving runner_image unset lets the target workflow keep its own resolution
+    // (AI_IMPLEMENT_RUNNER_IMAGE repo variable, then the built-in default), so
+    // repos that pin via that variable are not silently overridden.
+    const resolved = { image: DEFAULT_IMAGE, source: "default" as const };
+    expect(selectRunnerImageInput({ resolved, sessionImageExplicit: false })).toBeUndefined();
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -22,6 +22,13 @@ interface DispatchInputs {
   run_token?: string;
   /** Signed reusable token authorizing step progress POSTs. Empty when progress callback disabled. */
   run_progress_token?: string;
+  /**
+   * Overrides the runner container image the target workflow runs in. Only set
+   * when the orchestrator has an explicit image to pin (a per-repo
+   * `.ai-implement/image.yml` override, or an explicitly-set SESSION_IMAGE);
+   * otherwise omitted so the workflow keeps its own image resolution.
+   */
+  runner_image?: string;
 }
 
 interface DispatchResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { safeDestroyMachine, sweepOrphanedMachines, SWEEP_MACHINE_MAX_AGE_MS } f
 import { getRunnerMode, getFlySecretsMinVersion, initSettingsTable, resolveExecutionPath } from "./runner-mode.js";
 import { handleGitHubWebhook } from "./webhook.js";
 import { initReconciliationTable, getPendingReconciliations, updateReconciliationStatus } from "./reconciliation.js";
-import { resolveSessionImage } from "./repo-image.js";
+import { resolveSessionImage, selectRunnerImageInput } from "./repo-image.js";
 import { getStepRecord, initStepLogTable } from "./step-log.js";
 import { getOrchestratorSettings } from "./orchestrator-settings.js";
 import { handleRunnerProgress, handleRunnerResult } from "./runner-callback.js";
@@ -45,6 +45,9 @@ import { listOpenReviewFindings } from "./review-ledger-store.js";
 
 // ---------- Configuration ----------
 
+/** Built-in fallback runner image when SESSION_IMAGE is unset. Mirrors the default in claude-implement.yml. */
+const DEFAULT_SESSION_IMAGE = "ghcr.io/builddownai/ai-implement-runner:latest";
+
 interface AppConfig {
   linearApiKey: string | null;
   githubAppId: string;
@@ -61,6 +64,8 @@ interface AppConfig {
   flyOrchestratorApp: string | null;
   tenantId: string | null;
   sessionImage: string;
+  /** True when SESSION_IMAGE was explicitly set (vs. falling back to the built-in default). */
+  sessionImageExplicit: boolean;
   anthropicApiKey: string | null;
   claudeOAuthToken: string | null;
   githubWebhookSecret: string | null;
@@ -136,7 +141,8 @@ function loadConfig(): AppConfig {
     })(),
     flyOrchestratorApp: process.env.FLY_APP_NAME || null,
     tenantId: process.env.CLIENT_SLUG || process.env.FLY_APP_NAME || null,
-    sessionImage: process.env.SESSION_IMAGE || "ghcr.io/builddownai/ai-implement-runner:latest",
+    sessionImage: process.env.SESSION_IMAGE || DEFAULT_SESSION_IMAGE,
+    sessionImageExplicit: Boolean(process.env.SESSION_IMAGE),
     anthropicApiKey: process.env.ANTHROPIC_API_KEY || null,
     claudeOAuthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN || null,
     githubWebhookSecret,
@@ -331,6 +337,34 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
 
 // ---------- Dispatch: GitHub Actions ----------
 
+/**
+ * Resolves the runner image to forward on an orchestrator-initiated workflow
+ * dispatch. Returns the value for the `runner_image` workflow_dispatch input,
+ * or undefined to leave the target workflow's own image resolution in place
+ * (its AI_IMPLEMENT_RUNNER_IMAGE variable, then built-in default).
+ *
+ * This is the GitHub Actions counterpart to the Fly Machines image resolution
+ * at the session-machine dispatch: both honor a per-repo `.ai-implement/image.yml`
+ * override and the orchestrator's SESSION_IMAGE, so a testing orchestrator
+ * pinned to `:next` dispatches `:next` workflows.
+ */
+async function resolveDispatchRunnerImage(
+  config: AppConfig,
+  mapping: RepoMapping,
+  ghToken: string,
+): Promise<string | undefined> {
+  const resolved = await resolveSessionImage({
+    owner: mapping.owner,
+    repo: mapping.repo,
+    token: ghToken,
+    defaultImage: config.sessionImage,
+  });
+  return selectRunnerImageInput({
+    resolved,
+    sessionImageExplicit: config.sessionImageExplicit,
+  });
+}
+
 async function dispatchGitHubActions(
   config: AppConfig,
   provider: TicketingProvider,
@@ -369,6 +403,8 @@ async function dispatchGitHubActions(
     runProgressToken = progressMinted.token;
   }
 
+  const runnerImage = await resolveDispatchRunnerImage(config, mapping, ghToken);
+
   const result = await dispatchWorkflow(ghToken, mapping, {
     issue_id: issue.id,
     issue_identifier: issue.identifier,
@@ -379,6 +415,7 @@ async function dispatchGitHubActions(
     runner_callback_url: runnerCallbackUrl,
     run_token: runToken,
     run_progress_token: runProgressToken,
+    ...(runnerImage ? { runner_image: runnerImage } : {}),
   });
 
   if (!result.success) {
@@ -398,6 +435,7 @@ async function dispatchGitHubActions(
     dispatchNumber: prior.count + 1,
     executionMode: "github-actions",
     runnerMode,
+    sessionImage: runnerImage ?? null,
   });
 
   // Suppress pending notifications for earlier failed attempts — they're stale.
@@ -1511,6 +1549,7 @@ async function processReconciliations(config: AppConfig): Promise<void> {
 
       // Dispatch a gap-fill run using the existing claude-implement.yml workflow,
       // passing the merged PR number so Claude checks out the right branch.
+      const runnerImage = await resolveDispatchRunnerImage(config, mapping, ghToken);
       const result = await dispatchWorkflow(ghToken, mapping, {
         issue_id: job.issueId,
         issue_identifier: job.issueIdentifier ?? job.issueId,
@@ -1519,6 +1558,7 @@ async function processReconciliations(config: AppConfig): Promise<void> {
         pr_number: String(job.prNumber),
         runner_phase: "gap-analysis",
         ...providerDispatchFields(mapping),
+        ...(runnerImage ? { runner_image: runnerImage } : {}),
       });
 
       if (result.success) {
@@ -1603,6 +1643,7 @@ async function processReviewFixQueue(config: AppConfig): Promise<void> {
 
       const [owner] = fix.repo.split("/");
       const ghToken = await getInstallationToken(config.githubAppId, config.githubAppPrivateKey, owner);
+      const runnerImage = await resolveDispatchRunnerImage(config, mapping, ghToken);
       const result = await dispatchWorkflow(ghToken, mapping, {
         issue_id: fix.issueId,
         issue_identifier: fix.issueIdentifier ?? fix.issueId,
@@ -1614,6 +1655,7 @@ async function processReviewFixQueue(config: AppConfig): Promise<void> {
         runner_callback_url: runnerCallbackUrl,
         run_token: runToken,
         run_progress_token: runProgressToken,
+        ...(runnerImage ? { runner_image: runnerImage } : {}),
       });
 
       if (!result.success) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,7 +446,7 @@ async function dispatchGitHubActions(
 
   await postDispatch(config, provider, issue, mapping, ghToken, jobId, "github-actions");
 
-  console.log(`[poll] Dispatched ${issue.identifier} -> ${mapping.owner}/${mapping.repo} (github-actions)`);
+  console.log(`[poll] Dispatched ${issue.identifier} -> ${mapping.owner}/${mapping.repo} (github-actions, image: ${runnerImage ?? "workflow-default"})`);
 }
 
 // ---------- Dispatch: Planning ----------
@@ -1564,7 +1564,7 @@ async function processReconciliations(config: AppConfig): Promise<void> {
       if (result.success) {
         updateReconciliationStatus(job.id, "dispatched");
         console.log(
-          `[reconcile] Dispatched gap-fill for ${job.issueIdentifier} (PR #${job.prNumber} in ${job.repo})`,
+          `[reconcile] Dispatched gap-fill for ${job.issueIdentifier} (PR #${job.prNumber} in ${job.repo}, image: ${runnerImage ?? "workflow-default"})`,
         );
       } else {
         console.error(
@@ -1688,7 +1688,7 @@ async function processReviewFixQueue(config: AppConfig): Promise<void> {
       }
       suppressStaleNotifications(fix.issueId, jobId);
       updateReviewFixStatus(fix.id, "dispatched");
-      console.log(`[review-fix] Dispatched review fix for ${fix.issueIdentifier ?? fix.issueId} (PR #${fix.prNumber} in ${fix.repo})`);
+      console.log(`[review-fix] Dispatched review fix for ${fix.issueIdentifier ?? fix.issueId} (PR #${fix.prNumber} in ${fix.repo}, image: ${runnerImage ?? "workflow-default"})`);
     } catch (err) {
       console.error(`[review-fix] Error processing review fix #${fix.id}:`, err);
     }

--- a/src/repo-image.ts
+++ b/src/repo-image.ts
@@ -108,3 +108,27 @@ async function fetchImage(
 
   return { image: candidate, source: "override" };
 }
+
+/**
+ * Decides whether a resolved image should be forwarded to a target workflow as
+ * the `runner_image` workflow_dispatch input.
+ *
+ * We only forward when the image represents an *explicit* choice:
+ *   - a per-repo `.ai-implement/image.yml` override (source === "override"), or
+ *   - an explicitly-set SESSION_IMAGE on the orchestrator.
+ *
+ * When neither is true the resolved image is just the built-in fallback, so we
+ * return `undefined` and let the target workflow keep its own resolution
+ * (the `AI_IMPLEMENT_RUNNER_IMAGE` repo/org variable, then its built-in
+ * default). This keeps repos that pin via that variable from being silently
+ * overridden by the orchestrator's default.
+ */
+export function selectRunnerImageInput(opts: {
+  resolved: ResolveSessionImageResult;
+  sessionImageExplicit: boolean;
+}): string | undefined {
+  if (opts.resolved.source === "override" || opts.sessionImageExplicit) {
+    return opts.resolved.image;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Problem

`SESSION_IMAGE` only fed the **Fly Machines** path (`resolveSessionImage`). The **GitHub Actions** path never sent a `runner_image` input — `DispatchInputs` lacked the field — so `claude-implement.yml`'s `validate-runner-image` job always fell through to its hardcoded `ghcr.io/builddownai/ai-implement-runner:latest` default. A testing orchestrator pinned to `:next` still dispatched `:latest` workflows, and setting `SESSION_IMAGE` had no effect on that path.

## Fix

Forward the orchestrator's resolved image as the `runner_image` `workflow_dispatch` input on the three `claude-implement.yml` dispatch sites (implementation, reconcile gap-fill, review-fix) — but **only when the choice is explicit**: a per-repo `.ai-implement/image.yml` override, or an explicitly-set `SESSION_IMAGE`. When neither is set, no `runner_image` is sent, so the workflow keeps its own resolution (`AI_IMPLEMENT_RUNNER_IMAGE` repo/org variable, then built-in `:latest`) and repos that pin via that variable are not silently overridden.

Planning (`claude-plan.yml`) has no runner container, so it is intentionally excluded — passing the input there would 422 the dispatch.

## Changes

- `src/github.ts` — add optional `runner_image` to `DispatchInputs`
- `src/repo-image.ts` — add pure `selectRunnerImageInput()` (forward/skip decision)
- `src/index.ts` — add `sessionImageExplicit` config + `DEFAULT_SESSION_IMAGE`, `resolveDispatchRunnerImage()` helper, wire into the 3 dispatch sites, log the pinned image on the GH Actions path
- `src/__tests__/{repo-image,github}.test.ts` — 5 new tests (written failing first, TDD)
- `CLAUDE.md` — document that image resolution now applies to both execution modes

## Verification

- `npm run typecheck` clean
- `npm test` — 1138 passing (incl. 5 new)

## Deploy note

Once this lands and the testing orchestrator is redeployed, its existing `SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:next` will pin every dispatched GitHub Actions workflow to `:next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)