### PR TITLE
Fix build: allow gap-analysis phase in postRunnerResult

### DIFF
--- a/src/runner-result.ts
+++ b/src/runner-result.ts
@@ -11,7 +11,7 @@ export function collectRunnerComments(workspaceDir: string): Array<{ body: strin
 }
 
 export async function postRunnerResult(params: {
-  phase: "planning" | "implementation";
+  phase: "planning" | "implementation" | "gap-analysis";
   workspaceDir: string;
   outcome: "success" | "failure";
   prUrl?: string;


### PR DESCRIPTION
## Problem

`npm run build` (tsc) fails on `testing`:

```
src/run-autonomous.ts(195,7): error TS2322: Type '"implementation" | "gap-analysis"' is not assignable to type '"implementation" | "planning"'.
src/run-autonomous.ts(205,7): error TS2322: ...
```

`run-autonomous.ts` resolves `runnerPhase` to `"implementation" | "gap-analysis"` (`resolveRunnerPhase`) and passes it to `postRunnerResult`, whose `phase` param was typed only `"planning" | "implementation"`.

This is purely a too-narrow type, not a behavior bug:
- The orchestrator callback handler (`runner-callback.ts:75-77`, `:186`) already validates and has a dedicated branch for `"gap-analysis"`.
- Run tokens for reconcile / review-fix dispatches are minted with `phase: "gap-analysis"`, and the handler enforces `claims.phase === body.phase`.
- A runtime test (`run-autonomous.test.ts` — "posts gap-analysis callback phase for PR_NUMBER runs") already asserts this path. It passed under vitest (esbuild, no type-check) while `tsc` build failed — which is how it slipped in.

## Fix

Widen `postRunnerResult`'s `phase` param to `"planning" | "implementation" | "gap-analysis"`. The internal missing-`prUrl` guard already special-cases only `implementation` (matching the handler's `missing_prUrl` check), so no logic change is needed.

## Verification

- `npm run build` — exit 0 (was failing)
- `npm test` — all run-autonomous / runner-callback tests pass

## Out of scope (flagged separately)

`src/__tests__/entrypoint-shellcheck.test.ts` has a **pre-existing, unrelated** failure on `testing`: it asserts a literal `node /app/dist/run-autonomous.js`, but `entrypoint.sh` was refactored to `node /app/dist/$RUNNER_ENTRY` (to branch planning vs autonomous). It's a stale test assertion, not a runtime bug. Not touched here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)