### PR TITLE
feat(runner): observability foundation — stream-json telemetry + AI_IMPLEMENT_LOG_LEVEL

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -228,6 +228,7 @@ jobs:
           AWS_REGION: ${{ inputs.aws_region }}
           AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
+          AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -229,6 +229,7 @@ jobs:
           PROVIDER: ${{ needs.check-trigger.outputs.provider }}
           AI_IMPLEMENT_MAX_TURNS: ${{ needs.check-trigger.outputs.max_turns }}
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ needs.check-trigger.outputs.max_iterations }}
+          AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ All tables live in a single SQLite file at `DEDUP_DB_PATH` (default `/data/dedup
 | `DEDUP_DB_PATH` | No | SQLite path (default `/data/dedup.sqlite`) |
 | `POLL_INTERVAL_MS` | No | Poll interval ms (default `60000`) |
 | `PORT` | No | HTTP port (default `8080`) |
+| `AI_IMPLEMENT_LOG_LEVEL` | No | Runner log verbosity: `summary` (default) or `stream`. `stream` tees per-turn tool activity to the log. Telemetry (turns/cost/tokens/outcome) is captured at both levels. |
 
 ## Adding a new target repo
 
@@ -158,6 +159,14 @@ Each project's mapping carries three optional caps, editable in the `/admin` Pro
 `maxTurns`/`maxIterations` reach the runner as `workflow_dispatch` inputs (GHA) or runner env (Fly/local); `maxJobMinutes` is a GHA-only `job_timeout_minutes` dispatch input. The orchestrator only **sends** a cap input when it is set on the mapping, so a project's target repo must have **re-synced `claude-implement.yml`** before you set caps — otherwise GitHub rejects the dispatch with "unexpected inputs". Caps also apply to gap-fill and review-feedback re-dispatches, not just the initial run.
 
 `/ai-implement` comment-triggered gap-fill runs bypass the orchestrator, so they read caps from target-repo **variables** instead (mirroring `AI_IMPLEMENT_PROVIDER`): set `AI_IMPLEMENT_MAX_TURNS`, `AI_IMPLEMENT_MAX_ITERATIONS`, and `AI_IMPLEMENT_MAX_JOB_MINUTES` (Settings → Secrets and variables → Actions → Variables) to cap those runs too.
+
+### Runner log verbosity
+
+`AI_IMPLEMENT_LOG_LEVEL` controls how much the runner logs during an implement pass:
+- `summary` (default): logs a single result line per Claude invocation — outcome (incl. `max_turns`), turns, duration, cost (when reported), tokens.
+- `stream`: additionally tees each per-turn tool call (name + truncated input; not tool output) to the log.
+
+Set it as a repository or organization **variable** (Settings → Secrets and variables → Actions → Variables), mirroring `AI_IMPLEMENT_PROVIDER`. It is read inside the runner container, so it applies to both orchestrator-initiated and `/ai-implement` comment-triggered runs **after the target repo has re-synced `claude-implement.yml`**. It is not a per-project admin field and not a dispatch input.
 
 `workflows/claude-plan.yml` is the planning workflow synced to target repos. It runs read-only codebase analysis and posts structured planning comments to Linear when dispatched. It supports:
 - **PLANNING.md** — per-repo Claude prompt template; front matter carries `model:` (same rules as WORKFLOW.md)

--- a/docs/superpowers/plans/2026-06-04-runner-observability-foundation.md
+++ b/docs/superpowers/plans/2026-06-04-runner-observability-foundation.md
@@ -1,0 +1,815 @@
+# Runner Observability Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make implementation runs observable — stream Claude's per-turn activity to the log (gated by a verbosity setting) and always capture structured run telemetry (turns/duration/cost/tokens/outcome).
+
+**Architecture:** Switch `ClaudeCliExecutor` to `--output-format stream-json --verbose`. A new pure module `claude-stream.ts` parses the JSONL event stream into log lines and telemetry. The executor returns Claude's final text as `stdout` (preserving existing consumers) plus a new `telemetry` field. Verbosity comes from `AI_IMPLEMENT_LOG_LEVEL` (`summary` default | `stream`), read in `run-autonomous.ts` and passed to the executor.
+
+**Tech Stack:** TypeScript (ESM, NodeNext), Vitest, Node `child_process.spawn`, the `claude` CLI in the runner image.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-runner-observability-foundation-design.md`
+
+**Dependency:** Soft-depends on PR #72 (`fix/review-prompt-too-long-nonfatal`). Land/rebase after it merges to `testing`. This branch (`feat/runner-observability-foundation`) is cut from `testing`.
+
+**Refinement vs spec:** Per-line timestamps are dropped from stream output — GitHub Actions timestamps every log line already, and a timestamp-free `formatEvent` stays pure/deterministic. All other behavior matches the spec.
+
+---
+
+## File Structure
+
+- **Create** `src/pipeline/claude-stream.ts` — pure parser/formatter: `StreamEvent`, `parseLine`, `finalText`, `extractTelemetry`, `formatEvent`, `summaryLine`. No I/O.
+- **Create** `src/__tests__/claude-stream.test.ts` — fixture-driven unit tests for the parser.
+- **Modify** `src/pipeline/types.ts` — add `LogLevel`, `RunTelemetry`, and `LLMResult.telemetry`.
+- **Modify** `src/pipeline/executor.ts` — stream-json args, line-buffered parsing, live logging, telemetry, `logLevel` ctor arg.
+- **Modify** `src/__tests__/` (new file `executor.test.ts`) — fake-`claude` integration test.
+- **Modify** `src/run-autonomous.ts` — resolve `AI_IMPLEMENT_LOG_LEVEL`, pass to executor; export `resolveLogLevel`.
+- **Modify** `src/__tests__/run-autonomous.test.ts` — test `resolveLogLevel`.
+- **Modify** `workflows/claude-implement.yml` — forward `vars.AI_IMPLEMENT_LOG_LEVEL` into the container env.
+- **Create** `src/__tests__/workflow-log-level.test.ts` — guard that the template forwards the variable.
+- **Modify** `CLAUDE.md` — document `AI_IMPLEMENT_LOG_LEVEL`.
+
+---
+
+## Task 1: Types — `LogLevel`, `RunTelemetry`, `LLMResult.telemetry`
+
+**Files:**
+- Modify: `src/pipeline/types.ts:89-103` (the `LLMResult` / `LLMExecutor` block)
+
+- [ ] **Step 1: Add the types**
+
+In `src/pipeline/types.ts`, replace the existing `LLMResult` interface (currently lines 89-94) with the version below and add the two new types immediately above it:
+
+```ts
+export type LogLevel = "summary" | "stream";
+
+export interface RunTelemetry {
+  outcome: "success" | "max_turns" | "error" | "unknown";
+  numTurns: number | null;
+  durationMs: number | null;
+  costUsd: number | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+}
+
+export interface LLMResult {
+  stdout: string;
+  stderr?: string;
+  exitCode: number;
+  tokensUsed: number;
+  telemetry?: RunTelemetry;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no usages broken — `telemetry` is optional).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pipeline/types.ts
+git commit -m "feat(types): add LogLevel and RunTelemetry; telemetry on LLMResult"
+```
+
+---
+
+## Task 2: Parser module — telemetry + final text
+
+**Files:**
+- Create: `src/pipeline/claude-stream.ts`
+- Test: `src/__tests__/claude-stream.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/claude-stream.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  parseLine,
+  finalText,
+  extractTelemetry,
+  type StreamEvent,
+} from "../pipeline/claude-stream.js";
+
+const initEvent: StreamEvent = { type: "system", subtype: "init", model: "claude-x", cwd: "/workspace" };
+const toolEvent: StreamEvent = {
+  type: "assistant",
+  message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm check" } }] },
+};
+const textEvent: StreamEvent = {
+  type: "assistant",
+  message: { content: [{ type: "text", text: "All done." }] },
+};
+const resultSuccess: StreamEvent = {
+  type: "result",
+  subtype: "success",
+  result: "Final answer text",
+  num_turns: 12,
+  duration_ms: 372000,
+  total_cost_usd: 0.83,
+  usage: { input_tokens: 182000, output_tokens: 4100 },
+};
+
+describe("parseLine", () => {
+  it("parses a JSON line", () => {
+    expect(parseLine('{"type":"result"}')).toEqual({ type: "result" });
+  });
+  it("returns null for a non-JSON line", () => {
+    expect(parseLine("not json")).toBeNull();
+  });
+  it("returns null for a blank line", () => {
+    expect(parseLine("   ")).toBeNull();
+  });
+});
+
+describe("finalText", () => {
+  it("returns the result event's text", () => {
+    expect(finalText([initEvent, resultSuccess])).toBe("Final answer text");
+  });
+  it("falls back to concatenated assistant text when no result event", () => {
+    expect(finalText([initEvent, textEvent])).toBe("All done.");
+  });
+});
+
+describe("extractTelemetry", () => {
+  it("extracts metrics from a success result", () => {
+    const t = extractTelemetry([initEvent, toolEvent, resultSuccess]);
+    expect(t).toEqual({
+      outcome: "success",
+      numTurns: 12,
+      durationMs: 372000,
+      costUsd: 0.83,
+      tokensIn: 182000,
+      tokensOut: 4100,
+    });
+  });
+  it("maps error_max_turns to outcome=max_turns", () => {
+    const t = extractTelemetry([{ type: "result", subtype: "error_max_turns", num_turns: 50 }]);
+    expect(t.outcome).toBe("max_turns");
+    expect(t.numTurns).toBe(50);
+  });
+  it("returns outcome=unknown with nulls when no result event", () => {
+    expect(extractTelemetry([initEvent])).toEqual({
+      outcome: "unknown",
+      numTurns: null,
+      durationMs: null,
+      costUsd: null,
+      tokensIn: null,
+      tokensOut: null,
+    });
+  });
+  it("tolerates a Bedrock result with no cost", () => {
+    const t = extractTelemetry([{ type: "result", subtype: "success", num_turns: 3, usage: { input_tokens: 10, output_tokens: 2 } }]);
+    expect(t.costUsd).toBeNull();
+    expect(t.outcome).toBe("success");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/claude-stream.test.ts`
+Expected: FAIL — cannot resolve `../pipeline/claude-stream.js`.
+
+- [ ] **Step 3: Create the module (telemetry + final text portion)**
+
+Create `src/pipeline/claude-stream.ts`:
+
+```ts
+import type { RunTelemetry } from "./types.js";
+
+export interface StreamEvent {
+  type?: string;
+  subtype?: string;
+  [key: string]: unknown;
+}
+
+export function parseLine(line: string): StreamEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as StreamEvent;
+  } catch {
+    return null;
+  }
+}
+
+function lastResult(events: StreamEvent[]): StreamEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].type === "result") return events[i];
+  }
+  return undefined;
+}
+
+export function finalText(events: StreamEvent[]): string {
+  const result = lastResult(events);
+  if (result && typeof result.result === "string") return result.result;
+  const texts: string[] = [];
+  for (const e of events) {
+    if (e.type !== "assistant") continue;
+    const msg = e.message as { content?: Array<{ type?: string; text?: string }> } | undefined;
+    for (const block of msg?.content ?? []) {
+      if (block.type === "text" && typeof block.text === "string") texts.push(block.text);
+    }
+  }
+  return texts.join("\n");
+}
+
+function num(v: unknown): number | null {
+  return typeof v === "number" ? v : null;
+}
+
+function mapOutcome(subtype: unknown): RunTelemetry["outcome"] {
+  if (subtype === "success") return "success";
+  if (subtype === "error_max_turns") return "max_turns";
+  if (typeof subtype === "string" && subtype.startsWith("error")) return "error";
+  return "unknown";
+}
+
+export function extractTelemetry(events: StreamEvent[]): RunTelemetry {
+  const result = lastResult(events);
+  if (!result) {
+    return { outcome: "unknown", numTurns: null, durationMs: null, costUsd: null, tokensIn: null, tokensOut: null };
+  }
+  const usage = (result.usage ?? {}) as { input_tokens?: number; output_tokens?: number };
+  return {
+    outcome: mapOutcome(result.subtype),
+    numTurns: num(result.num_turns),
+    durationMs: num(result.duration_ms),
+    costUsd: num(result.total_cost_usd),
+    tokensIn: num(usage.input_tokens),
+    tokensOut: num(usage.output_tokens),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/claude-stream.test.ts`
+Expected: PASS (all `parseLine`/`finalText`/`extractTelemetry` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/claude-stream.ts src/__tests__/claude-stream.test.ts
+git commit -m "feat(claude-stream): parse stream-json into telemetry and final text"
+```
+
+---
+
+## Task 3: Parser module — `formatEvent` + `summaryLine`
+
+**Files:**
+- Modify: `src/pipeline/claude-stream.ts`
+- Test: `src/__tests__/claude-stream.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `src/__tests__/claude-stream.test.ts`:
+
+```ts
+import { formatEvent, summaryLine } from "../pipeline/claude-stream.js";
+
+describe("formatEvent", () => {
+  it("formats an init event", () => {
+    expect(formatEvent({ type: "system", subtype: "init", model: "claude-x", cwd: "/workspace" }))
+      .toBe("[claude] init model=claude-x cwd=/workspace");
+  });
+  it("formats a tool_use as tool name + command", () => {
+    expect(
+      formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm check" } }] } }),
+    ).toBe("[claude] tool Bash pnpm check");
+  });
+  it("truncates long tool input", () => {
+    const long = "x".repeat(500);
+    const out = formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Edit", input: { command: long } }] } });
+    expect(out!.length).toBeLessThan(220);
+    expect(out!.endsWith("…")).toBe(true);
+  });
+  it("returns null for a result event (summary handles it)", () => {
+    expect(formatEvent({ type: "result", subtype: "success" })).toBeNull();
+  });
+  it("returns null for an unknown event type", () => {
+    expect(formatEvent({ type: "whatever" })).toBeNull();
+  });
+});
+
+describe("summaryLine", () => {
+  it("renders a full success summary", () => {
+    expect(
+      summaryLine({ outcome: "success", numTurns: 12, durationMs: 372000, costUsd: 0.83, tokensIn: 182000, tokensOut: 4100 }),
+    ).toBe("[claude] result=success turns=12 duration=6m12s cost=$0.83 tokens=182.0k/4.1k (in/out)");
+  });
+  it("omits cost when null", () => {
+    const line = summaryLine({ outcome: "success", numTurns: 3, durationMs: 5000, costUsd: null, tokensIn: 10, tokensOut: 2 });
+    expect(line).not.toContain("cost=");
+    expect(line).toContain("result=success");
+  });
+  it("shows max_turns outcome at summary level", () => {
+    expect(summaryLine({ outcome: "max_turns", numTurns: 50, durationMs: null, costUsd: null, tokensIn: null, tokensOut: null }))
+      .toContain("result=max_turns");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/claude-stream.test.ts`
+Expected: FAIL — `formatEvent`/`summaryLine` are not exported.
+
+- [ ] **Step 3: Implement formatting**
+
+Append to `src/pipeline/claude-stream.ts`:
+
+```ts
+const TOOL_INPUT_MAX = 160;
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
+
+function summarizeToolInput(input: unknown): string {
+  if (input == null) return "";
+  if (typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    const candidate =
+      (typeof obj.command === "string" && obj.command) ||
+      (typeof obj.file_path === "string" && obj.file_path) ||
+      (typeof obj.path === "string" && obj.path) ||
+      (typeof obj.pattern === "string" && obj.pattern) ||
+      JSON.stringify(obj);
+    return truncate(String(candidate), TOOL_INPUT_MAX);
+  }
+  return truncate(String(input), TOOL_INPUT_MAX);
+}
+
+export function formatEvent(event: StreamEvent): string | null {
+  switch (event.type) {
+    case "system":
+      if (event.subtype === "init") {
+        const model = typeof event.model === "string" ? event.model : "?";
+        const cwd = typeof event.cwd === "string" ? event.cwd : "?";
+        return `[claude] init model=${model} cwd=${cwd}`;
+      }
+      return null;
+    case "assistant": {
+      const msg = event.message as { content?: Array<Record<string, unknown>> } | undefined;
+      const lines: string[] = [];
+      for (const block of msg?.content ?? []) {
+        if (block.type === "tool_use") {
+          const name = typeof block.name === "string" ? block.name : "tool";
+          lines.push(`[claude] tool ${name} ${summarizeToolInput(block.input)}`.trimEnd());
+        } else if (block.type === "text" && typeof block.text === "string" && block.text.trim()) {
+          lines.push(`[claude] assistant: ${truncate(block.text.trim(), TOOL_INPUT_MAX)}`);
+        }
+      }
+      return lines.length ? lines.join("\n") : null;
+    }
+    case "user":
+      return "[claude] tool_result";
+    default:
+      return null;
+  }
+}
+
+function humanizeMs(ms: number): string {
+  const s = Math.round(ms / 1000);
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return m > 0 ? `${m}m${rem.toString().padStart(2, "0")}s` : `${rem}s`;
+}
+
+function kfmt(n: number | null): string {
+  if (n == null) return "?";
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+export function summaryLine(t: RunTelemetry): string {
+  const parts = [`[claude] result=${t.outcome}`];
+  if (t.numTurns != null) parts.push(`turns=${t.numTurns}`);
+  if (t.durationMs != null) parts.push(`duration=${humanizeMs(t.durationMs)}`);
+  if (t.costUsd != null && t.costUsd > 0) parts.push(`cost=$${t.costUsd.toFixed(2)}`);
+  if (t.tokensIn != null || t.tokensOut != null) {
+    parts.push(`tokens=${kfmt(t.tokensIn)}/${kfmt(t.tokensOut)} (in/out)`);
+  }
+  return parts.join(" ");
+}
+```
+
+Note: `result` (the case) is handled by returning `null` via the `default` branch — `formatEvent` intentionally has no `case "result"` since `summaryLine` renders it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/claude-stream.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/claude-stream.ts src/__tests__/claude-stream.test.ts
+git commit -m "feat(claude-stream): formatEvent and summaryLine renderers"
+```
+
+---
+
+## Task 4: Wire the executor to stream-json + telemetry
+
+**Files:**
+- Modify: `src/pipeline/executor.ts` (full rewrite of the class body)
+- Test: `src/__tests__/executor.test.ts`
+
+- [ ] **Step 1: Write the failing test (fake `claude` on PATH)**
+
+Create `src/__tests__/executor.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ClaudeCliExecutor } from "../pipeline/executor.js";
+
+let binDir: string;
+let originalPath: string | undefined;
+
+// Writes a fake `claude` that prints the given lines to stdout then exits `code`.
+function installFakeClaude(stdoutLines: string[], code = 0): void {
+  const script = `#!/usr/bin/env bash
+cat <<'JSONL'
+${stdoutLines.join("\n")}
+JSONL
+exit ${code}
+`;
+  const path = join(binDir, "claude");
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+}
+
+const SUCCESS_LINES = [
+  JSON.stringify({ type: "system", subtype: "init", model: "claude-x", cwd: "/workspace" }),
+  JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm check" } }] } }),
+  JSON.stringify({ type: "result", subtype: "success", result: "Done implementing.", num_turns: 4, duration_ms: 5000, usage: { input_tokens: 100, output_tokens: 20 } }),
+];
+
+beforeEach(() => {
+  binDir = mkdtempSync(join(tmpdir(), "fakebin-"));
+  originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}:${process.env.PATH ?? ""}`;
+});
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+  rmSync(binDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("ClaudeCliExecutor", () => {
+  it("returns the result event's text as stdout (compat) plus telemetry", async () => {
+    installFakeClaude(SUCCESS_LINES, 0);
+    const exec = new ClaudeCliExecutor("/tmp", "summary");
+    const result = await exec.invoke({ prompt: "do it", model: "claude-x" });
+
+    expect(result.stdout).toBe("Done implementing.");
+    expect(result.exitCode).toBe(0);
+    expect(result.telemetry?.outcome).toBe("success");
+    expect(result.telemetry?.numTurns).toBe(4);
+    expect(result.tokensUsed).toBe(120);
+  });
+
+  it("does NOT print per-event lines at summary level, but prints the summary", async () => {
+    installFakeClaude(SUCCESS_LINES, 0);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await new ClaudeCliExecutor("/tmp", "summary").invoke({ prompt: "p", model: "m" });
+
+    const lines = log.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.startsWith("[claude] result="))).toBe(true);
+    expect(lines.some((l) => l.startsWith("[claude] tool "))).toBe(false);
+  });
+
+  it("prints per-event lines at stream level", async () => {
+    installFakeClaude(SUCCESS_LINES, 0);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await new ClaudeCliExecutor("/tmp", "stream").invoke({ prompt: "p", model: "m" });
+
+    const lines = log.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes("tool Bash pnpm check"))).toBe(true);
+    expect(lines.some((l) => l.startsWith("[claude] result="))).toBe(true);
+  });
+
+  it("propagates a non-zero exit code and degrades telemetry to unknown", async () => {
+    installFakeClaude(["not even json"], 1);
+    const result = await new ClaudeCliExecutor("/tmp", "summary").invoke({ prompt: "p", model: "m" });
+    expect(result.exitCode).toBe(1);
+    expect(result.telemetry?.outcome).toBe("unknown");
+    expect(result.stdout).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/executor.test.ts`
+Expected: FAIL — current executor doesn't return `telemetry`, returns raw stdout, and never logs a summary.
+
+- [ ] **Step 3: Rewrite the executor**
+
+Replace the entire body of `src/pipeline/executor.ts` with:
+
+```ts
+import { spawn } from "node:child_process";
+import type { LLMExecutor, LLMResult, LogLevel } from "./types.js";
+import {
+  parseLine,
+  formatEvent,
+  finalText,
+  extractTelemetry,
+  summaryLine,
+  type StreamEvent,
+} from "./claude-stream.js";
+
+/**
+ * Shells out to the Claude Code CLI in stream-json mode. Each JSONL event is
+ * parsed for live logging (when logLevel="stream") and accumulated for final
+ * telemetry. The CLI's final `result` text is returned as `stdout` so existing
+ * consumers (e.g. review-step JSON extraction) are unaffected by the format
+ * change. A one-line summary is always logged.
+ */
+export class ClaudeCliExecutor implements LLMExecutor {
+  constructor(
+    private readonly workspaceDir: string,
+    private readonly logLevel: LogLevel = "summary",
+  ) {}
+
+  invoke(params: {
+    prompt: string;
+    model: string;
+    maxTurns?: number;
+    tools?: string[];
+  }): Promise<LLMResult> {
+    return new Promise((resolve, reject) => {
+      const args: string[] = [
+        "--dangerously-skip-permissions",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+      ];
+      if (params.model) args.push("--model", params.model);
+      if (params.maxTurns != null) args.push("--max-turns", String(params.maxTurns));
+      if (params.tools && params.tools.length > 0) {
+        args.push("--allowed-tools", params.tools.join(","));
+      }
+      args.push("-p", params.prompt);
+
+      const proc = spawn("claude", args, {
+        cwd: this.workspaceDir,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env },
+      });
+
+      const events: StreamEvent[] = [];
+      const stderrChunks: Buffer[] = [];
+      let buf = "";
+
+      const handleLine = (line: string) => {
+        const event = parseLine(line);
+        if (!event) return;
+        events.push(event);
+        if (this.logLevel === "stream") {
+          const formatted = formatEvent(event);
+          if (formatted) console.log(formatted);
+        }
+      };
+
+      proc.stdout.on("data", (d: Buffer) => {
+        buf += d.toString();
+        let idx: number;
+        while ((idx = buf.indexOf("\n")) !== -1) {
+          handleLine(buf.slice(0, idx));
+          buf = buf.slice(idx + 1);
+        }
+      });
+      proc.stderr.on("data", (d: Buffer) => stderrChunks.push(d));
+
+      proc.on("close", (code) => {
+        if (buf.trim()) handleLine(buf); // flush trailing partial line
+        const telemetry = extractTelemetry(events);
+        console.log(summaryLine(telemetry));
+        resolve({
+          stdout: finalText(events),
+          stderr: Buffer.concat(stderrChunks).toString(),
+          exitCode: code ?? 1,
+          tokensUsed: (telemetry.tokensIn ?? 0) + (telemetry.tokensOut ?? 0),
+          telemetry,
+        });
+      });
+
+      proc.on("error", reject);
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/executor.test.ts`
+Expected: PASS (all four cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/executor.ts src/__tests__/executor.test.ts
+git commit -m "feat(executor): stream-json mode with live logging and telemetry"
+```
+
+---
+
+## Task 5: Resolve `AI_IMPLEMENT_LOG_LEVEL` in run-autonomous
+
+**Files:**
+- Modify: `src/run-autonomous.ts:175` (executor construction) + add exported helper
+- Modify: `src/run-autonomous.ts` imports (add `LogLevel`)
+- Test: `src/__tests__/run-autonomous.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/__tests__/run-autonomous.test.ts` (inside the file, near other unit tests — adjust the import to include `resolveLogLevel`):
+
+```ts
+import { resolveLogLevel } from "../run-autonomous.js";
+
+describe("resolveLogLevel", () => {
+  it("returns stream when set to stream", () => {
+    expect(resolveLogLevel("stream")).toBe("stream");
+  });
+  it("defaults to summary when unset", () => {
+    expect(resolveLogLevel(undefined)).toBe("summary");
+  });
+  it("defaults to summary for an unrecognized value", () => {
+    expect(resolveLogLevel("loud")).toBe("summary");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/run-autonomous.test.ts`
+Expected: FAIL — `resolveLogLevel` is not exported.
+
+- [ ] **Step 3: Add the helper and use it**
+
+In `src/run-autonomous.ts`, add `LogLevel` to the existing type import from `./pipeline/types.js` (line 8):
+
+```ts
+import type { LLMExecutor, LogLevel, PipelineDefinition, StepReporter } from "./pipeline/types.js";
+```
+
+Add this exported helper near the top of the file (after imports, before the main function):
+
+```ts
+export function resolveLogLevel(raw: string | undefined): LogLevel {
+  return raw === "stream" ? "stream" : "summary";
+}
+```
+
+Change line 175 from:
+
+```ts
+  const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir);
+```
+
+to:
+
+```ts
+  const logLevel = resolveLogLevel(process.env.AI_IMPLEMENT_LOG_LEVEL);
+  const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir, logLevel);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/run-autonomous.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/run-autonomous.ts src/__tests__/run-autonomous.test.ts
+git commit -m "feat(runner): resolve AI_IMPLEMENT_LOG_LEVEL and pass to executor"
+```
+
+---
+
+## Task 6: Forward the variable through the GHA workflow template
+
+**Files:**
+- Modify: `workflows/claude-implement.yml:230` (the "Run pipeline" env block)
+- Test: `src/__tests__/workflow-log-level.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/workflow-log-level.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("claude-implement.yml forwards AI_IMPLEMENT_LOG_LEVEL", () => {
+  it("passes the repo variable into the pipeline container env", () => {
+    const yml = readFileSync(join(process.cwd(), "workflows/claude-implement.yml"), "utf-8");
+    expect(yml).toContain("AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/workflow-log-level.test.ts`
+Expected: FAIL — string not present.
+
+- [ ] **Step 3: Add the env line**
+
+In `workflows/claude-implement.yml`, in the `Run pipeline` step's `env:` block, add this line immediately after `AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}` (line 230):
+
+```yaml
+          AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}
+```
+
+This reads the repo/org variable directly (like `AI_IMPLEMENT_RUNNER_IMAGE`), so both orchestrator-dispatched and `/ai-implement` comment-triggered runs (which both ultimately run `claude-implement.yml`) pick it up with no `workflow_dispatch` input and no orchestrator change.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/workflow-log-level.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add workflows/claude-implement.yml src/__tests__/workflow-log-level.test.ts
+git commit -m "feat(workflow): forward AI_IMPLEMENT_LOG_LEVEL repo variable to runner"
+```
+
+---
+
+## Task 7: Document the setting + full verification
+
+**Files:**
+- Modify: `CLAUDE.md` (env var table + a short note)
+
+- [ ] **Step 1: Document in CLAUDE.md**
+
+In `CLAUDE.md`, add a row to the "Key environment variables" table:
+
+```markdown
+| `AI_IMPLEMENT_LOG_LEVEL` | No | Runner log verbosity: `summary` (default) or `stream`. `stream` tees per-turn tool activity to the log. Telemetry (turns/cost/tokens/outcome) is captured at both levels. |
+```
+
+And add this note near the per-project caps / variables discussion:
+
+```markdown
+### Runner log verbosity
+
+`AI_IMPLEMENT_LOG_LEVEL` controls how much the runner logs during an implement pass:
+- `summary` (default): logs a single result line per Claude invocation — outcome (incl. `max_turns`), turns, duration, cost (when reported), tokens.
+- `stream`: additionally tees each per-turn tool call (name + truncated input; not tool output) to the log.
+
+Set it as a repository or organization **variable** (Settings → Secrets and variables → Actions → Variables), mirroring `AI_IMPLEMENT_PROVIDER`. It is read inside the runner container, so it applies to both orchestrator-initiated and `/ai-implement` comment-triggered runs **after the target repo has re-synced `claude-implement.yml`**. It is not a per-project admin field and not a dispatch input.
+```
+
+- [ ] **Step 2: Commit docs**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document AI_IMPLEMENT_LOG_LEVEL runner verbosity setting"
+```
+
+- [ ] **Step 3: Full verification**
+
+Run: `npm run typecheck && npm test`
+Expected: typecheck clean; all tests pass (the full suite plus the new `claude-stream`, `executor`, `run-autonomous`, and `workflow-log-level` tests).
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/runner-observability-foundation
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 verbosity setting (`AI_IMPLEMENT_LOG_LEVEL`, summary default, env/repo-variable, not per-project/dispatch) → Tasks 5, 6, 7. ✓
+- §2 stream-json executor + parser + `RunTelemetry` + stdout compat → Tasks 1, 2, 3, 4. ✓
+- §3 summary line (always) + stream lines (gated) + secret-safety (tool input not output) → Task 3 (`summaryLine`, `formatEvent` emits tool name+input only) + Task 4 (gating). ✓
+- §4 error handling (non-JSON skipped, missing-result degrades, exitCode preserved) → Task 2 (`parseLine`/`extractTelemetry` nulls), Task 4 (exit-code test). ✓
+- §5 testing (claude-stream unit, fake-claude executor, run-autonomous resolution) → Tasks 2-6. ✓
+- Non-goals (persist/Linear) correctly excluded; telemetry rides on `LLMResult.telemetry` seam. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `RunTelemetry` fields (`outcome`/`numTurns`/`durationMs`/`costUsd`/`tokensIn`/`tokensOut`) identical across types.ts, claude-stream.ts, and tests. `LogLevel` (`summary`|`stream`) consistent in types.ts, executor ctor, `resolveLogLevel`. `StreamEvent` and all exported function names (`parseLine`/`finalText`/`extractTelemetry`/`formatEvent`/`summaryLine`) match between module and tests. ✓
+
+**Deviation from spec:** per-line timestamps dropped (GHA already timestamps log lines; keeps `formatEvent` pure). Documented in header. ✓

--- a/docs/superpowers/specs/2026-06-03-runner-observability-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-03-runner-observability-foundation-design.md
@@ -1,0 +1,130 @@
+# Runner Observability Foundation — Design
+
+**Date:** 2026-06-03
+**Status:** Approved (design)
+**Scope:** Goal 1 of 3 (stream-json foundation + live GHA trace + verbosity setting). Goals 2 (persist metrics) and 3 (customer-facing Linear progress) are filed as separate placeholder Linear issues and build on this foundation.
+
+## Problem
+
+When an implementation run misbehaves, the runner is a black box. A real failure on a Bedrock target repo (`Forecast-it/dark-factory-hello-world`, [run 26929090702](https://github.com/Forecast-it/dark-factory-hello-world/actions/runs/26929090702/job/79445108400)) spent **6m32s** with zero log output before failing — there was no way to see what Claude was doing, how many turns it took, whether it hit the turn cap, or what it cost.
+
+Root cause is the executor (`src/pipeline/executor.ts`): `ClaudeCliExecutor` runs `claude -p <prompt>`, buffers stdout, and only reads it on process close. There is:
+- No live streaming (hence the silence),
+- No `--output-format stream-json --verbose`, so no per-turn / per-tool events,
+- No telemetry — `tokensUsed` is hardcoded `0`, and `num_turns` / duration / cost / max-turns-outcome are never captured.
+
+## Goals (this spec)
+
+1. Make a running implementation observable **live** in the GitHub Actions log, gated by a verbosity setting.
+2. Always capture structured run telemetry (turns, duration, cost, tokens, outcome) and expose it on the result object, regardless of verbosity.
+
+## Non-goals (deferred to G2 / G3)
+
+- Persisting telemetry to `dispatch_log` or rendering it in the admin UI (**G2**).
+- Posting progress/telemetry to Linear for customer visibility (**G3**).
+
+The foundation emits telemetry onto `LLMResult.telemetry` and logs it; the two consumers above read that seam later.
+
+## Core principle
+
+**Capture is decoupled from surface.** Telemetry is always captured and the one-line summary is always logged. The verbosity setting controls only how much *additional* per-event detail is streamed to the log. Low verbosity must never reintroduce the black box — the summary line (including a max-turns outcome) prints at every level.
+
+## Dependency
+
+Soft-depends on PR #72 (`fix/review-prompt-too-long-nonfatal`: non-fatal review + bounded review diff). Section "Error handling" references that non-fatal behavior. Implementation should land after #72 is merged to `testing`, or rebase onto it.
+
+## Design
+
+### 1. The verbosity setting
+
+- **Name / values:** `AI_IMPLEMENT_LOG_LEVEL` ∈ { `summary` (default), `stream` }. Unrecognized or empty → `summary`.
+- **Resolution:** read once as an environment variable in `run-autonomous.ts` and passed into `ClaudeCliExecutor` as a constructor argument. The executor does not reach into `process.env` itself (keeps it unit-testable).
+- **Sources:**
+  - Orchestrator-initiated runs (Fly / local / GHA): an `AI_IMPLEMENT_LOG_LEVEL` repo/org **variable** read by the workflow and passed into the runner container, mirroring how `AI_IMPLEMENT_PROVIDER` is plumbed. This gives a single consistent source across execution modes; the orchestrator sends nothing extra.
+  - `/ai-implement` comment-triggered gap-fill runs: the same `AI_IMPLEMENT_LOG_LEVEL` repo variable.
+- **Explicitly NOT:** a per-project admin-UI field, and NOT a `workflow_dispatch` input. A dispatch input would inherit the "re-sync `claude-implement.yml` or GitHub rejects with 'unexpected inputs'" tax documented in CLAUDE.md. This is an operator/debugging knob set at the environment/repo level.
+
+### 2. Foundation: stream-json executor + parser
+
+**Executor (`src/pipeline/executor.ts`):** add `--output-format stream-json --verbose` to the spawn args. (`--verbose` is required by the CLI for `stream-json` in `-p` mode.) stdout becomes JSONL — one event per line. The executor splits stdout on newlines, parses each line, feeds it to the parser module (below), logs the formatted line live when level is `stream`, and accumulates events for final telemetry extraction.
+
+**New pure module `src/pipeline/claude-stream.ts`** (no I/O, fully unit-testable):
+- `formatEvent(event): string | null` — render one parsed event as a compact human line, or `null` to skip. Handles `system/init`, `assistant` (tool_use → `tool <Name> <input>`, text → `turn N (assistant)`), `user` (tool_result), `result`.
+- `extractTelemetry(events): RunTelemetry` — from the final `result` event, pull `num_turns`, `duration_ms`, `total_cost_usd`, token `usage` (input/output), and `subtype` mapped to an outcome (`success` | `max_turns` | `error` | `unknown`).
+- `finalText(events): string` — the `result` event's `result` field (Claude's final assistant text), with a fallback to concatenated `assistant` text blocks if the result event is missing.
+
+**Type change (`src/pipeline/types.ts`):**
+```ts
+export interface RunTelemetry {
+  outcome: "success" | "max_turns" | "error" | "unknown";
+  numTurns: number | null;
+  durationMs: number | null;
+  costUsd: number | null;      // often null on Bedrock
+  tokensIn: number | null;
+  tokensOut: number | null;
+}
+export interface LLMResult {
+  stdout: string;
+  stderr?: string;
+  exitCode: number;
+  tokensUsed: number;
+  telemetry?: RunTelemetry;    // new
+}
+```
+
+**Compatibility (load-bearing):** existing consumers (`review.ts`'s JSON extraction; any reader of `result.stdout`) expect `stdout` to be Claude's final text answer. With stream-json, raw stdout is JSONL. The executor therefore returns `stdout = finalText(events)`, preserving every existing consumer unchanged. The JSONL is consumed internally for logging and telemetry only. `tokensUsed` is populated from `telemetry.tokensIn + tokensOut` (best-effort; `0` when unknown) — a free win the existing budget-tracking comment in the file asks for.
+
+**Data flow:**
+```
+spawn claude --output-format stream-json --verbose -p <prompt>
+  stdout → split lines → JSON.parse(line)
+    if level === "stream": const l = formatEvent(event); if (l) console.log(l)
+    events.push(event)
+  on close:
+    const t = extractTelemetry(events)
+    console.log(summaryLine(t))                 // ALWAYS
+    resolve({
+      stdout: finalText(events),
+      exitCode: code ?? 1,
+      tokensUsed: (t.tokensIn ?? 0) + (t.tokensOut ?? 0),
+      telemetry: t,
+    })
+```
+
+### 3. Output format
+
+**Summary line (always, both levels)** — one greppable line on close:
+```
+[claude] result=success turns=47 duration=6m12s cost=$0.83 tokens=182k/4.1k (in/out)
+```
+- `result=` is the outcome; `max_turns` makes a turn-cap exhaustion visible at the default level.
+- `cost=` omitted when null or `0` (Bedrock typically does not report `total_cost_usd`).
+- `tokens=` shown whenever `usage` is present; `duration=` humanized from `duration_ms`.
+
+**Live stream lines (`stream` only)** — one compact, timestamped line per meaningful event:
+```
+[claude 12:03:41] init model=anthropic.claude-...:0 cwd=/workspace
+[claude 12:03:44] tool Read forecast-ticketing-poc/schema/schema.sql
+[claude 12:03:51] tool Bash pnpm -C forecast-ticketing-poc db:sync
+[claude 12:06:10] turn 12 (assistant)
+```
+- Tool inputs truncated to ~160 chars so a large Edit payload can't flood the log.
+- **Secret safety:** tool *outputs* (e.g. Bash stdout) are NOT streamed — only the tool name and (truncated) input. Streaming command text but not command output is the deliberate boundary; GHA secret masking applies on top. This is a second reason `summary` is the default.
+
+### 4. Error handling
+
+Observability code may degrade but must never break a run or swallow an exit code.
+- A non-JSON line → skipped (optionally noted once as `[claude] (unparsed line)` at `stream` level), never throws.
+- Missing/malformed `result` event (process killed/crashed) → telemetry fields best-effort/`null`; `stdout` falls back to concatenated `assistant` text; summary prints `result=unknown`. The run still resolves with the real `exitCode`.
+- `exitCode` semantics unchanged: non-zero still surfaces to the step, where PR #72's non-fatal review handling continues to apply.
+
+### 5. Testing (TDD)
+
+- `claude-stream.test.ts` (pure, fixture-driven): `formatEvent` per event type, tool-input truncation, `extractTelemetry` (success, `error_max_turns`, missing-result, Bedrock-no-cost), `finalText` extraction + fallback.
+- `executor.test.ts`: a temporary fake `claude` shell script on `PATH` emitting canned stream-json and a chosen exit code. Assert `stdout` equals unwrapped final text (compat), `telemetry` populated, summary printed at both levels, per-event lines only at `stream`, malformed-line tolerance, missing-result degradation.
+- `run-autonomous` test: `AI_IMPLEMENT_LOG_LEVEL` resolves into the executor; default `summary` when unset or garbage.
+
+## Open items validated during implementation
+
+- Exact `claude` stream-json event field names / `result` subtypes against the runner image's CLI version (design is defensive: best-effort parse, unknown fields ignored).
+- Whether the GHA workflow templates need an `AI_IMPLEMENT_LOG_LEVEL` env passthrough edit (and therefore a target-repo re-sync) — preferred resolution is the repo/org variable read inside the container, requiring no dispatch-input change.

--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -35,6 +35,11 @@ describe("parseLine", () => {
   it("returns null for a blank line", () => {
     expect(parseLine("   ")).toBeNull();
   });
+  it("returns null for valid JSON that is not an object", () => {
+    expect(parseLine('"just a string"')).toBeNull();
+    expect(parseLine("42")).toBeNull();
+    expect(parseLine("[1,2,3]")).toBeNull();
+  });
 });
 
 describe("finalText", () => {
@@ -43,6 +48,9 @@ describe("finalText", () => {
   });
   it("falls back to concatenated assistant text when no result event", () => {
     expect(finalText([initEvent, textEvent])).toBe("All done.");
+  });
+  it("returns empty string for an empty event list", () => {
+    expect(finalText([])).toBe("");
   });
 });
 

--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -3,6 +3,8 @@ import {
   parseLine,
   finalText,
   extractTelemetry,
+  formatEvent,
+  summaryLine,
   type StreamEvent,
 } from "../pipeline/claude-stream.js";
 
@@ -85,5 +87,46 @@ describe("extractTelemetry", () => {
     const t = extractTelemetry([{ type: "result", subtype: "success", num_turns: 3, usage: { input_tokens: 10, output_tokens: 2 } }]);
     expect(t.costUsd).toBeNull();
     expect(t.outcome).toBe("success");
+  });
+});
+
+describe("formatEvent", () => {
+  it("formats an init event", () => {
+    expect(formatEvent({ type: "system", subtype: "init", model: "claude-x", cwd: "/workspace" }))
+      .toBe("[claude] init model=claude-x cwd=/workspace");
+  });
+  it("formats a tool_use as tool name + command", () => {
+    expect(
+      formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm check" } }] } }),
+    ).toBe("[claude] tool Bash pnpm check");
+  });
+  it("truncates long tool input", () => {
+    const long = "x".repeat(500);
+    const out = formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Edit", input: { command: long } }] } });
+    expect(out!.length).toBeLessThan(220);
+    expect(out!.endsWith("…")).toBe(true);
+  });
+  it("returns null for a result event (summary handles it)", () => {
+    expect(formatEvent({ type: "result", subtype: "success" })).toBeNull();
+  });
+  it("returns null for an unknown event type", () => {
+    expect(formatEvent({ type: "whatever" })).toBeNull();
+  });
+});
+
+describe("summaryLine", () => {
+  it("renders a full success summary", () => {
+    expect(
+      summaryLine({ outcome: "success", numTurns: 12, durationMs: 372000, costUsd: 0.83, tokensIn: 182000, tokensOut: 4100 }),
+    ).toBe("[claude] result=success turns=12 duration=6m12s cost=$0.83 tokens=182.0k/4.1k (in/out)");
+  });
+  it("omits cost when null", () => {
+    const line = summaryLine({ outcome: "success", numTurns: 3, durationMs: 5000, costUsd: null, tokensIn: 10, tokensOut: 2 });
+    expect(line).not.toContain("cost=");
+    expect(line).toContain("result=success");
+  });
+  it("shows max_turns outcome at summary level", () => {
+    expect(summaryLine({ outcome: "max_turns", numTurns: 50, durationMs: null, costUsd: null, tokensIn: null, tokensOut: null }))
+      .toContain("result=max_turns");
   });
 });

--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -103,8 +103,23 @@ describe("formatEvent", () => {
   it("truncates long tool input", () => {
     const long = "x".repeat(500);
     const out = formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Edit", input: { command: long } }] } });
-    expect(out!.length).toBeLessThan(220);
+    expect(out!.length).toBeLessThanOrEqual(180);
     expect(out!.endsWith("…")).toBe(true);
+  });
+  it("uses file_path for tools like Read", () => {
+    expect(
+      formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Read", input: { file_path: "src/app.ts" } }] } }),
+    ).toBe("[claude] tool Read src/app.ts");
+  });
+  it("renders a tool with no input without a trailing space", () => {
+    expect(
+      formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "ListMcp", input: {} }] } }),
+    ).toBe("[claude] tool ListMcp {}");
+  });
+  it("renders a tool with null input without a trailing space", () => {
+    expect(
+      formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash" }] } }),
+    ).toBe("[claude] tool Bash");
   });
   it("returns null for a result event (summary handles it)", () => {
     expect(formatEvent({ type: "result", subtype: "success" })).toBeNull();
@@ -127,6 +142,6 @@ describe("summaryLine", () => {
   });
   it("shows max_turns outcome at summary level", () => {
     expect(summaryLine({ outcome: "max_turns", numTurns: 50, durationMs: null, costUsd: null, tokensIn: null, tokensOut: null }))
-      .toContain("result=max_turns");
+      .toBe("[claude] result=max_turns turns=50");
   });
 });

--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -127,6 +127,16 @@ describe("formatEvent", () => {
       formatEvent({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash" }] } }),
     ).toBe("[claude] tool Bash");
   });
+  it("renders a user event carrying a tool_result as tool_result", () => {
+    expect(
+      formatEvent({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "t1", content: "ok" }] } }),
+    ).toBe("[claude] tool_result");
+  });
+  it("returns null for the initial user prompt turn (no tool_result)", () => {
+    expect(
+      formatEvent({ type: "user", message: { content: [{ type: "text", text: "implement the thing" }] } }),
+    ).toBeNull();
+  });
   it("returns null for a result event (summary handles it)", () => {
     expect(formatEvent({ type: "result", subtype: "success" })).toBeNull();
   });

--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -54,6 +54,12 @@ describe("finalText", () => {
   it("returns empty string for an empty event list", () => {
     expect(finalText([])).toBe("");
   });
+  it("preserves an embedded JSON object in the result text (review/fix consumers depend on this)", () => {
+    const text = 'Here is my review.\n{"approved":true,"score":95}';
+    const events: StreamEvent[] = [{ type: "result", subtype: "success", result: text }];
+    expect(finalText(events)).toBe(text);
+    expect(finalText(events)).toContain('{"approved":true,"score":95}');
+  });
 });
 
 describe("extractTelemetry", () => {

--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseLine,
+  finalText,
+  extractTelemetry,
+  type StreamEvent,
+} from "../pipeline/claude-stream.js";
+
+const initEvent: StreamEvent = { type: "system", subtype: "init", model: "claude-x", cwd: "/workspace" };
+const toolEvent: StreamEvent = {
+  type: "assistant",
+  message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm check" } }] },
+};
+const textEvent: StreamEvent = {
+  type: "assistant",
+  message: { content: [{ type: "text", text: "All done." }] },
+};
+const resultSuccess: StreamEvent = {
+  type: "result",
+  subtype: "success",
+  result: "Final answer text",
+  num_turns: 12,
+  duration_ms: 372000,
+  total_cost_usd: 0.83,
+  usage: { input_tokens: 182000, output_tokens: 4100 },
+};
+
+describe("parseLine", () => {
+  it("parses a JSON line", () => {
+    expect(parseLine('{"type":"result"}')).toEqual({ type: "result" });
+  });
+  it("returns null for a non-JSON line", () => {
+    expect(parseLine("not json")).toBeNull();
+  });
+  it("returns null for a blank line", () => {
+    expect(parseLine("   ")).toBeNull();
+  });
+});
+
+describe("finalText", () => {
+  it("returns the result event's text", () => {
+    expect(finalText([initEvent, resultSuccess])).toBe("Final answer text");
+  });
+  it("falls back to concatenated assistant text when no result event", () => {
+    expect(finalText([initEvent, textEvent])).toBe("All done.");
+  });
+});
+
+describe("extractTelemetry", () => {
+  it("extracts metrics from a success result", () => {
+    const t = extractTelemetry([initEvent, toolEvent, resultSuccess]);
+    expect(t).toEqual({
+      outcome: "success",
+      numTurns: 12,
+      durationMs: 372000,
+      costUsd: 0.83,
+      tokensIn: 182000,
+      tokensOut: 4100,
+    });
+  });
+  it("maps error_max_turns to outcome=max_turns", () => {
+    const t = extractTelemetry([{ type: "result", subtype: "error_max_turns", num_turns: 50 }]);
+    expect(t.outcome).toBe("max_turns");
+    expect(t.numTurns).toBe(50);
+  });
+  it("returns outcome=unknown with nulls when no result event", () => {
+    expect(extractTelemetry([initEvent])).toEqual({
+      outcome: "unknown",
+      numTurns: null,
+      durationMs: null,
+      costUsd: null,
+      tokensIn: null,
+      tokensOut: null,
+    });
+  });
+  it("tolerates a Bedrock result with no cost", () => {
+    const t = extractTelemetry([{ type: "result", subtype: "success", num_turns: 3, usage: { input_tokens: 10, output_tokens: 2 } }]);
+    expect(t.costUsd).toBeNull();
+    expect(t.outcome).toBe("success");
+  });
+});

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -62,10 +62,15 @@ afterEach(() => {
 });
 
 function installFakeClaudeNoTrailingNewline(stdoutLines: string[], code = 0): void {
-  // printf '%b' interprets \n as a real newline; no trailing \n — exercises the close-handler flush.
-  const joined = stdoutLines.join("\\n");
+  // Emit every line but the last via a quoted heredoc, then the final line with
+  // `printf '%s'` so there is NO trailing newline — exercises the close-handler
+  // flush. Quoted heredoc + single-quoted printf arg means `$`/backtick in JSON
+  // values are never interpreted by the shell.
+  const lines = [...stdoutLines];
+  const last = (lines.pop() ?? "").replace(/'/g, `'\\''`);
+  const head = lines.length ? `cat <<'JSONL'\n${lines.join("\n")}\nJSONL\n` : "";
   const script = `#!/usr/bin/env bash
-printf '%b' "${joined.replace(/"/g, '\\"')}"
+${head}printf '%s' '${last}'
 exit ${code}
 `;
   const path = join(binDir, "claude");

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ClaudeCliExecutor } from "../pipeline/executor.js";
+
+let binDir: string;
+let originalPath: string | undefined;
+
+function installFakeClaude(stdoutLines: string[], code = 0): void {
+  const script = `#!/usr/bin/env bash
+cat <<'JSONL'
+${stdoutLines.join("\n")}
+JSONL
+exit ${code}
+`;
+  const path = join(binDir, "claude");
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+}
+
+const SUCCESS_LINES = [
+  JSON.stringify({ type: "system", subtype: "init", model: "claude-x", cwd: "/workspace" }),
+  JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm check" } }] } }),
+  JSON.stringify({ type: "result", subtype: "success", result: "Done implementing.", num_turns: 4, duration_ms: 5000, usage: { input_tokens: 100, output_tokens: 20 } }),
+];
+
+beforeEach(() => {
+  binDir = mkdtempSync(join(tmpdir(), "fakebin-"));
+  originalPath = process.env.PATH;
+  process.env.PATH = `${binDir}:${process.env.PATH ?? ""}`;
+});
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+  rmSync(binDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("ClaudeCliExecutor", () => {
+  it("returns the result event's text as stdout (compat) plus telemetry", async () => {
+    installFakeClaude(SUCCESS_LINES, 0);
+    const exec = new ClaudeCliExecutor("/tmp", "summary");
+    const result = await exec.invoke({ prompt: "do it", model: "claude-x" });
+
+    expect(result.stdout).toBe("Done implementing.");
+    expect(result.exitCode).toBe(0);
+    expect(result.telemetry?.outcome).toBe("success");
+    expect(result.telemetry?.numTurns).toBe(4);
+    expect(result.tokensUsed).toBe(120);
+  });
+
+  it("does NOT print per-event lines at summary level, but prints the summary", async () => {
+    installFakeClaude(SUCCESS_LINES, 0);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await new ClaudeCliExecutor("/tmp", "summary").invoke({ prompt: "p", model: "m" });
+
+    const lines = log.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.startsWith("[claude] result="))).toBe(true);
+    expect(lines.some((l) => l.startsWith("[claude] tool "))).toBe(false);
+  });
+
+  it("prints per-event lines at stream level", async () => {
+    installFakeClaude(SUCCESS_LINES, 0);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await new ClaudeCliExecutor("/tmp", "stream").invoke({ prompt: "p", model: "m" });
+
+    const lines = log.mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes("tool Bash pnpm check"))).toBe(true);
+    expect(lines.some((l) => l.startsWith("[claude] result="))).toBe(true);
+  });
+
+  it("propagates a non-zero exit code and degrades telemetry to unknown", async () => {
+    installFakeClaude(["not even json"], 1);
+    const result = await new ClaudeCliExecutor("/tmp", "summary").invoke({ prompt: "p", model: "m" });
+    expect(result.exitCode).toBe(1);
+    expect(result.telemetry?.outcome).toBe("unknown");
+    expect(result.stdout).toBe("");
+  });
+});

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -37,8 +37,21 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function installFakeClaudeNoTrailingNewline(stdoutLines: string[], code = 0): void {
+  // printf '%b' interprets \n as a real newline; no trailing \n — exercises the close-handler flush.
+  const joined = stdoutLines.join("\\n");
+  const script = `#!/usr/bin/env bash
+printf '%b' "${joined.replace(/"/g, '\\"')}"
+exit ${code}
+`;
+  const path = join(binDir, "claude");
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+}
+
 describe("ClaudeCliExecutor", () => {
   it("returns the result event's text as stdout (compat) plus telemetry", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
     installFakeClaude(SUCCESS_LINES, 0);
     const exec = new ClaudeCliExecutor("/tmp", "summary");
     const result = await exec.invoke({ prompt: "do it", model: "claude-x" });
@@ -71,10 +84,20 @@ describe("ClaudeCliExecutor", () => {
   });
 
   it("propagates a non-zero exit code and degrades telemetry to unknown", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
     installFakeClaude(["not even json"], 1);
     const result = await new ClaudeCliExecutor("/tmp", "summary").invoke({ prompt: "p", model: "m" });
     expect(result.exitCode).toBe(1);
     expect(result.telemetry?.outcome).toBe("unknown");
     expect(result.stdout).toBe("");
+  });
+
+  it("parses a final line that has no trailing newline", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    installFakeClaudeNoTrailingNewline(SUCCESS_LINES, 0);
+    const result = await new ClaudeCliExecutor("/tmp", "summary").invoke({ prompt: "p", model: "m" });
+    expect(result.stdout).toBe("Done implementing.");
+    expect(result.telemetry?.outcome).toBe("success");
+    expect(result.telemetry?.numTurns).toBe(4);
   });
 });

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -19,6 +19,18 @@ exit ${code}
   chmodSync(path, 0o755);
 }
 
+// A fake `claude` that writes a message to stderr (e.g. an auth/model error)
+// and exits non-zero, with no JSONL on stdout.
+function installFakeClaudeStderr(message: string, code = 1): void {
+  const script = `#!/usr/bin/env bash
+printf '%s\\n' '${message.replace(/'/g, `'\\''`)}' >&2
+exit ${code}
+`;
+  const path = join(binDir, "claude");
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+}
+
 // A fake `claude` that records the argv it was invoked with and whatever arrived
 // on stdin, then emits a single valid result line so the stream executor settles
 // cleanly. This exercises the actual spawn + stdio plumbing — the only thing that
@@ -128,6 +140,18 @@ describe("ClaudeCliExecutor", () => {
     expect(result.stdout).toBe("Done implementing.");
     expect(result.telemetry?.outcome).toBe("success");
     expect(result.telemetry?.numTurns).toBe(4);
+  });
+
+  it("surfaces non-empty CLI stderr via console.error and returns it", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    installFakeClaudeStderr("Authentication failed: invalid API key", 1);
+    const result = await new ClaudeCliExecutor("/tmp", "summary").invoke({ prompt: "p", model: "m" });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Authentication failed");
+    const errLines = err.mock.calls.map((c) => c.join(" "));
+    expect(errLines.some((l) => l.includes("[claude] stderr:") && l.includes("Authentication failed"))).toBe(true);
   });
 
   it("delivers the prompt over stdin, never as a command-line argument", async () => {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync } from "node:
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runAutonomous } from "../run-autonomous.js";
+import { runAutonomous, resolveLogLevel } from "../run-autonomous.js";
 import { PipelineRunner } from "../pipeline/runner.js";
 import { NoopStepReporter } from "../pipeline/reporter.js";
 import type { LLMExecutor, PipelineDefinition, StepModule } from "../pipeline/types.js";
@@ -790,5 +790,17 @@ describe("runAutonomous", () => {
 
     expect(result.exitCode).toBe(1);
     expect(existsSync(join(workspaceDir, "teardown-ran.marker"))).toBe(true);
+  });
+});
+
+describe("resolveLogLevel", () => {
+  it("returns stream when set to stream", () => {
+    expect(resolveLogLevel("stream")).toBe("stream");
+  });
+  it("defaults to summary when unset", () => {
+    expect(resolveLogLevel(undefined)).toBe("summary");
+  });
+  it("defaults to summary for an unrecognized value", () => {
+    expect(resolveLogLevel("loud")).toBe("summary");
   });
 });

--- a/src/__tests__/workflow-log-level.test.ts
+++ b/src/__tests__/workflow-log-level.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("claude-implement.yml forwards AI_IMPLEMENT_LOG_LEVEL", () => {
+  it("passes the repo variable into the pipeline container env", () => {
+    const yml = readFileSync(join(process.cwd(), "workflows/claude-implement.yml"), "utf-8");
+    expect(yml).toContain("AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}");
+  });
+});

--- a/src/__tests__/workflow-log-level.test.ts
+++ b/src/__tests__/workflow-log-level.test.ts
@@ -2,9 +2,18 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-describe("claude-implement.yml forwards AI_IMPLEMENT_LOG_LEVEL", () => {
-  it("passes the repo variable into the pipeline container env", () => {
-    const yml = readFileSync(join(process.cwd(), "workflows/claude-implement.yml"), "utf-8");
-    expect(yml).toContain("AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}");
-  });
+const FILES = [
+  "workflows/claude-implement.yml",
+  ".github/workflows/claude-implement.yml",
+  "workflows/comment-trigger.yml",
+  ".github/workflows/comment-trigger.yml",
+];
+
+describe("workflows forward AI_IMPLEMENT_LOG_LEVEL", () => {
+  for (const f of FILES) {
+    it(`${f} passes the repo variable into the pipeline container env`, () => {
+      const yml = readFileSync(join(process.cwd(), f), "utf-8");
+      expect(yml).toContain("AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}");
+    });
+  }
 });

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -65,3 +65,76 @@ export function extractTelemetry(events: StreamEvent[]): RunTelemetry {
     tokensOut: num(usage.output_tokens),
   };
 }
+
+const TOOL_INPUT_MAX = 160;
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max)}…`;
+}
+
+function summarizeToolInput(input: unknown): string {
+  if (input == null) return "";
+  if (typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    const candidate =
+      (typeof obj.command === "string" && obj.command) ||
+      (typeof obj.file_path === "string" && obj.file_path) ||
+      (typeof obj.path === "string" && obj.path) ||
+      (typeof obj.pattern === "string" && obj.pattern) ||
+      JSON.stringify(obj);
+    return truncate(String(candidate), TOOL_INPUT_MAX);
+  }
+  return truncate(String(input), TOOL_INPUT_MAX);
+}
+
+export function formatEvent(event: StreamEvent): string | null {
+  switch (event.type) {
+    case "system":
+      if (event.subtype === "init") {
+        const model = typeof event.model === "string" ? event.model : "?";
+        const cwd = typeof event.cwd === "string" ? event.cwd : "?";
+        return `[claude] init model=${model} cwd=${cwd}`;
+      }
+      return null;
+    case "assistant": {
+      const msg = event.message as { content?: Array<Record<string, unknown>> } | undefined;
+      const lines: string[] = [];
+      for (const block of msg?.content ?? []) {
+        if (block.type === "tool_use") {
+          const name = typeof block.name === "string" ? block.name : "tool";
+          lines.push(`[claude] tool ${name} ${summarizeToolInput(block.input)}`.trimEnd());
+        } else if (block.type === "text" && typeof block.text === "string" && block.text.trim()) {
+          lines.push(`[claude] assistant: ${truncate(block.text.trim(), TOOL_INPUT_MAX)}`);
+        }
+      }
+      return lines.length ? lines.join("\n") : null;
+    }
+    case "user":
+      return "[claude] tool_result";
+    default:
+      return null;
+  }
+}
+
+function humanizeMs(ms: number): string {
+  const s = Math.round(ms / 1000);
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return m > 0 ? `${m}m${rem.toString().padStart(2, "0")}s` : `${rem}s`;
+}
+
+function kfmt(n: number | null): string {
+  if (n == null) return "?";
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+export function summaryLine(t: RunTelemetry): string {
+  const parts = [`[claude] result=${t.outcome}`];
+  if (t.numTurns != null) parts.push(`turns=${t.numTurns}`);
+  if (t.durationMs != null) parts.push(`duration=${humanizeMs(t.durationMs)}`);
+  if (t.costUsd != null && t.costUsd > 0) parts.push(`cost=$${t.costUsd.toFixed(2)}`);
+  if (t.tokensIn != null || t.tokensOut != null) {
+    parts.push(`tokens=${kfmt(t.tokensIn)}/${kfmt(t.tokensOut)} (in/out)`);
+  }
+  return parts.join(" ");
+}

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -1,0 +1,65 @@
+import type { RunTelemetry } from "./types.js";
+
+export interface StreamEvent {
+  type?: string;
+  subtype?: string;
+  [key: string]: unknown;
+}
+
+export function parseLine(line: string): StreamEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as StreamEvent;
+  } catch {
+    return null;
+  }
+}
+
+function lastResult(events: StreamEvent[]): StreamEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].type === "result") return events[i];
+  }
+  return undefined;
+}
+
+export function finalText(events: StreamEvent[]): string {
+  const result = lastResult(events);
+  if (result && typeof result.result === "string") return result.result;
+  const texts: string[] = [];
+  for (const e of events) {
+    if (e.type !== "assistant") continue;
+    const msg = e.message as { content?: Array<{ type?: string; text?: string }> } | undefined;
+    for (const block of msg?.content ?? []) {
+      if (block.type === "text" && typeof block.text === "string") texts.push(block.text);
+    }
+  }
+  return texts.join("\n");
+}
+
+function num(v: unknown): number | null {
+  return typeof v === "number" ? v : null;
+}
+
+function mapOutcome(subtype: unknown): RunTelemetry["outcome"] {
+  if (subtype === "success") return "success";
+  if (subtype === "error_max_turns") return "max_turns";
+  if (typeof subtype === "string" && subtype.startsWith("error")) return "error";
+  return "unknown";
+}
+
+export function extractTelemetry(events: StreamEvent[]): RunTelemetry {
+  const result = lastResult(events);
+  if (!result) {
+    return { outcome: "unknown", numTurns: null, durationMs: null, costUsd: null, tokensIn: null, tokensOut: null };
+  }
+  const usage = (result.usage ?? {}) as { input_tokens?: number; output_tokens?: number };
+  return {
+    outcome: mapOutcome(result.subtype),
+    numTurns: num(result.num_turns),
+    durationMs: num(result.duration_ms),
+    costUsd: num(result.total_cost_usd),
+    tokensIn: num(usage.input_tokens),
+    tokensOut: num(usage.output_tokens),
+  };
+}

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -72,6 +72,14 @@ function truncate(s: string, max: number): string {
   return s.length <= max ? s : `${s.slice(0, max)}…`;
 }
 
