### PR TITLE
Bedrock reliability fixes: per-project caps, hooks, and timeout

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -165,6 +165,23 @@ jobs:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
+      - name: Validate Bedrock inputs
+        if: inputs.provider == 'bedrock'
+        env:
+          AWS_REGION: ${{ inputs.aws_region }}
+          ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_REGION" ]; then
+            echo "::error::provider=bedrock but aws_region dispatch input is empty."
+            echo "::error::Set awsRegion on this team's mapping in the orchestrator admin UI."
+            exit 1
+          fi
+          if [ -z "$ROLE_ARN" ]; then
+            echo "::error::provider=bedrock but AWS_BEDROCK_ROLE_ARN repo secret is not set."
+            echo "::error::Add the IAM role ARN trusted to GitHub OIDC with bedrock:InvokeModel permission."
+            exit 1
+          fi
+
       - name: Configure AWS credentials (Bedrock)
         if: inputs.provider == 'bedrock'
         uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -60,6 +60,21 @@ on:
         required: false
         type: string
         default: ""
+      max_turns:
+        description: "Cap on Claude turns per implement pass (empty = runner default)"
+        required: false
+        type: string
+        default: ""
+      max_iterations:
+        description: "Cap on implement/review iterations (empty = provider default)"
+        required: false
+        type: string
+        default: ""
+      job_timeout_minutes:
+        description: "Per-project job timeout in minutes (empty = 90)"
+        required: false
+        type: string
+        default: ""
       runner_callback_url:
         description: "Base URL the orchestrator advertises for /runner/result; empty skips callback"
         required: false
@@ -154,7 +169,7 @@ jobs:
   implement:
     needs: validate-runner-image
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.job_timeout_minutes && fromJSON(inputs.job_timeout_minutes) || 90 }}
     container:
       image: ${{ needs.validate-runner-image.outputs.runner_image }}
     steps:
@@ -211,6 +226,8 @@ jobs:
           RUNNER_PHASE: ${{ inputs.runner_phase }}
           PROVIDER: ${{ inputs.provider }}
           AWS_REGION: ${{ inputs.aws_region }}
+          AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -71,7 +71,7 @@ on:
         type: string
         default: ""
       job_timeout_minutes:
-        description: "Per-project job timeout in minutes (empty = 90)"
+        description: "Per-project job timeout in minutes, must be a positive integer (empty = 90)"
         required: false
         type: string
         default: ""

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -10,6 +10,12 @@
 #   AI_IMPLEMENT_PROVIDER    - Set to "bedrock" to route through AWS Bedrock.
 #   AI_IMPLEMENT_AWS_REGION  - AWS region (required when provider=bedrock).
 #
+# Optional repository variables (per-project run caps — mirror the orchestrator
+# admin UI mapping so /ai-implement comment runs get the same caps):
+#   AI_IMPLEMENT_MAX_TURNS       - Cap on Claude turns per implement pass (default 50).
+#   AI_IMPLEMENT_MAX_ITERATIONS  - Cap on implement/review iterations (default: bedrock 2 / anthropic 3).
+#   AI_IMPLEMENT_MAX_JOB_MINUTES - Per-project job timeout in minutes (default 90).
+#
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
 #   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
@@ -37,6 +43,9 @@ jobs:
       default_branch: ${{ steps.pr.outputs.default_branch }}
       provider: ${{ steps.pr.outputs.provider }}
       aws_region: ${{ steps.pr.outputs.aws_region }}
+      max_turns: ${{ steps.pr.outputs.max_turns }}
+      max_iterations: ${{ steps.pr.outputs.max_iterations }}
+      max_job_minutes: ${{ steps.pr.outputs.max_job_minutes }}
       runner_image: ${{ steps.runner-image.outputs.runner_image }}
     steps:
       - name: Check trigger command
@@ -82,6 +91,9 @@ jobs:
         env:
           AI_IMPLEMENT_PROVIDER: ${{ vars.AI_IMPLEMENT_PROVIDER }}
           AI_IMPLEMENT_AWS_REGION: ${{ vars.AI_IMPLEMENT_AWS_REGION }}
+          AI_IMPLEMENT_MAX_TURNS: ${{ vars.AI_IMPLEMENT_MAX_TURNS }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ vars.AI_IMPLEMENT_MAX_ITERATIONS }}
+          AI_IMPLEMENT_MAX_JOB_MINUTES: ${{ vars.AI_IMPLEMENT_MAX_JOB_MINUTES }}
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -103,6 +115,9 @@ jobs:
             core.setOutput("default_branch", pr.data.base.ref || context.payload.repository.default_branch || "");
             core.setOutput("provider", process.env.AI_IMPLEMENT_PROVIDER || "anthropic");
             core.setOutput("aws_region", process.env.AI_IMPLEMENT_AWS_REGION || "");
+            core.setOutput("max_turns", process.env.AI_IMPLEMENT_MAX_TURNS || "");
+            core.setOutput("max_iterations", process.env.AI_IMPLEMENT_MAX_ITERATIONS || "");
+            core.setOutput("max_job_minutes", process.env.AI_IMPLEMENT_MAX_JOB_MINUTES || "");
 
       - name: Resolve and validate runner image
         if: steps.trigger.outputs.matched == 'true'
@@ -163,7 +178,7 @@ jobs:
     needs: check-trigger
     if: needs.check-trigger.outputs.matched == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: ${{ needs.check-trigger.outputs.max_job_minutes && fromJSON(needs.check-trigger.outputs.max_job_minutes) || 90 }}
     permissions:
       contents: write
       pull-requests: write
@@ -212,6 +227,8 @@ jobs:
           RUNNER_PHASE: gap-analysis
           ISSUE_META: ${{ needs.check-trigger.outputs.issue_meta }}
           PROVIDER: ${{ needs.check-trigger.outputs.provider }}
