### PR TITLE
Pipeline correctness: fix E2BIG + provider-agnostic planning context

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -7,7 +7,6 @@
 #   AI_IMPLEMENT_PRIVATE_KEY - GitHub App PEM private key
 #   ANTHROPIC_API_KEY        - Anthropic API key
 #   CLAUDE_CODE_OAUTH_TOKEN  - Claude Code OAuth token (preferred over API key)
-#   LINEAR_API_KEY           - Linear API key for status updates
 #
 # Additional secret (Bedrock provider):
 #   AWS_BEDROCK_ROLE_ARN     - IAM role ARN trusted to GitHub OIDC; needs bedrock:InvokeModel
@@ -25,19 +24,19 @@ on:
   workflow_dispatch:
     inputs:
       issue_id:
-        description: "Linear issue UUID"
+        description: "Ticketing-system issue ID"
         required: true
         type: string
       issue_identifier:
-        description: "Linear issue identifier (e.g., ENG-123)"
+        description: "Ticketing-system issue identifier (e.g., ENG-123)"
         required: true
         type: string
       issue_title:
-        description: "Linear issue title"
+        description: "Ticketing-system issue title"
         required: true
         type: string
       issue_description:
-        description: "Linear issue description"
+        description: "Ticketing-system issue description"
         required: true
         type: string
       pr_number:
@@ -230,7 +229,6 @@ jobs:
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           RUNNER_CALLBACK_URL: ${{ inputs.runner_callback_url }}
           RUN_TOKEN: ${{ inputs.run_token }}
           RUN_PROGRESS_TOKEN: ${{ inputs.run_progress_token }}

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -4,7 +4,7 @@
 #
 # Required secrets:
 #   AI_IMPLEMENT_APP_ID, AI_IMPLEMENT_PRIVATE_KEY
-#   ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, LINEAR_API_KEY
+#   ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 #
 # Optional repository variables (Bedrock-enabled repos only):
 #   AI_IMPLEMENT_PROVIDER    - Set to "bedrock" to route through AWS Bedrock.
@@ -231,7 +231,6 @@ jobs:
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ needs.check-trigger.outputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         run: |
           # ISSUE_META is parsed from the PR body. The JavaScript parser only emits
           # lower_snake_case keys, jq allows only expected metadata keys here, and

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, chmodSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ClaudeCliExecutor } from "../pipeline/executor.js";
+
+// Real-subprocess test: a fake `claude` on PATH records the argv it was invoked
+// with and whatever arrived on stdin. This exercises the actual spawn + stdio
+// plumbing — the only thing that meaningfully proves the E2BIG fix.
+describe("ClaudeCliExecutor", () => {
+  let dir: string;
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "claude-exec-"));
+    const script = `#!/usr/bin/env bash
+printf '%s\\n' "$@" > "${dir}/argv.txt"
+cat > "${dir}/stdin.txt"
+echo "ok"
+`;
+    const fakeClaude = join(dir, "claude");
+    writeFileSync(fakeClaude, script);
+    chmodSync(fakeClaude, 0o755);
+    originalPath = process.env.PATH;
+    process.env.PATH = `${dir}:${originalPath ?? ""}`;
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("delivers the prompt over stdin, never as a command-line argument", async () => {
+    // A prompt larger than Linux MAX_ARG_STRLEN (128 KiB) trips spawn E2BIG when
+    // passed as a single argv element. Delivering it on stdin sidesteps that.
+    const bigPrompt = "X".repeat(200_000);
+
+    const result = await new ClaudeCliExecutor(dir).invoke({
+      prompt: bigPrompt,
+      model: "claude-sonnet-4-6",
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const argv = readFileSync(join(dir, "argv.txt"), "utf-8");
+    const stdin = readFileSync(join(dir, "stdin.txt"), "utf-8");
+
+    // The prompt must arrive via stdin...
+    expect(stdin).toContain(bigPrompt);
+    // ...and must NOT appear in argv (that is what causes E2BIG).
+    expect(argv).not.toContain(bigPrompt);
+  });
+
+  it("still passes model and flags as arguments", async () => {
+    await new ClaudeCliExecutor(dir).invoke({
+      prompt: "hello",
+      model: "claude-sonnet-4-6",
+      maxTurns: 7,
+    });
+
+    const argv = readFileSync(join(dir, "argv.txt"), "utf-8");
+    expect(argv).toContain("--dangerously-skip-permissions");
+    expect(argv).toContain("--model");
+    expect(argv).toContain("claude-sonnet-4-6");
+    expect(argv).toContain("--max-turns");
+    expect(argv).toContain("7");
+  });
+});

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -60,7 +60,6 @@ function makeContext(overrides: Partial<PipelineContextData> = {}): DefaultPipel
     issueDescription: "Desc",
     nonce: "nonce",
     orchestratorUrl: "http://localhost:8080",
