### PR TITLE
fix(runner): don't let a too-long review diff discard a working implementation

### DIFF
--- a/src/__tests__/steps-feedback-loop-diff.test.ts
+++ b/src/__tests__/steps-feedback-loop-diff.test.ts
@@ -76,6 +76,15 @@ describe("getDiff generated-file exclusion", () => {
     expect(diff).not.toContain("pnpm-lock.yaml");
   });
 
+  it("returns an empty string when git diff fails (non-git directory)", () => {
+    const notARepo = mkdtempSync(join(tmpdir(), "diff-nogit-"));
+    try {
+      expect(getDiff(notARepo)).toBe("");
+    } finally {
+      rmSync(notARepo, { recursive: true, force: true });
+    }
+  });
+
   it("keeps a real source change while dropping a regenerated file in the same diff", () => {
     writeFileSync(join(repo, "schema.sql"), "CREATE TABLE accounts (id INT, timezone VARCHAR(64));\n");
     writeFileSync(join(repo, "server/src/graphql/generated/types.ts"), "z".repeat(50_000) + "\n");

--- a/src/__tests__/steps-feedback-loop-diff.test.ts
+++ b/src/__tests__/steps-feedback-loop-diff.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { getDiff } from "../pipeline/steps/feedback-loop.js";
+
+function git(cwd: string, args: string[]): void {
+  const r = spawnSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${r.stderr.toString()}`);
+  }
+}
+
+describe("getDiff generated-file exclusion", () => {
+  let repo: string;
+
+  // Seed committed baselines for every path so getDiff (git diff HEAD) sees
+  // them as *modifications* — the real scenario where db:sync/codegen rewrites
+  // already-tracked generated files.
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "diff-test-"));
+    git(repo, ["init", "-q"]);
+    git(repo, ["config", "user.email", "t@t.com"]);
+    git(repo, ["config", "user.name", "t"]);
+    mkdirSync(join(repo, "client/src/__generated__"), { recursive: true });
+    mkdirSync(join(repo, "server/src/graphql/generated"), { recursive: true });
+    writeFileSync(join(repo, "schema.sql"), "CREATE TABLE accounts (id INT);\n");
+    writeFileSync(join(repo, "client/src/__generated__/Big.graphql.ts"), "export const a = 1;\n");
+    writeFileSync(join(repo, "server/src/graphql/generated/types.ts"), "export const b = 1;\n");
+    writeFileSync(join(repo, "pnpm-lock.yaml"), "lockfileVersion: 9\n");
+    git(repo, ["add", "-A"]);
+    git(repo, ["commit", "-qm", "seed"]);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("includes hand-written source changes", () => {
+    writeFileSync(join(repo, "schema.sql"), "CREATE TABLE accounts (id INT, timezone VARCHAR(64));\n");
+    const diff = getDiff(repo);
+    expect(diff).toContain("schema.sql");
+    expect(diff).toContain("timezone");
+  });
+
+  it("excludes regenerated relay __generated__ files", () => {
+    writeFileSync(join(repo, "client/src/__generated__/Big.graphql.ts"), "x".repeat(50_000) + "\n");
+    const diff = getDiff(repo);
+    expect(diff).not.toContain("__generated__");
+  });
+
+  it("excludes codegen output under a generated/ directory", () => {
+    writeFileSync(join(repo, "server/src/graphql/generated/types.ts"), "y".repeat(50_000) + "\n");
+    const diff = getDiff(repo);
+    expect(diff).not.toContain("generated/types.ts");
+  });
+
+  it("excludes lockfiles", () => {
+    writeFileSync(join(repo, "pnpm-lock.yaml"), "lockfileVersion: 9\n" + "dep\n".repeat(5000));
+    const diff = getDiff(repo);
+    expect(diff).not.toContain("pnpm-lock.yaml");
+  });
+
+  it("keeps a real source change while dropping a regenerated file in the same diff", () => {
+    writeFileSync(join(repo, "schema.sql"), "CREATE TABLE accounts (id INT, timezone VARCHAR(64));\n");
+    writeFileSync(join(repo, "server/src/graphql/generated/types.ts"), "z".repeat(50_000) + "\n");
+    const diff = getDiff(repo);
+    expect(diff).toContain("schema.sql");
+    expect(diff).not.toContain("generated/types.ts");
+  });
+});

--- a/src/__tests__/steps-feedback-loop-diff.test.ts
+++ b/src/__tests__/steps-feedback-loop-diff.test.ts
@@ -25,10 +25,14 @@ describe("getDiff generated-file exclusion", () => {
     git(repo, ["config", "user.name", "t"]);
     mkdirSync(join(repo, "client/src/__generated__"), { recursive: true });
     mkdirSync(join(repo, "server/src/graphql/generated"), { recursive: true });
+    mkdirSync(join(repo, "packages/api"), { recursive: true });
     writeFileSync(join(repo, "schema.sql"), "CREATE TABLE accounts (id INT);\n");
     writeFileSync(join(repo, "client/src/__generated__/Big.graphql.ts"), "export const a = 1;\n");
     writeFileSync(join(repo, "server/src/graphql/generated/types.ts"), "export const b = 1;\n");
     writeFileSync(join(repo, "pnpm-lock.yaml"), "lockfileVersion: 9\n");
+    writeFileSync(join(repo, "package-lock.json"), '{"lockfileVersion": 3}\n');
+    writeFileSync(join(repo, "yarn.lock"), "# yarn lockfile v1\n");
+    writeFileSync(join(repo, "packages/api/pnpm-lock.yaml"), "lockfileVersion: 9\n");
     git(repo, ["add", "-A"]);
     git(repo, ["commit", "-qm", "seed"]);
   });
@@ -56,8 +60,18 @@ describe("getDiff generated-file exclusion", () => {
     expect(diff).not.toContain("generated/types.ts");
   });
 
-  it("excludes lockfiles", () => {
+  it("excludes lockfiles at the repo root", () => {
     writeFileSync(join(repo, "pnpm-lock.yaml"), "lockfileVersion: 9\n" + "dep\n".repeat(5000));
+    writeFileSync(join(repo, "package-lock.json"), '{"lockfileVersion": 3, "x": 1}\n');
+    writeFileSync(join(repo, "yarn.lock"), "# yarn lockfile v1\nfoo@1:\n");
+    const diff = getDiff(repo);
+    expect(diff).not.toContain("pnpm-lock.yaml");
+    expect(diff).not.toContain("package-lock.json");
+    expect(diff).not.toContain("yarn.lock");
+  });
+
+  it("excludes lockfiles nested in workspace packages (monorepo)", () => {
+    writeFileSync(join(repo, "packages/api/pnpm-lock.yaml"), "lockfileVersion: 9\n" + "dep\n".repeat(5000));
     const diff = getDiff(repo);
     expect(diff).not.toContain("pnpm-lock.yaml");
   });

--- a/src/__tests__/steps-feedback-loop.test.ts
+++ b/src/__tests__/steps-feedback-loop.test.ts
@@ -218,7 +218,19 @@ describe("feedbackLoopStep", () => {
     expect(failedStep?.type).toBe("implement");
   });
 
-  it("propagates review step error and reports the sub-step as failed", async () => {
+  it("does not throw when the review step fails, so the pipeline can still push", async () => {
+    vi.mocked(reviewStep.run).mockRejectedValueOnce(new Error("Prompt is too long"));
+
+    const outputs = await feedbackLoopStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    // A review failure must not discard a successful implementation. The loop
+    // ends, approved stays false, and the reason is surfaced in finalFeedback.
+    expect(outputs.approved).toBe(false);
+    expect(outputs.finalFeedback).toContain("Prompt is too long");
+    expect(implementStep.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the review sub-step as failed and stops the loop when review throws", async () => {
     vi.mocked(reviewStep.run).mockRejectedValueOnce(new Error("review failed"));
 
     const reportedSteps: Step[] = [];
@@ -228,13 +240,18 @@ describe("feedbackLoopStep", () => {
       }),
     };
 
-    await expect(
-      feedbackLoopStep.run(makeContext(), BASE_INPUTS, reporter),
-    ).rejects.toThrow("review failed");
+    await feedbackLoopStep.run(
+      makeContext(),
+      { ...BASE_INPUTS, maxIterations: 3 },
+      reporter,
+    );
 
     const failedStep = reportedSteps.find((s) => s.status === "failed");
     expect(failedStep).toBeDefined();
     expect(failedStep?.type).toBe("review");
+    // The loop must not retry implementation after an infrastructure-level
+    // review failure — retrying would burn another implement pass for nothing.
+    expect(implementStep.run).toHaveBeenCalledTimes(1);
   });
 
   it("passes issueTitle and issueDescription to review step", async () => {

--- a/src/__tests__/steps-review.test.ts
+++ b/src/__tests__/steps-review.test.ts
@@ -151,6 +151,26 @@ describe("reviewStep", () => {
     expect(call.prompt).toContain("diff truncated");
   });
 
+  it("truncates an oversized diff at a clean line boundary when one precedes the cap", async () => {
+    const executor = makeExecutor(APPROVED_JSON);
+    // Oversized diff whose only newline sits before the 200k char cap, so the
+    // cut should land on that newline (the `cut > 0` branch) rather than the
+    // hard cap. Lengths chosen so the boundary is unambiguous: 150_000.
+    // Distinct head/tail chars so the tail assertion is meaningful (a run of
+    // "+" would be a substring of an all-"+" head).
+    const head = "+".repeat(150_000);
+    const tail = "x".repeat(100_000);
+    const diff = `${head}\n${tail}`;
+
+    await reviewStep.run(makeContext(executor), { diff }, new NoopStepReporter());
+
+    const call = vi.mocked(executor.invoke).mock.calls[0][0];
+    // Marker reports the line-boundary cut (150_000), not the hard cap (200_000).
+    expect(call.prompt).toContain(`showing first 150000 of ${diff.length} characters`);
+    // The tail past the newline must not be embedded.
+    expect(call.prompt).not.toContain("x");
+  });
+
   it("does not truncate a normal-sized diff", async () => {
     const executor = makeExecutor(APPROVED_JSON);
     const smallDiff = "diff --git a/foo.ts\n+added line";

--- a/src/__tests__/steps-review.test.ts
+++ b/src/__tests__/steps-review.test.ts
@@ -138,6 +138,30 @@ describe("reviewStep", () => {
     expect(outputs.tokensUsed).toBe(200);
   });
 
+  it("truncates an oversized diff so the prompt stays within the model context window", async () => {
+    const executor = makeExecutor(APPROVED_JSON);
+    // A regenerated-codegen diff can be hundreds of KB — far past the model's
+    // input limit. The review prompt must cap it rather than embed it verbatim.
+    const hugeDiff = "+".repeat(500_000);
+
+    await reviewStep.run(makeContext(executor), { diff: hugeDiff }, new NoopStepReporter());
+
+    const call = vi.mocked(executor.invoke).mock.calls[0][0];
+    expect(call.prompt.length).toBeLessThan(hugeDiff.length);
+    expect(call.prompt).toContain("diff truncated");
+  });
+
+  it("does not truncate a normal-sized diff", async () => {
+    const executor = makeExecutor(APPROVED_JSON);
+    const smallDiff = "diff --git a/foo.ts\n+added line";
+
+    await reviewStep.run(makeContext(executor), { diff: smallDiff }, new NoopStepReporter());
+
+    const call = vi.mocked(executor.invoke).mock.calls[0][0];
+    expect(call.prompt).toContain("added line");
+    expect(call.prompt).not.toContain("diff truncated");
+  });
+
   it("correctly extracts JSON when preamble contains stray braces", async () => {
     // Greedy regex would match from first '{' in preamble to last '}' → invalid JSON.
     // Balanced-brace scanner skips the empty preamble '{}' and finds the real object.

--- a/src/pipeline/steps/feedback-loop.ts
+++ b/src/pipeline/steps/feedback-loop.ts
@@ -62,9 +62,9 @@ function buildImplementPrompt(
 const REVIEW_DIFF_EXCLUDES = [
   ":(exclude,glob)**/__generated__/**",
   ":(exclude,glob)**/generated/**",
-  ":(exclude)pnpm-lock.yaml",
-  ":(exclude)package-lock.json",
-  ":(exclude)yarn.lock",
+  ":(exclude,glob)**/pnpm-lock.yaml",
+  ":(exclude,glob)**/package-lock.json",
+  ":(exclude,glob)**/yarn.lock",
 ];
 
 export function getDiff(workspaceDir: string): string {

--- a/src/pipeline/steps/feedback-loop.ts
+++ b/src/pipeline/steps/feedback-loop.ts
@@ -52,11 +52,30 @@ function buildImplementPrompt(
   return basePrompt;
 }
 
-function getDiff(workspaceDir: string): string {
-  const result = spawnSync("git", ["diff", "HEAD"], {
-    cwd: workspaceDir,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+/**
+ * Pathspecs excluded from the review diff. Generated artifacts (relay
+ * `__generated__`, codegen `generated/` dirs) and lockfiles can each be
+ * hundreds of KB after a `db:sync` / codegen run, blowing the reviewer's
+ * prompt past the model context window. They are committed by the push step
+ * regardless — this only controls what the reviewer is shown.
+ */
+const REVIEW_DIFF_EXCLUDES = [
+  ":(exclude,glob)**/__generated__/**",
+  ":(exclude,glob)**/generated/**",
+  ":(exclude)pnpm-lock.yaml",
+  ":(exclude)package-lock.json",
+  ":(exclude)yarn.lock",
+];
+
+export function getDiff(workspaceDir: string): string {
+  const result = spawnSync(
+    "git",
+    ["diff", "HEAD", "--", ".", ...REVIEW_DIFF_EXCLUDES],
+    {
+      cwd: workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
   if (result.status !== 0) return "";
   return result.stdout.toString();
 }
@@ -196,11 +215,21 @@ export const feedbackLoopStep: StepModule<FeedbackLoopInputs, FeedbackLoopOutput
         approved = reviewOutputs.approved;
         feedback = reviewOutputs.feedback;
       } catch (err) {
+        // A review failure (e.g. "Prompt is too long", a transient API error)
+        // is NOT actionable feedback and must not discard a successful
+        // implementation. Record the failure, stop the loop, and let the
+        // pipeline push the working tree — retrying implementation would only
+        // burn another pass producing the same un-reviewable diff.
         reviewSubStep.status = "failed";
         reviewSubStep.ended_at = new Date().toISOString();
         reviewSubStep.outputs = { error: String(err) };
         await reporter.report(reviewSubStep);
-        throw err;
+        console.warn(
+          `[feedback-loop] Review step failed on iteration ${iteration}; skipping review and proceeding to push: ${String(err)}`,
+        );
+        approved = false;
+        feedback = `Review step failed and was skipped: ${String(err)}`;
+        break;
       }
     }
 

--- a/src/pipeline/steps/feedback-loop.ts
+++ b/src/pipeline/steps/feedback-loop.ts
@@ -76,7 +76,15 @@ export function getDiff(workspaceDir: string): string {
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
-  if (result.status !== 0) return "";
+  if (result.status !== 0) {
+    // A non-zero exit means the reviewer sees an empty diff and may spuriously
+    // approve. Behaviour is unchanged (still return ""), but surface it so the
+    // failure is observable in the runner logs rather than silent.
+    console.warn(
+      `[getDiff] git diff failed (exit ${result.status ?? "null"}): ${result.stderr?.toString().trim() ?? ""}`,
+    );
+    return "";
+  }
   return result.stdout.toString();
 }
 

--- a/src/pipeline/steps/review.ts
+++ b/src/pipeline/steps/review.ts
@@ -59,6 +59,19 @@ function extractFirstJsonObject(text: string): object | null {
   return null;
 }
 
+/**
+ * Hard cap on diff characters embedded in the review prompt. A regenerated
+ * codegen diff can be hundreds of KB; without a cap the prompt exceeds the
+ * model's input limit and the whole invocation fails ("Prompt is too long").
+ * ~200k chars ≈ 50k tokens, leaving ample headroom in a 200k-token window.
+ */
+const MAX_REVIEW_DIFF_CHARS = 200_000;
+
+function capDiff(diff: string): string {
+  if (diff.length <= MAX_REVIEW_DIFF_CHARS) return diff;
+  return `${diff.slice(0, MAX_REVIEW_DIFF_CHARS)}\n\n... [diff truncated: showing first ${MAX_REVIEW_DIFF_CHARS} of ${diff.length} characters] ...`;
+}
+
 const REVIEW_PROMPT = (
   issueTitle: string | undefined,
   issueDescription: string | undefined,
@@ -69,7 +82,7 @@ const REVIEW_PROMPT = (
 
   if (issueTitle) prompt += `\n\nIssue: ${issueTitle}`;
   if (issueDescription) prompt += `\n\nDescription:\n${issueDescription}`;
-  if (diff) prompt += `\n\n## Implementation Diff\n\`\`\`diff\n${diff}\n\`\`\``;
+  if (diff) prompt += `\n\n## Implementation Diff\n\`\`\`diff\n${capDiff(diff)}\n\`\`\``;
 
   prompt += `\n\nRespond with a JSON object only:
 {

--- a/src/pipeline/steps/review.ts
+++ b/src/pipeline/steps/review.ts
@@ -69,7 +69,9 @@ const MAX_REVIEW_DIFF_CHARS = 200_000;
 
 function capDiff(diff: string): string {
   if (diff.length <= MAX_REVIEW_DIFF_CHARS) return diff;
-  return `${diff.slice(0, MAX_REVIEW_DIFF_CHARS)}\n\n... [diff truncated: showing first ${MAX_REVIEW_DIFF_CHARS} of ${diff.length} characters] ...`;
+  const cut = diff.lastIndexOf("\n", MAX_REVIEW_DIFF_CHARS);
+  const boundary = cut > 0 ? cut : MAX_REVIEW_DIFF_CHARS;
+  return `${diff.slice(0, boundary)}\n\n... [diff truncated: showing first ${boundary} of ${diff.length} characters] ...`;
 }
 
 const REVIEW_PROMPT = (

--- a/src/pipeline/steps/review.ts
+++ b/src/pipeline/steps/review.ts
@@ -70,6 +70,9 @@ const MAX_REVIEW_DIFF_CHARS = 200_000;
 function capDiff(diff: string): string {
   if (diff.length <= MAX_REVIEW_DIFF_CHARS) return diff;
   const cut = diff.lastIndexOf("\n", MAX_REVIEW_DIFF_CHARS);
+  // `> 0` (not `!== -1`) on purpose: fall back to the hard cap both when no
+  // newline precedes the boundary (-1) and in the degenerate case where the
+  // only one is at index 0, which would otherwise slice to an empty diff.
   const boundary = cut > 0 ? cut : MAX_REVIEW_DIFF_CHARS;
   return `${diff.slice(0, boundary)}\n\n... [diff truncated: showing first ${boundary} of ${diff.length} characters] ...`;
 }


### PR DESCRIPTION
## Problem

A real failure on a Bedrock target repo (Forecast-it/dark-factory-hello-world [run](https://github.com/Forecast-it/dark-factory-hello-world/actions/runs/26929090702/job/79445108400)): a trivial additive schema-change ticket failed with `Pipeline failed: Error: Review LLM invocation failed with exit code 1: Prompt is too long`.

Timeline from the job log:
- Clone + install: ~25s
- **6m32s** of Claude implementing on Bedrock (likely thrashing to regenerate codegen for `pnpm check`)
- Review step fails: **Prompt is too long**

Root cause: `review.ts` embeds the entire `git diff HEAD` verbatim with **no size cap and no file exclusions** — the only unbounded input to the review prompt. When `db:sync`/codegen rewrites large tracked files (relay `__generated__`, graphql `generated/types.ts`), the diff blows past the model's context window. Worse, the thrown review error **aborts the whole pipeline before `push`** (`autonomous.yml` has no skip conditions and `push` doesn't gate on `approved`), so a successful implementation produced **no PR**.

## Fix

**A — review failure is non-fatal** (`feedback-loop.ts`): report the review sub-step as failed, warn, end the loop, return `approved=false` so `push` still runs and the PR is created. No implementation retry — an infra-level review failure isn't actionable feedback.

**B — bound the review diff**:
- `getDiff` excludes `**/__generated__/**`, `**/generated/**`, `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock` via git pathspec. Still committed by `push`; only the reviewer's view is trimmed.
- `reviewStep` hard-caps the embedded diff at 200k chars (~50k tokens) with a `[diff truncated]` marker as a backstop.

Note: planning is **not** involved — planning context only ever appends to the *implement* prompt, never review.

## Tests

9 new tests (TDD, watched fail first). `npm test` → **1167 passed**, `npm run typecheck` clean.
- review: truncates oversized diff / leaves normal diff intact
- feedback-loop: does not throw on review failure (push proceeds), reports sub-step failed, no implement retry
- getDiff (real temp git repo): includes source changes, excludes `__generated__`/`generated/`/lockfiles, mixed source+generated diff keeps source drops generated

## Deploy note

This pipeline code runs inside the runner image. Landing on `testing` rebuilds the base `:next` runner; Forecast-it's custom `ai-implement-runner-db:next` (built FROM the base) must then be rebuilt to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)