+          AI_IMPLEMENT_MAX_TURNS: ${{ needs.check-trigger.outputs.max_turns }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ needs.check-trigger.outputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Neither workflow validates model IDs — whatever `model:` says in front matter 
 
 ### Using AWS Bedrock
 
-To run a target repo against AWS Bedrock instead of the Anthropic API:
+To run a target repo against AWS Bedrock instead of the Anthropic API, use the GitHub Actions execution mode. Bedrock is not supported on Fly Machines or local Docker because those backends do not have a role-assumption mechanism equivalent to GitHub OIDC.
 
 1. **In the orchestrator admin UI (`/admin`)**, edit the repo's mapping:
    - Set **Provider** to `bedrock`
@@ -181,7 +181,7 @@ IAM trust policy shape (use the `sub` condition to restrict to this specific rep
 }
 ```
 
-The workflow re-runs `aws-actions/configure-aws-credentials` before each Bedrock action step (once before the main implementation run, once before gap analysis) so the STS session token doesn't expire during long runs. Only OIDC is supported — there is no static-key path.
+The workflow runs `aws-actions/configure-aws-credentials` once before the containerized runner step with a 4-hour session duration, covering implementation and gap-analysis runs. Only GitHub OIDC is supported — there is no static-key path.
 
 ## Custom extensions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,8 @@ Each project's mapping carries three optional caps, editable in the `/admin` Pro
 
 `maxTurns`/`maxIterations` reach the runner as `workflow_dispatch` inputs (GHA) or runner env (Fly/local); `maxJobMinutes` is a GHA-only `job_timeout_minutes` dispatch input. The orchestrator only **sends** a cap input when it is set on the mapping, so a project's target repo must have **re-synced `claude-implement.yml`** before you set caps — otherwise GitHub rejects the dispatch with "unexpected inputs". Caps also apply to gap-fill and review-feedback re-dispatches, not just the initial run.
 
+`/ai-implement` comment-triggered gap-fill runs bypass the orchestrator, so they read caps from target-repo **variables** instead (mirroring `AI_IMPLEMENT_PROVIDER`): set `AI_IMPLEMENT_MAX_TURNS`, `AI_IMPLEMENT_MAX_ITERATIONS`, and `AI_IMPLEMENT_MAX_JOB_MINUTES` (Settings → Secrets and variables → Actions → Variables) to cap those runs too.
+
 `workflows/claude-plan.yml` is the planning workflow synced to target repos. It runs read-only codebase analysis and posts structured planning comments to Linear when dispatched. It supports:
 - **PLANNING.md** — per-repo Claude prompt template; front matter carries `model:` (same rules as WORKFLOW.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,19 @@ The 14 not-yet-implemented routes (`overview`, `issues`, `pulls`, `blockers`, `p
 - **Gap analysis** — secondary Claude invocation after each PR
 - **Comment trigger** — `/ai-implement` on a PR kicks off a gap-fill run
 - **Triple auth** — bedrock (when orchestrator sets `provider=bedrock`), OAuth (`CLAUDE_CODE_OAUTH_TOKEN`), or API key (`ANTHROPIC_API_KEY`)
+- **setup / verify / teardown hooks** — `WORKFLOW.md` front-matter keys `setup:` / `verify:` / `teardown:` are paths (relative to repo root) to shell scripts that the runner now executes: `setup` before the implement loop (its failure aborts the run early), `verify` after a successful push, and `teardown` always (even on failure, via a `finally` in the runner). Scripts run with `set -euo pipefail`; env vars a setup script appends via `echo "VAR=value" >> "$GITHUB_ENV"` are visible to Claude and to the verify/teardown scripts (the runner manages `$GITHUB_ENV` across all execution modes). Repos with no hooks behave exactly as before.
+
+### Per-project run caps (admin UI)
+
+Each project's mapping carries three optional caps, editable in the `/admin` Projects edit dialog (blank = use the default):
+
+| Field | Default when blank | Applies to |
+|-------|--------------------|------------|
+| **Max Turns** | `50` | Claude turns per implement pass (both providers) |
+| **Max Iterations** | bedrock `2`, anthropic `3` | implement/review cycles in the feedback loop |
+| **Job Timeout (min)** | `90` | GitHub Actions job `timeout-minutes` (GHA mode only) |
+
+`maxTurns`/`maxIterations` reach the runner as `workflow_dispatch` inputs (GHA) or runner env (Fly/local); `maxJobMinutes` is a GHA-only `job_timeout_minutes` dispatch input. The orchestrator only **sends** a cap input when it is set on the mapping, so a project's target repo must have **re-synced `claude-implement.yml`** before you set caps — otherwise GitHub rejects the dispatch with "unexpected inputs". Caps also apply to gap-fill and review-feedback re-dispatches, not just the initial run.
 
 `workflows/claude-plan.yml` is the planning workflow synced to target repos. It runs read-only codebase analysis and posts structured planning comments to Linear when dispatched. It supports:
 - **PLANNING.md** — per-repo Claude prompt template; front matter carries `model:` (same rules as WORKFLOW.md)

--- a/docs/superpowers/plans/2026-06-02-bedrock-reliability-fixes.md
+++ b/docs/superpowers/plans/2026-06-02-bedrock-reliability-fixes.md
@@ -1,0 +1,1334 @@
+# Bedrock Reliability Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop AWS-Bedrock implementation runs from timing out, by disabling the cache-breaking experimental beta, capping turns and feedback iterations per project, running the documented setup/verify/teardown hooks, and making turns/iterations/job-timeout configurable per project from the admin UI.
+
+**Architecture:** Three new nullable per-project columns (`max_turns`, `max_iterations`, `max_job_minutes`) on the `mappings` table flow to their consumers by *where they run*: turns/iterations reach the runner (GitHub Actions: new `workflow_dispatch` inputs → env; Fly/local: merged into the runner env), and are read in `run-autonomous.ts` onto `ctx.data`, then threaded into the feedback loop where provider-aware defaults apply. Job-timeout becomes a `workflow_dispatch` input feeding `timeout-minutes`. Setup/verify run as new custom pipeline steps (skipped when absent); teardown runs in a `finally` in `run-autonomous.ts`.
+
+**Tech Stack:** Node.js, TypeScript, better-sqlite3, Vitest, GitHub Actions YAML, string-composed admin SPA.
+
+**Branch:** `bedrock-reliability-fixes` (already checked out).
+
+---
+
+## Conventions for every task
+
+- Run a single test file with: `npx vitest run src/__tests__/<file>.test.ts`
+- Run the whole suite with: `npm test`
+- Typecheck with: `npm run typecheck`
+- Tests live in `src/__tests__/`. Pipeline-step tests import from `../pipeline/...`.
+- Commit after each task. Use the message shown in the task's commit step.
+- All commit messages must end with the trailer:
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+
+## Deferred / explicitly out of scope (do NOT implement)
+
+- The original "Fix 4" (per-issue re-dispatch attempt cap) — dropped per the spec.
+- Emitting `setup_complete` / `verify_*` **status comments** to Linear. The receiver
+  exists (`src/session-api.ts`) but the autonomous runner has no status-event sender;
+  setup/verify will instead surface as normal pipeline steps via the existing
+  `StepReporter`. Adding a runner-side status emitter is separate future work.
+- Feeding `maxJobMinutes` into the Fly/local monitor timeouts. Bedrock (the failing
+  client) is GitHub-Actions-only; `maxJobMinutes` is wired for GitHub Actions only.
+  Fly/local keep their existing timeout behavior.
+
+---
+
+## Task 1: Fix 1 — disable experimental betas on Bedrock
+
+**Files:**
+- Modify: `session/entrypoint.sh:25`
+
+- [ ] **Step 1: Make the edit**
+
+In `session/entrypoint.sh`, the `bedrock)` branch currently reads (line 25):
+
+```bash
+  bedrock) [ "$AI_IMPLEMENT_MODE" = "gha" ] || fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
+```
+
+Replace it with (adds the disable-betas export; `anthropic)` branch untouched):
+
+```bash
+  bedrock) [ "$AI_IMPLEMENT_MODE" = "gha" ] || fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1; export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 ;;
+```
+
+- [ ] **Step 2: Verify the edit**
+
+Run: `grep -n "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS" session/entrypoint.sh`
+Expected: one line, inside the `bedrock)` branch.
+
+Run: `bash -n session/entrypoint.sh`
+Expected: no output (syntax OK).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add session/entrypoint.sh
+git commit -m "fix(runner): disable experimental betas on bedrock to restore prompt caching
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Data layer — three nullable mapping columns
+
+**Files:**
+- Modify: `src/config.ts` (RepoMapping interface ~24-52; `ensureMappingsColumns` ~58-114; `initMappingsTable` DDL ~117-155 + seed insert; `getMappings` SELECT + row type + mapping ~156-216; `upsertMapping` ~219-245)
+- Test: `src/__tests__/config.test.ts`
+
+The three columns are nullable INTEGER (`NULL` = "use built-in default"). Field names on `RepoMapping`: `maxTurns`, `maxIterations`, `maxJobMinutes`, each typed `number | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+Open `src/__tests__/config.test.ts`. Find the existing `mapping()` test helper (it builds a `RepoMapping` with defaults). Add the three new fields to that helper's returned object so it stays a complete `RepoMapping`:
+
+```typescript
+    maxTurns: null,
+    maxIterations: null,
+    maxJobMinutes: null,
+```
+
+Then add this test inside the top-level `describe` block:
+
+```typescript
+  it("round-trips maxTurns, maxIterations, maxJobMinutes (including null)", () => {
+    upsertMapping("CAPS", mapping({ maxTurns: 40, maxIterations: 2, maxJobMinutes: 30 }));
+    upsertMapping("NULLS", mapping({ maxTurns: null, maxIterations: null, maxJobMinutes: null }));
+
+    const all = getMappings();
+    expect(all.CAPS.maxTurns).toBe(40);
+    expect(all.CAPS.maxIterations).toBe(2);
+    expect(all.CAPS.maxJobMinutes).toBe(30);
+    expect(all.NULLS.maxTurns).toBeNull();
+    expect(all.NULLS.maxIterations).toBeNull();
+    expect(all.NULLS.maxJobMinutes).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/__tests__/config.test.ts`
+Expected: FAIL — `maxTurns`/`maxIterations`/`maxJobMinutes` not on the type / undefined at runtime.
+
+- [ ] **Step 3: Extend the `RepoMapping` interface**
+
+In `src/config.ts`, inside `export interface RepoMapping { ... }`, add after `awsRegion: string | null;`:
+
+```typescript
+  maxTurns: number | null;
+  maxIterations: number | null;
+  maxJobMinutes: number | null;
+```
+
+- [ ] **Step 4: Add the migration columns**
+
+In `ensureMappingsColumns()`, just before the closing `}` of the function (after the `paused` block), add:
+
+```typescript
+  if (!names.has("max_turns")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN max_turns INTEGER`);
+  }
+  if (!names.has("max_iterations")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN max_iterations INTEGER`);
+  }
+  if (!names.has("max_job_minutes")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN max_job_minutes INTEGER`);
+  }
+```
+
+- [ ] **Step 5: Add columns to the CREATE TABLE DDL**
+
+In `initMappingsTable()`, inside the `CREATE TABLE IF NOT EXISTS mappings (...)`, add these lines immediately after `paused INTEGER NOT NULL DEFAULT 0` (add a comma after the `paused` line):
+
+```sql
+      paused INTEGER NOT NULL DEFAULT 0,
+      max_turns INTEGER,
+      max_iterations INTEGER,
+      max_job_minutes INTEGER
+```
+
+- [ ] **Step 6: Update the seed INSERT in `initMappingsTable()`**
+
+The seed `INSERT INTO mappings (...) VALUES (...)` lists every column. Append `, max_turns, max_iterations, max_job_minutes` to the column list, append `, ?, ?, ?` to the VALUES placeholders, and append the three values to each `insert.run(...)` call:
+
+Column list — change the trailing `aws_region, paused)` to:
+```
+aws_region, paused, max_turns, max_iterations, max_job_minutes)
+```
+Placeholders — change the trailing `?, ?, ?)` count by adding three; the full VALUES becomes 22 placeholders.
+`insert.run(...)` — change the final argument `m.paused ? 1 : 0` to:
+```typescript
+m.paused ? 1 : 0, m.maxTurns, m.maxIterations, m.maxJobMinutes
+```
+
+- [ ] **Step 7: Update `getMappings()` SELECT, row type, and mapping**
+
+In `getMappings()`:
+
+Change the SELECT column list ending `aws_region, paused FROM mappings` to:
+```
+aws_region, paused, max_turns, max_iterations, max_job_minutes FROM mappings
+```
+
+In the `as Array<{ ... }>` row type, after `paused: number;` add:
+```typescript
+      max_turns: number | null;
+      max_iterations: number | null;
+      max_job_minutes: number | null;
+```
+
+In the `result[row.team_key] = { ... }` object, after `paused: Boolean(row.paused),` add:
+```typescript
+      maxTurns: row.max_turns,
+      maxIterations: row.max_iterations,
+      maxJobMinutes: row.max_job_minutes,
+```
+
+- [ ] **Step 8: Update `upsertMapping()`**
+
+Change the INSERT column list ending `aws_region, paused)` to:
+```
+aws_region, paused, max_turns, max_iterations, max_job_minutes)
+```
+Add three placeholders to the VALUES list (so the `VALUES (...)` has 22 `?`).
+After the last `.run(...)` argument `mapping.paused ? 1 : 0,` add:
+```typescript
+      mapping.maxTurns,
+      mapping.maxIterations,
+      mapping.maxJobMinutes,
+```
+
+- [ ] **Step 9: Run the test to verify it passes**
+
+Run: `npx vitest run src/__tests__/config.test.ts`
+Expected: PASS.
+
+- [ ] **Step 10: Typecheck**
+
+Run: `npm run typecheck`
+Expected: errors ONLY in files that construct a `RepoMapping` literal without the new fields (admin.ts, github.test.ts, other test helpers). These are fixed in later tasks. Note them; do not fix unrelated files here. If `src/config.ts` itself has errors, fix them.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/config.ts src/__tests__/config.test.ts
+git commit -m "feat(config): add per-project maxTurns/maxIterations/maxJobMinutes mapping columns
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Admin API — accept and validate the three fields
+
+**Files:**
+- Modify: `src/admin.ts` (`handleUpsertMapping` request body type + validation + mapping literal)
+- Test: `src/__tests__/admin.test.ts` (if a mapping-upsert test exists; otherwise add to the closest admin handler test file)
+
+Semantics: each field is optional in the request. Absent or `null` → store `null`. If present and not null, it must be a positive integer, else 400.
+
+- [ ] **Step 1: Write the failing test**
+
+Find the test file that exercises `handleUpsertMapping` (search: `grep -rln "handleUpsertMapping\|/api/mappings" src/__tests__`). If one exists, add a case that POSTs a mapping with `maxTurns: 40, maxIterations: 2, maxJobMinutes: 30` and asserts `getMappings()[key].maxTurns === 40` (etc.), plus a case with `maxTurns: 0` asserting a 400. If no such test file exists, create `src/__tests__/admin-mapping-caps.test.ts` that imports `getMappings`/`upsertMapping` indirectly through the handler. Minimal example asserting validation logic via a direct call is acceptable if the handler isn't easily invokable; in that case test `getMappings` round-trip is already covered by Task 2 and you may assert only the 400-path through whatever HTTP test harness admin.test.ts uses.
+
+```typescript
+// Shape of the positive assertion (adapt to the existing harness):
+// POST /api/mappings with { teamKey:"X", owner:"o", repo:"r", defaultBranch:"main",
+//   maxTurns:40, maxIterations:2, maxJobMinutes:30 }
+// then expect getMappings()["X"].maxTurns === 40, .maxIterations === 2, .maxJobMinutes === 30
+// POST with maxTurns:0 -> expect 400 with /maxTurns/ in the error
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/__tests__/<the file>.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Extend the request body type**
+
+In `handleUpsertMapping`, add to the `JSON.parse(...) as { ... }` body type, after `paused?: boolean;`:
+
+```typescript
+      maxTurns?: number | null;
+      maxIterations?: number | null;
+      maxJobMinutes?: number | null;
+```
+
+- [ ] **Step 4: Add validation + resolution**
+
+Just before the `const mapping: RepoMapping = { ... }` literal, add a reusable validator and resolve the three values:
+
+```typescript
+    const resolveCap = (
+      name: string,
+      value: number | null | undefined,
+    ): number | null => {
+      if (value === undefined || value === null) return null;
+      if (!Number.isInteger(value) || value < 1) {
+        throw new Error(`${name} must be a positive integer or null`);
+      }
+      return value;
+    };
+
+    let maxTurns: number | null;
+    let maxIterations: number | null;
+    let maxJobMinutes: number | null;
+    try {
+      maxTurns = resolveCap("maxTurns", body.maxTurns);
+      maxIterations = resolveCap("maxIterations", body.maxIterations);
+      maxJobMinutes = resolveCap("maxJobMinutes", body.maxJobMinutes);
+    } catch (err) {
+      json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+      return;
+    }
+```
+
+- [ ] **Step 5: Add the fields to the mapping literal**
+
+In the `const mapping: RepoMapping = { ... }`, after the `paused: ...` property, add:
+
+```typescript
+      maxTurns,
+      maxIterations,
+      maxJobMinutes,
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest run src/__tests__/<the file>.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npm run typecheck`
+Expected: `src/admin.ts` no longer errors on the mapping literal. Remaining errors only in test helpers / github.ts (fixed later).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/admin.ts src/__tests__/
+git commit -m "feat(admin): validate and persist per-project turn/iteration/timeout caps
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Admin UI — three inputs in the edit dialog
+
+**Files:**
+- Modify: `src/admin-ui/pages/projects.ts` (dialog markup ~124; `openMappingDialog` populate ~259; submit `body` ~556)
+
+The dialog is the simple modal (not the wizard). Blank input = `null`.
+
+- [ ] **Step 1: Add the input markup**
+
+In `src/admin-ui/pages/projects.ts`, find the "Max AI Issues" field (line ~124):
+
+```javascript
+          <div class="md-field"><label>Max AI Issues</label><input id="md-max-ai" type="number" min="1" value="3"></div>
+```
+
+Immediately after that `<div>`, add three fields (blank = use default):
+
+```javascript
+          <div class="md-field"><label>Max Turns <span class="text-tertiary" style="font-size:0.85em">(blank = 50)</span></label><input id="md-max-turns" type="number" min="1" placeholder="50"></div>
+          <div class="md-field"><label>Max Iterations <span class="text-tertiary" style="font-size:0.85em">(blank = bedrock 2 / anthropic 3)</span></label><input id="md-max-iter" type="number" min="1" placeholder="3"></div>
+          <div class="md-field"><label>Job Timeout (min) <span class="text-tertiary" style="font-size:0.85em">(blank = 90)</span></label><input id="md-max-job-min" type="number" min="1" placeholder="90"></div>
+```
+
+- [ ] **Step 2: Populate the inputs in `openMappingDialog`**
+
+After the line (~269) `document.getElementById('md-aws-region').value = m.awsRegion || '';` add:
+
+```javascript
+    document.getElementById('md-max-turns').value = (m.maxTurns ?? '') === '' ? '' : String(m.maxTurns ?? '');
+    document.getElementById('md-max-iter').value = (m.maxIterations ?? '') === '' ? '' : String(m.maxIterations ?? '');
+    document.getElementById('md-max-job-min').value = (m.maxJobMinutes ?? '') === '' ? '' : String(m.maxJobMinutes ?? '');
+```
+
+- [ ] **Step 3: Add to the submit body**
+
+In the `const body = { ... }` (line ~550), after `awsRegion: document.getElementById('md-aws-region').value.trim() || null,` add:
+
+```javascript
+      maxTurns: (function(){ var v = document.getElementById('md-max-turns').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+      maxIterations: (function(){ var v = document.getElementById('md-max-iter').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+      maxJobMinutes: (function(){ var v = document.getElementById('md-max-job-min').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+```
+
+- [ ] **Step 4: Verify the admin HTML still assembles**
+
+Run: `npm run typecheck`
+Expected: PASS for `src/admin-ui/pages/projects.ts` (these are string literals; no type errors introduced).
+
+Run: `npx vitest run src/__tests__/admin-html.test.ts` (if present; otherwise skip)
+Expected: PASS — the assembled admin HTML still builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin-ui/pages/projects.ts
+git commit -m "feat(admin-ui): add per-project turn/iteration/timeout inputs to project edit dialog
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: github.ts — dispatch inputs + cap dispatch fields
+
+**Files:**
+- Modify: `src/github.ts` (`DispatchInputs` ~3-32; new `capDispatchFields` helper)
+- Test: `src/__tests__/github.test.ts`
+
+Dispatch input values are strings (workflow_dispatch inputs are strings). Only included when the mapping sets them.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/__tests__/github.test.ts`, ensure the `makeMapping` helper includes the new RepoMapping fields. Find `makeMapping` and add to its base object: `maxTurns: null, maxIterations: null, maxJobMinutes: null,`. Then import `capDispatchFields` at the top alongside `providerDispatchFields`, and add:
+
+```typescript
+describe("capDispatchFields", () => {
+  it("returns empty object when no caps are set", () => {
+    expect(capDispatchFields(makeMapping({}))).toEqual({});
+  });
+
+  it("includes only the caps that are set, as strings", () => {
+    expect(
+      capDispatchFields(makeMapping({ maxTurns: 40, maxIterations: 2, maxJobMinutes: 30 })),
+    ).toEqual({ max_turns: "40", max_iterations: "2", job_timeout_minutes: "30" });
+  });
+
+  it("omits caps left null", () => {
+    expect(capDispatchFields(makeMapping({ maxTurns: 40 }))).toEqual({ max_turns: "40" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/__tests__/github.test.ts`
+Expected: FAIL — `capDispatchFields` not exported.
+
+- [ ] **Step 3: Extend `DispatchInputs`**
+
+In `src/github.ts`, inside `interface DispatchInputs`, after `aws_region?: string;` add:
+
+```typescript
+  /** Cap on Claude turns per implement pass. Only forwarded when set on the mapping. */
+  max_turns?: string;
+  /** Cap on implement/review iterations. Only forwarded when set on the mapping. */
+  max_iterations?: string;
+  /** Per-project GitHub Actions job timeout in minutes. Only forwarded when set. */
+  job_timeout_minutes?: string;
+```
+
+- [ ] **Step 4: Add `capDispatchFields`**
+
+After the `providerDispatchFields` function, add:
+
+```typescript
+/**
+ * Returns the cap-related dispatch inputs for a mapping. Each field is only
+ * included when set on the mapping (non-null), so default repos keep
+ * dispatching to workflow templates that haven't been re-synced with the new
+ * inputs. Values are stringified because workflow_dispatch inputs are strings.
+ */
+export function capDispatchFields(
+  mapping: RepoMapping,
+): Pick<DispatchInputs, "max_turns" | "max_iterations" | "job_timeout_minutes"> {
+  const fields: Pick<DispatchInputs, "max_turns" | "max_iterations" | "job_timeout_minutes"> = {};
+  if (mapping.maxTurns != null) fields.max_turns = String(mapping.maxTurns);
+  if (mapping.maxIterations != null) fields.max_iterations = String(mapping.maxIterations);
+  if (mapping.maxJobMinutes != null) fields.job_timeout_minutes = String(mapping.maxJobMinutes);
+  return fields;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/__tests__/github.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/github.ts src/__tests__/github.test.ts
+git commit -m "feat(github): add cap dispatch fields (max_turns/max_iterations/job_timeout_minutes)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: index.ts — wire caps into dispatch (GHA) and runner env (Fly/local)
+
+**Files:**
+- Modify: `src/github.ts` (export a small env helper) OR `src/index.ts` directly
+- Modify: `src/index.ts` (GHA dispatch call ~406; Fly machine config ~717-747; local docker ~797-818)
+
+GitHub Actions: add `capDispatchFields(mapping)` to the dispatch inputs. Fly/local: merge turn/iteration caps as `AI_IMPLEMENT_MAX_TURNS` / `AI_IMPLEMENT_MAX_ITERATIONS` env vars into `extraEnv` (job-timeout is GHA-only, not a runner env var).
+
+- [ ] **Step 1: Add a runner-env helper in `src/github.ts`**
+
+After `capDispatchFields`, add:
+
+```typescript
+/**
+ * Cap env vars for the runner process (Fly/local execution modes), where caps
+ * arrive via container env rather than workflow inputs. Job timeout is omitted
+ * because it controls the GitHub Actions job, not the runner.
+ */
+export function capRunnerEnv(mapping: RepoMapping): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (mapping.maxTurns != null) env.AI_IMPLEMENT_MAX_TURNS = String(mapping.maxTurns);
+  if (mapping.maxIterations != null) env.AI_IMPLEMENT_MAX_ITERATIONS = String(mapping.maxIterations);
+  return env;
+}
+```
+
+- [ ] **Step 2: Import the helpers in `src/index.ts`**
+
+Find the existing import of `providerDispatchFields` from `./github.js` and add `capDispatchFields, capRunnerEnv` to it.
+
+- [ ] **Step 3: Wire GHA dispatch**
+
+In the `dispatchWorkflow(ghToken, mapping, { ... })` call (~406), after the line `...providerDispatchFields(mapping),` add:
+
+```typescript
+    ...capDispatchFields(mapping),
+```
+
+- [ ] **Step 4: Wire Fly machine env**
+
+In the `buildSessionMachineConfig({ ... })` call (~717-747), change the `extraEnv:` line from:
+
+```typescript
+        extraEnv: Object.keys(mapping.extraEnv).length > 0 ? mapping.extraEnv : undefined,
+```
+
+to:
+
+```typescript
+        extraEnv: (() => {
+          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping) };
+          return Object.keys(merged).length > 0 ? merged : undefined;
+        })(),
+```
+
+- [ ] **Step 5: Wire local docker env**
+
+In the `startLocalRunnerContainer({ ... })` call (~797-818), apply the identical change to its `extraEnv:` line (same before/after as Step 4).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS for `src/index.ts` and `src/github.ts`.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm test`
+Expected: PASS (no behavior change for mappings without caps; caps default to null).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/github.ts src/index.ts
+git commit -m "feat(dispatch): forward per-project caps to GHA inputs and Fly/local runner env
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: claude-implement.yml — dispatch inputs, env, per-project timeout
+
+**Files:**
+- Modify: `workflows/claude-implement.yml` (`workflow_dispatch.inputs`; job `timeout-minutes`; "Run pipeline" step `env:`)
+
+- [ ] **Step 1: Add the three dispatch inputs**
+
+In `on.workflow_dispatch.inputs`, after the `aws_region:` input block, add:
+
+```yaml
+      max_turns:
+        description: "Cap on Claude turns per implement pass (empty = runner default)"
+        required: false
+        type: string
+        default: ""
+      max_iterations:
+        description: "Cap on implement/review iterations (empty = provider default)"
+        required: false
+        type: string
+        default: ""
+      job_timeout_minutes:
+        description: "Per-project job timeout in minutes (empty = 90)"
+        required: false
+        type: string
+        default: ""
+```
+
+- [ ] **Step 2: Make the job timeout per-project**
+
+Change the `implement` job's line `    timeout-minutes: 90` to:
+
+```yaml
+    timeout-minutes: ${{ inputs.job_timeout_minutes && fromJSON(inputs.job_timeout_minutes) || 90 }}
+```
+
+- [ ] **Step 3: Map the cap inputs into the runner env**
+
+In the "Run pipeline" step's `env:` block, after `AWS_REGION: ${{ inputs.aws_region }}` add:
+
+```yaml
+          AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
+```
+
+- [ ] **Step 4: Validate YAML**
+
+Run: `npx js-yaml workflows/claude-implement.yml > /dev/null && echo OK` (if `js-yaml` CLI is unavailable, run `node -e "require('yaml').parse(require('fs').readFileSync('workflows/claude-implement.yml','utf8')); console.log('OK')"`)
+Expected: `OK`.
+
+- [ ] **Step 5: Manual verification note (record in commit body)**
+
+> GitHub's support for expressions in job-level `timeout-minutes` referencing
+> `inputs` must be confirmed on a real dispatch. If a dispatched run errors at
+> parse time on `timeout-minutes`, fall back to a static `timeout-minutes: 90`
+> and enforce `maxJobMinutes` from the orchestrator monitor instead. This is the
+> documented fallback in the design spec.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add workflows/claude-implement.yml
+git commit -m "feat(workflow): per-project job timeout + cap inputs in claude-implement.yml
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: types.ts — extend PipelineContextData
+
+**Files:**
+- Modify: `src/pipeline/types.ts` (`PipelineContextData` ~27-55)
+
+- [ ] **Step 1: Add the fields**
+
+In `export interface PipelineContextData`, after `branch?: string;` add:
+
+```typescript
+  /** Autonomous runner: Claude provider ("anthropic" | "bedrock"), from PROVIDER env. */
+  provider?: string;
+  /** Autonomous runner: cap on Claude turns per implement pass (from env). */
+  maxTurns?: number;
+  /** Autonomous runner: cap on implement/review iterations (from env). */
+  maxIterations?: number;
+  /** Autonomous runner: WORKFLOW.md hook script paths (relative to repo root). */
+  hooks?: { setup?: string; verify?: string; teardown?: string };
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (additive optional fields).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pipeline/types.ts
+git commit -m "feat(pipeline): add provider/maxTurns/maxIterations/hooks to PipelineContextData
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: feedback-loop — provider-aware iterations + turn cap
+
+**Files:**
+- Modify: `src/pipeline/steps/feedback-loop.ts` (`FeedbackLoopInputs` ~9-27; iteration resolution; `implementStep.run` inputs ~128-138)
+- Modify: `src/pipeline/pipeline-loader.ts` (feedback-loop case ~99-116)
+- Test: `src/__tests__/steps-feedback-loop.test.ts` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/steps-feedback-loop.test.ts` (or extend an existing feedback-loop test). It must assert (a) `maxTurns` defaults to 50 and is passed to the implement executor, and (b) iterations default to 2 for bedrock, 3 otherwise. Use a fake `LLMExecutor` that records `invoke` params and returns an "approved" review so the loop stops after one pass. Mirror the executor/context construction from `src/__tests__/steps-clone.test.ts`.
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { feedbackLoopStep } from "../pipeline/steps/feedback-loop.js";
+import { DefaultPipelineContext } from "../pipeline/context.js";
+import { NoopStepReporter } from "../pipeline/reporter.js";
+import type { LLMExecutor, LLMResult } from "../pipeline/types.js";
+
+function recordingExecutor(): { exec: LLMExecutor; calls: Array<{ maxTurns?: number }> } {
+  const calls: Array<{ maxTurns?: number }> = [];
+  const exec: LLMExecutor = {
+    async invoke(params): Promise<LLMResult> {
+      calls.push({ maxTurns: params.maxTurns });
+      // Return text the review step reads as "approved" so the loop ends after 1 pass.
+      return { stdout: "APPROVED", stderr: "", exitCode: 0, tokensUsed: 0 };
+    },
+  };
+  return { exec, calls };
+}
+
+function ctxWith(exec: LLMExecutor) {
+  return new DefaultPipelineContext(
+    {
+      jobId: 1, issueId: "i", issueIdentifier: "ENG-1", issueTitle: "T",
+      issueDescription: "D", nonce: "n", orchestratorUrl: "", ticketingProvider: "linear",
+    },
+    exec,
+  );
+}
+
+const BASE = {
+  workspaceDir: "/tmp/x",
+  issueTitle: "T",
+  issueDescription: "D",
+  implementationPrompt: "do it",
+};
+
+describe("feedbackLoopStep caps", () => {
+  it("passes maxTurns=50 by default to the implement invocation", async () => {
+    const { exec, calls } = recordingExecutor();
+    await feedbackLoopStep.run(ctxWith(exec), { ...BASE }, new NoopStepReporter());
+    expect(calls[0].maxTurns).toBe(50);
+  });
+
+  it("honors an explicit maxTurns input", async () => {
+    const { exec, calls } = recordingExecutor();
+    await feedbackLoopStep.run(ctxWith(exec), { ...BASE, maxTurns: 25 }, new NoopStepReporter());
+    expect(calls[0].maxTurns).toBe(25);
+  });
+});
+```
+
+> NOTE: If the review step's "approved" detection requires specific text, read
+> `src/pipeline/steps/review.ts` first and return matching `stdout` so the loop
+> terminates after one implement pass. Adjust `"APPROVED"` accordingly. If the
+> loop is hard to terminate in a unit test, assert on the FIRST recorded
+> `invoke` call's `maxTurns` (the implement pass) — that is all these tests need.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/__tests__/steps-feedback-loop.test.ts`
+Expected: FAIL — `maxTurns` is `undefined` in the recorded call.
+
+- [ ] **Step 3: Extend `FeedbackLoopInputs`**
+
+In `src/pipeline/steps/feedback-loop.ts`, add to the interface after `maxIterations?: number;`:
+
+```typescript
+  maxTurns?: number;
+  provider?: string;
+```
+
+- [ ] **Step 4: Resolve provider-aware iterations + turn cap**
+
+Near the top of the `run` function (where inputs are first read), find the line that resolves iterations using `DEFAULT_MAX_ITERATIONS` (grep for `DEFAULT_MAX_ITERATIONS` in the file). Replace that resolution with:
+
+```typescript
+    const effectiveMaxIterations =
+      inputs.maxIterations ?? (inputs.provider === "bedrock" ? 2 : DEFAULT_MAX_ITERATIONS);
+    const effectiveMaxTurns = inputs.maxTurns ?? 50;
+```
+
+Then use `effectiveMaxIterations` everywhere the loop currently used the old resolved iterations value (e.g. the loop bound and any log/report referencing it).
+
+- [ ] **Step 5: Pass `maxTurns` into the implement step**
+
+In the `implementStep.run(context, { ... }, reporter)` call (~128-138), add to the inputs object:
+
+```typescript
+            maxTurns: effectiveMaxTurns,
+```
+
+(Keep the existing `workspaceDir`, `prompt`, `model`, `planningContext` keys.)
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npx vitest run src/__tests__/steps-feedback-loop.test.ts`
+Expected: PASS (both cases).
+
+- [ ] **Step 7: Wire inputs in `pipeline-loader.ts`**
+
+In `src/pipeline/pipeline-loader.ts`, the `case "feedback-loop":` returns an `inputs` function. Inside the returned object (after `repoReviewModel: repoModels?.review,`), add:
+
+```typescript
+            provider: ctx.data.provider,
+            maxTurns: ctx.data.maxTurns,
+            maxIterations: ctx.data.maxIterations,
+```
+
+- [ ] **Step 8: Typecheck + full suite**
+
+Run: `npm run typecheck`
+Expected: PASS.
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pipeline/steps/feedback-loop.ts src/pipeline/pipeline-loader.ts src/__tests__/steps-feedback-loop.test.ts
+git commit -m "feat(feedback-loop): cap turns (default 50) and provider-aware iterations (bedrock 2)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: run-autonomous — read caps/provider from env, capture hooks
+
+**Files:**
+- Modify: `src/run-autonomous.ts` (env reads + ctx.data + hook capture ~126-186)
+
+- [ ] **Step 1: Capture hooks and caps before context construction**
+
+In `src/run-autonomous.ts`, the WORKFLOW.md parse block sets `workflowModel`. Add hook capture there. Before the `const wfPath = ...` line, declare:
+
+```typescript
+  let setupHook: string | undefined;
+  let verifyHook: string | undefined;
+  let teardownHook: string | undefined;
+```
+
+Inside the `if (existsSync(wfPath)) { ... }` block, after `workflowModel = parsed.frontMatter.model;` add:
+
+```typescript
+    setupHook = parsed.frontMatter.setup;
+    verifyHook = parsed.frontMatter.verify;
+    teardownHook = parsed.frontMatter.teardown;
+```
+
+- [ ] **Step 2: Read provider/caps from env**
+
+After the line `const model = process.env.CLAUDE_MODEL || workflowModel || "claude-sonnet-4-6";` add:
+
+```typescript
+  const provider = process.env.PROVIDER || "anthropic";
+  const parseEnvInt = (raw: string | undefined): number | undefined => {
+    if (!raw) return undefined;
+    const n = parseInt(raw, 10);
+    return Number.isInteger(n) && n > 0 ? n : undefined;
+  };
+  const maxTurns = parseEnvInt(process.env.AI_IMPLEMENT_MAX_TURNS);
+  const maxIterations = parseEnvInt(process.env.AI_IMPLEMENT_MAX_ITERATIONS);
+```
+
+- [ ] **Step 3: Add fields to the context data**
+
+In the `new DefaultPipelineContext({ ... }, llmExecutor)` data object, after `branch,` add:
+
+```typescript
+      provider,
+      maxTurns,
+      maxIterations,
+      hooks: { setup: setupHook, verify: verifyHook, teardown: teardownHook },
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/run-autonomous.ts
+git commit -m "feat(runner): read provider/turn/iteration caps from env and capture WORKFLOW.md hooks
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: hook runner utility
+
+**Files:**
+- Create: `src/pipeline/steps/hooks.ts`
+- Test: `src/__tests__/hooks.test.ts`
+
+A shared helper that runs a hook script with `set -euo pipefail`, streams output, points `$GITHUB_ENV` at a managed temp file, and merges any `KEY=value` lines that file gains into `process.env` (so subsequent Claude invocations inherit them — the executor spawns with `env: { ...process.env }`).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runHookScript } from "../pipeline/steps/hooks.js";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "hook-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe("runHookScript", () => {
+  it("runs the script and merges GITHUB_ENV exports into process.env", () => {
+    writeFileSync(join(dir, "setup.sh"), 'echo "FOO_TEST_VAR=bar123" >> "$GITHUB_ENV"\n');
+    const result = runHookScript("setup", "setup.sh", dir);
+    expect(result.exitCode).toBe(0);
+    expect(process.env.FOO_TEST_VAR).toBe("bar123");
+    delete process.env.FOO_TEST_VAR;
+  });
+
+  it("returns a non-zero exit code when the script fails", () => {
+    writeFileSync(join(dir, "bad.sh"), "exit 3\n");
+    const result = runHookScript("setup", "bad.sh", dir);
+    expect(result.exitCode).toBe(3);
+  });
+
+  it("throws a clear error when the script path does not exist", () => {
+    expect(() => runHookScript("setup", "missing.sh", dir)).toThrow(/missing\.sh/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/__tests__/hooks.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `hooks.ts`**
+
+```typescript
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+export interface HookResult {
+  exitCode: number;
+}
+
+/**
+ * Runs a WORKFLOW.md hook script (setup/verify/teardown) relative to the repo
+ * root with `set -euo pipefail`. Output streams to the runner's stdout/stderr.
+ * `$GITHUB_ENV` points at a managed temp file; any `KEY=value` lines the script
+ * appends to it are merged into process.env so subsequent Claude invocations
+ * (which spawn with `env: { ...process.env }`) inherit them.
+ *
+ * Throws if the resolved script path does not exist. Returns the child's exit
+ * code otherwise (caller decides whether a non-zero code aborts).
+ */
+export function runHookScript(
+  name: string,
+  scriptPath: string,
+  workspaceDir: string,
+): HookResult {
+  const resolved = isAbsolute(scriptPath) ? scriptPath : resolve(workspaceDir, scriptPath);
+  if (!existsSync(resolved)) {
+    throw new Error(`${name} hook script not found: ${scriptPath} (resolved: ${resolved})`);
+  }
+
+  const envDir = mkdtempSync(join(tmpdir(), "ai-implement-hook-"));
+  const githubEnvFile = join(envDir, "github_env");
+  writeFileSync(githubEnvFile, "");
+
+  try {
+    const proc = spawnSync("bash", ["-euo", "pipefail", resolved], {
+      cwd: workspaceDir,
+      env: { ...process.env, GITHUB_ENV: githubEnvFile },
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+
+    mergeGithubEnv(githubEnvFile);
+
+    if (proc.error) throw proc.error;
+    return { exitCode: proc.status ?? 1 };
+  } finally {
+    rmSync(envDir, { recursive: true, force: true });
+  }
+}
+
+/** Parses KEY=value lines from a $GITHUB_ENV-style file into process.env. */
+function mergeGithubEnv(file: string): void {
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf-8");
+  } catch {
+    return;
+  }
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (key) process.env[key] = value;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/__tests__/hooks.test.ts`
+Expected: PASS (all three cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/steps/hooks.ts src/__tests__/hooks.test.ts
+git commit -m "feat(hooks): add runHookScript with \$GITHUB_ENV merge for setup/verify/teardown
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: setup + verify step modules
+
+**Files:**
+- Create: `src/pipeline/steps/setup.ts`
+- Create: `src/pipeline/steps/verify.ts`
+- Test: `src/__tests__/steps-setup-verify.test.ts`
+
+Both steps assume a `scriptPath` input is present (the loader's `skip` predicate guarantees it — see Task 13). Setup aborts the run on failure (throws). Verify also throws on failure so the run surfaces as failed (the PR already exists from push; teardown still runs via Task 14).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setupStep } from "../pipeline/steps/setup.js";
+import { verifyStep } from "../pipeline/steps/verify.js";
+import { DefaultPipelineContext } from "../pipeline/context.js";
+import { NoopStepReporter } from "../pipeline/reporter.js";
+import type { LLMExecutor } from "../pipeline/types.js";
+
+const noopExec: LLMExecutor = { async invoke() { return { stdout: "", exitCode: 0, tokensUsed: 0 }; } };
+function ctx() {
+  return new DefaultPipelineContext(
+    { jobId: 1, issueId: "i", issueIdentifier: "ENG-1", issueTitle: "T", issueDescription: "D", nonce: "n", orchestratorUrl: "", ticketingProvider: "linear" },
+    noopExec,
+  );
+}
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "sv-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe("setupStep", () => {
+  it("runs the setup script and returns ran:true", async () => {
+    writeFileSync(join(dir, "s.sh"), "echo hi\n");
+    const out = await setupStep.run(ctx(), { workspaceDir: dir, scriptPath: "s.sh" }, new NoopStepReporter());
+    expect(out.ran).toBe(true);
+  });
+  it("throws when the setup script fails", async () => {
+    writeFileSync(join(dir, "s.sh"), "exit 1\n");
+    await expect(
+      setupStep.run(ctx(), { workspaceDir: dir, scriptPath: "s.sh" }, new NoopStepReporter()),
+    ).rejects.toThrow(/setup/i);
+  });
+});
+
+describe("verifyStep", () => {
+  it("throws when the verify script fails", async () => {
+    writeFileSync(join(dir, "v.sh"), "exit 2\n");
+    await expect(
+      verifyStep.run(ctx(), { workspaceDir: dir, scriptPath: "v.sh" }, new NoopStepReporter()),
+    ).rejects.toThrow(/verify/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/__tests__/steps-setup-verify.test.ts`
+Expected: FAIL — modules not found.
+
+- [ ] **Step 3: Implement `setup.ts`**
+
+```typescript
+import type { PipelineContext, StepModule, StepReporter } from "../types.js";
+import { runHookScript } from "./hooks.js";
+
+interface SetupInputs extends Record<string, unknown> {
+  workspaceDir: string;
+  scriptPath: string;
+}
+
+interface SetupOutputs extends Record<string, unknown> {
+  ran: boolean;
+}
+
+export const setupStep: StepModule<SetupInputs, SetupOutputs> = {
+  async run(
+    _context: PipelineContext,
+    inputs: SetupInputs,
+    _reporter: StepReporter,
+  ): Promise<SetupOutputs> {
+    const result = runHookScript("setup", inputs.scriptPath, inputs.workspaceDir);
+    if (result.exitCode !== 0) {
+      throw new Error(`setup hook failed with exit code ${result.exitCode}`);
+    }
+    return { ran: true };
+  },
+};
+
+export default setupStep;
+```
+
+- [ ] **Step 4: Implement `verify.ts`**
+
+```typescript
+import type { PipelineContext, StepModule, StepReporter } from "../types.js";
+import { runHookScript } from "./hooks.js";
+
+interface VerifyInputs extends Record<string, unknown> {
+  workspaceDir: string;
+  scriptPath: string;
+}
+
+interface VerifyOutputs extends Record<string, unknown> {
+  ran: boolean;
+}
+
+export const verifyStep: StepModule<VerifyInputs, VerifyOutputs> = {
+  async run(
+    _context: PipelineContext,
+    inputs: VerifyInputs,
+    _reporter: StepReporter,
+  ): Promise<VerifyOutputs> {
+    const result = runHookScript("verify", inputs.scriptPath, inputs.workspaceDir);
+    if (result.exitCode !== 0) {
+      throw new Error(`verify hook failed with exit code ${result.exitCode}`);
+    }
+    return { ran: true };
+  },
+};
+
+export default verifyStep;
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run src/__tests__/steps-setup-verify.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pipeline/steps/setup.ts src/pipeline/steps/verify.ts src/__tests__/steps-setup-verify.test.ts
+git commit -m "feat(pipeline): add setup and verify hook step modules
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: wire setup/verify into the pipeline (registration, YAML, loader)
+
+**Files:**
+- Modify: `src/pipeline/default-pipeline.ts` (imports + `BUILTIN_STEPS`)
+- Modify: `pipelines/autonomous.yml` (insert setup + verify steps)
+- Modify: `src/pipeline/pipeline-loader.ts` (`case "setup"` + `case "verify"` wiring)
+
+- [ ] **Step 1: Register the modules**
+
+In `src/pipeline/default-pipeline.ts`, add imports after the `pushStep` import:
+
+```typescript
+import { setupStep } from "./steps/setup.js";
+import { verifyStep } from "./steps/verify.js";
+```
+
+In `BUILTIN_STEPS`, add entries (order in this array does not matter; pipeline order comes from the YAML):
+
+```typescript
+  ["setup", setupStep],
+  ["verify", verifyStep],
+```
+
+- [ ] **Step 2: Insert steps into `pipelines/autonomous.yml`**
+
+Rewrite `pipelines/autonomous.yml` to (setup after install, verify after push):
+
+```yaml
+id: autonomous-loop
+steps:
+  - id: clone
+    type: clone
+  - id: install
+    type: install
+  - id: setup
+    type: custom
+    moduleId: setup
+  - id: feedback-loop
+    type: custom
+    moduleId: feedback-loop
+  - id: preflight
+    type: preflight
+  - id: push
+    type: push
+  - id: verify
+    type: custom
+    moduleId: verify
+  - id: post-push-review
+    type: custom
+    moduleId: post-push-review
+```
+
+- [ ] **Step 3: Add loader wiring with skip predicates**
+
+In `src/pipeline/pipeline-loader.ts`'s `applyWiring` switch, add a `case "setup"` before `case "feedback-loop":`:
+
+```typescript
+    case "setup":
+      return {
+        ...step,
+        inputs: (ctx: PipelineContext) => ({
+          workspaceDir: ctx.getOutputs("clone").workspaceDir,
+          scriptPath: ctx.data.hooks?.setup,
+        }),
+        skip: (ctx: PipelineContext) => !ctx.data.hooks?.setup,
+      };
+```
+
+And add a `case "verify"` before `case "post-push-review":`:
+
+```typescript
+    case "verify":
+      return {
+        ...step,
+        inputs: (ctx: PipelineContext) => ({
+          workspaceDir: ctx.getOutputs("clone").workspaceDir,
+          scriptPath: ctx.data.hooks?.verify,
+        }),
+        skip: (ctx: PipelineContext) => {
+          if (!ctx.data.hooks?.verify) return true;
+          return ctx.getOutputs("feedback-loop").approved !== true;
+        },
+      };
+```
+
+- [ ] **Step 4: Typecheck + full suite**
+
+Run: `npm run typecheck`
+Expected: PASS.
+Run: `npm test`
+Expected: PASS. If a test asserts the exact step list of the autonomous pipeline, update its expected list to include `setup` and `verify` in the new positions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/default-pipeline.ts pipelines/autonomous.yml src/pipeline/pipeline-loader.ts
+git commit -m "feat(pipeline): wire setup (pre-loop) and verify (post-push) steps, skipped when absent
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: teardown in a finally
+
+**Files:**
+- Modify: `src/run-autonomous.ts` (the `try { ... } catch { ... }` around `runner.run`)
+- Test: extend `src/__tests__/` run-autonomous test if one exists; otherwise rely on the hooks.test.ts coverage and a manual check.
+
+Teardown runs even when the pipeline throws. It is best-effort: a teardown failure is logged, not thrown (the run's real outcome is already determined).
+
+- [ ] **Step 1: Add the finally block**
+
+In `src/run-autonomous.ts`, the pipeline run is wrapped in `try { ... return { exitCode: 0 }; } catch (err) { ... return { exitCode: 1 }; }`. Add a `finally` after the `catch` block:
+
+```typescript
+  } finally {
+    if (teardownHook) {
+      try {
+        const result = runHookScript("teardown", teardownHook, workspaceDir);
+        if (result.exitCode !== 0) {
+          console.error(`teardown hook exited with code ${result.exitCode}`);
+        }
+      } catch (teardownErr) {
+        console.error(`teardown hook error: ${teardownErr}`);
+      }
+    }
+  }
+```
+
+- [ ] **Step 2: Import `runHookScript`**
+
+At the top of `src/run-autonomous.ts`, add:
+
+```typescript
+import { runHookScript } from "./pipeline/steps/hooks.js";
+```
+
+- [ ] **Step 3: Typecheck + full suite**
+
+Run: `npm run typecheck`
+Expected: PASS.
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/run-autonomous.ts
+git commit -m "feat(runner): run teardown hook in a finally so it executes even on failure
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: docs + rollout note
+
+**Files:**
+- Modify: `CLAUDE.md` (workflow templates / config sections)
+- Create: short rollout note in the PR description (no file needed)
+
+- [ ] **Step 1: Document the new per-project fields**
+
+In `CLAUDE.md`, in the workflow-templates area, add a short subsection noting that `maxTurns`, `maxIterations`, and `maxJobMinutes` are now set per project in the admin UI Projects edit dialog, that null means "use the default" (`maxTurns` 50; `maxIterations` bedrock 2 / anthropic 3; timeout 90), and that **setting any of them requires the target repo's `claude-implement.yml` to be re-synced first** (the new `workflow_dispatch` inputs must exist or GitHub rejects the dispatch). Note that `maxJobMinutes` applies to GitHub Actions mode only.
+
+- [ ] **Step 2: Document the hooks now run**
+
+Add a note that `setup` / `verify` / `teardown` front-matter hooks in `WORKFLOW.md` are now executed (setup before the implement loop, verify after a successful push, teardown always), and that env vars exported via `>> "$GITHUB_ENV"` in setup are visible to Claude and to verify/teardown.
+
+- [ ] **Step 3: Full suite + typecheck (final gate)**
+
+Run: `npm run typecheck`
+Expected: PASS.
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: per-project caps + executed WORKFLOW.md hooks; note re-sync requirement
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Post-implementation rollout (operational, not a commit)
+
+After this branch merges and the orchestrator deploys:
+
+1. In `/admin`, open the Bedrock project's edit dialog. Click **Sync workflows** so the target repo picks up the new `claude-implement.yml` (new inputs + per-project timeout). Merge the resulting PR in the target repo.
+2. Then set the project's **Max Turns** (e.g. 50), **Max Iterations** (e.g. 2), and **Job Timeout** (e.g. 30–45) in the edit dialog.
+3. Confirm on the next Bedrock run: logs no longer show `cache_control.scope` / `Extra inputs are not permitted`; cache-read tokens appear; the run finishes well under the timeout. If the run errors at parse time on `timeout-minutes`, apply the Task 7 Step 5 fallback.
+
+---
+
+## Self-review checklist (completed during authoring)
+
+- **Spec coverage:** Fix 1 → Task 1. Per-project fields → Tasks 2-4. Fix 2+3 → Tasks 5-10. Fix 5 hooks → Tasks 11-14. Fix 6 timeout → Tasks 5-7. Docs/rollout → Task 15 + rollout section. Fix 4 → intentionally absent (documented).
+- **Placeholders:** none — every code step shows literal code; the two "read the file first" notes (feedback-loop iteration line; review approval text) are precise locate-then-edit instructions with the exact replacement code.
+- **Type consistency:** `RepoMapping.maxTurns/maxIterations/maxJobMinutes: number | null` (Task 2) ↔ admin null-coercion (Tasks 3-4) ↔ `capDispatchFields`/`capRunnerEnv` null checks (Tasks 5-6) ↔ env vars `AI_IMPLEMENT_MAX_TURNS`/`AI_IMPLEMENT_MAX_ITERATIONS` (Tasks 6,7,10) ↔ `ctx.data.maxTurns/maxIterations/provider/hooks` (Task 8) ↔ `FeedbackLoopInputs.maxTurns/provider` (Task 9). `runHookScript(name, scriptPath, workspaceDir)` signature consistent across Tasks 11-14.

--- a/docs/superpowers/specs/2026-06-02-bedrock-reliability-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-02-bedrock-reliability-fixes-design.md
@@ -1,0 +1,257 @@
+# Bedrock reliability fixes — design
+
+**Date:** 2026-06-02
+**Status:** Approved for planning
+**Branch:** `bedrock-reliability-fixes`
+
+## Context
+
+One client runs implementations against AWS Bedrock through the GitHub Actions
+execution mode. Its runs take ~1h and die at the job timeout even on trivial
+single-file tickets. Bedrock makes roughly 3x the tool calls/turns of the direct
+Anthropic API (anthropics/claude-code issue #51064), which amplifies every
+uncapped loop in the pipeline. Investigation traced the slowness to four
+independent causes plus one missing feature.
+
+This spec covers five fixes. Each lands as its own commit. The original
+investigation proposed a sixth fix (a per-issue re-dispatch attempt cap); it has
+been **dropped** — see Non-goals.
+
+## Goals
+
+- Stop Bedrock runs from re-sending uncached context every turn.
+- Bound the work a single run can do (turns and implement/review iterations) so a
+  stuck run fails in minutes, not at the wall.
+- Let DB-dependent repos prepare their environment via the already-documented
+  `setup` / `verify` / `teardown` hooks.
+- Make turn count, iteration count, and job timeout tunable **per project** from
+  the orchestrator admin UI.
+
+## Non-goals
+
+- **Per-issue re-dispatch attempt cap (original "Fix 4") — dropped.** On the GHA
+  execution mode the failure path (`monitorGitHubActionsJob` in `src/index.ts`)
+  only calls `updateJobStatus(..., "failed")`; it does **not** call `resetTicket`
+  and does **not** clear the dedup row. So a failed Bedrock run stays deduped and
+  does not auto-re-dispatch. The reconcile loop (`src/index.ts` ~183–208) can
+  clear dedup, but only when Linear reports the issue terminal/cancelled or no
+  provider recognizes it — not on a plain failure that leaves the issue active.
+  The unconditional `resetTicket()` → `deleteDispatched()` re-dispatch loop is
+  specific to the **Fly / local-docker** monitors, which this client does not
+  use. The manual escape hatch (remove the `AI-Implement` label in Linear) is
+  sufficient for the rare case. Revisit only if a client moves onto Fly/local,
+  where the cleaner fix is "stop unconditionally deleting dedup in `resetTicket`"
+  rather than a counter + pause state machine.
+- No change to model-ID validation (still passed through verbatim).
+- No new global-env default layer for the caps (see "Defaults" below).
+
+## Per-project configuration mechanism
+
+Three new nullable fields are added to the orchestrator's `mappings` table and
+the `/admin` Projects edit form. Null means "omit the dispatch input and let the
+consumer's built-in default apply" — existing rows and un-touched repos behave
+exactly as today.
+
+| Field | Mapping column | Consumed by | Built-in default when null |
+|---|---|---|---|
+| `maxTurns` | `max_turns` | runner (feedback-loop → executor `--max-turns`) | `50` |
+| `maxIterations` | `max_iterations` | runner (feedback-loop) | provider-aware: bedrock `2`, anthropic `3` |
+| `maxJobMinutes` | `max_job_minutes` | GHA job `timeout-minutes`; Fly/local monitors | template's `90` |
+
+Delivery differs by **where each value is consumed**:
+
+- `maxTurns` / `maxIterations` run **inside the runner**. They need new
+  `workflow_dispatch` inputs on `claude-implement.yml`, mapped into the
+  "Run pipeline" step env, plus new fields on `DispatchInputs` in
+  `src/github.ts`. They are only forwarded when set on the mapping (the same
+  pattern as `provider`/`aws_region`), so default repos keep dispatching to
+  not-yet-resynced workflows. For Fly/local execution modes the same env vars
+  ride the machine/container env alongside `extraEnv`.
+- `maxJobMinutes` is consumed by the **GHA job itself** (and the Fly/local
+  monitors), via a `job_timeout_minutes` dispatch input feeding `timeout-minutes`.
+
+### Backward compatibility / rollout
+
+GitHub rejects a `workflow_dispatch` with inputs the target workflow does not
+declare. The new inputs (`max_turns`, `max_iterations`, `job_timeout_minutes`)
+are therefore **only sent when the corresponding mapping field is set**. Setting
+any of them on a project requires that project's target repo to have re-synced
+`claude-implement.yml` first. Re-syncing is already part of Fix 6's rollout.
+
+### Defaults
+
+Defaults live in the **consumer**, not in an orchestrator env layer:
+
+- `maxTurns` default `50` is applied in `feedback-loop.ts` (`maxTurns ?? 50`).
+  This bounds **both** providers — anthropic runs are currently unbounded too.
+- `maxIterations` default is computed in `feedback-loop.ts` from the provider on
+  `ctx.data`: `maxIterations ?? (provider === "bedrock" ? 2 : 3)`.
+- `maxJobMinutes` default is the static `timeout-minutes: 90` already in the
+  workflow template; when no `job_timeout_minutes` input is sent the template
+  keeps that value.
+
+Env var names threaded to the runner: `AI_IMPLEMENT_MAX_TURNS`,
+`AI_IMPLEMENT_MAX_ITERATIONS` (prefixed to avoid collisions). `job_timeout_minutes`
+is consumed directly in the workflow expression, not as a runner env var.
+
+## Fix 1 — Disable experimental betas on Bedrock
+
+**Why:** the runner pins `@anthropic-ai/claude-code@2.1.114`. Since v2.1.24 Claude
+Code sends a `cache_control.ephemeral.scope` beta field that Bedrock rejects
+(`system.1.cache_control.scope: Extra inputs are not permitted`). When that
+errors, prompt caching fails and every turn re-sends the full, growing context
+uncached — the primary slowdown, amplified by Bedrock's higher turn count. Claude
+Code ≥2.1.81 honors `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`.
+
+**Change:** in `session/entrypoint.sh`, the `bedrock)` branch of the provider
+`case`, also `export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`. Leave the
+`anthropic)` branch untouched.
+
+**Acceptance:** a Bedrock run's logs no longer contain
+`cache_control.scope` / `Extra inputs are not permitted`; cache-read tokens
+appear and wall-clock drops.
+
+## Fix 2 + 3 — Cap turns + provider-aware iterations
+
+These share one delivery rail, so they are designed together (and may be one or
+two commits at implementation time).
+
+**Why:** `ClaudeCliExecutor.invoke` (`src/pipeline/executor.ts`) only appends
+`--max-turns` when `maxTurns != null`, and `feedback-loop.ts` never sets it, so
+each implement pass runs unbounded turns. The loop runs up to
+`DEFAULT_MAX_ITERATIONS = 3` implement→review cycles. On Bedrock, unbounded turns
+× 3 iterations × 3x turn inflation is what blows past the timeout.
+
+**Changes:**
+
+- `src/run-autonomous.ts`: read `process.env.PROVIDER` (entrypoint already
+  defaults it to `anthropic`) onto `ctx.data.provider`. Read
+  `AI_IMPLEMENT_MAX_TURNS` / `AI_IMPLEMENT_MAX_ITERATIONS` env → parsed ints onto
+  `ctx.data.maxTurns` / `ctx.data.maxIterations` (`undefined` when absent).
+- `src/pipeline/pipeline-loader.ts`, feedback-loop case: thread `provider`,
+  `maxTurns`, `maxIterations` from `ctx.data` into the step inputs.
+- `src/pipeline/steps/feedback-loop.ts`: add `maxTurns` (and `provider`) to
+  `FeedbackLoopInputs`; pass `maxTurns` into `implementStep.run(...)` and into the
+  reported sub-step inputs. Effective values:
+  `maxTurns ?? 50`; `maxIterations ?? (provider === "bedrock" ? 2 : 3)`.
+- `src/pipeline/steps/implement.ts` / `src/pipeline/executor.ts`: no change
+  (already accept/forward/append `maxTurns`).
+- `workflows/claude-implement.yml`: add `max_turns` and `max_iterations`
+  `workflow_dispatch` inputs; map them into the "Run pipeline" step env as
+  `AI_IMPLEMENT_MAX_TURNS` / `AI_IMPLEMENT_MAX_ITERATIONS`.
+- `src/github.ts`: add `max_turns` / `max_iterations` to `DispatchInputs`; extend
+  the dispatch-field builder to include them only when the mapping sets them.
+- Fly/local dispatch paths in `src/index.ts`: include the same env vars in the
+  machine/container env when set on the mapping.
+
+**Acceptance:** `claude` is invoked with `--max-turns 50` (or the configured
+value) on both providers. Bedrock repos run ≤2 implement/review cycles by
+default; anthropic repos stay at 3. A deliberately-looping ticket fails in
+minutes with a clear "max turns reached" error instead of at the timeout.
+`.ai-implement/config.yml` is **not** used for these caps — they come from the
+mapping (admin UI) only.
+
+## Fix 5 — Execute setup / verify / teardown hooks
+
+**Why:** `src/workflow-md.ts` already parses `setup`, `verify`, `teardown`
+front-matter keys, and `WORKFLOW.md` documents them, but `src/run-autonomous.ts`
+only consumes `model` and `body`. The hook scripts are never run, so DB-dependent
+repos (e.g. one that must `pnpm db:sync` against a live MySQL DB) cannot prepare
+their environment and the agent flails. The `setup_complete` / `verify_running` /
+`verify_passed` / `verify_failed` status events already exist
+(`src/status-events.ts`, `src/session-api.ts`) but are only exercised by tests.
+
+**Changes:**
+
+- `src/run-autonomous.ts`: after parsing `WORKFLOW.md`, capture
+  `parsed.frontMatter.setup` / `.verify` / `.teardown` onto `ctx.data.hooks`.
+- `pipelines/autonomous.yml` + `src/pipeline/pipeline-loader.ts`: add a **setup**
+  step that runs before `feedback-loop`, and a **verify** step that runs after a
+  successful `push`. Run **teardown** in a `finally` in `run-autonomous` so it
+  executes even when the pipeline throws or times out (best-effort) — this is
+  simpler and more robust than adding `alwaysRun` semantics to the executor.
+- Each hook resolves relative to the repo root, runs via the executor shell-out
+  pattern with `set -euo pipefail`, cwd = repo root, output streamed.
+- **Env passing:** for each hook the runner points `GITHUB_ENV` at a managed temp
+  file, runs the hook, then parses `KEY=value` lines from that file and merges
+  them into the env handed to subsequent claude invocations and to verify/teardown.
+  This makes `WORKFLOW.md`'s documented `echo "DATABASE_URL=… >> $GITHUB_ENV`
+  convention work across **all** execution modes, not just GHA.
+- Emit `setup_complete` after setup; `verify_running` / `verify_passed` /
+  `verify_failed` around verify.
+- **Setup failure** aborts the run early (before the feedback loop) with a clear
+  comment; teardown still runs. **Verify failure** emits `verify_failed` and is
+  surfaced, but the PR already exists from the successful push; teardown still
+  runs. Repos with no hooks behave exactly as before.
+
+**Acceptance:** a repo with `setup:` / `verify:` / `teardown:` front matter runs
+all three at the right times; setup failure aborts early with a clear comment and
+teardown still runs; repos with no hooks are unchanged.
+
+## Fix 6 — Per-project job timeout + re-sync
+
+**Why:** `workflows/claude-implement.yml` is `timeout-minutes: 90` in this repo,
+but the Bedrock client's target repo still runs the old 60 (its runs die at
+~1h00m). With the caps above in place, a shorter, per-project timeout makes
+failures surface fast.
+
+**Changes:**
+
+- `maxJobMinutes` mapping field + `/admin` field (see "Per-project configuration").
+- `workflows/claude-implement.yml`: add a `job_timeout_minutes` dispatch input and
+  consume it in the job:
+  `timeout-minutes: ${{ inputs.job_timeout_minutes && fromJSON(inputs.job_timeout_minutes) || 90 }}`.
+  **Implementation note (verify during planning):** GitHub's support for
+  expressions in job-level `timeout-minutes` is finicky. If the expression form
+  does not take, fall back to **orchestrator-monitor enforcement** — have
+  `monitorGitHubActionsJob` cancel the run once it exceeds `maxJobMinutes` — which
+  also unifies behavior with Fly/local.
+- Fly/local monitors already time out; feed `maxJobMinutes` into their timeout
+  bounds when set.
+- Template default stays 90.
+- **Rollout:** after the above land, re-run **Sync workflows** for the Bedrock
+  project from `/admin` so the target repo picks up the current template (this
+  also clears the stale-60 problem). New inputs are only sent when the mapping
+  sets them, so un-resynced repos keep working.
+
+**Acceptance:** the Bedrock repo can run a tighter timeout (e.g. 30–45) while
+other repos stay at 90; re-synced target repos pick up the new template.
+
+## Testing
+
+- `feedback-loop.ts`: provider-aware `maxIterations` default (bedrock 2 /
+  anthropic 3) and `maxTurns` default (50) when inputs are absent; explicit
+  values override.
+- `src/github.ts`: dispatch-field builder includes `max_turns` /
+  `max_iterations` / `job_timeout_minutes` only when the mapping sets them, and
+  omits them otherwise (backward-compat).
+- `src/config.ts`: round-trip of the three new mapping columns (read/write,
+  null-safe).
+- Hook env-merge: parsing `KEY=value` lines from the managed `GITHUB_ENV` file
+  and merging into the executor env.
+- Existing dedup/dispatch tests stay green (no behavior change there — Fix 4
+  dropped).
+
+## Commit plan
+
+1. Fix 1 — entrypoint betas flag.
+2. Per-project mapping fields + admin UI (foundation for 2/3/6).
+3. Fix 2 + 3 — caps wired runner-side and through dispatch.
+4. Fix 5 — setup/verify/teardown hooks.
+5. Fix 6 — per-project timeout + template input.
+
+(Rollout step — re-sync the Bedrock target repo from `/admin` — is operational,
+done after merge/deploy, not a commit.)
+
+## Risks
+
+- **GHA `timeout-minutes` expression support** (Fix 6) — mitigated by the
+  orchestrator-monitor fallback.
+- **Forgotten re-sync** — setting a per-project cap before the target repo
+  re-syncs would make dispatch fail with "unexpected inputs." Mitigated by only
+  sending inputs when set and documenting the re-sync requirement; consider an
+  admin-UI guard that warns when a mapping sets caps but the target template is
+  stale (the Projects page already classifies template staleness).
+- **Hook env leakage** — secrets exported to `$GITHUB_ENV` by setup are merged
+  into the agent env by design; ensure the managed temp file is per-run and not
+  logged.

--- a/pipelines/autonomous.yml
+++ b/pipelines/autonomous.yml
@@ -4,6 +4,9 @@ steps:
     type: clone
   - id: install
     type: install
+  - id: setup
+    type: custom
+    moduleId: setup
   - id: feedback-loop
     type: custom
     moduleId: feedback-loop
@@ -11,6 +14,9 @@ steps:
     type: preflight
   - id: push
     type: push
+  - id: verify
+    type: custom
+    moduleId: verify
   - id: post-push-review
     type: custom
     moduleId: post-push-review

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -20,7 +20,13 @@ log "Execution mode: $AI_IMPLEMENT_MODE"
 export AI_IMPLEMENT_MODE
 
 # ── 2. Env validation ────────────────────────────────────────────────────────
-require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN
+PROVIDER="${PROVIDER:-anthropic}"
+case "$PROVIDER" in
+  bedrock) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
+  anthropic) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ;;
+  *) fail "Unsupported provider: $PROVIDER" ;;
+esac
+export PROVIDER
 require_env ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION
 
 if [ "$AI_IMPLEMENT_MODE" = "gha" ]; then

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -22,7 +22,7 @@ export AI_IMPLEMENT_MODE
 # ── 2. Env validation ────────────────────────────────────────────────────────
 PROVIDER="${PROVIDER:-anthropic}"
 case "$PROVIDER" in
-  bedrock) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
+  bedrock) [ "$AI_IMPLEMENT_MODE" = "gha" ] || fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
   anthropic) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ;;
   *) fail "Unsupported provider: $PROVIDER" ;;
 esac

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -22,7 +22,7 @@ export AI_IMPLEMENT_MODE
 # ── 2. Env validation ────────────────────────────────────────────────────────
 PROVIDER="${PROVIDER:-anthropic}"
 case "$PROVIDER" in
-  bedrock) [ "$AI_IMPLEMENT_MODE" = "gha" ] || fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1 ;;
+  bedrock) [ "$AI_IMPLEMENT_MODE" = "gha" ] || fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1; export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1 ;;
   anthropic) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ;;
   *) fail "Unsupported provider: $PROVIDER" ;;
 esac

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -526,6 +526,65 @@ describe("admin mappings", () => {
     expect(JSON.parse(res.body).error).toMatch(/bedrock.*fly-machines/);
   });
 
+  it("creates a mapping with maxTurns/maxIterations/maxJobMinutes and round-trips them", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "CAPS", owner: "org", repo: "caps-repo",
+      maxTurns: 40, maxIterations: 2, maxJobMinutes: 30,
+    }, token);
+    expect(create.statusCode).toBe(200);
+    const body = JSON.parse(create.body);
+    expect(body.maxTurns).toBe(40);
+    expect(body.maxIterations).toBe(2);
+    expect(body.maxJobMinutes).toBe(30);
+
+    const list = await request("/api/mappings", "GET", "secret", undefined, token);
+    const m = JSON.parse(list.body).CAPS;
+    expect(m.maxTurns).toBe(40);
+    expect(m.maxIterations).toBe(2);
+    expect(m.maxJobMinutes).toBe(30);
+  });
+
+  it("defaults maxTurns/maxIterations/maxJobMinutes to null when omitted", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "CAPD", owner: "org", repo: "capd-repo",
+    }, token);
+    expect(create.statusCode).toBe(200);
+    const body = JSON.parse(create.body);
+    expect(body.maxTurns).toBeNull();
+    expect(body.maxIterations).toBeNull();
+    expect(body.maxJobMinutes).toBeNull();
+  });
+
+  it("rejects maxTurns:0 with 400 mentioning maxTurns", async () => {
+    const token = await login("secret");
+    const res = await request("/api/mappings", "POST", "secret", {
+      teamKey: "BAD", owner: "org", repo: "bad", maxTurns: 0,
+    }, token);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/maxTurns/);
+  });
+
+  it("rejects maxIterations:-1 with 400 mentioning maxIterations", async () => {
+    const token = await login("secret");
+    const res = await request("/api/mappings", "POST", "secret", {
+      teamKey: "BAD", owner: "org", repo: "bad", maxIterations: -1,
+    }, token);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/maxIterations/);
+  });
+
+  it("accepts null maxTurns explicitly and stores null", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "CAPN", owner: "org", repo: "capn-repo",
+      maxTurns: null,
+    }, token);
+    expect(create.statusCode).toBe(200);
+    expect(JSON.parse(create.body).maxTurns).toBeNull();
+  });
+
   it("upsertMapping accepts a Jira ticketingProvider with valid config", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -30,6 +30,9 @@ function mapping(overrides: Partial<RepoMapping> & Pick<RepoMapping, "owner" | "
     ticketingConfig: { kind: "linear" },
     awsRegion: null,
     paused: false,
+    maxTurns: null,
+    maxIterations: null,
+    maxJobMinutes: null,
     ...overrides,
   };
 }
