### PR TITLE
Consolidate ORCHESTRATOR_URL into RUNNER_CALLBACK_BASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,11 +75,6 @@ RUNNER_TOKEN_SECRET=
 # workflow uses to kick off gap-fill runs against an existing PR.
 GAP_FILL_TRIGGER_SECRET=
 
-# Used by session-side scripts to construct callback URLs back here. In Fly
-# Machines mode this is normally derived; set explicitly if running behind a
-# proxy or custom domain.
-ORCHESTRATOR_URL=
-
 # =============================================================================
 # Notifications (optional)
 # =============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,6 @@ interface AppConfig {
   anthropicApiKey: string | null;
   claudeOAuthToken: string | null;
   githubWebhookSecret: string | null;
-  orchestratorUrl: string | null;
   reaperDryRun: boolean;
   reaperAlertThreshold: number;
   runnerCallbackBaseUrl: string | null;
@@ -146,7 +145,6 @@ function loadConfig(): AppConfig {
     anthropicApiKey: process.env.ANTHROPIC_API_KEY || null,
     claudeOAuthToken: process.env.CLAUDE_CODE_OAUTH_TOKEN || null,
     githubWebhookSecret,
-    orchestratorUrl: process.env.ORCHESTRATOR_URL || null,
     reaperDryRun: process.env.REAPER_DRY_RUN === "true",
     reaperAlertThreshold: parseInt(process.env.REAPER_ALERT_THRESHOLD || "10", 10),
     runnerCallbackBaseUrl,
@@ -739,7 +737,7 @@ async function dispatchFlyMachine(
         teamKey: issue.scopeKey,
         teamSecretNames: allSecretNames,
         minSecretsVersion: minSecretsVersion ?? undefined,
-        orchestratorUrl: config.orchestratorUrl ?? undefined,
+        orchestratorUrl: config.runnerCallbackBaseUrl ?? undefined,
         runnerCallbackUrl: runnerCallbackUrl || undefined,
         runToken: runToken || undefined,
         orchestratorApp: config.flyOrchestratorApp ?? undefined,
@@ -793,7 +791,7 @@ async function dispatchLocalDocker(
     backend: async ({ sessionToken, machineNonce, runnerCallbackUrl, runToken }) => {
       const localOrchestratorUrl =
         config.localRunnerOrchestratorUrl ??
-        config.orchestratorUrl ??
+        config.runnerCallbackBaseUrl ??
         `http://host.docker.internal:${config.healthPort}`;
 
       const container = await startLocalRunnerContainer({


### PR DESCRIPTION
## Problem

The orchestrator exposes two operator-facing env vars that both point at the same orchestrator URL:

- `ORCHESTRATOR_URL` — consumed by the runner's step-reporter (`POST /api/step-report`)
- `RUNNER_CALLBACK_BASE_URL` — used for the runner-result callback (`POST /runner/result`) and run-token minting

They were never meaningfully different. Operators had to set both to the same value, and setting only one left runs silently half-wired (a class of "machine completes but is marked failed" bug).

## Change

Drop `ORCHESTRATOR_URL` from the operator-facing config — the `AppConfig` field, the env read, and the `.env.example` entry. Both dispatch paths now source the runner's `ORCHESTRATOR_URL` env from `RUNNER_CALLBACK_BASE_URL`:

- **fly-machines**: `machineConfig.orchestratorUrl` ← `config.runnerCallbackBaseUrl`
- **local-docker**: the `localOrchestratorUrl` fallback chain uses `runnerCallbackBaseUrl` instead of the removed field

## Runner contract is unchanged

The session still receives an `ORCHESTRATOR_URL` env var (set by `fly-machines.ts` / `local-docker.ts` and read by `run-autonomous.ts`). Only the *operator-facing source* is consolidated — one fewer env var to configure, with no way to half-wire a run.

## Verification

- `npm run typecheck` — clean
- `npm test` — 1126 passed (81 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)