-    ticketingProvider: "linear",
     ...overrides,
   });
 }

--- a/src/__tests__/pipeline-runner.test.ts
+++ b/src/__tests__/pipeline-runner.test.ts
@@ -19,7 +19,6 @@ function makeContext(overrides: Partial<Parameters<typeof DefaultPipelineContext
     issueDescription: "Description",
     nonce: "test-nonce",
     orchestratorUrl: "http://localhost:8080",
-    ticketingProvider: "linear",
     ...overrides,
   });
 }

--- a/src/__tests__/providers/fake.ts
+++ b/src/__tests__/providers/fake.ts
@@ -18,6 +18,8 @@ export interface FakeProviderOptions {
   latencyMs?: number;
   /** If true, lifecycle verb invocations are recorded for assertions. */
   recordCalls?: boolean;
+  /** Planning context returned by fetchPlanningContext. Default "". */
+  planningContext?: string;
 }
 
 export interface RecordedCall {
@@ -121,6 +123,11 @@ export class FakeProvider implements TicketingProvider {
   async postComment(issueId: string, body: string): Promise<void> {
     await this.tick("postComment", [issueId, body]);
     this.appendComment(issueId, body);
+  }
+
+  async fetchPlanningContext(issueId: string): Promise<string> {
+    await this.tick("fetchPlanningContext", [issueId]);
+    return this.opts.planningContext ?? "";
   }
 
   issueUrl(issue: TicketIssue): string {

--- a/src/__tests__/providers/linear.test.ts
+++ b/src/__tests__/providers/linear.test.ts
@@ -67,6 +67,49 @@ describe("LinearProvider.postComment", () => {
   });
 });
 
+describe("LinearProvider.fetchPlanningContext", () => {
+  beforeEach(() => { vi.stubGlobal("fetch", vi.fn()); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("returns the issue's planning comments, authenticated with the provider's api key", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          issue: {
+            comments: {
+              nodes: [
+                { body: "## 🏗️ AI Planning: Architecture Analysis\nUse the widget pattern.", createdAt: "2026-01-01T00:00:00Z" },
+                { body: "just a regular human comment", createdAt: "2026-01-02T00:00:00Z" },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      }),
+    } as Response);
+
+    const p = new LinearProvider({ linearApiKey: "test-key" });
+    const ctx = await p.fetchPlanningContext("issue-uuid-1");
+
+    expect(ctx).toContain("Use the widget pattern.");
+    expect(ctx).not.toContain("just a regular human comment");
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.linear.app/graphql",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "test-key" }),
+      }),
+    );
+  });
+
+  it("returns empty string (never throws) when Linear is unreachable", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+
+    const p = new LinearProvider({ linearApiKey: "test-key" });
+    await expect(p.fetchPlanningContext("issue-uuid-1")).resolves.toBe("");
+  });
+});
+
 describe("LinearProvider.fetchLifecycleStates", () => {
   beforeEach(() => { vi.stubGlobal("fetch", vi.fn()); });
   afterEach(() => { vi.restoreAllMocks(); });

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -348,16 +348,13 @@ describe("runAutonomous", () => {
     expect((executor.invoke as ReturnType<typeof vi.fn>).mock.calls[0][0].model).toBe("claude-sonnet-4-6");
   });
 
-  it("fetches planning context when LINEAR_API_KEY is set", async () => {
-    vi.stubEnv("LINEAR_API_KEY", "lin_api_test");
+  it("fetches planning context from the orchestrator using the progress token", async () => {
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orch.example.com");
+    vi.stubEnv("RUN_PROGRESS_TOKEN", "ptok");
 
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({
-        data: {
-          issue: { comments: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } } },
-        },
-      }),
+      json: async () => ({ planningContext: "" }),
     });
 
     const mod: StepModule = { run: vi.fn().mockResolvedValue({}) };
@@ -373,30 +370,39 @@ describe("runAutonomous", () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.linear.app/graphql",
-      expect.objectContaining({ method: "POST" }),
+      "https://orch.example.com/runner/planning-context",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer ptok" }),
+      }),
     );
   });
 