@@ -470,6 +473,20 @@ describe("config", () => {
 
     config.initMappingsTable();
     expect(config.getMappings().LEG.paused).toBe(false);
+  });
+
+  it("round-trips maxTurns, maxIterations, maxJobMinutes (including null)", () => {
+    config.initMappingsTable();
+    config.upsertMapping("CAPS", mapping({ owner: "org", repo: "repo", maxTurns: 40, maxIterations: 2, maxJobMinutes: 30 }));
+    config.upsertMapping("NULLS", mapping({ owner: "org", repo: "repo", maxTurns: null, maxIterations: null, maxJobMinutes: null }));
+
+    const all = config.getMappings();
+    expect(all.CAPS.maxTurns).toBe(40);
+    expect(all.CAPS.maxIterations).toBe(2);
+    expect(all.CAPS.maxJobMinutes).toBe(30);
+    expect(all.NULLS.maxTurns).toBeNull();
+    expect(all.NULLS.maxIterations).toBeNull();
+    expect(all.NULLS.maxJobMinutes).toBeNull();
   });
 
   it("getMappings falls back to {} when extra_env contains invalid JSON", () => {

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -26,6 +26,14 @@ describe("session/entrypoint.sh", () => {
     expect(content).toMatch(/GITHUB_ACTIONS.*=.*"true"/);
   });
 
+  it("routes auth validation by provider and enables Claude Code Bedrock mode", () => {
+    const content = readFileSync("session/entrypoint.sh", "utf-8");
+    expect(content).toMatch(/PROVIDER="\$\{PROVIDER:-anthropic\}"/);
+    expect(content).toMatch(/bedrock\) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1/);
+    expect(content).toMatch(/anthropic\) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN/);
+    expect(content.indexOf("CLAUDE_CODE_USE_BEDROCK=1")).toBeLessThan(content.indexOf("su -p coder"));
+  });
+
   it("exports GITHUB_DEFAULT_BRANCH for the TS runner", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     expect(content).toMatch(/GITHUB_DEFAULT_BRANCH="\$\{GITHUB_REF_NAME\}"/);

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -29,7 +29,7 @@ describe("session/entrypoint.sh", () => {
   it("routes auth validation by provider and enables Claude Code Bedrock mode", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     expect(content).toMatch(/PROVIDER="\$\{PROVIDER:-anthropic\}"/);
-    expect(content).toMatch(/bedrock\) require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1/);
+    expect(content).toMatch(/bedrock\) \[ "\$AI_IMPLEMENT_MODE" = "gha" \] \|\| fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1/);
     expect(content).toMatch(/anthropic\) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN/);
     expect(content.indexOf("CLAUDE_CODE_USE_BEDROCK=1")).toBeLessThan(content.indexOf("su -p coder"));
   });

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -30,6 +30,10 @@ describe("session/entrypoint.sh", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     expect(content).toMatch(/PROVIDER="\$\{PROVIDER:-anthropic\}"/);
     expect(content).toMatch(/bedrock\) \[ "\$AI_IMPLEMENT_MODE" = "gha" \] \|\| fail "provider=bedrock is supported only in GHA mode"; require_env AWS_REGION; export CLAUDE_CODE_USE_BEDROCK=1/);
