### PR TITLE
Update stale entrypoint test for $RUNNER_ENTRY selection

### DIFF
--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -14,9 +14,13 @@ describe("session/entrypoint.sh", () => {
     expect(content.split("\n").length).toBeLessThan(100);
   });
 
-  it("exec's node /app/dist/run-autonomous.js as the final step", () => {
+  it("exec's the selected TS runner entry (node /app/dist/$RUNNER_ENTRY) as the final step", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
-    expect(content).toMatch(/exec\s+(.*\s+)?node\s+\/app\/dist\/run-autonomous\.js/);
+    // The entrypoint picks the entry by phase, then execs it as the final step.
+    expect(content).toMatch(/exec\s+(.*\s+)?node\s+\/app\/dist\/\$\{?RUNNER_ENTRY\}?/);
+    // planning -> run-planning.js; implementation/gap-analysis -> run-autonomous.js
+    expect(content).toMatch(/RUNNER_ENTRY="run-planning\.js"/);
+    expect(content).toMatch(/RUNNER_ENTRY="run-autonomous\.js"/);
   });
 
   it("detects GHA mode by GITHUB_ACTIONS=true", () => {


### PR DESCRIPTION
## Problem

`src/__tests__/entrypoint-shellcheck.test.ts` fails on `testing`:

```
× exec's node /app/dist/run-autonomous.js as the final step
```

The test asserted a literal `node /app/dist/run-autonomous.js`, but `session/entrypoint.sh` was refactored to select the runner entry by phase and exec it via a variable:

```sh
if [ "$RUNNER_PHASE" = "planning" ]; then
  RUNNER_ENTRY="run-planning.js"
else
  RUNNER_ENTRY="run-autonomous.js"
fi
...
exec dbus-run-session -- su -p coder -c "HOME=/home/coder exec node /app/dist/$RUNNER_ENTRY"
```

This is a **stale test assertion, not a runtime bug** — implementation/gap-analysis runs still exec `run-autonomous.js`.

## Fix

Assert the real contract:
- the final step execs `node /app/dist/$RUNNER_ENTRY`, and
- `RUNNER_ENTRY` is set to both `run-planning.js` and `run-autonomous.js`.

## Verification

- `npm test` — 1121 passing (was 1 failing)

## Related

Companion to #66 (the `postRunnerResult` build-error fix). Both address breakage on `testing`; kept as separate focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)