+  it("does not fetch planning context when no callback token is present", async () => {
+    const mockFetch = vi.fn();
+    const mod: StepModule = { run: vi.fn().mockResolvedValue({}) };
+    const { pipeline, runner } = makeSingleStepPipeline("noop", mod);
+
+    await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("stores fetched planning context on the pipeline context", async () => {
-    vi.stubEnv("LINEAR_API_KEY", "lin_api_test");
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orch.example.com");
+    vi.stubEnv("RUN_PROGRESS_TOKEN", "ptok");
 
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: {
-          issue: {
-            comments: {
-              nodes: [
-                {
-                  body: "## 🏗️ AI Planning: Architecture Analysis\nUse the service layer",
-                  createdAt: "2026-05-15T00:00:00.000Z",
-                },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            },
-          },
-        },
+        planningContext: "## Planning Context\n\nUse the service layer",
       }),
     });
 

--- a/src/__tests__/runner-callback-routes.test.ts
+++ b/src/__tests__/runner-callback-routes.test.ts
@@ -108,6 +108,37 @@ async function callGapFillRoute(opts: {
   });
 }
 
+/**
+ * Mirror of the GET /runner/planning-context route wrapper in src/index.ts.
+ */
+async function callPlanningContextRoute(opts: {
+  runnerTokenSecret: string | null;
+  authorization?: string;
+  resolveProvider?: (key: string) => Promise<TicketingProvider | null>;
+}): Promise<{ status: number; body: Record<string, unknown> }> {
+  if (!opts.runnerTokenSecret) {
+    return { status: 501, body: { error: "Runner callback not configured" } };
+  }
+  return runnerCallback.handleRunnerPlanningContext({
+    authorization: opts.authorization,
+    secret: opts.runnerTokenSecret,
+    resolveProvider: opts.resolveProvider ?? (async () => new FakeProvider()),
+  });
+}
+
+describe("/runner/planning-context route wrapper", () => {
+  it("returns 501 when RUNNER_TOKEN_SECRET is unset", async () => {
+    const res = await callPlanningContextRoute({ runnerTokenSecret: null });
+    expect(res.status).toBe(501);
+    expect(res.body.error).toBe("Runner callback not configured");
+  });
+
+  it("returns 401 when bearer is missing", async () => {
+    const res = await callPlanningContextRoute({ runnerTokenSecret: "secret" });
+    expect(res.status).toBe(401);
+  });
+});
+
 describe("/runner/result route wrapper", () => {
   it("returns 501 when RUNNER_TOKEN_SECRET is unset", async () => {
     const res = await callRunnerResultRoute({

--- a/src/__tests__/runner-callback.test.ts
+++ b/src/__tests__/runner-callback.test.ts
@@ -368,6 +368,85 @@ describe("handleRunnerProgress", () => {
   });
 });
 
+describe("handleRunnerPlanningContext", () => {
+  function mintProgress(issueId: string, mappingTeamKey: string) {
+    return runnerTokens.mintRunToken({
+      issueId,
+      mappingTeamKey,
+      phase: "implementation",
+      audience: "progress",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+  }
+
+  it("returns 401 when the bearer token is missing or invalid", async () => {
+    const res = await runnerCallback.handleRunnerPlanningContext({
+      authorization: "Bearer nope",
+      secret: SECRET,
+      resolveProvider: makeResolve(new FakeProvider()),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a one-shot result token (wrong audience)", async () => {
+    const { token } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      audience: "result",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const res = await runnerCallback.handleRunnerPlanningContext({
+      authorization: `Bearer ${token}`,
+      secret: SECRET,
+      resolveProvider: makeResolve(new FakeProvider()),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the provider's planning context for the token's issue", async () => {
+    const { token } = mintProgress("issue-xyz", "ENG");
+    const provider = new FakeProvider({ planningContext: "## Planning Context\n\nUse the widget pattern." });
+    const spy = vi.spyOn(provider, "fetchPlanningContext");
+
+    const res = await runnerCallback.handleRunnerPlanningContext({
+      authorization: `Bearer ${token}`,
+      secret: SECRET,
+      resolveProvider: makeResolve(provider),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.planningContext).toContain("Use the widget pattern.");
+    expect(spy).toHaveBeenCalledWith("issue-xyz");
+  });
+
+  it("does not consume the token — it can be fetched more than once", async () => {
+    const { token } = mintProgress("issue-xyz", "ENG");
+    const provider = new FakeProvider({ planningContext: "ctx" });
+    const call = () =>
+      runnerCallback.handleRunnerPlanningContext({
+        authorization: `Bearer ${token}`,
+        secret: SECRET,
+        resolveProvider: makeResolve(provider),
+      });
+    expect((await call()).status).toBe(200);
+    expect((await call()).status).toBe(200);
+  });
+
+  it("returns empty context (200) when the mapping was deleted", async () => {
+    const { token } = mintProgress("issue-xyz", "ENG");
+    const res = await runnerCallback.handleRunnerPlanningContext({
+      authorization: `Bearer ${token}`,
+      secret: SECRET,
+      resolveProvider: makeResolve(null),
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.planningContext).toBe("");
+  });
+});
+
 describe("handleRunnerResult — gap-analysis", () => {
   it("posts comments but skips status transition on success", async () => {
     const { token } = runnerTokens.mintRunToken({

--- a/src/__tests__/runner-result.test.ts
+++ b/src/__tests__/runner-result.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchPlanningContextFromOrchestrator } from "../runner-result.js";
+
+describe("fetchPlanningContextFromOrchestrator", () => {
+  it("GETs /runner/planning-context with the progress token and returns the context", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ planningContext: "## Planning Context\n\nUse the widget pattern." }),
+    })) as unknown as typeof fetch;
+
+    const ctx = await fetchPlanningContextFromOrchestrator({
+      callbackUrl: "https://orch.example.com/",
+      progressToken: "ptok",
+      fetchImpl,
+    });
+
+    expect(ctx).toBe("## Planning Context\n\nUse the widget pattern.");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://orch.example.com/runner/planning-context",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer ptok" }),
+      }),
+    );
+  });
+
+  it("returns empty string on a non-ok response (best-effort)", async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 401, text: async () => "" })) as unknown as typeof fetch;
+    const ctx = await fetchPlanningContextFromOrchestrator({
+      callbackUrl: "https://orch.example.com",
+      progressToken: "ptok",
+      fetchImpl,
+    });
+    expect(ctx).toBe("");
+  });
+
+  it("returns empty string when the orchestrator is unreachable", async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    const ctx = await fetchPlanningContextFromOrchestrator({
+      callbackUrl: "https://orch.example.com",
+      progressToken: "ptok",
+      fetchImpl,
+    });
+    expect(ctx).toBe("");
+  });
+});

--- a/src/__tests__/steps-clone.test.ts
+++ b/src/__tests__/steps-clone.test.ts
@@ -41,7 +41,6 @@ function makeContext(): DefaultPipelineContext {
     issueDescription: "Desc",
     nonce: "nonce",
     orchestratorUrl: "http://localhost:8080",
-    ticketingProvider: "linear",
   });
 }
 

--- a/src/__tests__/steps-feedback-loop.test.ts
+++ b/src/__tests__/steps-feedback-loop.test.ts
@@ -54,7 +54,6 @@ function makeContext(): DefaultPipelineContext {
     issueDescription: "Description",
     nonce: "nonce",
     orchestratorUrl: "http://localhost:8080",
-    ticketingProvider: "linear",
   });
 }
 