+    // Bedrock must also disable experimental betas — Bedrock rejects the
+    // cache_control.scope field, which breaks prompt caching. Assert explicitly
+    // so removing or misspelling the export fails CI.
+    expect(content).toContain("export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1");
     expect(content).toMatch(/anthropic\) require_one_of ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN/);
     expect(content.indexOf("CLAUDE_CODE_USE_BEDROCK=1")).toBeLessThan(content.indexOf("su -p coder"));
   });

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { dispatchWorkflow, providerDispatchFields, cancelWorkflowRun } from "../github.js";
+import { dispatchWorkflow, providerDispatchFields, capDispatchFields, cancelWorkflowRun } from "../github.js";
 import type { RepoMapping } from "../config.js";
 
 function makeMapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
@@ -22,6 +22,9 @@ function makeMapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
     ticketingConfig: { kind: "linear" },
     awsRegion: null,
     paused: false,
+    maxTurns: null,
+    maxIterations: null,
+    maxJobMinutes: null,
     ...overrides,
   };
 }
@@ -135,6 +138,22 @@ describe("providerDispatchFields", () => {
     expect(
       providerDispatchFields(makeMapping({ provider: "bedrock", awsRegion: null })),
     ).toEqual({ provider: "bedrock" });
+  });
+});
+
+describe("capDispatchFields", () => {
+  it("returns empty object when no caps are set", () => {
+    expect(capDispatchFields(makeMapping({}))).toEqual({});
+  });
+
+  it("includes only the caps that are set, as strings", () => {
+    expect(
+      capDispatchFields(makeMapping({ maxTurns: 40, maxIterations: 2, maxJobMinutes: 30 })),
+    ).toEqual({ max_turns: "40", max_iterations: "2", job_timeout_minutes: "30" });
+  });
+
+  it("omits caps left null", () => {
+    expect(capDispatchFields(makeMapping({ maxTurns: 40 }))).toEqual({ max_turns: "40" });
   });
 });
 

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { dispatchWorkflow, providerDispatchFields, capDispatchFields, cancelWorkflowRun } from "../github.js";
+import { dispatchWorkflow, providerDispatchFields, capDispatchFields, capRunnerEnv, cancelWorkflowRun } from "../github.js";
 import type { RepoMapping } from "../config.js";
 
 function makeMapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