+function safeStringify(obj: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(obj);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
 function summarizeToolInput(input: unknown): string {
   if (input == null) return "";
   if (typeof input === "object") {
@@ -81,7 +89,7 @@ function summarizeToolInput(input: unknown): string {
       (typeof obj.file_path === "string" && obj.file_path) ||
       (typeof obj.path === "string" && obj.path) ||
       (typeof obj.pattern === "string" && obj.pattern) ||
-      JSON.stringify(obj);
+      safeStringify(obj);
     return truncate(String(candidate), TOOL_INPUT_MAX);
   }
   return truncate(String(input), TOOL_INPUT_MAX);
@@ -132,6 +140,7 @@ export function summaryLine(t: RunTelemetry): string {
   const parts = [`[claude] result=${t.outcome}`];
   if (t.numTurns != null) parts.push(`turns=${t.numTurns}`);
   if (t.durationMs != null) parts.push(`duration=${humanizeMs(t.durationMs)}`);
+  // Omit cost when absent or zero (Bedrock typically reports no cost).
   if (t.costUsd != null && t.costUsd > 0) parts.push(`cost=$${t.costUsd.toFixed(2)}`);
   if (t.tokensIn != null || t.tokensOut != null) {
     parts.push(`tokens=${kfmt(t.tokensIn)}/${kfmt(t.tokensOut)} (in/out)`);

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -117,8 +117,16 @@ export function formatEvent(event: StreamEvent): string | null {
       }
       return lines.length ? lines.join("\n") : null;
     }
-    case "user":
-      return "[claude] tool_result";
+    case "user": {
+      // A `user` event is either a tool_result echo or the initial prompt turn.
+      // Only the former should surface as tool_result; the initial prompt (plain
+      // text, no tool_use_id) would otherwise print a misleading first line.
+      const msg = event.message as { content?: Array<Record<string, unknown>> } | undefined;
+      const hasToolResult = (msg?.content ?? []).some(
+        (block) => block.type === "tool_result" || typeof block.tool_use_id === "string",
+      );
+      return hasToolResult ? "[claude] tool_result" : null;
+    }
     default:
       return null;
   }

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -10,7 +10,9 @@ export function parseLine(line: string): StreamEvent | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
   try {
-    return JSON.parse(trimmed) as StreamEvent;
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as StreamEvent;
   } catch {
     return null;
   }

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -52,13 +52,18 @@ export class ClaudeCliExecutor implements LLMExecutor {
         env: { ...process.env },
       });
 
-      proc.stdin.on("error", reject);
-      proc.stdin.end(params.prompt);
-
       const events: StreamEvent[] = [];
       const stderrChunks: Buffer[] = [];
       let buf = "";
       let settled = false;
+
+      proc.stdin.on("error", (err) => {
+        // EPIPE here means the child exited before consuming the prompt. Mark
+        // settled so the close handler doesn't log a phantom success summary.
+        settled = true;
+        reject(err);
+      });
+      proc.stdin.end(params.prompt);
 
       const handleLine = (line: string) => {
         const event = parseLine(line);
@@ -84,11 +89,15 @@ export class ClaudeCliExecutor implements LLMExecutor {
         if (settled) return;
         settled = true;
         if (buf.trim()) handleLine(buf); // flush trailing partial line
+        const stderr = Buffer.concat(stderrChunks).toString();
+        // Surface CLI stderr (auth failures, bad model IDs, rate limits) — it is
+        // otherwise invisible in GHA logs at any log level.
+        if (stderr.trim()) console.error("[claude] stderr:", stderr.trim());
         const telemetry = extractTelemetry(events);
         console.log(summaryLine(telemetry));
         resolve({
           stdout: finalText(events),
-          stderr: Buffer.concat(stderrChunks).toString(),
+          stderr,
           exitCode: code ?? 1,
           tokensUsed: (telemetry.tokensIn ?? 0) + (telemetry.tokensOut ?? 0),
           telemetry,

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -1,13 +1,26 @@
 import { spawn } from "node:child_process";
-import type { LLMExecutor, LLMResult } from "./types.js";
+import type { LLMExecutor, LLMResult, LogLevel } from "./types.js";
+import {
+  parseLine,
+  formatEvent,
+  finalText,
+  extractTelemetry,
+  summaryLine,
+  type StreamEvent,
+} from "./claude-stream.js";
 
 /**
- * Shells out to the Claude Code CLI installed in the session image.
- * Used on Fly Machines where the CLI is present in the runner image.
- * Other runtimes (GitHub Actions, direct API) inject a different executor.
+ * Shells out to the Claude Code CLI in stream-json mode. Each JSONL event is
+ * parsed for live logging (when logLevel="stream") and accumulated for final
+ * telemetry. The CLI's final `result` text is returned as `stdout` so existing
+ * consumers (e.g. review-step JSON extraction) are unaffected by the format
+ * change. A one-line summary is always logged.
  */
 export class ClaudeCliExecutor implements LLMExecutor {
-  constructor(private readonly workspaceDir: string) {}
+  constructor(
+    private readonly workspaceDir: string,
+    private readonly logLevel: LogLevel = "summary",
+  ) {}
 
   invoke(params: {
     prompt: string;
@@ -16,7 +29,12 @@ export class ClaudeCliExecutor implements LLMExecutor {
     tools?: string[];
   }): Promise<LLMResult> {
     return new Promise((resolve, reject) => {
-      const args: string[] = ["--dangerously-skip-permissions"];
+      const args: string[] = [
+        "--dangerously-skip-permissions",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+      ];
       if (params.model) args.push("--model", params.model);
       if (params.maxTurns != null) args.push("--max-turns", String(params.maxTurns));
       if (params.tools && params.tools.length > 0) {
@@ -30,19 +48,40 @@ export class ClaudeCliExecutor implements LLMExecutor {
         env: { ...process.env },
       });
 
-      const chunks: Buffer[] = [];
+      const events: StreamEvent[] = [];
       const stderrChunks: Buffer[] = [];
-      proc.stdout.on("data", (d: Buffer) => chunks.push(d));
+      let buf = "";
+
+      const handleLine = (line: string) => {
+        const event = parseLine(line);
+        if (!event) return;
+        events.push(event);
+        if (this.logLevel === "stream") {
+          const formatted = formatEvent(event);
+          if (formatted) console.log(formatted);
+        }
+      };
+
+      proc.stdout.on("data", (d: Buffer) => {
+        buf += d.toString();
+        let idx: number;
+        while ((idx = buf.indexOf("\n")) !== -1) {
+          handleLine(buf.slice(0, idx));
+          buf = buf.slice(idx + 1);
+        }
+      });
       proc.stderr.on("data", (d: Buffer) => stderrChunks.push(d));
 
       proc.on("close", (code) => {
-        // tokensUsed is not available from Claude CLI stdout; budget enforcement
-        // should rely on the orchestrator's own token tracking.
+        if (buf.trim()) handleLine(buf); // flush trailing partial line
+        const telemetry = extractTelemetry(events);
+        console.log(summaryLine(telemetry));
         resolve({
-          stdout: Buffer.concat(chunks).toString(),
+          stdout: finalText(events),
           stderr: Buffer.concat(stderrChunks).toString(),
           exitCode: code ?? 1,
-          tokensUsed: 0,
+          tokensUsed: (telemetry.tokensIn ?? 0) + (telemetry.tokensOut ?? 0),
+          telemetry,
         });
       });
 

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -51,6 +51,7 @@ export class ClaudeCliExecutor implements LLMExecutor {
       const events: StreamEvent[] = [];
       const stderrChunks: Buffer[] = [];
       let buf = "";
+      let settled = false;
 
       const handleLine = (line: string) => {
         const event = parseLine(line);
@@ -73,6 +74,8 @@ export class ClaudeCliExecutor implements LLMExecutor {
       proc.stderr.on("data", (d: Buffer) => stderrChunks.push(d));
 
       proc.on("close", (code) => {
+        if (settled) return;
+        settled = true;
         if (buf.trim()) handleLine(buf); // flush trailing partial line
         const telemetry = extractTelemetry(events);
         console.log(summaryLine(telemetry));
@@ -85,7 +88,10 @@ export class ClaudeCliExecutor implements LLMExecutor {
         });
       });
 
-      proc.on("error", reject);
+      proc.on("error", (err) => {
+        settled = true;
+        reject(err);
+      });
     });
   }
 }

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -86,11 +86,23 @@ export interface StepModule<
   run(context: PipelineContext, inputs: I, reporter: StepReporter): Promise<O>;
 }
 
+export type LogLevel = "summary" | "stream";
+
+export interface RunTelemetry {
+  outcome: "success" | "max_turns" | "error" | "unknown";
+  numTurns: number | null;
+  durationMs: number | null;
+  costUsd: number | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+}
+
 export interface LLMResult {
   stdout: string;
   stderr?: string;
   exitCode: number;
   tokensUsed: number;
+  telemetry?: RunTelemetry;
 }
 
 export interface LLMExecutor {

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -5,7 +5,7 @@ import { ClaudeCliExecutor } from "./pipeline/executor.js";
 import { DefaultPipelineContext } from "./pipeline/context.js";
 import { PipelineRunner } from "./pipeline/runner.js";
 import { DEFAULT_PIPELINE, createDefaultRunner } from "./pipeline/default-pipeline.js";
-import type { LLMExecutor, PipelineDefinition, StepReporter } from "./pipeline/types.js";
+import type { LLMExecutor, LogLevel, PipelineDefinition, StepReporter } from "./pipeline/types.js";
 import { HttpStepReporter, NoopStepReporter, TokenStepReporter } from "./pipeline/reporter.js";
 import { runHookScript } from "./pipeline/steps/hooks.js";
 import { parseWorkflowMd } from "./workflow-md.js";
@@ -102,6 +102,10 @@ The AI-Implement pipeline will create the implementation commit, push an issue-s
 
 
 
+export function resolveLogLevel(raw: string | undefined): LogLevel {
+  return raw === "stream" ? "stream" : "summary";
+}
+
 export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<RunAutonomousResult> {
   const workspaceDir = opts.workspaceDir ?? process.env.WORKSPACE_DIR ?? "/workspace";
   const issueId = requireEnv("ISSUE_ID");
@@ -172,7 +176,8 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   const maxTurns = parseEnvInt(process.env.AI_IMPLEMENT_MAX_TURNS, "AI_IMPLEMENT_MAX_TURNS");
   const maxIterations = parseEnvInt(process.env.AI_IMPLEMENT_MAX_ITERATIONS, "AI_IMPLEMENT_MAX_ITERATIONS");
 
-  const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir);
+  const logLevel = resolveLogLevel(process.env.AI_IMPLEMENT_LOG_LEVEL);
+  const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir, logLevel);
   const orchestratorUrl = process.env.ORCHESTRATOR_URL;
   const nonce = process.env.MACHINE_NONCE ?? "";
   const callbackUrl = process.env.RUNNER_CALLBACK_URL;

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -228,6 +228,7 @@ jobs:
           AWS_REGION: ${{ inputs.aws_region }}
           AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
+          AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -229,6 +229,7 @@ jobs:
           PROVIDER: ${{ needs.check-trigger.outputs.provider }}
           AI_IMPLEMENT_MAX_TURNS: ${{ needs.check-trigger.outputs.max_turns }}
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ needs.check-trigger.outputs.max_iterations }}
+          AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
## Summary

Makes Claude implementation runs observable (Goal 1 of 3 — design spec + plan in `docs/superpowers/`). Today the runner is a black box: a 6½-minute Bedrock run logged nothing, and `tokensUsed` was hardcoded `0`.

- **stream-json executor** — `ClaudeCliExecutor` now runs `claude --output-format stream-json --verbose`. A new pure module `src/pipeline/claude-stream.ts` parses the JSONL event stream into `RunTelemetry` (turns / duration / cost / tokens / outcome) and the final answer text.
- **Capture decoupled from surface** — a one-line summary (`[claude] result=success turns=47 duration=6m12s …`, incl. `max_turns` outcome) is **always** logged; per-turn tool lines are streamed only when `AI_IMPLEMENT_LOG_LEVEL=stream`.
- **Compatibility preserved** — the executor returns Claude's final text as `stdout` (via `finalText`), so review-step / post-push-review JSON extraction is unaffected by the format switch. `tokensUsed` is now populated from telemetry.
- **The setting** — `AI_IMPLEMENT_LOG_LEVEL` (`summary` default | `stream`), read inside the runner container. Forwarded as a repo/org **variable** by both `claude-implement.yml` and `comment-trigger.yml` (so it applies to orchestrator-initiated *and* `/ai-implement` gap-fill runs). Not a per-project field, not a dispatch input — avoids the "unexpected inputs" re-sync tax. **Target repos must re-sync these workflow templates to pick it up.**

Telemetry rides on `LLMResult.telemetry` as a seam for the deferred follow-ons: **AII-129** (persist to dispatch_log + admin UI) and **AII-130** (post progress to Linear).

Built TDD, 7 tasks, each spec- and quality-reviewed by subagents plus a final holistic review (which caught the comment-trigger gap, now fixed).

## Test Plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1194 passed / 86 files
- [x] New tests: `claude-stream` (parser/formatters/telemetry, incl. malformed-input + no-trailing-newline + embedded-JSON round-trip), `executor` (real fake-`claude` subprocess: compat stdout, telemetry, stream-gating, exit-code + double-settle), `run-autonomous` (`resolveLogLevel`), `workflow-log-level` (all 4 workflow copies forward the var)
- [ ] After merge: rebuild the `:next` base runner, then rebuild Forecast-it's custom `ai-implement-runner-db:next` FROM it
- [ ] Smoke: set `AI_IMPLEMENT_LOG_LEVEL=stream` repo variable on a test repo, run an implement, confirm per-turn lines + summary in the GHA log

## Notes
- Soft-depends on #72 (non-fatal review + bounded diff); branch cut from `testing`. No conflicts, but merge #72 first and this rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)