### PR TITLE
fix(runner): restore Bedrock Docker auth

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -165,6 +165,23 @@ jobs:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
+      - name: Validate Bedrock inputs
+        if: inputs.provider == 'bedrock'
+        env:
+          AWS_REGION: ${{ inputs.aws_region }}
+          ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_REGION" ]; then
+            echo "::error::provider=bedrock but aws_region dispatch input is empty."
+            echo "::error::Set awsRegion on this team's mapping in the orchestrator admin UI."
+            exit 1
+          fi
+          if [ -z "$ROLE_ARN" ]; then
+            echo "::error::provider=bedrock but AWS_BEDROCK_ROLE_ARN repo secret is not set."
+            echo "::error::Add the IAM role ARN trusted to GitHub OIDC with bedrock:InvokeModel permission."
+            exit 1
+          fi
+
       - name: Configure AWS credentials (Bedrock)
         if: inputs.provider == 'bedrock'
         uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Neither workflow validates model IDs — whatever `model:` says in front matter 
 
 ### Using AWS Bedrock
 
-To run a target repo against AWS Bedrock instead of the Anthropic API:
+To run a target repo against AWS Bedrock instead of the Anthropic API, use the GitHub Actions execution mode. Bedrock is not supported on Fly Machines or local Docker because those backends do not have a role-assumption mechanism equivalent to GitHub OIDC.
 
 1. **In the orchestrator admin UI (`/admin`)**, edit the repo's mapping:
    - Set **Provider** to `bedrock`
@@ -181,7 +181,7 @@ IAM trust policy shape (use the `sub` condition to restrict to this specific rep
 }
 ```
 
-The workflow re-runs `aws-actions/configure-aws-credentials` before each Bedrock action step (once before the main implementation run, once before gap analysis) so the STS session token doesn't expire during long runs. Only OIDC is supported — there is no static-key path.
+The workflow runs `aws-actions/configure-aws-credentials` once before the containerized runner step with a 4-hour session duration, covering implementation and gap-analysis runs. Only GitHub OIDC is supported — there is no static-key path.
 
 ## Custom extensions
 

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -20,7 +20,13 @@ log "Execution mode: $AI_IMPLEMENT_MODE"
 export AI_IMPLEMENT_MODE
 
 # ── 2. Env validation ────────────────────────────────────────────────────────
-require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN
+PROVIDER="${PROVIDER:-anthropic}"
+case "$PROVIDER" in
+  bedrock) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
+  anthropic) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ;;
+  *) fail "Unsupported provider: $PROVIDER" ;;
+esac
+export PROVIDER
 require_env ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION
 
 if [ "$AI_IMPLEMENT_MODE" = "gha" ]; then

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -22,7 +22,7 @@ export AI_IMPLEMENT_MODE
 # ── 2. Env validation ────────────────────────────────────────────────────────
 PROVIDER="${PROVIDER:-anthropic}"
 case "$PROVIDER" in
-  bedrock) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
+  bedrock) [ "$AI_IMPLEMENT_MODE" = "gha" ] || fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
   anthropic) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ;;
   *) fail "Unsupported provider: $PROVIDER" ;;
 esac

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -26,6 +26,14 @@ describe("session/entrypoint.sh", () => {
     expect(content).toMatch(/GITHUB_ACTIONS.*=.*"true"/);
   });
 
+  it("routes auth validation by provider and enables Claude Code Bedrock mode", () => {
+    const content = readFileSync("session/entrypoint.sh", "utf-8");
+    expect(content).toMatch(/PROVIDER="\$\{PROVIDER:-anthropic\}"/);
+    expect(content).toMatch(/bedrock\) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1/);
+    expect(content).toMatch(/anthropic\) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN/);
+    expect(content.indexOf("CLAUDE_CODE_USE_BEDROCK=1")).toBeLessThan(content.indexOf("su -p coder"));
+  });
+
   it("exports GITHUB_DEFAULT_BRANCH for the TS runner", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     expect(content).toMatch(/GITHUB_DEFAULT_BRANCH="\$\{GITHUB_REF_NAME\}"/);

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -29,7 +29,7 @@ describe("session/entrypoint.sh", () => {
   it("routes auth validation by provider and enables Claude Code Bedrock mode", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     expect(content).toMatch(/PROVIDER="\$\{PROVIDER:-anthropic\}"/);
-    expect(content).toMatch(/bedrock\) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1/);
+    expect(content).toMatch(/bedrock\) \[ "\$AI_IMPLEMENT_MODE" = "gha" \] \|\| fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1/);
     expect(content).toMatch(/anthropic\) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN/);
     expect(content.indexOf("CLAUDE_CODE_USE_BEDROCK=1")).toBeLessThan(content.indexOf("su -p coder"));
   });

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -164,6 +164,14 @@ describe("GHA workflow shims", () => {
       const yaml = readFileSync(f, "utf-8");
       expect(yaml).toMatch(/GITHUB_DEFAULT_BRANCH:\s*\$\{\{\s*github\.ref_name\s*\}\}/);
     });
+
+    it(`${f} validates Bedrock config before configuring AWS credentials`, () => {
+      const yaml = readFileSync(f, "utf-8");
+      expect(yaml).toMatch(/Validate Bedrock inputs/);
+      expect(yaml).toMatch(/provider=bedrock but aws_region dispatch input is empty/);
+      expect(yaml).toMatch(/provider=bedrock but AWS_BEDROCK_ROLE_ARN repo secret is not set/);
+      expect(yaml.indexOf("Validate Bedrock inputs")).toBeLessThan(yaml.indexOf("Configure AWS credentials (Bedrock)"));
+    });
   }
 
   it("comment trigger only runs implementation for an exact trimmed /ai-implement command", () => {

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -165,6 +165,23 @@ jobs:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
+      - name: Validate Bedrock inputs
+        if: inputs.provider == 'bedrock'
+        env:
+          AWS_REGION: ${{ inputs.aws_region }}
+          ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_REGION" ]; then
+            echo "::error::provider=bedrock but aws_region dispatch input is empty."
+            echo "::error::Set awsRegion on this team's mapping in the orchestrator admin UI."
+            exit 1
+          fi
+          if [ -z "$ROLE_ARN" ]; then
+            echo "::error::provider=bedrock but AWS_BEDROCK_ROLE_ARN repo secret is not set."
+            echo "::error::Add the IAM role ARN trusted to GitHub OIDC with bedrock:InvokeModel permission."
+            exit 1
+          fi
+
       - name: Configure AWS credentials (Bedrock)
         if: inputs.provider == 'bedrock'
         uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c


### PR DESCRIPTION
## Summary
- route runner entrypoint auth validation by provider
- enable Claude Code Bedrock mode in Docker sessions
- add Bedrock preflight validation to the implement workflow template

## Verification
- npm run typecheck
- npm test