### PR TITLE
fix(runner): keep ai-output/ out of the implementation PR

### DIFF
--- a/src/__tests__/steps-clone.test.ts
+++ b/src/__tests__/steps-clone.test.ts
@@ -13,6 +13,10 @@ vi.mock("node:fs", () => ({
   },
 }));
 
+vi.mock("../pipeline/steps/workspace-excludes.js", () => ({
+  ensureRunnerExcludes: vi.fn(),
+}));
+
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 

--- a/src/__tests__/workspace-excludes.test.ts
+++ b/src/__tests__/workspace-excludes.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureRunnerExcludes } from "../pipeline/steps/workspace-excludes.js";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+describe("ensureRunnerExcludes", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ws-excludes-"));
+    git(dir, ["init", "-q"]);
+    git(dir, ["config", "user.email", "t@example.com"]);
+    git(dir, ["config", "user.name", "Test"]);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("hides ai-output from git status and git add -A while keeping real changes", () => {
+    mkdirSync(join(dir, "ai-output", "comments"), { recursive: true });
+    writeFileSync(join(dir, "ai-output", "comments", "01-summary.md"), "summary");
+    writeFileSync(join(dir, "real.txt"), "real change");
+
+    ensureRunnerExcludes(dir);
+
+    const status = git(dir, ["status", "--porcelain"]);
+    expect(status).toContain("real.txt");
+    expect(status).not.toContain("ai-output");
+
+    git(dir, ["add", "-A"]);
+    const staged = git(dir, ["diff", "--cached", "--name-only"]);
+    expect(staged).toContain("real.txt");
+    expect(staged).not.toContain("ai-output");
+  });
+
+  it("is idempotent across repeated calls (incremental re-clone)", () => {
+    ensureRunnerExcludes(dir);
+    ensureRunnerExcludes(dir);
+
+    const exclude = readFileSync(join(dir, ".git", "info", "exclude"), "utf-8");
+    const occurrences = exclude.split("\n").filter((l) => l.trim() === "ai-output/").length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("does not throw when the workspace has no .git directory", () => {
+    const bare = mkdtempSync(join(tmpdir(), "no-git-"));
+    try {
+      expect(() => ensureRunnerExcludes(bare)).not.toThrow();
+    } finally {
+      rmSync(bare, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/pipeline/steps/clone.ts
+++ b/src/pipeline/steps/clone.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
+import { ensureRunnerExcludes } from "./workspace-excludes.js";
 
 interface CloneInputs extends Record<string, unknown> {
   repoOwner: string;
@@ -69,6 +70,10 @@ export const cloneStep: StepModule<CloneInputs, CloneOutputs> = {
 
       cloneMethod = "fresh";
     }
+
+    // Reserve the runner's transient output paths (e.g. ai-output/) so the
+    // commit steps never stage them into the PR.
+    ensureRunnerExcludes(workspaceDir);
 
     const revResult = spawnSync("git", ["rev-parse", "HEAD"], {
       cwd: workspaceDir,

--- a/src/pipeline/steps/workspace-excludes.ts
+++ b/src/pipeline/steps/workspace-excludes.ts
@@ -1,0 +1,33 @@
+import { existsSync, mkdirSync, readFileSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Paths the runner writes into the workspace as a transient orchestrator
+ * channel — collected by `collectRunnerComments` and posted to the ticketing
+ * provider, never meant to land in the PR. They are added to the clone's local
+ * `.git/info/exclude` (not a committed `.gitignore`) so that `git add -A` skips
+ * them and `git status --porcelain` ignores them, across every commit site
+ * (initial push and the post-push review fix loop).
+ */
+const RESERVED_PATTERNS = ["ai-output/"];
+const MARKER = "# ai-implement: runner-reserved paths (never committed)";
+
+/**
+ * Idempotently register the runner-reserved paths in the workspace's local git
+ * exclude file. No-op when the workspace has no `.git` directory.
+ */
+export function ensureRunnerExcludes(workspaceDir: string): void {
+  if (!existsSync(join(workspaceDir, ".git"))) return;
+
+  const infoDir = join(workspaceDir, ".git", "info");
+  mkdirSync(infoDir, { recursive: true });
+  const excludePath = join(infoDir, "exclude");
+  const existing = existsSync(excludePath) ? readFileSync(excludePath, "utf-8") : "";
+  const existingLines = new Set(existing.split("\n").map((l) => l.trim()));
+
+  const missing = RESERVED_PATTERNS.filter((p) => !existingLines.has(p));
+  if (missing.length === 0) return;
+
+  const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  appendFileSync(excludePath, `${prefix}${MARKER}\n${missing.join("\n")}\n`);
+}


### PR DESCRIPTION
## Problem

AI-Implement PRs were committing `ai-output/comments/01-summary.md` into the implementation branch (e.g. [eudoxus-ai/ai-implement-test-repo#2](https://github.com/eudoxus-ai/ai-implement-test-repo/pull/2)).

`ai-output/comments/*.md` is a **transient runner→orchestrator channel** — `WORKFLOW.md` instructs Claude to write the summary there, and `runner-result.ts:collectRunnerComments` reads it and posts it to the ticketing provider (Linear). It is never meant to be PR content.

## Root cause

The commit steps run `git add -A`, which indiscriminately stages the whole working tree — sweeping `ai-output/` into the commit. This happens in both `push.ts` (initial PR) and the `post-push-review.ts` review-feedback fix loop.

## Fix

Fixed at the source rather than patching each `git add` site: a new helper `ensureRunnerExcludes` registers `ai-output/` in the clone's local **`.git/info/exclude`**, called from the clone step after both the fresh-clone and incremental-fetch paths.

Why this layer:
- `.git/info/exclude` is **local to the clone** — never committed or pushed, so it doesn't add a stray `.gitignore` to the target repo / PR.
- Honored by **both** `git add -A` and `git status --porcelain`, so it covers every commit path *and* the "nothing to commit" guards — a pass that produced only `ai-output/` now correctly counts as no real change.
- All steps share the clone's `workspaceDir`, so one chokepoint fixes implement, gap-fill, and review-feedback runs.
- Idempotent, so incremental re-clones don't duplicate entries.

## Tests

`workspace-excludes.test.ts` uses a real temp git repo to assert `ai-output/` is hidden from `status`/`add -A` while real changes pass through, plus idempotency and the no-`.git` no-op. Full suite green (1230 tests), typecheck clean.

## Note

This prevents recurrence on future runs but does not retroactively rewrite already-open PR #2's branch — that file must be dropped from that branch separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)