@@ -154,6 +154,31 @@ describe("capDispatchFields", () => {
 
   it("omits caps left null", () => {
     expect(capDispatchFields(makeMapping({ maxTurns: 40 }))).toEqual({ max_turns: "40" });
+  });
+});
+
+describe("capRunnerEnv", () => {
+  it("returns empty object when no caps are set", () => {
+    expect(capRunnerEnv(makeMapping({}))).toEqual({});
+  });
+
+  it("includes turn/iteration caps as env vars (strings) when set", () => {
+    expect(capRunnerEnv(makeMapping({ maxTurns: 40, maxIterations: 2 }))).toEqual({
+      AI_IMPLEMENT_MAX_TURNS: "40",
+      AI_IMPLEMENT_MAX_ITERATIONS: "2",
+    });
+  });
+
+  it("omits job timeout (GHA-only, not a runner env var)", () => {
+    expect(capRunnerEnv(makeMapping({ maxTurns: 40, maxJobMinutes: 30 }))).toEqual({
+      AI_IMPLEMENT_MAX_TURNS: "40",
+    });
+  });
+
+  it("omits caps left null", () => {
+    expect(capRunnerEnv(makeMapping({ maxIterations: 3 }))).toEqual({
+      AI_IMPLEMENT_MAX_ITERATIONS: "3",
+    });
   });
 });
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -6,7 +6,14 @@ import { runHookScript } from "../pipeline/steps/hooks.js";
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "hook-")); });
-afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  // Clean up env the hook scripts export, so a failing assertion mid-test can't
+  // leak a var into other tests sharing this Vitest worker's process.env.
+  for (const k of ["FOO_TEST_VAR", "SIMPLE_TEST_VAR", "MULTI_TEST_VAR"]) {
+    delete process.env[k];
+  }
+});
 
 describe("runHookScript", () => {
   it("runs the script and merges GITHUB_ENV exports into process.env", () => {
@@ -14,7 +21,6 @@ describe("runHookScript", () => {
     const result = runHookScript("setup", "setup.sh", dir);
     expect(result.exitCode).toBe(0);
     expect(process.env.FOO_TEST_VAR).toBe("bar123");
-    delete process.env.FOO_TEST_VAR;
   });
 
   it("returns a non-zero exit code when the script fails", () => {
@@ -38,6 +44,5 @@ describe("runHookScript", () => {
     expect(result.exitCode).toBe(0);
     expect(process.env.MULTI_TEST_VAR).toBeUndefined();
     expect(process.env.SIMPLE_TEST_VAR).toBe("ok");
-    delete process.env.SIMPLE_TEST_VAR;
   });
 });

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runHookScript } from "../pipeline/steps/hooks.js";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "hook-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe("runHookScript", () => {
+  it("runs the script and merges GITHUB_ENV exports into process.env", () => {
+    writeFileSync(join(dir, "setup.sh"), 'echo "FOO_TEST_VAR=bar123" >> "$GITHUB_ENV"\n');
+    const result = runHookScript("setup", "setup.sh", dir);
+    expect(result.exitCode).toBe(0);
+    expect(process.env.FOO_TEST_VAR).toBe("bar123");
+    delete process.env.FOO_TEST_VAR;
+  });
+
+  it("returns a non-zero exit code when the script fails", () => {
+    writeFileSync(join(dir, "bad.sh"), "exit 3\n");
+    const result = runHookScript("setup", "bad.sh", dir);
+    expect(result.exitCode).toBe(3);
+  });
+
+  it("throws a clear error when the script path does not exist", () => {
+    expect(() => runHookScript("setup", "missing.sh", dir)).toThrow(/missing\.sh/);
+  });
+});

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -26,4 +26,18 @@ describe("runHookScript", () => {
   it("throws a clear error when the script path does not exist", () => {
     expect(() => runHookScript("setup", "missing.sh", dir)).toThrow(/missing\.sh/);
   });
+
+  it("ignores GHA heredoc multiline values (only KEY=value is supported)", () => {
+    // A heredoc opener (KEY<<EOF) must NOT be parsed as an env var; the simple
+    // line on the same file is still merged.
+    writeFileSync(
+      join(dir, "multi.sh"),
+      'printf "MULTI_TEST_VAR<<EOF\\nl1\\nl2\\nEOF\\nSIMPLE_TEST_VAR=ok\\n" >> "$GITHUB_ENV"\n',
+    );
+    const result = runHookScript("setup", "multi.sh", dir);
+    expect(result.exitCode).toBe(0);
+    expect(process.env.MULTI_TEST_VAR).toBeUndefined();
+    expect(process.env.SIMPLE_TEST_VAR).toBe("ok");
+    delete process.env.SIMPLE_TEST_VAR;
+  });
 });

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -308,6 +308,54 @@ describe("loadPipelineDefinition", () => {
     expect(step.skip?.(ctxMissingPr)).toBe(true);
   });
 
+  it("skips setup when no setup hook, runs it (with scriptPath) when present", () => {
+    const pipeline = loadPipelineDefinition("pipelines/autonomous.yml", {
+      existsSyncImpl: () => false,
+      readFileSyncImpl: (_path, _enc) => BUILTIN_PIPELINE_YAML,
+    });
+
+    const step = pipeline.steps.find((s) => s.id === "setup")!;
+
+    const ctxNoHook = makeContext();
+    ctxNoHook.setOutputs("clone", { workspaceDir: "/tmp/repo" });
+    expect(step.skip?.(ctxNoHook)).toBe(true);
+
+    const ctxWithHook = makeContext({ hooks: { setup: "scripts/setup.sh" } });
+    ctxWithHook.setOutputs("clone", { workspaceDir: "/tmp/repo" });
+    expect(step.skip?.(ctxWithHook)).toBe(false);
+    const inputs = ctxWithHook.resolveInputs(step.inputs);
+    expect(inputs.workspaceDir).toBe("/tmp/repo");
+    expect(inputs.scriptPath).toBe("scripts/setup.sh");
+  });
+
+  it("skips verify when no verify hook, or when feedback-loop not approved", () => {
+    const pipeline = loadPipelineDefinition("pipelines/autonomous.yml", {
+      existsSyncImpl: () => false,
+      readFileSyncImpl: (_path, _enc) => BUILTIN_PIPELINE_YAML,
+    });
+
+    const step = pipeline.steps.find((s) => s.id === "verify")!;
+
+    // No hook -> skip even if approved.
+    const ctxNoHook = makeContext();
+    ctxNoHook.setOutputs("feedback-loop", { approved: true });
+    expect(step.skip?.(ctxNoHook)).toBe(true);
+
+    // Hook present but loop not approved -> skip.
+    const ctxNotApproved = makeContext({ hooks: { verify: "scripts/verify.sh" } });
+    ctxNotApproved.setOutputs("feedback-loop", { approved: false });
+    expect(step.skip?.(ctxNotApproved)).toBe(true);
+
+    // Hook present and approved -> run, with scriptPath wired.
+    const ctxRun = makeContext({ hooks: { verify: "scripts/verify.sh" } });
+    ctxRun.setOutputs("clone", { workspaceDir: "/tmp/repo" });
+    ctxRun.setOutputs("feedback-loop", { approved: true });
+    expect(step.skip?.(ctxRun)).toBe(false);
+    const inputs = ctxRun.resolveInputs(step.inputs);
+    expect(inputs.workspaceDir).toBe("/tmp/repo");
+    expect(inputs.scriptPath).toBe("scripts/verify.sh");
+  });
+
   it("custom pipeline with extra step is used by the pipeline runner", async () => {
     const pipeline = loadPipelineDefinition("pipelines/autonomous.yml", {
       existsSyncImpl: (p) => p.includes("custom"),

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -29,6 +29,9 @@ steps:
     type: clone
   - id: install
     type: install
+  - id: setup
+    type: custom
+    moduleId: setup
   - id: feedback-loop
     type: custom
     moduleId: feedback-loop
@@ -36,6 +39,9 @@ steps:
     type: preflight
   - id: push
     type: push
+  - id: verify
+    type: custom
+    moduleId: verify
   - id: post-push-review
     type: custom
     moduleId: post-push-review
@@ -70,9 +76,11 @@ describe("loadPipelineDefinition", () => {
     expect(pipeline.steps.map((s) => s.id)).toEqual([
       "clone",
       "install",
+      "setup",
       "feedback-loop",
       "preflight",
       "push",
+      "verify",
       "post-push-review",
     ]);
   });

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -733,5 +733,62 @@ describe("runAutonomous", () => {
     await expect(
       runAutonomous({ workspaceDir, pipeline, runner, reporter: new NoopStepReporter() }),
     ).rejects.toThrow("Missing required env var: ISSUE_ID");
+  });
+
+  it("runs the teardown hook even when the pipeline fails", async () => {
+    writeFileSync(join(workspaceDir, "WORKFLOW.md"), "---\nteardown: teardown.sh\n---\nbody\n");
+    writeFileSync(join(workspaceDir, "teardown.sh"), 'touch "teardown-ran.marker"\n');
+    const { pipeline, runner } = makeSingleStepPipeline("bad-step", {
+      run: vi.fn().mockRejectedValue(new Error("step exploded")),
+    });
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(existsSync(join(workspaceDir, "teardown-ran.marker"))).toBe(true);
+  });
+
+  it("runs the teardown hook on a successful run", async () => {
+    writeFileSync(join(workspaceDir, "WORKFLOW.md"), "---\nteardown: teardown.sh\n---\nbody\n");
+    writeFileSync(join(workspaceDir, "teardown.sh"), 'touch "teardown-ran.marker"\n');
+    const { pipeline, runner } = makeSingleStepPipeline("ok-step", { run: vi.fn().mockResolvedValue({}) });
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(workspaceDir, "teardown-ran.marker"))).toBe(true);
+  });
+
+  it("a failing teardown does not mask the run outcome or throw", async () => {
+    writeFileSync(join(workspaceDir, "WORKFLOW.md"), "---\nteardown: teardown.sh\n---\nbody\n");
+    // Teardown runs (marker) but exits non-zero — its failure must not change the
+    // pipeline's exitCode 1 nor surface as an unhandled rejection.
+    writeFileSync(join(workspaceDir, "teardown.sh"), 'touch "teardown-ran.marker"\nexit 1\n');
+    const { pipeline, runner } = makeSingleStepPipeline("bad-step", {
+      run: vi.fn().mockRejectedValue(new Error("step exploded")),
+    });
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(existsSync(join(workspaceDir, "teardown-ran.marker"))).toBe(true);
   });
 });

--- a/src/__tests__/steps-feedback-loop.test.ts
+++ b/src/__tests__/steps-feedback-loop.test.ts
@@ -410,3 +410,66 @@ describe("feedbackLoopStep", () => {
     expect(reviewStep_?.inputs).toMatchObject({ model: "claude-haiku-4-5-20251001" });
   });
 });