@@ -333,7 +332,6 @@ describe("feedbackLoopStep", () => {
       issueDescription: "Description",
       nonce: "nonce",
       orchestratorUrl: "http://localhost:8080",
-      ticketingProvider: "linear",
       model: "claude-opus-4-7",
     });
 
@@ -356,7 +354,6 @@ describe("feedbackLoopStep", () => {
       issueDescription: "Description",
       nonce: "nonce",
       orchestratorUrl: "http://localhost:8080",
-      ticketingProvider: "linear",
       model: "claude-sonnet-4-6",
     });
 

--- a/src/__tests__/steps-implement.test.ts
+++ b/src/__tests__/steps-implement.test.ts
@@ -25,7 +25,6 @@ function makeContext(executor?: LLMExecutor): DefaultPipelineContext {
       issueDescription: "Description",
       nonce: "nonce",
       orchestratorUrl: "http://localhost:8080",
-      ticketingProvider: "linear",
     },
     executor ?? makeExecutor(),
   );

--- a/src/__tests__/steps-install.test.ts
+++ b/src/__tests__/steps-install.test.ts
@@ -35,7 +35,6 @@ function makeContext(): DefaultPipelineContext {
     issueDescription: "Desc",
     nonce: "nonce",
     orchestratorUrl: "http://localhost:8080",
-    ticketingProvider: "linear",
   });
 }
 