+
+describe("feedbackLoopStep caps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(implementStep.run).mockResolvedValue(IMPLEMENT_OUTPUTS);
+    vi.mocked(reviewStep.run).mockResolvedValue(APPROVED_REVIEW);
+    mockDiff();
+  });
+
+  it("passes maxTurns=50 by default to the implement invocation", async () => {
+    await feedbackLoopStep.run(makeContext(), { ...BASE_INPUTS }, new NoopStepReporter());
+
+    const implementCall = vi.mocked(implementStep.run).mock.calls[0];
+    expect(implementCall[1]).toMatchObject({ maxTurns: 50 });
+  });
+
+  it("honors an explicit maxTurns input", async () => {
+    await feedbackLoopStep.run(
+      makeContext(),
+      { ...BASE_INPUTS, maxTurns: 25 },
+      new NoopStepReporter(),
+    );
+
+    const implementCall = vi.mocked(implementStep.run).mock.calls[0];
+    expect(implementCall[1]).toMatchObject({ maxTurns: 25 });
+  });
+
+  it("defaults to 2 maxIterations when provider=bedrock", async () => {
+    vi.mocked(reviewStep.run).mockResolvedValue(REJECTED_REVIEW);
+
+    const outputs = await feedbackLoopStep.run(
+      makeContext(),
+      { ...BASE_INPUTS, provider: "bedrock" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.iterations).toBe(2);
+  });
+
+  it("defaults to 3 maxIterations when provider is not bedrock", async () => {
+    vi.mocked(reviewStep.run).mockResolvedValue(REJECTED_REVIEW);
+
+    const outputs = await feedbackLoopStep.run(
+      makeContext(),
+      { ...BASE_INPUTS, provider: "anthropic" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.iterations).toBe(3);
+  });
+
+  it("honors an explicit maxIterations even when provider=bedrock", async () => {
+    vi.mocked(reviewStep.run).mockResolvedValue(REJECTED_REVIEW);
+
+    const outputs = await feedbackLoopStep.run(
+      makeContext(),
+      { ...BASE_INPUTS, provider: "bedrock", maxIterations: 5 },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.iterations).toBe(5);
+  });
+});

--- a/src/__tests__/steps-setup-verify.test.ts
+++ b/src/__tests__/steps-setup-verify.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setupStep } from "../pipeline/steps/setup.js";
+import { verifyStep } from "../pipeline/steps/verify.js";
+import { DefaultPipelineContext } from "../pipeline/context.js";
+import { NoopStepReporter } from "../pipeline/reporter.js";
+import type { LLMExecutor } from "../pipeline/types.js";
+
+const noopExec: LLMExecutor = { async invoke() { return { stdout: "", exitCode: 0, tokensUsed: 0 }; } };
+function ctx() {
+  return new DefaultPipelineContext(
+    { jobId: 1, issueId: "i", issueIdentifier: "ENG-1", issueTitle: "T", issueDescription: "D", nonce: "n", orchestratorUrl: "", ticketingProvider: "linear" },
+    noopExec,
+  );
+}
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "sv-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe("setupStep", () => {
+  it("runs the setup script and returns ran:true", async () => {
+    writeFileSync(join(dir, "s.sh"), "echo hi\n");
+    const out = await setupStep.run(ctx(), { workspaceDir: dir, scriptPath: "s.sh" }, new NoopStepReporter());
+    expect(out.ran).toBe(true);
+  });
+  it("throws when the setup script fails", async () => {
+    writeFileSync(join(dir, "s.sh"), "exit 1\n");
+    await expect(
+      setupStep.run(ctx(), { workspaceDir: dir, scriptPath: "s.sh" }, new NoopStepReporter()),
+    ).rejects.toThrow(/setup/i);
+  });
+});
+
+describe("verifyStep", () => {
+  it("throws when the verify script fails", async () => {
+    writeFileSync(join(dir, "v.sh"), "exit 2\n");
+    await expect(
+      verifyStep.run(ctx(), { workspaceDir: dir, scriptPath: "v.sh" }, new NoopStepReporter()),
+    ).rejects.toThrow(/verify/i);
+  });
+});

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -164,6 +164,14 @@ describe("GHA workflow shims", () => {
       const yaml = readFileSync(f, "utf-8");
       expect(yaml).toMatch(/GITHUB_DEFAULT_BRANCH:\s*\$\{\{\s*github\.ref_name\s*\}\}/);
     });