--- a/src/__tests__/steps-preflight.test.ts
+++ b/src/__tests__/steps-preflight.test.ts
@@ -26,7 +26,6 @@ function makeContext(): DefaultPipelineContext {
     issueDescription: "Desc",
     nonce: "nonce",
     orchestratorUrl: "http://localhost:8080",
-    ticketingProvider: "linear",
   });
 }
 

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -18,7 +18,6 @@ function makeContext(overrides: Record<string, unknown> = {}): DefaultPipelineCo
     issueDescription: "Desc",
     nonce: "nonce",
     orchestratorUrl: "http://localhost:8080",
-    ticketingProvider: "linear",
     ...overrides,
   });
 }

--- a/src/__tests__/steps-review.test.ts
+++ b/src/__tests__/steps-review.test.ts
@@ -20,7 +20,6 @@ function makeContext(executor?: LLMExecutor): DefaultPipelineContext {
       issueDescription: "Description",
       nonce: "nonce",
       orchestratorUrl: "http://localhost:8080",
-      ticketingProvider: "linear",
     },
     executor,
   );

--- a/src/__tests__/steps-setup-verify.test.ts
+++ b/src/__tests__/steps-setup-verify.test.ts
@@ -11,7 +11,7 @@ import type { LLMExecutor } from "../pipeline/types.js";
 const noopExec: LLMExecutor = { async invoke() { return { stdout: "", exitCode: 0, tokensUsed: 0 }; } };
 function ctx() {
   return new DefaultPipelineContext(
-    { jobId: 1, issueId: "i", issueIdentifier: "ENG-1", issueTitle: "T", issueDescription: "D", nonce: "n", orchestratorUrl: "", ticketingProvider: "linear" },
+    { jobId: 1, issueId: "i", issueIdentifier: "ENG-1", issueTitle: "T", issueDescription: "D", nonce: "n", orchestratorUrl: "" },
     noopExec,
   );
 }

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -127,6 +127,13 @@ describe("GHA workflow shims", () => {
       expect(yaml).not.toMatch(/curl.*claude\.ai\/install/);
     });
 