+
+    it(`${f} validates Bedrock config before configuring AWS credentials`, () => {
+      const yaml = readFileSync(f, "utf-8");
+      expect(yaml).toMatch(/Validate Bedrock inputs/);
+      expect(yaml).toMatch(/provider=bedrock but aws_region dispatch input is empty/);
+      expect(yaml).toMatch(/provider=bedrock but AWS_BEDROCK_ROLE_ARN repo secret is not set/);
+      expect(yaml.indexOf("Validate Bedrock inputs")).toBeLessThan(yaml.indexOf("Configure AWS credentials (Bedrock)"));
+    });
   }
 
   it("comment trigger only runs implementation for an exact trimmed /ai-implement command", () => {

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -122,6 +122,9 @@ export const projectsHtml = `
           <div class="md-field"><label>Workflow File</label><input id="md-wf" value="claude-implement.yml"></div>
           <div class="md-field"><label>Default Branch</label><input id="md-branch" placeholder="development"></div>
           <div class="md-field"><label>Max AI Issues</label><input id="md-max-ai" type="number" min="1" value="3"></div>
+          <div class="md-field"><label>Max Turns <span class="text-tertiary" style="font-size:0.85em">(blank = 50)</span></label><input id="md-max-turns" type="number" min="1" placeholder="50"></div>
+          <div class="md-field"><label>Max Iterations <span class="text-tertiary" style="font-size:0.85em">(blank = bedrock 2 / anthropic 3)</span></label><input id="md-max-iter" type="number" min="1" placeholder="3"></div>
+          <div class="md-field"><label>Job Timeout (min) <span class="text-tertiary" style="font-size:0.85em">(blank = 90)</span></label><input id="md-max-job-min" type="number" min="1" placeholder="90"></div>
         </fieldset>
         <fieldset>
           <legend>Execution</legend>
@@ -267,6 +270,9 @@ export const projectsScript = `
     document.getElementById('md-planning-wf').value = m.planningWorkflowFile || 'claude-plan.yml';
     document.getElementById('md-provider').value = m.provider || 'anthropic';
     document.getElementById('md-aws-region').value = m.awsRegion || '';
+    document.getElementById('md-max-turns').value = m.maxTurns == null ? '' : String(m.maxTurns);
+    document.getElementById('md-max-iter').value = m.maxIterations == null ? '' : String(m.maxIterations);
+    document.getElementById('md-max-job-min').value = m.maxJobMinutes == null ? '' : String(m.maxJobMinutes);
 
     // Ticketing provider + Jira config
     const tp = m.ticketingProvider || 'linear';
@@ -564,6 +570,9 @@ export const projectsScript = `
       extraEnv: parseEnvText(document.getElementById('md-env').value),
       provider: document.getElementById('md-provider').value,
       awsRegion: document.getElementById('md-aws-region').value.trim() || null,
+      maxTurns: (function(){ var v = document.getElementById('md-max-turns').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+      maxIterations: (function(){ var v = document.getElementById('md-max-iter').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+      maxJobMinutes: (function(){ var v = document.getElementById('md-max-job-min').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
     };
 
     const ticketingProvider = document.getElementById('md-ticketing-provider').value;

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -122,9 +122,9 @@ export const projectsHtml = `
           <div class="md-field"><label>Workflow File</label><input id="md-wf" value="claude-implement.yml"></div>
           <div class="md-field"><label>Default Branch</label><input id="md-branch" placeholder="development"></div>
           <div class="md-field"><label>Max AI Issues</label><input id="md-max-ai" type="number" min="1" value="3"></div>
-          <div class="md-field"><label>Max Turns <span class="text-tertiary" style="font-size:0.85em">(blank = 50)</span></label><input id="md-max-turns" type="number" min="1" placeholder="50"></div>
-          <div class="md-field"><label>Max Iterations <span class="text-tertiary" style="font-size:0.85em">(blank = bedrock 2 / anthropic 3)</span></label><input id="md-max-iter" type="number" min="1" placeholder="3"></div>
-          <div class="md-field"><label>Job Timeout (min) <span class="text-tertiary" style="font-size:0.85em">(blank = 90)</span></label><input id="md-max-job-min" type="number" min="1" placeholder="90"></div>
+          <div class="md-field"><label>Max Turns <span class="text-tertiary" style="font-size:0.85em">(blank = 50)</span></label><input id="md-max-turns" type="number" min="1" step="1" placeholder="50"></div>
+          <div class="md-field"><label>Max Iterations <span class="text-tertiary" style="font-size:0.85em">(blank = bedrock 2 / anthropic 3)</span></label><input id="md-max-iter" type="number" min="1" step="1" placeholder="3"></div>
+          <div class="md-field"><label>Job Timeout (min) <span class="text-tertiary" style="font-size:0.85em">(blank = 90)</span></label><input id="md-max-job-min" type="number" min="1" step="1" placeholder="90"></div>
         </fieldset>
         <fieldset>
           <legend>Execution</legend>

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -963,6 +963,9 @@ async function handleUpsertMapping(
       ticketingProvider?: string;
       ticketingConfig?: unknown;
       paused?: boolean;
+      maxTurns?: number | null;
+      maxIterations?: number | null;
+      maxJobMinutes?: number | null;
     };
 
     if (!body.teamKey || !body.owner || !body.repo) {
@@ -1062,6 +1065,29 @@ async function handleUpsertMapping(
       return;
     }
 
+    const resolveCap = (
+      name: string,
+      value: number | null | undefined,
+    ): number | null => {
+      if (value === undefined || value === null) return null;
+      if (!Number.isInteger(value) || value < 1) {
+        throw new Error(`${name} must be a positive integer or null`);
+      }
+      return value;
+    };
+
+    let maxTurns: number | null;
+    let maxIterations: number | null;
+    let maxJobMinutes: number | null;
+    try {
+      maxTurns = resolveCap("maxTurns", body.maxTurns);
+      maxIterations = resolveCap("maxIterations", body.maxIterations);
+      maxJobMinutes = resolveCap("maxJobMinutes", body.maxJobMinutes);
+    } catch (err) {
+      json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+      return;
+    }
+
     const mapping: RepoMapping = {
       owner: body.owner,
       repo: body.repo,
@@ -1085,6 +1111,9 @@ async function handleUpsertMapping(
       paused: body.paused !== undefined
         ? body.paused === true
         : (existingMapping?.paused ?? false),
+      maxTurns,
+      maxIterations,
+      maxJobMinutes,
     };
 
     upsertMapping(body.teamKey, mapping);

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,12 @@ export interface RepoMapping {
   awsRegion: string | null;
   /** When true, the poller and gap-fill trigger skip this mapping. In-flight runs (runner callbacks) are unaffected. */
   paused: boolean;
+  /** Maximum number of Claude turns per run. NULL means use Claude's built-in default. */
+  maxTurns: number | null;
+  /** Maximum number of feedback-loop iterations per run. NULL means use the pipeline's built-in default. */
+  maxIterations: number | null;
+  /** Maximum wall-clock minutes for a job before it is forcibly terminated. NULL means use the runner's built-in default. */
+  maxJobMinutes: number | null;
 }
 
 // Seed mappings are only applied on first run (empty DB).
@@ -111,6 +117,15 @@ function ensureMappingsColumns(): void {
   if (!names.has("paused")) {
     db.exec(`ALTER TABLE mappings ADD COLUMN paused INTEGER NOT NULL DEFAULT 0`);
   }
+  if (!names.has("max_turns")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN max_turns INTEGER`);
+  }
+  if (!names.has("max_iterations")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN max_iterations INTEGER`);
+  }
+  if (!names.has("max_job_minutes")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN max_job_minutes INTEGER`);
+  }
 }
 
 export function initMappingsTable(): void {
@@ -135,7 +150,10 @@ export function initMappingsTable(): void {
       ticketing_provider TEXT NOT NULL DEFAULT '${DEFAULT_TICKETING_PROVIDER}',
       ticketing_config TEXT NOT NULL DEFAULT '{"kind":"linear"}',
       aws_region TEXT,
-      paused INTEGER NOT NULL DEFAULT 0
+      paused INTEGER NOT NULL DEFAULT 0,
+      max_turns INTEGER,
+      max_iterations INTEGER,
+      max_job_minutes INTEGER
     )
   `);
   ensureMappingsColumns();
@@ -144,10 +162,10 @@ export function initMappingsTable(): void {
   const count = db.prepare("SELECT COUNT(*) as n FROM mappings").get() as { n: number };
   if (count.n === 0 && Object.keys(SEED_MAPPINGS).length > 0) {
     const insert = db.prepare(
-      "INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     for (const [key, m] of Object.entries(SEED_MAPPINGS)) {
-      insert.run(key, m.owner, m.repo, m.workflowFile, m.defaultBranch, m.maxInProgressAiIssues, m.executionMode, m.sessionMode, m.machineCpus, m.machineMemoryMb, m.planningEnabled ? 1 : 0, m.planningWorkflowFile, m.autoApprovePlans ? 1 : 0, Object.keys(m.extraEnv).length > 0 ? JSON.stringify(m.extraEnv) : null, m.provider, m.ticketingProvider, JSON.stringify(m.ticketingConfig), m.awsRegion, m.paused ? 1 : 0);
+      insert.run(key, m.owner, m.repo, m.workflowFile, m.defaultBranch, m.maxInProgressAiIssues, m.executionMode, m.sessionMode, m.machineCpus, m.machineMemoryMb, m.planningEnabled ? 1 : 0, m.planningWorkflowFile, m.autoApprovePlans ? 1 : 0, Object.keys(m.extraEnv).length > 0 ? JSON.stringify(m.extraEnv) : null, m.provider, m.ticketingProvider, JSON.stringify(m.ticketingConfig), m.awsRegion, m.paused ? 1 : 0, m.maxTurns, m.maxIterations, m.maxJobMinutes);
     }
     console.log(`[config] Seeded ${Object.keys(SEED_MAPPINGS).length} default mappings`);
   }
@@ -156,7 +174,7 @@ export function initMappingsTable(): void {
 export function getMappings(): Record<string, RepoMapping> {
   const rows = getDb()
     .prepare(
-      "SELECT team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused FROM mappings",
+      "SELECT team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes FROM mappings",
     )
     .all() as Array<{
       team_key: string;
@@ -178,6 +196,9 @@ export function getMappings(): Record<string, RepoMapping> {
       ticketing_config: string;
       aws_region: string | null;
       paused: number;
+      max_turns: number | null;
+      max_iterations: number | null;
+      max_job_minutes: number | null;
     }>;
 
   const result: Record<string, RepoMapping> = {};
@@ -211,6 +232,9 @@ export function getMappings(): Record<string, RepoMapping> {
       ticketingConfig,
       awsRegion: row.aws_region,
       paused: Boolean(row.paused),
+      maxTurns: row.max_turns,
+      maxIterations: row.max_iterations,
+      maxJobMinutes: row.max_job_minutes,
     };
   }
   return result;
@@ -219,7 +243,7 @@ export function getMappings(): Record<string, RepoMapping> {
 export function upsertMapping(teamKey: string, mapping: RepoMapping): void {
   getDb()
     .prepare(
-      "INSERT OR REPLACE INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT OR REPLACE INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     .run(
       teamKey,
@@ -241,6 +265,9 @@ export function upsertMapping(teamKey: string, mapping: RepoMapping): void {
       JSON.stringify(mapping.ticketingConfig),
       mapping.awsRegion,
       mapping.paused ? 1 : 0,
+      mapping.maxTurns,
+      mapping.maxIterations,
+      mapping.maxJobMinutes,
     );
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -16,6 +16,12 @@ interface DispatchInputs {
   provider?: string;
   /** AWS region for Bedrock. Only forwarded when provider='bedrock'. */
   aws_region?: string;
+  /** Cap on Claude turns per implement pass. Only forwarded when set on the mapping. */
+  max_turns?: string;
+  /** Cap on implement/review iterations. Only forwarded when set on the mapping. */
+  max_iterations?: string;
+  /** Per-project GitHub Actions job timeout in minutes. Only forwarded when set. */
+  job_timeout_minutes?: string;
   /** Public base URL the runner should POST results back to. Empty when callback disabled. */
   runner_callback_url?: string;
   /** Signed run token authorizing the runner's callback POST. Empty when callback disabled. */
@@ -63,6 +69,22 @@ export function providerDispatchFields(
     };
   }
   return {};
+}
+
+/**
+ * Returns the cap-related dispatch inputs for a mapping. Each field is only
+ * included when set on the mapping (non-null), so default repos keep
+ * dispatching to workflow templates that haven't been re-synced with the new
+ * inputs. Values are stringified because workflow_dispatch inputs are strings.
+ */
+export function capDispatchFields(
+  mapping: RepoMapping,
+): Pick<DispatchInputs, "max_turns" | "max_iterations" | "job_timeout_minutes"> {
+  const fields: Pick<DispatchInputs, "max_turns" | "max_iterations" | "job_timeout_minutes"> = {};
+  if (mapping.maxTurns != null) fields.max_turns = String(mapping.maxTurns);
+  if (mapping.maxIterations != null) fields.max_iterations = String(mapping.maxIterations);
+  if (mapping.maxJobMinutes != null) fields.job_timeout_minutes = String(mapping.maxJobMinutes);
+  return fields;
 }
 
 export async function dispatchWorkflow(

--- a/src/github.ts
+++ b/src/github.ts
@@ -87,6 +87,18 @@ export function capDispatchFields(
   return fields;
 }
 
+/**
+ * Cap env vars for the runner process (Fly/local execution modes), where caps
+ * arrive via container env rather than workflow inputs. Job timeout is omitted
+ * because it controls the GitHub Actions job, not the runner.
+ */
+export function capRunnerEnv(mapping: RepoMapping): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (mapping.maxTurns != null) env.AI_IMPLEMENT_MAX_TURNS = String(mapping.maxTurns);
+  if (mapping.maxIterations != null) env.AI_IMPLEMENT_MAX_ITERATIONS = String(mapping.maxIterations);
+  return env;
+}
+
 export async function dispatchWorkflow(
   token: string,
   mapping: RepoMapping,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1599,6 +1599,7 @@ async function processReconciliations(config: AppConfig): Promise<void> {
         pr_number: String(job.prNumber),
         runner_phase: "gap-analysis",
         ...providerDispatchFields(mapping),
+        ...capDispatchFields(mapping),
         ...(runnerImage ? { runner_image: runnerImage } : {}),
       });
 
@@ -1693,6 +1694,7 @@ async function processReviewFixQueue(config: AppConfig): Promise<void> {
         pr_number: String(fix.prNumber),
         runner_phase: "gap-analysis",
         ...providerDispatchFields(mapping),
+        ...capDispatchFields(mapping),
         runner_callback_url: runnerCallbackUrl,
         run_token: runToken,
         run_progress_token: runProgressToken,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "./config.js";
 import type { RepoMapping } from "./config.js";
 import { isAlreadyDispatched, markDispatched, closeDb, getDispatchedIds, deleteDispatched } from "./dedup.js";
-import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun, providerDispatchFields } from "./github.js";
+import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun, providerDispatchFields, capDispatchFields, capRunnerEnv } from "./github.js";
 import { providerConfigFromEnv, ProviderRegistry } from "./providers/index.js";
 import type { TicketingProvider, IssueLifecycleState } from "./providers/types.js";
 import type { TicketIssue } from "./providers/types.js";
@@ -410,6 +410,7 @@ async function dispatchGitHubActions(
     issue_description: issue.description || issue.title,
     runner_phase: "implementation",
     ...providerDispatchFields(mapping),
+    ...capDispatchFields(mapping),
     runner_callback_url: runnerCallbackUrl,
     run_token: runToken,
     run_progress_token: runProgressToken,
@@ -743,7 +744,10 @@ async function dispatchFlyMachine(
         orchestratorApp: config.flyOrchestratorApp ?? undefined,
         tenantId: config.tenantId ?? undefined,
         expectedTtlSeconds: Math.round(SWEEP_MACHINE_MAX_AGE_MS / 1000),
-        extraEnv: Object.keys(mapping.extraEnv).length > 0 ? mapping.extraEnv : undefined,
+        extraEnv: (() => {
+          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping) };
+          return Object.keys(merged).length > 0 ? merged : undefined;
+        })(),
       });
 
       const machine = await createMachine(flyToken, flyApp, machineConfig);
@@ -814,7 +818,10 @@ async function dispatchLocalDocker(
         orchestratorUrl: localOrchestratorUrl,
         runnerCallbackUrl: runnerCallbackUrl || undefined,
         runToken: runToken || undefined,
-        extraEnv: Object.keys(mapping.extraEnv).length > 0 ? mapping.extraEnv : undefined,
+        extraEnv: (() => {
+          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping) };
+          return Object.keys(merged).length > 0 ? merged : undefined;
+        })(),
       });
 
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1590,6 +1590,9 @@ async function processReconciliations(config: AppConfig): Promise<void> {
 
       // Dispatch a gap-fill run using the existing claude-implement.yml workflow,
       // passing the merged PR number so Claude checks out the right branch.
+      // Reconciliation/gap-fill and review-fix re-dispatches always go through
+      // GitHub Actions (this dispatchWorkflow path), so caps ride capDispatchFields
+      // here — there is no Fly/local gap-fill path needing capRunnerEnv.
       const runnerImage = await resolveDispatchRunnerImage(config, mapping, ghToken);
       const result = await dispatchWorkflow(ghToken, mapping, {
         issue_id: job.issueId,

--- a/src/pipeline/default-pipeline.ts
+++ b/src/pipeline/default-pipeline.ts
@@ -6,6 +6,8 @@ import { installStep } from "./steps/install.js";
 import { postPushReviewStep } from "./steps/post-push-review.js";
 import { preflightStep } from "./steps/preflight.js";
 import { pushStep } from "./steps/push.js";
+import { setupStep } from "./steps/setup.js";
+import { verifyStep } from "./steps/verify.js";
 import { loadPipelineDefinition } from "./pipeline-loader.js";
 import { resolveModuleImport, type ImportModuleOptions } from "./resolve-module.js";
 
@@ -20,9 +22,11 @@ export const DEFAULT_PIPELINE: PipelineDefinition = loadPipelineDefinition(
 const BUILTIN_STEPS: Array<[string, StepModule]> = [
   ["clone", cloneStep],
   ["install", installStep],
+  ["setup", setupStep],
   ["feedback-loop", feedbackLoopStep],
   ["preflight", preflightStep],
   ["push", pushStep],
+  ["verify", verifyStep],
   ["post-push-review", postPushReviewStep],
 ];
 

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -111,6 +111,9 @@ function applyWiring(step: YamlStep): StepDefinition {
             planningContext: ctx.data.planningContext,
             repoImplementModel: repoModels?.implement,
             repoReviewModel: repoModels?.review,
+            provider: ctx.data.provider,
+            maxTurns: ctx.data.maxTurns,
+            maxIterations: ctx.data.maxIterations,
           };
         },
       };

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -96,6 +96,16 @@ function applyWiring(step: YamlStep): StepDefinition {
         }),
       };
 
+    case "setup":
+      return {
+        ...step,
+        inputs: (ctx: PipelineContext) => ({
+          workspaceDir: ctx.getOutputs("clone").workspaceDir,
+          scriptPath: ctx.data.hooks?.setup,
+        }),
+        skip: (ctx: PipelineContext) => !ctx.data.hooks?.setup,
+      };
+
     case "feedback-loop":
       return {
         ...step,
@@ -141,6 +151,19 @@ function applyWiring(step: YamlStep): StepDefinition {
           prTitle: `${ctx.data.issueIdentifier}: ${ctx.data.issueTitle}`,
         }),
         skip: (ctx: PipelineContext) => ctx.getOutputs("feedback-loop").approved !== true,
+      };
+
+    case "verify":
+      return {
+        ...step,
+        inputs: (ctx: PipelineContext) => ({
+          workspaceDir: ctx.getOutputs("clone").workspaceDir,
+          scriptPath: ctx.data.hooks?.verify,
+        }),
+        skip: (ctx: PipelineContext) => {
+          if (!ctx.data.hooks?.verify) return true;
+          return ctx.getOutputs("feedback-loop").approved !== true;
+        },
       };
 
     case "post-push-review":

--- a/src/pipeline/steps/feedback-loop.ts
+++ b/src/pipeline/steps/feedback-loop.ts
@@ -21,6 +21,8 @@ interface FeedbackLoopInputs extends Record<string, unknown> {
   /** Repo-level review model from .ai-implement/config.yml, injected by the install step. */
   repoReviewModel?: string;
   maxIterations?: number;
+  maxTurns?: number;
+  provider?: string;
   planningContext?: string;
   implementationPrompt?: string;
   parentStepId?: string;
@@ -72,8 +74,9 @@ export const feedbackLoopStep: StepModule<FeedbackLoopInputs, FeedbackLoopOutput
   ): Promise<FeedbackLoopOutputs> {
     const parentStepId =
       typeof inputs.parentStepId === "string" ? inputs.parentStepId : "feedback-loop";
-    const maxIterations =
-      typeof inputs.maxIterations === "number" ? inputs.maxIterations : DEFAULT_MAX_ITERATIONS;
+    const effectiveMaxIterations =
+      inputs.maxIterations ?? (inputs.provider === "bedrock" ? 2 : DEFAULT_MAX_ITERATIONS);
+    const effectiveMaxTurns = inputs.maxTurns ?? 50;
 
     // Fallback hierarchy: explicit per-step > unified `model` input > repo config > tenant default > hard default
     const tenantModel = context.data.model;
@@ -94,7 +97,7 @@ export const feedbackLoopStep: StepModule<FeedbackLoopInputs, FeedbackLoopOutput
     let approved = false;
     let feedback = "";
 
-    while (iteration < maxIterations && !approved) {
+    while (iteration < effectiveMaxIterations && !approved) {
       iteration++;
 
       const implementPrompt = buildImplementPrompt(
@@ -117,6 +120,7 @@ export const feedbackLoopStep: StepModule<FeedbackLoopInputs, FeedbackLoopOutput
           workspaceDir: inputs.workspaceDir,
           prompt: implementPrompt,
           model: resolvedImplementModel,
+          maxTurns: effectiveMaxTurns,
           planningContext: inputs.planningContext,
         },
         outputs: {},
@@ -131,6 +135,7 @@ export const feedbackLoopStep: StepModule<FeedbackLoopInputs, FeedbackLoopOutput
             workspaceDir: String(inputs.workspaceDir),
             prompt: implementPrompt,
             model: resolvedImplementModel,
+            maxTurns: effectiveMaxTurns,
             planningContext:
               inputs.planningContext !== undefined ? String(inputs.planningContext) : undefined,
           },

--- a/src/pipeline/steps/hooks.ts
+++ b/src/pipeline/steps/hooks.ts
@@ -46,9 +46,11 @@ export function runHookScript(
       stdio: ["ignore", "inherit", "inherit"],
     });
 
-    mergeGithubEnv(githubEnvFile);
-
+    // Surface a spawn-level failure (e.g. bash missing) before merging — a
+    // failed spawn leaves no meaningful env to merge.
     if (proc.error) throw proc.error;
+
+    mergeGithubEnv(githubEnvFile);
     return { exitCode: proc.status ?? 1 };
   } finally {
     rmSync(envDir, { recursive: true, force: true });

--- a/src/pipeline/steps/hooks.ts
+++ b/src/pipeline/steps/hooks.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+export interface HookResult {
+  exitCode: number;
+}
+
+/**
+ * Runs a WORKFLOW.md hook script (setup/verify/teardown) relative to the repo
+ * root with `set -euo pipefail`. Output streams to the runner's stdout/stderr.
+ * `$GITHUB_ENV` points at a managed temp file; any `KEY=value` lines the script
+ * appends to it are merged into process.env so subsequent Claude invocations
+ * (which spawn with `env: { ...process.env }`) inherit them.
+ *
+ * Throws if the resolved script path does not exist. Returns the child's exit
+ * code otherwise (caller decides whether a non-zero code aborts).
+ */
+export function runHookScript(
+  name: string,
+  scriptPath: string,
+  workspaceDir: string,
+): HookResult {
+  const resolved = isAbsolute(scriptPath) ? scriptPath : resolve(workspaceDir, scriptPath);
+  if (!existsSync(resolved)) {
+    throw new Error(`${name} hook script not found: ${scriptPath} (resolved: ${resolved})`);
+  }
+
+  const envDir = mkdtempSync(join(tmpdir(), "ai-implement-hook-"));
+  const githubEnvFile = join(envDir, "github_env");
+  writeFileSync(githubEnvFile, "");
+
+  try {
+    const proc = spawnSync("bash", ["-euo", "pipefail", resolved], {
+      cwd: workspaceDir,
+      env: { ...process.env, GITHUB_ENV: githubEnvFile },
+      stdio: ["ignore", "inherit", "inherit"],
+    });
+
+    mergeGithubEnv(githubEnvFile);
+
+    if (proc.error) throw proc.error;
+    return { exitCode: proc.status ?? 1 };
+  } finally {
+    rmSync(envDir, { recursive: true, force: true });
+  }
+}
+
+/** Parses KEY=value lines from a $GITHUB_ENV-style file into process.env. */
+function mergeGithubEnv(file: string): void {
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf-8");
+  } catch {
+    return;
+  }
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1);
+    if (key) process.env[key] = value;
+  }
+}

--- a/src/pipeline/steps/hooks.ts
+++ b/src/pipeline/steps/hooks.ts
@@ -14,6 +14,10 @@ export interface HookResult {
  * appends to it are merged into process.env so subsequent Claude invocations
  * (which spawn with `env: { ...process.env }`) inherit them.
  *
+ * Only the simple `KEY=value` form is supported — NOT GitHub Actions' heredoc
+ * multiline syntax (`KEY<<EOF` … `EOF`). A line that looks like a heredoc opener
+ * is logged as a warning and skipped rather than silently dropped.
+ *
  * Throws if the resolved script path does not exist. Returns the child's exit
  * code otherwise (caller decides whether a non-zero code aborts).
  */
@@ -32,6 +36,10 @@ export function runHookScript(
   writeFileSync(githubEnvFile, "");
 
   try {
+    // spawnSync intentionally blocks the runner's event loop until the hook
+    // finishes. The runner handles one issue per container and has nothing else
+    // to do meanwhile, so blocking keeps the pipeline strictly ordered (the
+    // env merge below must complete before the next step's Claude invocation).
     const proc = spawnSync("bash", ["-euo", "pipefail", resolved], {
       cwd: workspaceDir,
       env: { ...process.env, GITHUB_ENV: githubEnvFile },
@@ -59,7 +67,16 @@ function mergeGithubEnv(file: string): void {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
     const eq = trimmed.indexOf("=");
-    if (eq <= 0) continue;
+    if (eq <= 0) {
+      // A `KEY<<EOF` heredoc opener has no `=` before the `<<`. Warn so users
+      // porting GHA hooks that use multiline values aren't silently surprised.
+      if (trimmed.includes("<<")) {
+        console.warn(
+          `[hooks] Ignoring GITHUB_ENV line "${trimmed}": heredoc/multiline values are not supported, only KEY=value.`,
+        );
+      }
+      continue;
+    }
     const key = trimmed.slice(0, eq).trim();
     const value = trimmed.slice(eq + 1);
     if (key) process.env[key] = value;

--- a/src/pipeline/steps/setup.ts
+++ b/src/pipeline/steps/setup.ts
@@ -1,0 +1,27 @@
+import type { PipelineContext, StepModule, StepReporter } from "../types.js";
+import { runHookScript } from "./hooks.js";
+
+interface SetupInputs extends Record<string, unknown> {
+  workspaceDir: string;
+  scriptPath: string;
+}
+
+interface SetupOutputs extends Record<string, unknown> {
+  ran: boolean;
+}
+
+export const setupStep: StepModule<SetupInputs, SetupOutputs> = {
+  async run(
+    _context: PipelineContext,
+    inputs: SetupInputs,
+    _reporter: StepReporter,
+  ): Promise<SetupOutputs> {
+    const result = runHookScript("setup", inputs.scriptPath, inputs.workspaceDir);
+    if (result.exitCode !== 0) {
+      throw new Error(`setup hook failed with exit code ${result.exitCode}`);
+    }
+    return { ran: true };
+  },
+};
+
+export default setupStep;

--- a/src/pipeline/steps/verify.ts
+++ b/src/pipeline/steps/verify.ts
@@ -1,0 +1,27 @@
+import type { PipelineContext, StepModule, StepReporter } from "../types.js";
+import { runHookScript } from "./hooks.js";
+
+interface VerifyInputs extends Record<string, unknown> {
+  workspaceDir: string;
+  scriptPath: string;
+}
+
+interface VerifyOutputs extends Record<string, unknown> {
+  ran: boolean;
+}
+
+export const verifyStep: StepModule<VerifyInputs, VerifyOutputs> = {
+  async run(
+    _context: PipelineContext,
+    inputs: VerifyInputs,
+    _reporter: StepReporter,
+  ): Promise<VerifyOutputs> {
+    const result = runHookScript("verify", inputs.scriptPath, inputs.workspaceDir);
+    if (result.exitCode !== 0) {
+      throw new Error(`verify hook failed with exit code ${result.exitCode}`);
+    }
+    return { ran: true };
+  },
+};
+
+export default verifyStep;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -52,6 +52,14 @@ export interface PipelineContextData {
   githubToken?: string;
   /** Autonomous runner: base branch to clone. Implementation branches are derived per issue. */
   branch?: string;
+  /** Autonomous runner: Claude provider ("anthropic" | "bedrock"), from PROVIDER env. */
+  provider?: string;
+  /** Autonomous runner: cap on Claude turns per implement pass (from env). */
+  maxTurns?: number;
+  /** Autonomous runner: cap on implement/review iterations (from env). */
+  maxIterations?: number;
+  /** Autonomous runner: WORKFLOW.md hook script paths (relative to repo root). */
+  hooks?: { setup?: string; verify?: string; teardown?: string };
 }
 
 export interface PipelineContext {

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -124,6 +124,9 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     : "";
 
   let workflowModel: string | undefined;
+  let setupHook: string | undefined;
+  let verifyHook: string | undefined;
+  let teardownHook: string | undefined;
   let implementationPrompt = buildDefaultImplementationPrompt({
     issueIdentifier,
     issueTitle,
@@ -141,10 +144,21 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       PLANNING_CONTEXT: planningContext,
     });
     workflowModel = parsed.frontMatter.model;
+    setupHook = parsed.frontMatter.setup;
+    verifyHook = parsed.frontMatter.verify;
+    teardownHook = parsed.frontMatter.teardown;
     if (parsed.body.trim()) implementationPrompt = parsed.body;
   }
   implementationPrompt = appendPipelineOwnedGitInstructions(implementationPrompt, prNumber);
   const model = process.env.CLAUDE_MODEL || workflowModel || "claude-sonnet-4-6";
+  const provider = process.env.PROVIDER || "anthropic";
+  const parseEnvInt = (raw: string | undefined): number | undefined => {
+    if (!raw) return undefined;
+    const n = parseInt(raw, 10);
+    return Number.isInteger(n) && n > 0 ? n : undefined;
+  };
+  const maxTurns = parseEnvInt(process.env.AI_IMPLEMENT_MAX_TURNS);
+  const maxIterations = parseEnvInt(process.env.AI_IMPLEMENT_MAX_ITERATIONS);
 
   const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir);
   const orchestratorUrl = process.env.ORCHESTRATOR_URL;
@@ -181,6 +195,10 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       githubRepo,
       githubToken,
       branch,
+      provider,
+      maxTurns,
+      maxIterations,
+      hooks: { setup: setupHook, verify: verifyHook, teardown: teardownHook },
     },
     llmExecutor,
   );

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -7,6 +7,7 @@ import { PipelineRunner } from "./pipeline/runner.js";
 import { DEFAULT_PIPELINE, createDefaultRunner } from "./pipeline/default-pipeline.js";
 import type { LLMExecutor, PipelineDefinition, StepReporter } from "./pipeline/types.js";
 import { HttpStepReporter, NoopStepReporter, TokenStepReporter } from "./pipeline/reporter.js";
+import { runHookScript } from "./pipeline/steps/hooks.js";
 import { parseWorkflowMd } from "./workflow-md.js";
 import { fetchPlanningContext } from "./linear-planning-fetch.js";
 import { postRunnerResult } from "./runner-result.js";
@@ -226,6 +227,17 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       fetchImpl: opts.fetchImpl,
     });
     return { exitCode: 1 };
+  } finally {
+    if (teardownHook) {
+      try {
+        const result = runHookScript("teardown", teardownHook, workspaceDir);
+        if (result.exitCode !== 0) {
+          console.error(`teardown hook exited with code ${result.exitCode}`);
+        }
+      } catch (teardownErr) {
+        console.error(`teardown hook error: ${teardownErr}`);
+      }
+    }
   }
 }
 

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -134,6 +134,11 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     issueDescription,
     prNumber,
   });
+  // WORKFLOW.md (and therefore the hook paths, incl. teardown) is read once here
+  // from `workspaceDir`. This is the runner's single workspace for the whole run
+  // in every execution mode: GHA pre-clones into it, and on Fly/local the pipeline's
+  // `clone` step clones into this same path. So the teardown path captured now is
+  // still valid at `finally` time, even though clone runs later in the pipeline.
   const wfPath = join(workspaceDir, "WORKFLOW.md");
   if (existsSync(wfPath)) {
     const parsed = parseWorkflowMd(readFileSync(wfPath, "utf-8"), {
@@ -153,13 +158,18 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   implementationPrompt = appendPipelineOwnedGitInstructions(implementationPrompt, prNumber);
   const model = process.env.CLAUDE_MODEL || workflowModel || "claude-sonnet-4-6";
   const provider = process.env.PROVIDER || "anthropic";
-  const parseEnvInt = (raw: string | undefined): number | undefined => {
+  const parseEnvInt = (raw: string | undefined, name: string): number | undefined => {
     if (!raw) return undefined;
     const n = parseInt(raw, 10);
-    return Number.isInteger(n) && n > 0 ? n : undefined;
+    if (Number.isInteger(n) && n > 0) return n;
+    // The orchestrator validates caps before dispatch, so this only happens on a
+    // manual GHA dispatch with a bad value. Warn so "my cap isn't taking effect"
+    // is diagnosable rather than a silent fallback to the default.
+    console.warn(`[runner] Ignoring invalid ${name}="${raw}" (must be a positive integer); using default`);
+    return undefined;
   };
-  const maxTurns = parseEnvInt(process.env.AI_IMPLEMENT_MAX_TURNS);
-  const maxIterations = parseEnvInt(process.env.AI_IMPLEMENT_MAX_ITERATIONS);
+  const maxTurns = parseEnvInt(process.env.AI_IMPLEMENT_MAX_TURNS, "AI_IMPLEMENT_MAX_TURNS");
+  const maxIterations = parseEnvInt(process.env.AI_IMPLEMENT_MAX_ITERATIONS, "AI_IMPLEMENT_MAX_ITERATIONS");
 
   const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir);
   const orchestratorUrl = process.env.ORCHESTRATOR_URL;

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -134,11 +134,12 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     issueDescription,
     prNumber,
   });
-  // WORKFLOW.md (and therefore the hook paths, incl. teardown) is read once here
-  // from `workspaceDir`. This is the runner's single workspace for the whole run
-  // in every execution mode: GHA pre-clones into it, and on Fly/local the pipeline's
-  // `clone` step clones into this same path. So the teardown path captured now is
-  // still valid at `finally` time, even though clone runs later in the pipeline.
+  // WORKFLOW.md (and therefore the hook paths, incl. teardown) is read once here,
+  // before the pipeline runs. In GHA mode the repo is already checked out into
+  // `workspaceDir`, so the hooks resolve and the captured teardown path stays valid
+  // through `finally`. In Fly/local modes the `clone` step runs later in the
+  // pipeline, so `workspaceDir` is empty at this point — WORKFLOW.md isn't found and
+  // all hooks resolve to undefined (hooks are effectively GHA-only; see WORKFLOW.md).
   const wfPath = join(workspaceDir, "WORKFLOW.md");
   if (existsSync(wfPath)) {
     const parsed = parseWorkflowMd(readFileSync(wfPath, "utf-8"), {

--- a/workflows/WORKFLOW.md
+++ b/workflows/WORKFLOW.md
@@ -52,6 +52,10 @@ model: claude-sonnet-4-6
     teardown   Path to a shell script that runs AFTER Claude, even on failure.
                Use this to stop containers or clean up resources.
 
+    NOTE: Hooks run only in GitHub Actions execution mode. On Fly/local modes the
+    workspace is empty when WORKFLOW.md is read (the repo is cloned later), so
+    setup/verify/teardown are silently skipped.
+
   SETUP AND TEARDOWN HOOKS
   ------------------------
   Repos that need a database or other services should define scripts instead of

--- a/workflows/WORKFLOW.md
+++ b/workflows/WORKFLOW.md
@@ -44,7 +44,9 @@ model: claude-sonnet-4-6
     setup      Path (relative to repo root) to a shell script that runs BEFORE Claude.
                Use this to start services, install dependencies, and run migrations.
                Export env vars via `echo "VAR=value" >> "$GITHUB_ENV"` — they persist
-               to Claude and all subsequent steps.
+               to Claude and all subsequent steps. Only the simple `VAR=value` form
+               is supported; GitHub Actions' heredoc multiline syntax (`VAR<<EOF`) is
+               NOT — such lines are ignored with a warning.
     verify     Path to a shell script that runs AFTER Claude, only on success.
                Use this to run tests or smoke checks.
     teardown   Path to a shell script that runs AFTER Claude, even on failure.

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -165,6 +165,23 @@ jobs:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
 
+      - name: Validate Bedrock inputs
+        if: inputs.provider == 'bedrock'
+        env:
+          AWS_REGION: ${{ inputs.aws_region }}
+          ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_REGION" ]; then
+            echo "::error::provider=bedrock but aws_region dispatch input is empty."
+            echo "::error::Set awsRegion on this team's mapping in the orchestrator admin UI."
+            exit 1
+          fi
+          if [ -z "$ROLE_ARN" ]; then
+            echo "::error::provider=bedrock but AWS_BEDROCK_ROLE_ARN repo secret is not set."
+            echo "::error::Add the IAM role ARN trusted to GitHub OIDC with bedrock:InvokeModel permission."
+            exit 1
+          fi
+
       - name: Configure AWS credentials (Bedrock)
         if: inputs.provider == 'bedrock'
         uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -60,6 +60,21 @@ on:
         required: false
         type: string
         default: ""
+      max_turns:
+        description: "Cap on Claude turns per implement pass (empty = runner default)"
+        required: false
+        type: string
+        default: ""
+      max_iterations:
+        description: "Cap on implement/review iterations (empty = provider default)"
+        required: false
+        type: string
+        default: ""
+      job_timeout_minutes:
+        description: "Per-project job timeout in minutes (empty = 90)"
+        required: false
+        type: string
+        default: ""
       runner_callback_url:
         description: "Base URL the orchestrator advertises for /runner/result; empty skips callback"
         required: false
@@ -154,7 +169,7 @@ jobs:
   implement:
     needs: validate-runner-image
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.job_timeout_minutes && fromJSON(inputs.job_timeout_minutes) || 90 }}
     container:
       image: ${{ needs.validate-runner-image.outputs.runner_image }}
     steps:
@@ -211,6 +226,8 @@ jobs:
           RUNNER_PHASE: ${{ inputs.runner_phase }}
           PROVIDER: ${{ inputs.provider }}
           AWS_REGION: ${{ inputs.aws_region }}
+          AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -71,7 +71,7 @@ on:
         type: string
         default: ""
       job_timeout_minutes:
-        description: "Per-project job timeout in minutes (empty = 90)"
+        description: "Per-project job timeout in minutes, must be a positive integer (empty = 90)"
         required: false
         type: string
         default: ""

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -10,6 +10,12 @@
 #   AI_IMPLEMENT_PROVIDER    - Set to "bedrock" to route through AWS Bedrock.
 #   AI_IMPLEMENT_AWS_REGION  - AWS region (required when provider=bedrock).
 #
+# Optional repository variables (per-project run caps — mirror the orchestrator
+# admin UI mapping so /ai-implement comment runs get the same caps):
+#   AI_IMPLEMENT_MAX_TURNS       - Cap on Claude turns per implement pass (default 50).
+#   AI_IMPLEMENT_MAX_ITERATIONS  - Cap on implement/review iterations (default: bedrock 2 / anthropic 3).
+#   AI_IMPLEMENT_MAX_JOB_MINUTES - Per-project job timeout in minutes (default 90).
+#
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
 #   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
@@ -37,6 +43,9 @@ jobs:
       default_branch: ${{ steps.pr.outputs.default_branch }}
       provider: ${{ steps.pr.outputs.provider }}
       aws_region: ${{ steps.pr.outputs.aws_region }}
+      max_turns: ${{ steps.pr.outputs.max_turns }}
+      max_iterations: ${{ steps.pr.outputs.max_iterations }}
+      max_job_minutes: ${{ steps.pr.outputs.max_job_minutes }}
       runner_image: ${{ steps.runner-image.outputs.runner_image }}
     steps:
       - name: Check trigger command
@@ -82,6 +91,9 @@ jobs:
         env:
           AI_IMPLEMENT_PROVIDER: ${{ vars.AI_IMPLEMENT_PROVIDER }}
           AI_IMPLEMENT_AWS_REGION: ${{ vars.AI_IMPLEMENT_AWS_REGION }}
+          AI_IMPLEMENT_MAX_TURNS: ${{ vars.AI_IMPLEMENT_MAX_TURNS }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ vars.AI_IMPLEMENT_MAX_ITERATIONS }}
+          AI_IMPLEMENT_MAX_JOB_MINUTES: ${{ vars.AI_IMPLEMENT_MAX_JOB_MINUTES }}
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -103,6 +115,9 @@ jobs:
             core.setOutput("default_branch", pr.data.base.ref || context.payload.repository.default_branch || "");
             core.setOutput("provider", process.env.AI_IMPLEMENT_PROVIDER || "anthropic");
             core.setOutput("aws_region", process.env.AI_IMPLEMENT_AWS_REGION || "");
+            core.setOutput("max_turns", process.env.AI_IMPLEMENT_MAX_TURNS || "");
+            core.setOutput("max_iterations", process.env.AI_IMPLEMENT_MAX_ITERATIONS || "");
+            core.setOutput("max_job_minutes", process.env.AI_IMPLEMENT_MAX_JOB_MINUTES || "");
 
       - name: Resolve and validate runner image
         if: steps.trigger.outputs.matched == 'true'
@@ -163,7 +178,7 @@ jobs:
     needs: check-trigger
     if: needs.check-trigger.outputs.matched == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: ${{ needs.check-trigger.outputs.max_job_minutes && fromJSON(needs.check-trigger.outputs.max_job_minutes) || 90 }}
     permissions:
       contents: write
       pull-requests: write
@@ -212,6 +227,8 @@ jobs:
           RUNNER_PHASE: gap-analysis
           ISSUE_META: ${{ needs.check-trigger.outputs.issue_meta }}
           PROVIDER: ${{ needs.check-trigger.outputs.provider }}
+          AI_IMPLEMENT_MAX_TURNS: ${{ needs.check-trigger.outputs.max_turns }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ needs.check-trigger.outputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
## Summary

Fixes AWS-Bedrock implementation runs that were hitting the job timeout (~1h) even on trivial tickets. Bedrock makes ~3× the tool calls of the direct API, which amplified several uncapped loops.

- **Disable cache-breaking beta on Bedrock** — `entrypoint.sh` now exports `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` for bedrock, so prompt caching works again (the `cache_control.scope` field Bedrock rejects is no longer sent).
- **Cap Claude turns** — implement passes now run with `--max-turns` (default **50**) instead of unbounded.
- **Provider-aware feedback iterations** — bedrock defaults to **2** implement/review cycles, anthropic stays at **3**.
- **Per-project config (admin UI)** — `maxTurns` / `maxIterations` / `maxJobMinutes` are editable per project in the `/admin` Projects edit dialog (blank = default). Delivered as `workflow_dispatch` inputs (GHA) / runner env (Fly/local); job-timeout drives the GHA `timeout-minutes`. Caps also apply to gap-fill and review-fix re-dispatches.
- **Execute `setup` / `verify` / `teardown` hooks** — WORKFLOW.md front-matter hooks now actually run: setup before the implement loop (failure aborts early), verify after a successful push, teardown always (via a `finally`). Env exported with `>> "$GITHUB_ENV"` reaches Claude. Unblocks DB-dependent repos.

Design + plan: `docs/superpowers/specs/2026-06-02-bedrock-reliability-fixes-design.md`, `docs/superpowers/plans/2026-06-02-bedrock-reliability-fixes.md`.

The originally-proposed re-dispatch attempt cap (Fix 4) was intentionally **dropped** — on GHA mode a failed run does not auto-re-dispatch (the dedup row survives), so it solved a problem this deployment doesn't have. `maxJobMinutes` is wired for GitHub Actions only (Bedrock's mode).

## Stacking note

This branch is built on top of `codex/restore-bedrock-docker-runner`, which is not yet in `testing`, so this PR includes its 2 commits (`restore bedrock docker auth`, `keep bedrock gha-only`) in addition to this work. My Fix 1 depends on the `gha-only` guard those add. If that branch merges to `testing` first, GitHub drops the duplicates automatically.

## Rollout (post-merge, operational)

1. Re-sync `claude-implement.yml` to the Bedrock target repo (it needs the new dispatch inputs before any cap is set, or GitHub rejects the dispatch with "unexpected inputs").
2. Set the project's Max Turns / Max Iterations / Job Timeout in `/admin`.
3. Confirm next run: no `cache_control.scope` errors, cache-read tokens appear, finishes under the timeout.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1149/1149 passing (added tests: config null round-trip, admin 400 validation, cap dispatch-field omission, provider-aware iteration + turn defaults, hook `$GITHUB_ENV` merge, setup/verify throw-on-failure, pipeline step ordering)
- [ ] On a real Bedrock dispatch, confirm the `timeout-minutes` expression parses (documented fallback: static 90 + monitor enforcement if GitHub rejects the input expression)
- [ ] Manually verify a repo with `setup:`/`verify:`/`teardown:` runs all three at the right times

🤖 Generated with [Claude Code](https://claude.com/claude-code)