+    it(`${f} is ticketing-agnostic — no Linear references`, () => {
+      const yaml = readFileSync(f, "utf-8");
+      expect(yaml).not.toMatch(/LINEAR_API_KEY/);
+      expect(yaml).not.toMatch(/api\.linear\.app/);
+      expect(yaml).not.toMatch(/Linear issue/);
+    });
+
     it(`${f} has at most one configure-aws-credentials step`, () => {
       const yaml = readFileSync(f, "utf-8");
       const awsCount = (yaml.match(/configure-aws-credentials/g) ?? []).length;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import { initReconciliationTable, getPendingReconciliations, updateReconciliatio
 import { resolveSessionImage, selectRunnerImageInput } from "./repo-image.js";
 import { getStepRecord, initStepLogTable } from "./step-log.js";
 import { getOrchestratorSettings } from "./orchestrator-settings.js";
-import { handleRunnerProgress, handleRunnerResult } from "./runner-callback.js";
+import { handleRunnerPlanningContext, handleRunnerProgress, handleRunnerResult } from "./runner-callback.js";
 import type { RunnerProgressBody, RunnerResultBody } from "./runner-callback.js";
 import { mintRunToken, PLANNING_TTL_SECONDS, IMPLEMENTATION_TTL_SECONDS } from "./runner-tokens.js";
 import { handleGapFillTrigger } from "./gap-fill-trigger.js";
@@ -1848,6 +1848,37 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
         res.end(JSON.stringify(result.body));
       })().catch((err) => {
         console.error("[runner-callback] Unhandled error:", err);
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+      });
+      return;
+    }
+
+    // Runner planning-context fetch — reusable progress token authenticated.
+    // Lets the runner pull planning context provider-agnostically instead of
+    // calling the ticketing system directly with an API key.
+    if (url === "/runner/planning-context" && req.method === "GET") {
+      (async () => {
+        if (!config.runnerTokenSecret) {
+          res.writeHead(501, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Runner callback not configured" }));
+          return;
+        }
+        const result = await handleRunnerPlanningContext({
+          authorization: req.headers.authorization,
+          secret: config.runnerTokenSecret,
+          resolveProvider: async (mappingTeamKey) => {
+            const mapping = getMappings()[mappingTeamKey];
+            if (!mapping) return null;
+            return await registry.forMapping(mapping);
+          },
+        });
+        res.writeHead(result.status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result.body));
+      })().catch((err) => {
+        console.error("[runner-planning-context] Unhandled error:", err);
         if (!res.headersSent) {
           res.writeHead(500, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "Internal server error" }));

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -22,13 +22,20 @@ export class ClaudeCliExecutor implements LLMExecutor {
       if (params.tools && params.tools.length > 0) {
         args.push("--allowed-tools", params.tools.join(","));
       }
-      args.push("-p", params.prompt);
+      // Pass the prompt on stdin rather than as an argv element. A large prompt
+      // (e.g. one carrying full planning context) can exceed the OS single-argument
+      // limit — MAX_ARG_STRLEN, 128 KiB on Linux — which makes spawn fail with E2BIG.
+      // `claude -p` reads the prompt from stdin, so there is no size ceiling.
+      args.push("-p");
 
       const proc = spawn("claude", args, {
         cwd: this.workspaceDir,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env },
       });
+
+      proc.stdin.on("error", reject);
+      proc.stdin.end(params.prompt);
 
       const chunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -1,5 +1,3 @@
-import type { ProviderId } from "../providers/types.js";
-
 export type StepStatus = "running" | "passed" | "failed" | "skipped" | "cancelled";
 
 export type StepType =
@@ -32,8 +30,6 @@ export interface PipelineContextData {
   issueDescription: string;
   nonce: string;
   orchestratorUrl: string;
-  /** Ticketing provider for the runner to use when posting comments. */
-  ticketingProvider: ProviderId;
   /** Optional model override for Claude invocations (e.g. "claude-opus-4-5"). */
   model?: string;
   /** Autonomous runner: absolute path to the cloned workspace. */

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -264,6 +264,12 @@ export class JiraProvider implements TicketingProvider {
     await this.client.addComment(issueId, adfParagraph(body));
   }
 
+  async fetchPlanningContext(_issueId: string): Promise<string> {
+    // Jira planning-context extraction is not implemented yet; the
+    // implementation run proceeds without it (best-effort context).
+    return "";
+  }
+
   issueUrl(issue: TicketIssue): string {
     return `${this.siteUrl}/browse/${issue.identifier}`;
   }

--- a/src/providers/linear.ts
+++ b/src/providers/linear.ts
@@ -6,6 +6,7 @@ import type {
   ProviderConfig,
 } from "./types.js";
 import { MissingProviderConfigError } from "./types.js";
+import { fetchPlanningContext as fetchLinearPlanningContext } from "../linear-planning-fetch.js";
 
 interface GraphQLResponse<T> {
   data?: T;
@@ -65,6 +66,10 @@ export class LinearProvider implements TicketingProvider {
       scopeKey: node.team.key,
       nativeStatus: `${node.state.name} (${node.state.type})`,
     };
+  }
+
+  async fetchPlanningContext(issueId: string): Promise<string> {
+    return fetchLinearPlanningContext({ issueId, linearApiKey: this.apiKey });
   }
 
   private async linearMutation<T>(

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -45,6 +45,11 @@ export interface TicketingProvider {
   // Communication
   postComment(issueId: string, body: string): Promise<void>;
 
+  /** Planning context produced during the planning phase, formatted for injection
+   *  into the implementation prompt. Returns "" when there is none (or on any
+   *  fetch error — this is best-effort context, never a hard dependency). */
+  fetchPlanningContext(issueId: string): Promise<string>;
+
   /** Stable user-facing URL for the issue. */
   issueUrl(issue: TicketIssue): string;
 

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -201,7 +201,6 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       issueDescription,
       nonce,
       orchestratorUrl: orchestratorUrl ?? "",
-      ticketingProvider: "linear",
       model,
       workspaceDir,
       planningContext,

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -9,8 +9,7 @@ import type { LLMExecutor, PipelineDefinition, StepReporter } from "./pipeline/t
 import { HttpStepReporter, NoopStepReporter, TokenStepReporter } from "./pipeline/reporter.js";
 import { runHookScript } from "./pipeline/steps/hooks.js";
 import { parseWorkflowMd } from "./workflow-md.js";
-import { fetchPlanningContext } from "./linear-planning-fetch.js";
-import { postRunnerResult } from "./runner-result.js";
+import { fetchPlanningContextFromOrchestrator, postRunnerResult } from "./runner-result.js";
 
 export interface RunAutonomousOptions {
   workspaceDir?: string;
@@ -116,10 +115,17 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   const prNumber = process.env.PR_NUMBER ?? "";
   const runnerPhase = resolveRunnerPhase(process.env.RUNNER_PHASE, prNumber);
 
-  const planningContext = process.env.LINEAR_API_KEY
-    ? await fetchPlanningContext({
-        issueId,
-        linearApiKey: process.env.LINEAR_API_KEY,
+  const callbackUrl = optionalEnv("RUNNER_CALLBACK_URL");
+  const progressToken = optionalEnv("RUN_PROGRESS_TOKEN");
+
+  // Planning context is fetched from the orchestrator's provider-agnostic
+  // endpoint using the reusable progress token — the runner never calls the
+  // ticketing system directly. Absent a callback URL/token (e.g. a
+  // comment-triggered gap-fill), the run proceeds without planning context.
+  const planningContext = callbackUrl && progressToken
+    ? await fetchPlanningContextFromOrchestrator({
+        callbackUrl,
+        progressToken,
         fetchImpl: opts.fetchImpl,
       })
     : "";
@@ -175,8 +181,6 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir);
   const orchestratorUrl = process.env.ORCHESTRATOR_URL;
   const nonce = process.env.MACHINE_NONCE ?? "";
-  const callbackUrl = process.env.RUNNER_CALLBACK_URL;
-  const progressToken = process.env.RUN_PROGRESS_TOKEN;
   if (orchestratorUrl && !nonce) {
     console.warn("ORCHESTRATOR_URL is set but MACHINE_NONCE is empty — step reports will be rejected (403).");
   }

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -38,6 +38,12 @@ export interface HandleRunnerProgressInput {
   secret: string;
 }
 
+export interface HandleRunnerPlanningContextInput {
+  authorization: string | undefined;
+  secret: string;
+  resolveProvider: (mappingTeamKey: string) => Promise<TicketingProvider | null>;
+}
+
 function bad(status: number, error: string): HandleRunnerResultOutput {
   return { status, body: { error } };
 }
@@ -231,4 +237,41 @@ export async function handleRunnerProgress(
 
   upsertStepRecord(job.id, stepOrError);
   return { status: 200, body: { acknowledged: true } };
+}
+
+/**
+ * Serves the planning context for a run to the runner, provider-agnostically.
+ * The runner authenticates with its reusable progress token (it never holds a
+ * ticketing-system API key), and the orchestrator resolves the right provider
+ * from the token's mapping. Planning context is best-effort: a missing mapping
+ * or a provider error returns 200 with an empty string rather than failing the
+ * implementation run.
+ */
+export async function handleRunnerPlanningContext(
+  input: HandleRunnerPlanningContextInput,
+): Promise<HandleRunnerResultOutput> {
+  const bearerToken = parseBearerToken(input.authorization);
+  if (!bearerToken) return bad(401, "missing_bearer");
+
+  const verified = verifyRunToken(bearerToken, input.secret, "progress", { consume: false });
+  if (!verified.ok) return bad(401, verified.reason);
+
+  const provider = await input.resolveProvider(verified.mappingTeamKey);
+  if (!provider) {
+    console.warn(
+      `[runner-planning-context] mapping deleted between mint and fetch: ${verified.mappingTeamKey}`,
+    );
+    return { status: 200, body: { planningContext: "" } };
+  }
+
+  try {
+    const planningContext = await provider.fetchPlanningContext(verified.claims.issueId);
+    return { status: 200, body: { planningContext } };
+  } catch (err) {
+    console.error(
+      `[runner-planning-context] fetchPlanningContext failed for issueId=${verified.claims.issueId}:`,
+      err,
+    );
+    return { status: 200, body: { planningContext: "" } };
+  }
 }

--- a/src/runner-result.ts
+++ b/src/runner-result.ts
@@ -10,6 +10,34 @@ export function collectRunnerComments(workspaceDir: string): Array<{ body: strin
     .map((n) => ({ body: readFileSync(join(dir, n), "utf-8") }));
 }
 
+/**
+ * Pull planning context from the orchestrator's provider-agnostic endpoint using
+ * the run's reusable progress token. The runner never holds a ticketing-system
+ * API key. Best-effort: any failure yields "" so the implementation run proceeds.
+ */
+export async function fetchPlanningContextFromOrchestrator(params: {
+  callbackUrl: string;
+  progressToken: string;
+  fetchImpl?: typeof fetch;
+}): Promise<string> {
+  const fetchFn = params.fetchImpl ?? fetch;
+  try {
+    const res = await fetchFn(`${params.callbackUrl.replace(/\/$/, "")}/runner/planning-context`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${params.progressToken}` },
+    });
+    if (!res.ok) {
+      console.warn(`[runner] planning-context fetch failed HTTP ${res.status}; proceeding without it.`);
+      return "";
+    }
+    const data = (await res.json()) as { planningContext?: unknown };
+    return typeof data.planningContext === "string" ? data.planningContext : "";
+  } catch (err) {
+    console.warn("[runner] planning-context fetch failed; proceeding without it:", err);
+    return "";
+  }
+}
+
 export async function postRunnerResult(params: {
   phase: "planning" | "implementation" | "gap-analysis";
   workspaceDir: string;

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -7,7 +7,6 @@
 #   AI_IMPLEMENT_PRIVATE_KEY - GitHub App PEM private key
 #   ANTHROPIC_API_KEY        - Anthropic API key
 #   CLAUDE_CODE_OAUTH_TOKEN  - Claude Code OAuth token (preferred over API key)
-#   LINEAR_API_KEY           - Linear API key for status updates
 #
 # Additional secret (Bedrock provider):
 #   AWS_BEDROCK_ROLE_ARN     - IAM role ARN trusted to GitHub OIDC; needs bedrock:InvokeModel
@@ -25,19 +24,19 @@ on:
   workflow_dispatch:
     inputs:
       issue_id:
-        description: "Linear issue UUID"
+        description: "Ticketing-system issue ID"
         required: true
         type: string
       issue_identifier:
-        description: "Linear issue identifier (e.g., ENG-123)"
+        description: "Ticketing-system issue identifier (e.g., ENG-123)"
         required: true
         type: string
       issue_title:
-        description: "Linear issue title"
+        description: "Ticketing-system issue title"
         required: true
         type: string
       issue_description:
-        description: "Linear issue description"
+        description: "Ticketing-system issue description"
         required: true
         type: string
       pr_number:
@@ -230,7 +229,6 @@ jobs:
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           RUNNER_CALLBACK_URL: ${{ inputs.runner_callback_url }}
           RUN_TOKEN: ${{ inputs.run_token }}
           RUN_PROGRESS_TOKEN: ${{ inputs.run_progress_token }}

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -4,7 +4,7 @@
 #
 # Required secrets:
 #   AI_IMPLEMENT_APP_ID, AI_IMPLEMENT_PRIVATE_KEY
-#   ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, LINEAR_API_KEY
+#   ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN
 #
 # Optional repository variables (Bedrock-enabled repos only):
 #   AI_IMPLEMENT_PROVIDER    - Set to "bedrock" to route through AWS Bedrock.
@@ -231,7 +231,6 @@ jobs:
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ needs.check-trigger.outputs.max_iterations }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         run: |
           # ISSUE_META is parsed from the PR body. The JavaScript parser only emits
           # lower_snake_case keys, jq allows only expected metadata keys here, and


### PR DESCRIPTION
Three focused fixes to the implementation pipeline, surfaced while debugging a plan→implement run that failed with `spawn E2BIG` and never reached Claude.

### 1. Fix `spawn E2BIG` (prompt over stdin)
`ClaudeCliExecutor` passed the full prompt as a `-p <prompt>` argv element. A large prompt — notably one carrying re-injected planning context — exceeds the OS single-argument limit (`MAX_ARG_STRLEN`, 128 KiB on Linux), so `spawn` failed with `E2BIG` before Claude ran. Now the prompt is delivered on stdin (`claude -p` reads stdin), removing the per-argument ceiling. The better planning works, the larger the context — so this was failing exactly when planning succeeded.

### 2. Provider-agnostic planning-context fetch
The runner fetched planning context by calling the Linear GraphQL API directly with `LINEAR_API_KEY`, coupling the runner to one ticketing provider and forcing `claude-implement.yml` / `comment-trigger.yml` to carry a Linear secret.

- New `TicketingProvider.fetchPlanningContext(issueId)` seam — `LinearProvider` implements it; Jira/Fake return `""`.
- New `GET /runner/planning-context` on the orchestrator: authenticates with the run's reusable **progress** token, resolves the provider from the token's mapping, returns the context. Missing mapping or provider error → `200` + `""` (logged, never a hard dependency).
- The runner fetches from that endpoint using `RUNNER_CALLBACK_URL` + `RUN_PROGRESS_TOKEN`; any failure yields `""`.
- `LINEAR_API_KEY` removed and `"Linear issue"` → `"Ticketing-system issue"` in both workflows (+ synced `.github` copies). A structure test enforces they stay Linear-free.

Comment-triggered gap-fills have no orchestrator token, so they now run without planning context (graceful) rather than reaching into Linear.

### 3. Remove dead hardcoded `ticketingProvider`
The pipeline context carried a `ticketingProvider` field hardcoded to `"linear"` that no step ever read. Removed it (and the dead test-fixture entries). `RepoMapping.ticketingProvider` — the real provider-selecting config — is untouched.

---
All test-first (TDD). Full suite green: **1178 tests**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)