### PR TITLE
feat: per-project PR branch prefix + sync-branch refresh

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -74,6 +74,11 @@ on:
         required: false
         type: string
         default: ""
+      branch_prefix:
+        description: "Optional branch-name prefix prepended as a path segment (empty = no prefix)"
+        required: false
+        type: string
+        default: ""
       runner_callback_url:
         description: "Base URL the orchestrator advertises for /runner/result; empty skips callback"
         required: false
@@ -227,6 +232,7 @@ jobs:
           AWS_REGION: ${{ inputs.aws_region }}
           AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
+          AI_IMPLEMENT_BRANCH_PREFIX: ${{ inputs.branch_prefix }}
           AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,12 @@ Each project's mapping carries three optional caps, editable in the `/admin` Pro
 
 `/ai-implement` comment-triggered gap-fill runs bypass the orchestrator, so they read caps from target-repo **variables** instead (mirroring `AI_IMPLEMENT_PROVIDER`): set `AI_IMPLEMENT_MAX_TURNS`, `AI_IMPLEMENT_MAX_ITERATIONS`, and `AI_IMPLEMENT_MAX_JOB_MINUTES` (Settings → Secrets and variables → Actions → Variables) to cap those runs too.
 
+### Per-project branch prefix (admin UI)
+
+Each project's mapping carries an optional **Branch Prefix** (blank = none, the default). When set, it is prepended as a path segment to the implementation branch name: with prefix `pr`, a branch that would be `ai-implement/PROJ-123-add-login` becomes `pr/ai-implement/PROJ-123-add-login`. Each `/`-separated segment of the prefix must start with a letter or digit and may otherwise contain only letters, digits, `.`, `_`, `-` (no `..` or `//`, ≤ 64 chars); the admin API rejects anything else.
+
+The prefix only affects the **initial orchestrator-driven run** — `/ai-implement` comment-triggered gap-fill runs commit to the existing PR branch and are unaffected. Like the run-caps, the prefix reaches the runner as the `branch_prefix` dispatch input (GitHub Actions) or `AI_IMPLEMENT_BRANCH_PREFIX` env var (Fly/local), and is only sent when set — so a project that sets a prefix must have **re-synced `claude-implement.yml`** to its target repo first, otherwise GitHub rejects the dispatch with "unexpected inputs".
+
 ### Runner log verbosity
 
 `AI_IMPLEMENT_LOG_LEVEL` controls how much the runner logs during an implement pass:

--- a/docs/superpowers/plans/2026-06-08-pr-branch-prefix.md
+++ b/docs/superpowers/plans/2026-06-08-pr-branch-prefix.md
@@ -739,6 +739,7 @@ git commit -m "feat(orchestrator): send branch_prefix on initial implementation 
 
 **Files:**
 - Modify: `.github/workflows/claude-implement.yml`
+- Modify: `workflows/claude-implement.yml` (the canonical synced template — `workflow-shim-structure.test.ts` enforces that these two files are byte-for-byte identical, so apply the SAME edits to both)
 
 - [ ] **Step 1: Add the workflow_dispatch input**
 

--- a/docs/superpowers/plans/2026-06-08-pr-branch-prefix.md
+++ b/docs/superpowers/plans/2026-06-08-pr-branch-prefix.md
@@ -857,6 +857,33 @@ git commit -m "docs: document per-project branch prefix"
 
 ---
 
+## Task 11: Apply the prefix to the Sync Workflows PR branch
+
+**Files:**
+- Modify: `src/workflow-sync.ts`
+- Test: `src/__tests__/workflow-sync.test.ts`
+
+The admin "Sync Workflows" action (`syncWorkflowTemplates`) opens a PR in the target repo
+on the hardcoded branch `sync/ai-implement`. Apply the per-project prefix there too so a
+repo with a blanket "all PR branches start with `<prefix>`" policy is satisfied.
+
+- [ ] Add a module-private helper that mirrors `buildIssueBranchName`'s defensive
+      trim/slash-strip:
+
+```typescript
+function buildSyncBranchName(prefix: string | null | undefined): string {
+  const cleaned = (prefix ?? "").trim().replace(/^\/+|\/+$/g, "");
+  return cleaned ? `${cleaned}/sync/ai-implement` : "sync/ai-implement";
+}
+```
+
+- [ ] Change `const syncBranch = options.syncBranch ?? "sync/ai-implement";` to
+      `const syncBranch = options.syncBranch ?? buildSyncBranchName(mapping.branchPrefix);`
+      so an explicit `options.syncBranch` is still used verbatim and only the default is prefixed.
+- [ ] Tests: prefix applied (`pr` → `pr/sync/ai-implement`, branch created, opened PR head
+      matches), null prefix → `sync/ai-implement`, explicit `syncBranch` bypasses the prefix.
+- [ ] Commit: `feat(sync): apply per-project branch prefix to Sync Workflows PR branch`
+
 ## Task 10: Full verification
 
 - [ ] **Step 1: Typecheck**

--- a/docs/superpowers/plans/2026-06-08-pr-branch-prefix.md
+++ b/docs/superpowers/plans/2026-06-08-pr-branch-prefix.md
@@ -1,0 +1,880 @@
+# Per-project PR branch prefix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional, per-project branch-name prefix so a project can require its AI-Implement PR branches to start with a custom segment (e.g. `pr/ai-implement/...`), defaulting to today's `ai-implement/...` shape.
+
+**Architecture:** The prefix is a new nullable field on the `mappings` table, edited in the admin UI, validated at the admin API, and threaded to the runner exactly like the existing run-caps (`maxTurns` etc.) — as a `branch_prefix` workflow_dispatch input (GitHub Actions) or `AI_IMPLEMENT_BRANCH_PREFIX` env var (Fly/local). The runner re-validates it and `buildIssueBranchName` prepends it. The existing-PR matcher is made prefix-tolerant. Gap-fill runs reuse the existing PR branch and are untouched.
+
+**Tech Stack:** TypeScript, Node, better-sqlite3, Vitest, GitHub Actions YAML.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/pipeline/branch-name.ts` | Branch name construction + matching | Add `normalizeBranchPrefix`; add `prefix` param to `buildIssueBranchName`; make `branchMatchesIssueIdentifier` prefix-tolerant |
+| `src/__tests__/branch-name.test.ts` | Unit tests for the above | New cases |
+| `src/config.ts` | Mapping storage | New `branchPrefix` field + `branch_prefix` column + migration |
+| `src/__tests__/config.test.ts` | Storage round-trip tests | New cases + `mapping()` helper field |
+| `src/github.ts` | Dispatch inputs / runner env | New `branchPrefixDispatchFields` + `branchPrefixRunnerEnv` + `DispatchInputs.branch_prefix` |
+| `src/__tests__/github.test.ts` | Helper tests | New cases + `makeMapping` helper field |
+| `src/admin.ts` | Admin API upsert | Accept + validate `branchPrefix` |
+| `src/__tests__/admin.test.ts` | Admin API tests | New cases |
+| `src/pipeline/types.ts` | Pipeline context shape | Add `branchPrefix?` to `PipelineContextData` |
+| `src/run-autonomous.ts` | Runner env ingest | Read + re-validate `AI_IMPLEMENT_BRANCH_PREFIX` into context |
+| `src/pipeline/pipeline-loader.ts` | Step wiring | Pass `ctx.data.branchPrefix` to `buildIssueBranchName` |
+| `src/index.ts` | Dispatch call sites | Spread the two new helpers on the initial run |
+| `.github/workflows/claude-implement.yml` | Workflow template | New `branch_prefix` input + env |
+| `src/admin-ui/pages/projects.ts` | Admin UI | New "Branch Prefix" field (HTML + load + save) |
+| `CLAUDE.md` | Docs | Document the new field |
+
+---
+
+## Task 1: Branch-name core — normalize, prefix, matcher
+
+**Files:**
+- Modify: `src/pipeline/branch-name.ts`
+- Test: `src/__tests__/branch-name.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these cases inside `src/__tests__/branch-name.test.ts` (before the final closing of the file). Add the `normalizeBranchPrefix` import to the existing import line at the top so it reads:
+
+```typescript
+import { branchMatchesIssueIdentifier, buildIssueBranchName, normalizeBranchPrefix } from "../pipeline/branch-name.js";
+```
+
+Then append:
+
+```typescript
+describe("buildIssueBranchName with prefix", () => {
+  it("prepends a configured prefix as a path segment", () => {
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", "pr")).toBe(
+      "pr/ai-implement/gen-123-add-login-flow",
+    );
+  });
+
+  it("leaves the branch unchanged for an empty/undefined prefix", () => {
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", "")).toBe(
+      "ai-implement/gen-123-add-login-flow",
+    );
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", null)).toBe(
+      "ai-implement/gen-123-add-login-flow",
+    );
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow")).toBe(
+      "ai-implement/gen-123-add-login-flow",
+    );
+  });
+
+  it("normalizes surrounding slashes on the prefix", () => {
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", "/pr/")).toBe(
+      "pr/ai-implement/gen-123-add-login-flow",
+    );
+  });
+});
+
+describe("normalizeBranchPrefix", () => {
+  it("returns null for blank input", () => {
+    expect(normalizeBranchPrefix(undefined)).toBeNull();
+    expect(normalizeBranchPrefix(null)).toBeNull();
+    expect(normalizeBranchPrefix("")).toBeNull();
+    expect(normalizeBranchPrefix("   ")).toBeNull();
+  });
+
+  it("trims and strips surrounding slashes", () => {
+    expect(normalizeBranchPrefix("  /pr/  ")).toBe("pr");
+    expect(normalizeBranchPrefix("team/pr")).toBe("team/pr");
+  });
+
+  it("rejects invalid prefixes", () => {
+    expect(() => normalizeBranchPrefix("has space")).toThrow();
+    expect(() => normalizeBranchPrefix("../etc")).toThrow();
+    expect(() => normalizeBranchPrefix("a//b")).toThrow();
+    expect(() => normalizeBranchPrefix(".hidden")).toThrow();
+    expect(() => normalizeBranchPrefix("x".repeat(65))).toThrow();
+  });
+});
+
+describe("branchMatchesIssueIdentifier with prefix", () => {
+  it("matches a prefixed ai-implement branch", () => {
+    expect(branchMatchesIssueIdentifier(
+      "pr/ai-implement/gen-65-task-2-add-parse-schema",
+      "GEN-65",
+    )).toBe(true);
+  });
+
+  it("matches a multi-segment prefixed branch", () => {
+    expect(branchMatchesIssueIdentifier(
+      "team/pr/ai-implement/gen-65-task-2",
+      "GEN-65",
+    )).toBe(true);
+  });
+
+  it("still rejects longer issue keys sharing a prefix", () => {
+    expect(branchMatchesIssueIdentifier("pr/ai-implement/gen-650-task-2", "GEN-65")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- branch-name`
+Expected: FAIL — `normalizeBranchPrefix` is not exported; prefixed `buildIssueBranchName`/matcher cases fail.
+
+- [ ] **Step 3: Implement in `src/pipeline/branch-name.ts`**
+
+Replace the entire contents of `src/pipeline/branch-name.ts` with:
+
+```typescript
+const MAX_BRANCH_SUMMARY_LENGTH = 48;
+const MAX_BRANCH_PREFIX_LENGTH = 64;
+const BRANCH_PREFIX_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+function slugify(value: string | undefined, fallback: string): string {
+  const slug = (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_BRANCH_SUMMARY_LENGTH)
+    .replace(/-+$/g, "");
+  return slug || fallback;
+}
+
+/**
+ * Validates and normalizes a per-project branch prefix.
+ * - Blank/whitespace/undefined -> null (no prefix).
+ * - Strips surrounding slashes.
+ * - Must be a safe git ref path segment: only [A-Za-z0-9._/-], starting with an
+ *   alphanumeric, no "..", no "//", <= 64 chars.
+ * Throws on an invalid (non-blank) value so callers can surface a clear error.
+ */
+export function normalizeBranchPrefix(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  let value = raw.trim().replace(/^\/+|\/+$/g, "");
+  if (value === "") return null;
+  if (value.length > MAX_BRANCH_PREFIX_LENGTH) {
+    throw new Error(`branchPrefix must be ${MAX_BRANCH_PREFIX_LENGTH} characters or fewer`);
+  }
+  if (value.includes("..") || value.includes("//")) {
+    throw new Error("branchPrefix must not contain '..' or '//'");
+  }
+  if (!BRANCH_PREFIX_PATTERN.test(value)) {
+    throw new Error(
+      "branchPrefix may contain only letters, digits, '.', '_', '-', '/' and must start with a letter or digit",
+    );
+  }
+  return value;
+}
+
+export function buildIssueBranchName(
+  issueIdentifier: string | undefined,
+  issueTitle: string | undefined,
+  prefix?: string | null,
+): string {
+  const key = slugify(issueIdentifier, "issue");
+  const summary = slugify(issueTitle, "implementation");
+  const base = `ai-implement/${key}-${summary}`;
+  // The prefix is already validated upstream (admin API + runner ingest); here we
+  // only trim and strip surrounding slashes so the join stays well-formed.
+  const cleaned = (prefix ?? "").trim().replace(/^\/+|\/+$/g, "");
+  return cleaned ? `${cleaned}/${base}` : base;
+}
+
+export function branchMatchesIssueIdentifier(branchRef: string | undefined, issueIdentifier: string | undefined): boolean {
+  if (!branchRef || !issueIdentifier) return false;
+
+  const ref = branchRef.toLowerCase();
+  const rawIdentifier = issueIdentifier.toLowerCase();
+  const slugIdentifier = slugify(issueIdentifier, "");
+  const candidates = [...new Set([rawIdentifier, slugIdentifier].filter(Boolean))];
+
+  return candidates.some((identifier) => {
+    // Legacy bare-identifier branches: "gen-65" or "gen-65/...".
+    if (ref === identifier || ref.startsWith(`${identifier}/`)) return true;
+
+    // ai-implement/<identifier>, optionally preceded by a prefix path segment
+    // (e.g. "pr/ai-implement/gen-65-..."). The marker must sit at a segment
+    // boundary and be followed by end, '-' or '/' so "gen-65" never matches
+    // "gen-650".
+    const marker = `ai-implement/${identifier}`;
+    const idx = ref.indexOf(marker);
+    if (idx === -1) return false;
+    if (idx !== 0 && ref[idx - 1] !== "/") return false;
+    const after = ref[idx + marker.length];
+    return after === undefined || after === "-" || after === "/";
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- branch-name`
+Expected: PASS (all old + new cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/branch-name.ts src/__tests__/branch-name.test.ts
+git commit -m "feat(branch): normalizeBranchPrefix + prefix-aware branch naming and matching"
+```
+
+---
+
+## Task 2: Config storage — branchPrefix field, column, migration
+
+**Files:**
+- Modify: `src/config.ts`
+- Test: `src/__tests__/config.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/__tests__/config.test.ts`, add `branchPrefix: null` to the defaults object in the `mapping()` helper (after the `maxJobMinutes: null,` line, before `...overrides,`):
+
+```typescript
+    maxJobMinutes: null,
+    branchPrefix: null,
+    ...overrides,
+```
+
+Then append these tests inside the top-level `describe("config", ...)` block (e.g. right after the `round-trips maxTurns...` test):
+
+```typescript
+  it("round-trips branchPrefix (including null)", () => {
+    config.initMappingsTable();
+    config.upsertMapping("PFX", mapping({ owner: "org", repo: "repo", branchPrefix: "pr" }));
+    config.upsertMapping("NOPFX", mapping({ owner: "org", repo: "repo", branchPrefix: null }));
+
+    const all = config.getMappings();
+    expect(all.PFX.branchPrefix).toBe("pr");
+    expect(all.NOPFX.branchPrefix).toBeNull();
+  });
+
+  it("migrates a pre-existing mappings table to include the branch_prefix column (default null)", () => {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE mappings (
+        team_key TEXT PRIMARY KEY,
+        owner TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        workflow_file TEXT NOT NULL,
+        default_branch TEXT NOT NULL
+      )
+    `);
+    db.prepare("INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch) VALUES (?, ?, ?, ?, ?)")
+      .run("LEG", "org", "legacy", "claude-implement.yml", "main");
+    db.close();
+
+    config.initMappingsTable();
+    expect(config.getMappings().LEG.branchPrefix).toBeNull();
+
+    const reopened = new Database(dbPath);
+    const info = reopened.prepare("PRAGMA table_info(mappings)").all() as Array<{ name: string }>;
+    reopened.close();
+    expect(info.map((c) => c.name)).toContain("branch_prefix");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- config`
+Expected: FAIL — `branchPrefix` is not on `RepoMapping` (type error) and/or returns `undefined`.
+
+- [ ] **Step 3: Implement in `src/config.ts`**
+
+3a. Add the field to the `RepoMapping` interface, immediately after the `maxJobMinutes` field (around line 57):
+
+```typescript
+  /** Maximum wall-clock minutes for a job before it is forcibly terminated. NULL means use the runner's built-in default. */
+  maxJobMinutes: number | null;
+  /** Optional branch-name prefix prepended as a path segment (e.g. "pr" -> pr/ai-implement/...). NULL means no prefix. */
+  branchPrefix: string | null;
+}
+```
+
+3b. Add the migration in `ensureMappingsColumns()`, after the `max_job_minutes` block (around line 128):
+
+```typescript
+  if (!names.has("max_job_minutes")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN max_job_minutes INTEGER`);
+  }
+  if (!names.has("branch_prefix")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN branch_prefix TEXT`);
+  }
+}
+```
+
+3c. Add the column to the `CREATE TABLE` in `initMappingsTable()` (after `max_job_minutes INTEGER`, around line 156):
+
+```typescript
+      max_turns INTEGER,
+      max_iterations INTEGER,
+      max_job_minutes INTEGER,
+      branch_prefix TEXT
+    )
+  `);
+```
+
+3d. Update the seed `INSERT` statement's column list and placeholders (around line 165). Change the column list to end with `..., max_iterations, max_job_minutes, branch_prefix)` and add one more `?` to the `VALUES`:
+
+```typescript
+    const insert = db.prepare(
+      "INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+```
+
+And add `m.branchPrefix` as the final argument of `insert.run(...)` (around line 168), after `m.maxJobMinutes`:
+
+```typescript
+      insert.run(key, m.owner, m.repo, m.workflowFile, m.defaultBranch, m.maxInProgressAiIssues, m.executionMode, m.sessionMode, m.machineCpus, m.machineMemoryMb, m.planningEnabled ? 1 : 0, m.planningWorkflowFile, m.autoApprovePlans ? 1 : 0, Object.keys(m.extraEnv).length > 0 ? JSON.stringify(m.extraEnv) : null, m.provider, m.ticketingProvider, JSON.stringify(m.ticketingConfig), m.awsRegion, m.paused ? 1 : 0, m.maxTurns, m.maxIterations, m.maxJobMinutes, m.branchPrefix);
+```
+
+3e. Update `getMappings()`: add `branch_prefix` to the SELECT column list (around line 177, end of the list before `FROM mappings`):
+
+```typescript
+      "SELECT team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix FROM mappings",
+```
+
+Add it to the row type (after `max_job_minutes: number | null;`, around line 201):
+
+```typescript
+      max_job_minutes: number | null;
+      branch_prefix: string | null;
+    }>;
+```
+
+Add it to the result mapping object (after `maxJobMinutes: row.max_job_minutes,`, around line 237):
+
+```typescript
+      maxJobMinutes: row.max_job_minutes,
+      branchPrefix: row.branch_prefix,
+    };
+```
+
+3f. Update `upsertMapping()`: add `branch_prefix` to the column list and one more `?` (around line 246):
+
+```typescript
+      "INSERT OR REPLACE INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+```
+
+Add `mapping.branchPrefix` as the final `.run(...)` argument (after `mapping.maxJobMinutes,`, around line 270):
+
+```typescript
+      mapping.maxJobMinutes,
+      mapping.branchPrefix,
+    );
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- config`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.ts src/__tests__/config.test.ts
+git commit -m "feat(config): persist per-project branchPrefix on mappings"
+```
+
+---
+
+## Task 3: github.ts — dispatch input + runner env helpers
+
+**Files:**
+- Modify: `src/github.ts`
+- Test: `src/__tests__/github.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/__tests__/github.test.ts`, add `branchPrefix: null` to the `makeMapping` defaults (after `maxJobMinutes: null,`, before `...overrides,`):
+
+```typescript
+    maxJobMinutes: null,
+    branchPrefix: null,
+    ...overrides,
+```
+
+Update the import line at the top to include the new helpers:
+
+```typescript
+import { dispatchWorkflow, providerDispatchFields, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv, cancelWorkflowRun } from "../github.js";
+```
+
+Append these describe blocks at the end of the file:
+
+```typescript
+describe("branchPrefixDispatchFields", () => {
+  it("returns empty object when no prefix is set", () => {
+    expect(branchPrefixDispatchFields(makeMapping({}))).toEqual({});
+    expect(branchPrefixDispatchFields(makeMapping({ branchPrefix: null }))).toEqual({});
+  });
+
+  it("includes branch_prefix when set", () => {
+    expect(branchPrefixDispatchFields(makeMapping({ branchPrefix: "pr" }))).toEqual({
+      branch_prefix: "pr",
+    });
+  });
+});
+
+describe("branchPrefixRunnerEnv", () => {
+  it("returns empty object when no prefix is set", () => {
+    expect(branchPrefixRunnerEnv(makeMapping({}))).toEqual({});
+  });
+
+  it("includes AI_IMPLEMENT_BRANCH_PREFIX when set", () => {
+    expect(branchPrefixRunnerEnv(makeMapping({ branchPrefix: "pr" }))).toEqual({
+      AI_IMPLEMENT_BRANCH_PREFIX: "pr",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- github.test`
+Expected: FAIL — `branchPrefixDispatchFields`/`branchPrefixRunnerEnv` not exported.
+
+- [ ] **Step 3: Implement in `src/github.ts`**
+
+3a. Add the new dispatch input to the `DispatchInputs` interface, after the `job_timeout_minutes` field (around line 24):
+
+```typescript
+  /** Per-project GitHub Actions job timeout in minutes. Only forwarded when set. */
+  job_timeout_minutes?: string;
+  /** Per-project branch-name prefix. Only forwarded when set on the mapping. */
+  branch_prefix?: string;
+```
+
+3b. Add the two helpers immediately after `capRunnerEnv` (around line 100):
+
+```typescript
+/**
+ * Branch-prefix dispatch input for a mapping. Only included when the mapping
+ * configures a prefix, so default repos keep dispatching to workflow templates
+ * that haven't been re-synced with the new input.
+ */
+export function branchPrefixDispatchFields(
+  mapping: RepoMapping,
+): Pick<DispatchInputs, "branch_prefix"> {
+  return mapping.branchPrefix ? { branch_prefix: mapping.branchPrefix } : {};
+}
+
+/**
+ * Branch-prefix env var for the runner process (Fly/local execution modes),
+ * where the prefix arrives via container env rather than a workflow input.
+ */
+export function branchPrefixRunnerEnv(mapping: RepoMapping): Record<string, string> {
+  return mapping.branchPrefix ? { AI_IMPLEMENT_BRANCH_PREFIX: mapping.branchPrefix } : {};
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- github.test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/github.ts src/__tests__/github.test.ts
+git commit -m "feat(github): branch_prefix dispatch input + runner env helpers"
+```
+
+---
+
+## Task 4: Admin API — accept and validate branchPrefix
+
+**Files:**
+- Modify: `src/admin.ts`
+- Test: `src/__tests__/admin.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside the `describe("admin mappings", ...)` block in `src/__tests__/admin.test.ts`:
+
+```typescript
+  it("persists a valid branchPrefix and returns it", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFX", owner: "org", repo: "app", branchPrefix: "pr",
+    }, token);
+    expect(create.statusCode).toBe(200);
+    expect(JSON.parse(create.body).branchPrefix).toBe("pr");
+
+    const list = await request("/api/mappings", "GET", "secret", undefined, token);
+    expect(JSON.parse(list.body).PFX.branchPrefix).toBe("pr");
+  });
+
+  it("normalizes surrounding slashes on branchPrefix", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFX2", owner: "org", repo: "app", branchPrefix: "/pr/",
+    }, token);
+    expect(create.statusCode).toBe(200);
+    expect(JSON.parse(create.body).branchPrefix).toBe("pr");
+  });
+
+  it("treats a blank branchPrefix as null", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFX3", owner: "org", repo: "app", branchPrefix: "  ",
+    }, token);
+    expect(create.statusCode).toBe(200);
+    expect(JSON.parse(create.body).branchPrefix).toBeNull();
+  });
+
+  it("rejects an invalid branchPrefix", async () => {
+    const token = await login("secret");
+    const res = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFXBAD", owner: "org", repo: "app", branchPrefix: "has space",
+    }, token);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("branchPrefix");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- admin.test`
+Expected: FAIL — `branchPrefix` is dropped (returns `undefined`/`null` on create where `"pr"` expected) and the invalid case returns 200 instead of 400.
+
+- [ ] **Step 3: Implement in `src/admin.ts`**
+
+3a. Add the import. Find the existing import of config helpers near the top of `src/admin.ts` and add `normalizeBranchPrefix` from the branch-name module. If there is no existing import from `./pipeline/branch-name.js`, add this near the other imports:
+
+```typescript
+import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
+```
+
+3b. Add `branchPrefix` to the request body type in `handleUpsertMapping` (after `maxJobMinutes?: number | null;`, around line 968):
+
+```typescript
+      maxJobMinutes?: number | null;
+      branchPrefix?: string | null;
+    };
+```
+
+3c. Validate it. After the existing cap `try/catch` block that sets `maxTurns`/`maxIterations`/`maxJobMinutes` (ends around line 1089), add:
+
+```typescript
+    } catch (err) {
+      json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+      return;
+    }
+
+    let branchPrefix: string | null;
+    try {
+      branchPrefix = normalizeBranchPrefix(body.branchPrefix);
+    } catch (err) {
+      json(res, 400, { error: `branchPrefix invalid: ${err instanceof Error ? err.message : String(err)}` });
+      return;
+    }
+```
+
+3d. Add it to the constructed `mapping` object (after `maxJobMinutes,`, around line 1116):
+
+```typescript
+      maxJobMinutes,
+      branchPrefix,
+    };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- admin.test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin.ts src/__tests__/admin.test.ts
+git commit -m "feat(admin): accept and validate per-project branchPrefix"
+```
+
+---
+
+## Task 5: Pipeline context + runner ingest + step wiring
+
+**Files:**
+- Modify: `src/pipeline/types.ts`
+- Modify: `src/run-autonomous.ts`
+- Modify: `src/pipeline/pipeline-loader.ts`
+- Test: `src/__tests__/branch-name.test.ts` (already covers `buildIssueBranchName` with prefix — no new test here; this task is wiring verified by typecheck + existing tests)
+
+- [ ] **Step 1: Add the field to `PipelineContextData`**
+
+In `src/pipeline/types.ts`, after the `maxIterations?: number;` field (around line 56):
+
+```typescript
+  /** Autonomous runner: cap on implement/review iterations (from env). */
+  maxIterations?: number;
+  /** Autonomous runner: optional branch-name prefix (from AI_IMPLEMENT_BRANCH_PREFIX). */
+  branchPrefix?: string;
+```
+
+- [ ] **Step 2: Read + re-validate the env var in `src/run-autonomous.ts`**
+
+2a. Add the import. Update the top of `src/run-autonomous.ts` to import `normalizeBranchPrefix`. There is no current import from `./pipeline/branch-name.js`, so add this with the other `./pipeline/*` imports (e.g. after the `runHookScript` import line, around line 10):
+
+```typescript
+import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
+```
+
+2b. After the `maxIterations` line (around line 183), add the prefix ingest:
+
+```typescript
+  const maxTurns = parseEnvInt(process.env.AI_IMPLEMENT_MAX_TURNS, "AI_IMPLEMENT_MAX_TURNS");
+  const maxIterations = parseEnvInt(process.env.AI_IMPLEMENT_MAX_ITERATIONS, "AI_IMPLEMENT_MAX_ITERATIONS");
+  const branchPrefix = (() => {
+    try {
+      return normalizeBranchPrefix(process.env.AI_IMPLEMENT_BRANCH_PREFIX) ?? undefined;
+    } catch (err) {
+      // The orchestrator validates the prefix before dispatch, so this only
+      // happens on a manual dispatch with a bad value. Warn rather than fail the
+      // run, and fall back to the default (no prefix).
+      console.warn(`[runner] Ignoring invalid AI_IMPLEMENT_BRANCH_PREFIX: ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
+  })();
+```
+
+2c. Add `branchPrefix` to the `DefaultPipelineContext` data object (after `maxIterations,`, around line 220):
+
+```typescript
+      maxTurns,
+      maxIterations,
+      branchPrefix,
+      hooks: { setup: setupHook, verify: verifyHook, teardown: teardownHook },
+```
+
+- [ ] **Step 3: Pass the prefix into the push step in `src/pipeline/pipeline-loader.ts`**
+
+In the `case "push":` block, change the `branchName` input (around line 149) to pass the prefix:
+
+```typescript
+          branchName: buildIssueBranchName(ctx.data.issueIdentifier, ctx.data.issueTitle, ctx.data.branchPrefix),
+```
+
+- [ ] **Step 4: Verify typecheck + branch-name tests pass**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+Run: `npm test -- branch-name`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/types.ts src/run-autonomous.ts src/pipeline/pipeline-loader.ts
+git commit -m "feat(runner): thread branchPrefix from env into the push step"
+```
+
+---
+
+## Task 6: Wire the helpers into dispatch call sites (src/index.ts)
+
+**Files:**
+- Modify: `src/index.ts`
+
+Gap-fill and review re-dispatches reuse the existing PR branch, so the prefix only matters on the **initial implementation** dispatch (`runner_phase: "implementation"`, around line 411) and the two Fly/local initial-run env merges (around lines 748 and 822).
+
+- [ ] **Step 1: Extend the github.js import**
+
+Update the import on line 8 to add the two new helpers:
+
+```typescript
+import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun, providerDispatchFields, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv } from "./github.js";
+```
+
+- [ ] **Step 2: Add the dispatch field to the initial implementation dispatch**
+
+In the `dispatchWorkflow(...)` call around line 411-413, add the new spread right after `capDispatchFields(mapping)`:
+
+```typescript
+    runner_phase: "implementation",
+    ...providerDispatchFields(mapping),
+    ...capDispatchFields(mapping),
+    ...branchPrefixDispatchFields(mapping),
+    runner_callback_url: runnerCallbackUrl,
+```
+
+- [ ] **Step 3: Add the runner env to both Fly/local initial-run merges**
+
+At the Fly machine merge (around line 748):
+
+```typescript
+        extraEnv: (() => {
+          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping), ...branchPrefixRunnerEnv(mapping) };
+          return Object.keys(merged).length > 0 ? merged : undefined;
+        })(),
+```
+
+At the local Docker merge (around line 822) — apply the identical change:
+
+```typescript
+        extraEnv: (() => {
+          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping), ...branchPrefixRunnerEnv(mapping) };
+          return Object.keys(merged).length > 0 ? merged : undefined;
+        })(),
+```
+
+- [ ] **Step 4: Verify typecheck passes**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat(orchestrator): send branch_prefix on initial implementation dispatch"
+```
+
+---
+
+## Task 7: Workflow template — branch_prefix input + env
+
+**Files:**
+- Modify: `.github/workflows/claude-implement.yml`
+
+- [ ] **Step 1: Add the workflow_dispatch input**
+
+After the `job_timeout_minutes` input block (ends around line 76), add:
+
+```yaml
+      job_timeout_minutes:
+        description: "Per-project job timeout in minutes, must be a positive integer (empty = 90)"
+        required: false
+        type: string
+        default: ""
+      branch_prefix:
+        description: "Optional branch-name prefix prepended as a path segment (empty = no prefix)"
+        required: false
+        type: string
+        default: ""
+```
+
+- [ ] **Step 2: Add the env var on the Run pipeline step**
+
+In the `Run pipeline` step's `env:` block (around line 228-229), after `AI_IMPLEMENT_MAX_ITERATIONS`:
+
+```yaml
+          AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
+          AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
+          AI_IMPLEMENT_BRANCH_PREFIX: ${{ inputs.branch_prefix }}
+```
+
+- [ ] **Step 3: Verify the YAML parses**
+
+Run: `node -e "const yaml=require('yaml'); yaml.parse(require('fs').readFileSync('.github/workflows/claude-implement.yml','utf8')); console.log('ok')"`
+Expected: `ok` (no parse error). If `yaml` is not installed, instead run `npx --yes js-yaml .github/workflows/claude-implement.yml > /dev/null && echo ok` — expect `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/claude-implement.yml
+git commit -m "feat(workflow): branch_prefix input + AI_IMPLEMENT_BRANCH_PREFIX env"
+```
+
+---
+
+## Task 8: Admin UI — Branch Prefix field
+
+**Files:**
+- Modify: `src/admin-ui/pages/projects.ts`
+
+- [ ] **Step 1: Add the form field to the "Basic" fieldset (HTML)**
+
+In `projectsHtml`, after the `md-max-job-min` field (around line 127), add a new field:
+
+```html
+          <div class="md-field"><label>Job Timeout (min) <span class="text-tertiary" style="font-size:0.85em">(blank = 90)</span></label><input id="md-max-job-min" type="number" min="1" step="1" placeholder="90"></div>
+          <div class="md-field"><label>Branch Prefix <span class="text-tertiary" style="font-size:0.85em">(blank = none)</span></label><input id="md-branch-prefix" placeholder="pr"></div>
+```
+
+- [ ] **Step 2: Load the value in `openMappingDialog` (JS)**
+
+After the `md-max-job-min` load line (around line 275), add:
+
+```javascript
+    document.getElementById('md-max-job-min').value = m.maxJobMinutes == null ? '' : String(m.maxJobMinutes);
+    document.getElementById('md-branch-prefix').value = m.branchPrefix || '';
+```
+
+- [ ] **Step 3: Serialize the value in `saveMappingDialog` (JS)**
+
+In the `body` object literal (after the `maxJobMinutes` line, around line 575), add:
+
+```javascript
+      maxJobMinutes: (function(){ var v = document.getElementById('md-max-job-min').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+      branchPrefix: (function(){ var v = document.getElementById('md-branch-prefix').value.trim(); return v === '' ? null : v; })(),
+```
+
+- [ ] **Step 4: Verify typecheck + the admin-ui token/structure tests still pass**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+Run: `npm test -- admin-ui`
+Expected: PASS (or "no tests" — either is acceptable; this step just guards against breaking any existing admin-ui spot-check).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/admin-ui/pages/projects.ts
+git commit -m "feat(admin-ui): Branch Prefix field on the project edit dialog"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Document the field**
+
+In `CLAUDE.md`, in the "Per-project run caps (admin UI)" section, after the table of caps, add a paragraph:
+
+```markdown
+### Per-project branch prefix (admin UI)
+
+Each project's mapping carries an optional **Branch Prefix** (blank = none, the default). When set, it is prepended as a path segment to the implementation branch name: with prefix `pr`, a branch that would be `ai-implement/PROJ-123-add-login` becomes `pr/ai-implement/PROJ-123-add-login`. The prefix must be a valid git ref path segment (letters, digits, `.`, `_`, `-`, `/`; no `..` or `//`; ≤ 64 chars); the admin API rejects anything else.
+
+The prefix only affects the **initial orchestrator-driven run** — `/ai-implement` comment-triggered gap-fill runs commit to the existing PR branch and are unaffected. Like the run-caps, the prefix reaches the runner as the `branch_prefix` dispatch input (GitHub Actions) or `AI_IMPLEMENT_BRANCH_PREFIX` env var (Fly/local), and is only sent when set — so a project that sets a prefix must have **re-synced `claude-implement.yml`** to its target repo first, otherwise GitHub rejects the dispatch with "unexpected inputs".
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document per-project branch prefix"
+```
+
+---
+
+## Task 10: Full verification
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: all tests pass.
+
+- [ ] **Step 3: Manual sanity (optional, recommended)**
+
+Confirm the end-to-end shape by reasoning through the data flow once: admin saves `branchPrefix: "pr"` → `getMappings()` returns it → `branchPrefixDispatchFields` emits `branch_prefix: "pr"` on the initial dispatch → workflow sets `AI_IMPLEMENT_BRANCH_PREFIX=pr` → `run-autonomous` normalizes it into `context.data.branchPrefix` → push step calls `buildIssueBranchName(id, title, "pr")` → branch `pr/ai-implement/<key>-<summary>`.
+
+---
+
+## Delivery note
+
+When opening the PR for this work, target the **`testing`** branch as the base (not `main`).
+```

--- a/docs/superpowers/plans/2026-06-08-sync-branch-refresh.md
+++ b/docs/superpowers/plans/2026-06-08-sync-branch-refresh.md
@@ -1,0 +1,195 @@
+# Sync PR Branch Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every "Sync workflows" re-sync force-reset the canonical sync branch to the current base, so the reused sync PR always shows a clean diff (base + current templates) instead of layering onto stale state.
+
+**Architecture:** One function changes — `ensureSyncBranch` in `src/workflow-sync.ts`. When the sync branch already exists, it is force-reset to the current base SHA (dropping the `ahead_by === 0` guard that today leaves an ahead-of-base branch untouched). The branch-missing path (create from base) is unchanged. Downstream template application and PR reuse are unchanged.
+
+**Tech Stack:** TypeScript, Vitest. The sync flow talks to the GitHub REST API; tests use an in-memory fake `fetch`.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `src/workflow-sync.ts` | Orchestrator-side workflow template sync (branch + PR management) | `ensureSyncBranch`: always force-reset an existing sync branch to base; remove the `compare`/`ahead_by` check |
+| `src/__tests__/workflow-sync.test.ts` | Sync flow unit tests (in-memory GitHub fake) | Replace the "preserves ahead branch" test with a "resets stale ahead branch" test |
+
+---
+
+## Task 1: Force-reset the sync branch to base on every sync
+
+**Files:**
+- Modify: `src/workflow-sync.ts` (`ensureSyncBranch`, currently lines ~227-258)
+- Test: `src/__tests__/workflow-sync.test.ts`
+
+### Context for the implementer
+
+`ensureSyncBranch` runs at the start of `syncWorkflowTemplates`. Today:
+- If the sync branch is missing → it's created from base.
+- If it exists and is exactly even with base (`ahead_by === 0`) → it's force-reset to base.
+- If it exists and is **ahead** of base → it's **left untouched** (this is the bug: stale state from a prior sync PR persists and new template writes layer on top).
+
+The test harness in `workflow-sync.test.ts` models branches as `{ sha, aheadBy, files }`. Its fake `fetch`:
+- `POST /git/refs` creates a branch.
+- `PATCH /git/refs/heads/<branch>` resets the branch: sets its `files` to a copy of `branches.main.files` and `aheadBy` to 0.
+- `GET /compare/base...head` returns `branches[head].aheadBy`.
+- `PUT /contents/<path>` writes a file to the branch.
+- `makeGithubFetch({ syncFiles })` pre-creates `branches["sync/ai-implement"]`; `syncAheadBy` sets its `aheadBy`; `existingPr` seeds an open PR.
+
+Base (`main`) files default to `{}` (empty), so a reset clears any non-base files.
+
+- [ ] **Step 1: Replace the obsolete test with the new behavior test**
+
+In `src/__tests__/workflow-sync.test.ts`, find this existing test and DELETE it entirely:
+
+```typescript
+  it("preserves an existing sync branch that is ahead of base", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch({
+      syncFiles: {
+        "operator-note.txt": "keep me\n",
+      },
+      syncAheadBy: 2,
+    });
+
+    await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(fake.branches["sync/ai-implement"].files["operator-note.txt"]).toBe("keep me\n");
+    expect(fake.calls.some((call) => call.method === "PATCH" && call.path.includes("/git/refs/heads/"))).toBe(false);
+  });
+```
+
+In its place, add this test:
+
+```typescript
+  it("force-resets a stale sync branch that is ahead of base to produce a clean diff", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch({
+      syncFiles: {
+        ".github/workflows/claude-implement.yml": "OLD-implement\n",
+        "stale-leftover.txt": "stale\n",
+      },
+      syncAheadBy: 2,
+      existingPr: {
+        number: 55,
+        html_url: "https://github.com/acme/app/pull/55",
+        head: "sync/ai-implement",
+        base: { ref: "main" },
+      },
+    });
+
+    const result = await syncWorkflowTemplates({
+      mapping,
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    // The existing open PR is reused, not duplicated.
+    expect(result.status).toBe("pr-updated");
+    expect(result.prNumber).toBe(55);
+    expect(fake.pulls).toHaveLength(1);
+
+    // The branch was force-reset to the current base before templates were applied.
+    expect(
+      fake.calls.some(
+        (call) =>
+          call.method === "PATCH" &&
+          call.path.includes("/git/refs/heads/") &&
+          (call.body as { sha?: string; force?: boolean }).sha === "base-sha" &&
+          (call.body as { sha?: string; force?: boolean }).force === true,
+      ),
+    ).toBe(true);
+
+    // Stale non-template leftover is gone; current template content is present.
+    expect(fake.branches["sync/ai-implement"].files["stale-leftover.txt"]).toBeUndefined();
+    expect(fake.branches["sync/ai-implement"].files[".github/workflows/claude-implement.yml"]).toBe("implement-yml\n");
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- workflow-sync`
+Expected: the new `force-resets a stale sync branch...` test FAILS — with the current code the branch is left untouched (`ahead_by` is 2), so `stale-leftover.txt` is still present and no force-reset PATCH occurs. (All other workflow-sync tests should still pass.)
+
+- [ ] **Step 3: Implement the change in `src/workflow-sync.ts`**
+
+Replace the entire body of `ensureSyncBranch` with the version below. The only change from the current code is that the trailing `compare`/`ahead_by` block is replaced by an unconditional force-reset of the existing branch:
+
+```typescript
+async function ensureSyncBranch(params: {
+  gh: GitHubClient;
+  repo: string;
+  baseBranch: string;
+  syncBranch: string;
+}): Promise<void> {
+  const { gh, repo, baseBranch, syncBranch } = params;
+  const base = await gh.request<{ object: { sha: string } }>(
+    `/repos/${repo}/git/ref/heads/${encodeRefPath(baseBranch)}`,
+  );
+  const syncRef = await gh.maybeRequest<{ object: { sha: string } }>(
+    `/repos/${repo}/git/ref/heads/${encodeRefPath(syncBranch)}`,
+  );
+
+  if (!syncRef) {
+    await gh.request(`/repos/${repo}/git/refs`, {
+      method: "POST",
+      body: JSON.stringify({ ref: `refs/heads/${syncBranch}`, sha: base.object.sha }),
+    });
+    return;
+  }
+
+  // The sync branch is orchestrator-owned and disposable: always force-reset it to the
+  // current base so each re-sync produces a clean diff (base + freshly regenerated
+  // templates) and never layers onto stale state from a prior sync PR — whether that
+  // branch is ahead of, behind, or lingering after a merge.
+  await gh.request(`/repos/${repo}/git/refs/heads/${encodeRefPath(syncBranch)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ sha: base.object.sha, force: true }),
+  });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm test -- workflow-sync`
+Expected: PASS — all workflow-sync tests, including the new `force-resets a stale sync branch...` test, and the unchanged ones (`returns up-to-date...`, `updates an existing sync PR when files change`, `returns pr-existing...`, the `pr/sync/ai-implement` prefix tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workflow-sync.ts src/__tests__/workflow-sync.test.ts
+git commit -m "fix(sync): force-reset the sync branch to base on every re-sync"
+```
+
+---
+
+## Task 2: Full verification
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: all tests pass (0 failures).
+
+---
+
+## Delivery note
+
+This change is on the `feat/pr-branch-prefix` branch and targets `testing` as its PR base. Unless told otherwise, it folds into the open PR #79 (which already modifies `src/workflow-sync.ts`).

--- a/docs/superpowers/specs/2026-06-08-pr-branch-prefix-design.md
+++ b/docs/superpowers/specs/2026-06-08-pr-branch-prefix-design.md
@@ -21,6 +21,11 @@ for every existing project).
   Claude not to create a new branch, and `appendPipelineOwnedGitInstructions` skips the
   pipeline-owned push for gap-fill). They therefore need no prefix plumbing — no
   `comment-trigger.yml` changes and no target-repo variable, unlike the run-caps.
+- **Sync Workflows PR branch too.** The admin "Sync Workflows" action opens a PR in
+  the target repo on the branch `sync/ai-implement` (`src/workflow-sync.ts`). The prefix
+  is also prepended there (`pr/sync/ai-implement`), so a repo with a blanket "all PR
+  branches start with `<prefix>`" policy is satisfied for sync PRs as well. An explicitly
+  passed `syncBranch` override is used verbatim (not prefixed).
 
 ## Semantics & validation
 

--- a/docs/superpowers/specs/2026-06-08-pr-branch-prefix-design.md
+++ b/docs/superpowers/specs/2026-06-08-pr-branch-prefix-design.md
@@ -1,0 +1,94 @@
+# Per-project PR branch prefix — design
+
+**Date:** 2026-06-08
+**Status:** Approved, ready for planning
+
+## Problem
+
+AI-Implement names every PR branch `ai-implement/<issue-key>-<summary>`. One client
+requires all PR branches in their repo to start with `pr`. We need a per-project,
+optional branch-name prefix that defaults to no prefix (preserving today's behavior
+for every existing project).
+
+## Scope
+
+- **Branch name only.** PR titles are unchanged.
+- **Prepend as a path segment.** A project configured with prefix `pr` produces
+  `pr/ai-implement/<key>-<summary>`. The default (blank) prefix leaves the branch as
+  `ai-implement/<key>-<summary>`.
+- **Initial orchestrator-driven runs only.** Comment-triggered `/ai-implement`
+  gap-fill runs reuse the existing PR branch (`src/run-autonomous.ts:65-70` instructs
+  Claude not to create a new branch, and `appendPipelineOwnedGitInstructions` skips the
+  pipeline-owned push for gap-fill). They therefore need no prefix plumbing — no
+  `comment-trigger.yml` changes and no target-repo variable, unlike the run-caps.
+
+## Semantics & validation
+
+The prefix is stored normalized and validated once at the admin API, then re-validated
+defensively in the runner.
+
+- Trim input; an empty string is stored as `NULL` and means "no prefix."
+- Strip any leading and trailing `/`.
+- Must match `^[A-Za-z0-9][A-Za-z0-9._/-]*$`, contain no `..` and no `//`, and be
+  ≤ 64 characters. This keeps the result a valid git ref path segment.
+- Invalid input → admin API returns HTTP 400 (mirroring the `resolveCap` error style in
+  `src/admin.ts`).
+
+## Components & data flow
+
+The prefix mirrors the existing per-project run-caps path (`maxTurns` etc.), minus the
+target-repo-variable fallback that caps need for comment-trigger runs.
+
+| Layer | File | Change |
+|-------|------|--------|
+| Storage | `src/config.ts` | Add `branchPrefix: string \| null` to `RepoMapping`; add `branch_prefix TEXT` column (CREATE + idempotent ALTER migration); thread through `getMappings()` SELECT/row-map and `upsertMapping()` INSERT. |
+| Admin API | `src/admin.ts` | `handleUpsertMapping` accepts `branchPrefix`; new `resolveBranchPrefix()` helper validates/normalizes; include in the persisted `RepoMapping`. |
+| Admin UI | `src/admin-ui/pages/projects.ts` | Text input "Branch Prefix (blank = none)" in the edit dialog; load in `openMappingDialog`, serialize in the save handler. |
+| Dispatch (GHA) | `src/github.ts` | Extend `DispatchInputs` with `branch_prefix?: string`; emit it **only when set** (same rule as `capDispatchFields`). |
+| Runner env (Fly/local) | `src/github.ts` | Extend `capRunnerEnv` (or a sibling) to emit `AI_IMPLEMENT_BRANCH_PREFIX` only when set. |
+| Workflow template | `.github/workflows/claude-implement.yml` | New `branch_prefix` input (`default: ""`) wired to the `AI_IMPLEMENT_BRANCH_PREFIX` env on the runner step. |
+| Runner ingest | `src/run-autonomous.ts` | Read + re-validate `AI_IMPLEMENT_BRANCH_PREFIX`; set `context.data.branchPrefix`. |
+| Branch builder | `src/pipeline/branch-name.ts` | `buildIssueBranchName(identifier, title, prefix?)` returns `${prefix}/ai-implement/...` when a prefix is set, else unchanged. |
+| Pipeline wiring | `src/pipeline/pipeline-loader.ts` | Push step passes `ctx.data.branchPrefix` to `buildIssueBranchName`. |
+
+## Existing-PR detection edge case
+
+`branchMatchesIssueIdentifier()` (`src/pipeline/branch-name.ts:19`, used at
+`src/index.ts:1134` and `src/webhook.ts:130` to find an already-open PR for an issue)
+currently recognizes only the bare `ai-implement/...` shape. A `pr/ai-implement/...`
+branch would not match, which could defeat duplicate-PR detection for prefixed projects.
+
+Update the matcher to tolerate an optional leading prefix segment — also match
+`<segment>/ai-implement/<identifier>-…` and `<segment>/ai-implement/<identifier>/`,
+anchored at path-segment boundaries so it does not over-match unrelated branches.
+
+## Testing
+
+- `branch-name.test.ts`
+  - prefix is prepended as a path segment; empty/undefined prefix leaves the branch
+    unchanged; trailing-slash input is normalized.
+  - `branchMatchesIssueIdentifier` matches prefixed branches and still rejects unrelated
+    branches.
+- `config.test.ts`
+  - `branchPrefix` round-trips through `upsertMapping`/`getMappings`; migration adds the
+    column to a pre-existing table.
+- admin API validation
+  - rejects spaces, `..`, leading slash, and over-length prefixes; accepts and normalizes
+    valid prefixes; treats blank as `null`.
+- `github.ts`
+  - `branch_prefix` dispatch input and `AI_IMPLEMENT_BRANCH_PREFIX` runner env are emitted
+    only when a prefix is set.
+
+## Backward compatibility & rollout
+
+- Existing projects have a `NULL` prefix → byte-for-byte identical branch names and
+  behavior.
+- The dispatch input is sent only when a prefix is configured, so a project that sets a
+  prefix must have re-synced `claude-implement.yml` to the target repo first (otherwise
+  GitHub rejects the dispatch with "unexpected inputs"). This is the same constraint that
+  already applies to the run-caps; document it in `CLAUDE.md` alongside the caps note.
+- Default (no-prefix) projects require no re-sync.
+
+## Delivery note
+
+The implementation PR targets the `testing` branch as its base (not `main`).

--- a/docs/superpowers/specs/2026-06-08-sync-branch-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-08-sync-branch-refresh-design.md
@@ -1,0 +1,101 @@
+# Sync PR branch refresh — design
+
+**Date:** 2026-06-08
+**Status:** Approved, ready for planning
+
+## Problem
+
+The admin "Sync workflows" action opens/updates a single canonical PR per target repo
+on the branch `sync/ai-implement` (or `<prefix>/sync/ai-implement` when the project sets
+a branch prefix). When that branch still exists from a prior sync, re-syncing produces
+"weird" results — confirmed across all three of these states:
+
+1. **Stale open-PR layering.** A previous sync PR was still open (branch ahead of base).
+   The current code leaves that branch untouched and layers new file updates on top, so
+   the reused PR reflects stale state rather than a clean diff against the current base.
+2. **Lingering post-merge branch.** A previous sync PR was merged but its branch was not
+   deleted, leading to confusing subsequent syncs.
+3. **Wrong/old base diff.** The reused branch is based on an outdated base SHA, so the PR
+   shows more than just the current workflow changes.
+
+The root cause is in `ensureSyncBranch` (`src/workflow-sync.ts`): when the sync branch
+already exists and is **ahead** of base, it is intentionally left untouched (only a branch
+that is exactly even with base, `ahead_by === 0`, is force-reset). That "preserve commits
+already on the sync branch" behavior is what lets stale state persist.
+
+## Decision
+
+Keep one canonical, reusable sync PR per repo (no unique/disposable branch names), but make
+every re-sync **refresh the branch to a clean state**: the sync branch always begins at the
+current base, then the workflow templates are re-applied on top. The reused PR therefore
+always shows a clean diff = *current base + current templates*.
+
+Rejected alternative: unique branch name per sync (e.g. `sync/ai-implement-<base-sha>`).
+It avoids staleness but accumulates branches/PRs and requires garbage-collecting prior open
+sync PRs. The canonical-PR-refreshed model achieves clean diffs without that clutter.
+
+## Change
+
+A single function changes: `ensureSyncBranch` in `src/workflow-sync.ts`.
+
+- **Branch does not exist** → create it from the current base SHA (unchanged; plain ref
+  create, no force needed).
+- **Branch exists** (whether ahead of, behind, or even with base, or lingering after a
+  merge) → **force-reset its ref to the current base SHA**. This replaces the current
+  logic that resets only when `ahead_by === 0` and otherwise leaves the branch untouched.
+  The `compare` (`ahead_by`) request is removed — it is no longer needed.
+
+The outcome is uniform in all cases: the sync branch is at current base before any
+templates are applied. The mechanism differs only in create (new branch) vs. force-reset
+(existing branch).
+
+Downstream flow in `syncWorkflowTemplates` is unchanged: after the branch is at base, the
+always-synced workflow files are written (overwriting), seed-once files are added only if
+absent on base, `changedFiles` is computed from real differences, and the existing PR is
+reused (`pr-updated`) or a new one opened (`pr-opened`).
+
+## Deliberate behavior reversal
+
+This removes the current guarantee that manual/operator commits on the sync branch survive
+a re-sync. The sync branch becomes fully orchestrator-owned and disposable — re-syncing
+force-resets it. This is intended: sync PRs are auto-generated. The existing test
+`preserves an existing sync branch that is ahead of base` (`src/__tests__/workflow-sync.test.ts`)
+encodes the old guarantee and is replaced (see Testing).
+
+## Out of scope
+
+- No unique branch names.
+- No change to status semantics (`up-to-date` / `pr-existing` / `pr-opened` / `pr-updated`).
+- No auto-close of an open PR that becomes empty after a reset (workflows already match
+  base, nothing to sync). This is a benign, pre-existing edge — the PR stays open with an
+  empty diff and an operator can close it. Not expanded here.
+
+## Testing
+
+In `src/__tests__/workflow-sync.test.ts`:
+
+- **Replace** the test `preserves an existing sync branch that is ahead of base` with a
+  test asserting the new behavior: given a sync branch that is ahead of base and carries a
+  non-template leftover file, after sync the branch is force-reset to base (a `PATCH` to
+  `…/git/refs/heads/<syncBranch>` with `sha === base` and `force === true` occurred), the
+  stale non-template file is gone, and the current workflow templates are present.
+- **Add** an assertion (same or sibling test) that a stale workflow file content on the old
+  branch (e.g. `claude-implement.yml` = "OLD") is replaced by the current template content.
+- Confirm a stale open PR is reused (`pr-updated`, same PR number), not duplicated.
+- All other existing sync tests stay green, including:
+  - `returns up-to-date when the sync branch already matches templates and no PR is open`
+  - `updates an existing sync PR when files change`
+  - `returns pr-existing when no files changed and a sync PR is already open`
+  - the branch-prefix tests (`pr/sync/ai-implement`).
+
+## Backward compatibility
+
+The canonical branch name is unchanged (`sync/ai-implement`, or the prefixed variant). The
+only change is that an existing sync branch is force-reset instead of conditionally
+preserved. Repos with no lingering sync branch behave exactly as before.
+
+## Delivery note
+
+The implementation PR targets the `testing` branch as its base (not `main`). This may fold
+into the open per-project branch-prefix PR (#79) or be a follow-up — to be decided at
+plan/finish time.

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -621,6 +621,45 @@ describe("admin mappings", () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/kind/);
   });
+
+  it("persists a valid branchPrefix and returns it", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFX", owner: "org", repo: "app", branchPrefix: "pr",
+    }, token);
+    expect(create.statusCode).toBe(200);
+    expect(JSON.parse(create.body).branchPrefix).toBe("pr");
+
+    const list = await request("/api/mappings", "GET", "secret", undefined, token);
+    expect(JSON.parse(list.body).PFX.branchPrefix).toBe("pr");
+  });
+
+  it("normalizes surrounding slashes on branchPrefix", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFX2", owner: "org", repo: "app", branchPrefix: "/pr/",
+    }, token);
+    expect(create.statusCode).toBe(200);
+    expect(JSON.parse(create.body).branchPrefix).toBe("pr");
+  });
+
+  it("treats a blank branchPrefix as null", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFX3", owner: "org", repo: "app", branchPrefix: "  ",
+    }, token);
+    expect(create.statusCode).toBe(200);
+    expect(JSON.parse(create.body).branchPrefix).toBeNull();
+  });
+
+  it("rejects an invalid branchPrefix", async () => {
+    const token = await login("secret");
+    const res = await request("/api/mappings", "POST", "secret", {
+      teamKey: "PFXBAD", owner: "org", repo: "app", branchPrefix: "has space",
+    }, token);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("branchPrefix");
+  });
 });
 
 describe("admin runner-mode", () => {

--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -93,6 +93,12 @@ describe("normalizeBranchPrefix", () => {
   it("rejects a path segment that starts with a dot", () => {
     expect(() => normalizeBranchPrefix("foo/.hidden")).toThrow();
   });
+
+  it("rejects segments ending with '.' or '.lock'", () => {
+    expect(() => normalizeBranchPrefix("foo.")).toThrow();
+    expect(() => normalizeBranchPrefix("foo.lock")).toThrow();
+    expect(() => normalizeBranchPrefix("team/foo.lock")).toThrow();
+  });
 });
 
 describe("branchMatchesIssueIdentifier with prefix", () => {

--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -113,4 +113,18 @@ describe("branchMatchesIssueIdentifier with prefix", () => {
   it("still rejects longer issue keys sharing a prefix", () => {
     expect(branchMatchesIssueIdentifier("pr/ai-implement/gen-650-task-2", "GEN-65")).toBe(false);
   });
+
+  it("matches when a prefix segment embeds the marker substring", () => {
+    expect(branchMatchesIssueIdentifier(
+      "foo-ai-implement/gen-65-extra/ai-implement/gen-65-task",
+      "GEN-65",
+    )).toBe(true);
+  });
+
+  it("matches when the real marker is first and a longer-key marker is last", () => {
+    expect(branchMatchesIssueIdentifier(
+      "ai-implement/gen-65-foo/ai-implement/gen-650-bar",
+      "GEN-65",
+    )).toBe(true);
+  });
 });

--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { branchMatchesIssueIdentifier, buildIssueBranchName } from "../pipeline/branch-name.js";
+import { branchMatchesIssueIdentifier, buildIssueBranchName, normalizeBranchPrefix } from "../pipeline/branch-name.js";
 
 describe("buildIssueBranchName", () => {
   it("builds issue-scoped branch names from issue metadata", () => {
@@ -36,5 +36,73 @@ describe("branchMatchesIssueIdentifier", () => {
   it("does not match longer issue keys sharing a prefix", () => {
     expect(branchMatchesIssueIdentifier("ai-implement/gen-650-task-2", "GEN-65")).toBe(false);
     expect(branchMatchesIssueIdentifier("gen-650/task-2", "GEN-65")).toBe(false);
+  });
+});
+
+describe("buildIssueBranchName with prefix", () => {
+  it("prepends a configured prefix as a path segment", () => {
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", "pr")).toBe(
+      "pr/ai-implement/gen-123-add-login-flow",
+    );
+  });
+
+  it("leaves the branch unchanged for an empty/undefined prefix", () => {
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", "")).toBe(
+      "ai-implement/gen-123-add-login-flow",
+    );
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", null)).toBe(
+      "ai-implement/gen-123-add-login-flow",
+    );
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow")).toBe(
+      "ai-implement/gen-123-add-login-flow",
+    );
+  });
+
+  it("normalizes surrounding slashes on the prefix", () => {
+    expect(buildIssueBranchName("GEN-123", "Add Login Flow", "/pr/")).toBe(
+      "pr/ai-implement/gen-123-add-login-flow",
+    );
+  });
+});
+
+describe("normalizeBranchPrefix", () => {
+  it("returns null for blank input", () => {
+    expect(normalizeBranchPrefix(undefined)).toBeNull();
+    expect(normalizeBranchPrefix(null)).toBeNull();
+    expect(normalizeBranchPrefix("")).toBeNull();
+    expect(normalizeBranchPrefix("   ")).toBeNull();
+  });
+
+  it("trims and strips surrounding slashes", () => {
+    expect(normalizeBranchPrefix("  /pr/  ")).toBe("pr");
+    expect(normalizeBranchPrefix("team/pr")).toBe("team/pr");
+  });
+
+  it("rejects invalid prefixes", () => {
+    expect(() => normalizeBranchPrefix("has space")).toThrow();
+    expect(() => normalizeBranchPrefix("../etc")).toThrow();
+    expect(() => normalizeBranchPrefix("a//b")).toThrow();
+    expect(() => normalizeBranchPrefix(".hidden")).toThrow();
+    expect(() => normalizeBranchPrefix("x".repeat(65))).toThrow();
+  });
+});
+
+describe("branchMatchesIssueIdentifier with prefix", () => {
+  it("matches a prefixed ai-implement branch", () => {
+    expect(branchMatchesIssueIdentifier(
+      "pr/ai-implement/gen-65-task-2-add-parse-schema",
+      "GEN-65",
+    )).toBe(true);
+  });
+
+  it("matches a multi-segment prefixed branch", () => {
+    expect(branchMatchesIssueIdentifier(
+      "team/pr/ai-implement/gen-65-task-2",
+      "GEN-65",
+    )).toBe(true);
+  });
+
+  it("still rejects longer issue keys sharing a prefix", () => {
+    expect(branchMatchesIssueIdentifier("pr/ai-implement/gen-650-task-2", "GEN-65")).toBe(false);
   });
 });

--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -85,6 +85,14 @@ describe("normalizeBranchPrefix", () => {
     expect(() => normalizeBranchPrefix(".hidden")).toThrow();
     expect(() => normalizeBranchPrefix("x".repeat(65))).toThrow();
   });
+
+  it("accepts a prefix at the max length boundary", () => {
+    expect(normalizeBranchPrefix("x".repeat(64))).toBe("x".repeat(64));
+  });
+
+  it("rejects a path segment that starts with a dot", () => {
+    expect(() => normalizeBranchPrefix("foo/.hidden")).toThrow();
+  });
 });
 
 describe("branchMatchesIssueIdentifier with prefix", () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -33,6 +33,7 @@ function mapping(overrides: Partial<RepoMapping> & Pick<RepoMapping, "owner" | "
     maxTurns: null,
     maxIterations: null,
     maxJobMinutes: null,
+    branchPrefix: null,
     ...overrides,
   };
 }
@@ -487,6 +488,40 @@ describe("config", () => {
     expect(all.NULLS.maxTurns).toBeNull();
     expect(all.NULLS.maxIterations).toBeNull();
     expect(all.NULLS.maxJobMinutes).toBeNull();
+  });
+
+  it("round-trips branchPrefix (including null)", () => {
+    config.initMappingsTable();
+    config.upsertMapping("PFX", mapping({ owner: "org", repo: "repo", branchPrefix: "pr" }));
+    config.upsertMapping("NOPFX", mapping({ owner: "org", repo: "repo", branchPrefix: null }));
+
+    const all = config.getMappings();
+    expect(all.PFX.branchPrefix).toBe("pr");
+    expect(all.NOPFX.branchPrefix).toBeNull();
+  });
+
+  it("migrates a pre-existing mappings table to include the branch_prefix column (default null)", () => {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE mappings (
+        team_key TEXT PRIMARY KEY,
+        owner TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        workflow_file TEXT NOT NULL,
+        default_branch TEXT NOT NULL
+      )
+    `);
+    db.prepare("INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch) VALUES (?, ?, ?, ?, ?)")
+      .run("LEG", "org", "legacy", "claude-implement.yml", "main");
+    db.close();
+
+    config.initMappingsTable();
+    expect(config.getMappings().LEG.branchPrefix).toBeNull();
+
+    const reopened = new Database(dbPath);
+    const info = reopened.prepare("PRAGMA table_info(mappings)").all() as Array<{ name: string }>;
+    reopened.close();
+    expect(info.map((c) => c.name)).toContain("branch_prefix");
   });
 
   it("getMappings falls back to {} when extra_env contains invalid JSON", () => {

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { dispatchWorkflow, providerDispatchFields, capDispatchFields, capRunnerEnv, cancelWorkflowRun } from "../github.js";
+import { dispatchWorkflow, providerDispatchFields, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv, cancelWorkflowRun } from "../github.js";
 import type { RepoMapping } from "../config.js";
 
 function makeMapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
@@ -25,6 +25,7 @@ function makeMapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
     maxTurns: null,
     maxIterations: null,
     maxJobMinutes: null,
+    branchPrefix: null,
     ...overrides,
   };
 }
@@ -211,5 +212,30 @@ describe("cancelWorkflowRun", () => {
   it("returns false on 404 without throwing", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({ status: 404, ok: false } as Response);
     await expect(cancelWorkflowRun("token", "owner", "repo", 1)).resolves.toBe(false);
+  });
+});
+
+describe("branchPrefixDispatchFields", () => {
+  it("returns empty object when no prefix is set", () => {
+    expect(branchPrefixDispatchFields(makeMapping({}))).toEqual({});
+    expect(branchPrefixDispatchFields(makeMapping({ branchPrefix: null }))).toEqual({});
+  });
+
+  it("includes branch_prefix when set", () => {
+    expect(branchPrefixDispatchFields(makeMapping({ branchPrefix: "pr" }))).toEqual({
+      branch_prefix: "pr",
+    });
+  });
+});
+
+describe("branchPrefixRunnerEnv", () => {
+  it("returns empty object when no prefix is set", () => {
+    expect(branchPrefixRunnerEnv(makeMapping({}))).toEqual({});
+  });
+
+  it("includes AI_IMPLEMENT_BRANCH_PREFIX when set", () => {
+    expect(branchPrefixRunnerEnv(makeMapping({ branchPrefix: "pr" }))).toEqual({
+      AI_IMPLEMENT_BRANCH_PREFIX: "pr",
+    });
   });
 });

--- a/src/__tests__/workflow-sync.test.ts
+++ b/src/__tests__/workflow-sync.test.ts
@@ -323,16 +323,23 @@ describe("syncWorkflowTemplates", () => {
     expect(result.changedFiles).toEqual([]);
   });
 
-  it("preserves an existing sync branch that is ahead of base", async () => {
+  it("force-resets a stale sync branch that is ahead of base to produce a clean diff", async () => {
     const templatesRoot = makeTemplatesRoot();
     const fake = makeGithubFetch({
       syncFiles: {
-        "operator-note.txt": "keep me\n",
+        ".github/workflows/claude-implement.yml": "OLD-implement\n",
+        "stale-leftover.txt": "stale\n",
       },
       syncAheadBy: 2,
+      existingPr: {
+        number: 55,
+        html_url: "https://github.com/acme/app/pull/55",
+        head: "sync/ai-implement",
+        base: { ref: "main" },
+      },
     });
 
-    await syncWorkflowTemplates({
+    const result = await syncWorkflowTemplates({
       mapping,
       githubAppId: "app-id",
       githubAppPrivateKey: "private-key",
@@ -341,8 +348,25 @@ describe("syncWorkflowTemplates", () => {
       getInstallationTokenImpl: async () => "token",
     });
 
-    expect(fake.branches["sync/ai-implement"].files["operator-note.txt"]).toBe("keep me\n");
-    expect(fake.calls.some((call) => call.method === "PATCH" && call.path.includes("/git/refs/heads/"))).toBe(false);
+    // The existing open PR is reused, not duplicated.
+    expect(result.status).toBe("pr-updated");
+    expect(result.prNumber).toBe(55);
+    expect(fake.pulls).toHaveLength(1);
+
+    // The branch was force-reset to the current base before templates were applied.
+    expect(
+      fake.calls.some(
+        (call) =>
+          call.method === "PATCH" &&
+          call.path.includes("/git/refs/heads/") &&
+          (call.body as { sha?: string; force?: boolean }).sha === "base-sha" &&
+          (call.body as { sha?: string; force?: boolean }).force === true,
+      ),
+    ).toBe(true);
+
+    // Stale non-template leftover is gone; current template content is present.
+    expect(fake.branches["sync/ai-implement"].files["stale-leftover.txt"]).toBeUndefined();
+    expect(fake.branches["sync/ai-implement"].files[".github/workflows/claude-implement.yml"]).toBe("implement-yml\n");
   });
 
   it("throws when an always-synced workflow template is missing", async () => {

--- a/src/__tests__/workflow-sync.test.ts
+++ b/src/__tests__/workflow-sync.test.ts
@@ -24,6 +24,10 @@ const mapping: RepoMapping = {
   ticketingConfig: { kind: "linear" },
   awsRegion: null,
   paused: false,
+  maxTurns: null,
+  maxIterations: null,
+  maxJobMinutes: null,
+  branchPrefix: null,
 };
 
 let tempRoot: string | null = null;

--- a/src/__tests__/workflow-sync.test.ts
+++ b/src/__tests__/workflow-sync.test.ts
@@ -359,4 +359,55 @@ describe("syncWorkflowTemplates", () => {
       getInstallationTokenImpl: async () => "token",
     })).rejects.toThrow("Missing workflow template: workflows/claude-plan.yml");
   });
+
+  it("prefixes the sync branch when the mapping sets a branchPrefix", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch();
+
+    const result = await syncWorkflowTemplates({
+      mapping: { ...mapping, branchPrefix: "pr" },
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.syncBranch).toBe("pr/sync/ai-implement");
+    expect(fake.branches["pr/sync/ai-implement"]).toBeDefined();
+    expect(fake.pulls[0].head).toBe("pr/sync/ai-implement");
+  });
+
+  it("uses the unprefixed sync branch when the mapping has no branchPrefix", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch();
+
+    const result = await syncWorkflowTemplates({
+      mapping: { ...mapping, branchPrefix: null },
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.syncBranch).toBe("sync/ai-implement");
+  });
+
+  it("does not prefix an explicitly provided syncBranch", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch();
+
+    const result = await syncWorkflowTemplates({
+      mapping: { ...mapping, branchPrefix: "pr" },
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      syncBranch: "sync/ai-implement",
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    });
+
+    expect(result.syncBranch).toBe("sync/ai-implement");
+  });
 });

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -125,6 +125,7 @@ export const projectsHtml = `
           <div class="md-field"><label>Max Turns <span class="text-tertiary" style="font-size:0.85em">(blank = 50)</span></label><input id="md-max-turns" type="number" min="1" step="1" placeholder="50"></div>
           <div class="md-field"><label>Max Iterations <span class="text-tertiary" style="font-size:0.85em">(blank = bedrock 2 / anthropic 3)</span></label><input id="md-max-iter" type="number" min="1" step="1" placeholder="3"></div>
           <div class="md-field"><label>Job Timeout (min) <span class="text-tertiary" style="font-size:0.85em">(blank = 90)</span></label><input id="md-max-job-min" type="number" min="1" step="1" placeholder="90"></div>
+          <div class="md-field"><label>Branch Prefix <span class="text-tertiary" style="font-size:0.85em">(blank = none)</span></label><input id="md-branch-prefix" placeholder="pr"></div>
         </fieldset>
         <fieldset>
           <legend>Execution</legend>
@@ -273,6 +274,7 @@ export const projectsScript = `
     document.getElementById('md-max-turns').value = m.maxTurns == null ? '' : String(m.maxTurns);
     document.getElementById('md-max-iter').value = m.maxIterations == null ? '' : String(m.maxIterations);
     document.getElementById('md-max-job-min').value = m.maxJobMinutes == null ? '' : String(m.maxJobMinutes);
+    document.getElementById('md-branch-prefix').value = m.branchPrefix || '';
 
     // Ticketing provider + Jira config
     const tp = m.ticketingProvider || 'linear';
@@ -573,6 +575,7 @@ export const projectsScript = `
       maxTurns: (function(){ var v = document.getElementById('md-max-turns').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
       maxIterations: (function(){ var v = document.getElementById('md-max-iter').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
       maxJobMinutes: (function(){ var v = document.getElementById('md-max-job-min').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+      branchPrefix: (function(){ var v = document.getElementById('md-branch-prefix').value.trim(); return v === '' ? null : v; })(),
     };
 
     const ticketingProvider = document.getElementById('md-ticketing-provider').value;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -40,6 +40,7 @@ import { inspectPipelinesAndSteps } from "./inspect-pipeline-graph.js";
 import { validateTicketingConfig, type TicketingMappingConfig } from "./providers/ticketing-config.js";
 import { JiraClient, JiraFieldNotSelectError } from "./providers/jira-client.js";
 import { syncWorkflowTemplates } from "./workflow-sync.js";
+import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -966,6 +967,7 @@ async function handleUpsertMapping(
       maxTurns?: number | null;
       maxIterations?: number | null;
       maxJobMinutes?: number | null;
+      branchPrefix?: string | null;
     };
 
     if (!body.teamKey || !body.owner || !body.repo) {
@@ -1088,6 +1090,14 @@ async function handleUpsertMapping(
       return;
     }
 
+    let branchPrefix: string | null;
+    try {
+      branchPrefix = normalizeBranchPrefix(body.branchPrefix);
+    } catch (err) {
+      json(res, 400, { error: `branchPrefix invalid: ${err instanceof Error ? err.message : String(err)}` });
+      return;
+    }
+
     const mapping: RepoMapping = {
       owner: body.owner,
       repo: body.repo,
@@ -1114,6 +1124,7 @@ async function handleUpsertMapping(
       maxTurns,
       maxIterations,
       maxJobMinutes,
+      branchPrefix,
     };
 
     upsertMapping(body.teamKey, mapping);

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,8 @@ export interface RepoMapping {
   maxIterations: number | null;
   /** Maximum wall-clock minutes for a job before it is forcibly terminated. NULL means use the runner's built-in default. */
   maxJobMinutes: number | null;
+  /** Optional branch-name prefix prepended as a path segment (e.g. "pr" -> pr/ai-implement/...). NULL means no prefix. */
+  branchPrefix: string | null;
 }
 
 // Seed mappings are only applied on first run (empty DB).
@@ -126,6 +128,9 @@ function ensureMappingsColumns(): void {
   if (!names.has("max_job_minutes")) {
     db.exec(`ALTER TABLE mappings ADD COLUMN max_job_minutes INTEGER`);
   }
+  if (!names.has("branch_prefix")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN branch_prefix TEXT`);
+  }
 }
 
 export function initMappingsTable(): void {
@@ -153,7 +158,8 @@ export function initMappingsTable(): void {
       paused INTEGER NOT NULL DEFAULT 0,
       max_turns INTEGER,
       max_iterations INTEGER,
-      max_job_minutes INTEGER
+      max_job_minutes INTEGER,
+      branch_prefix TEXT
     )
   `);
   ensureMappingsColumns();
@@ -162,10 +168,10 @@ export function initMappingsTable(): void {
   const count = db.prepare("SELECT COUNT(*) as n FROM mappings").get() as { n: number };
   if (count.n === 0 && Object.keys(SEED_MAPPINGS).length > 0) {
     const insert = db.prepare(
-      "INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     for (const [key, m] of Object.entries(SEED_MAPPINGS)) {
-      insert.run(key, m.owner, m.repo, m.workflowFile, m.defaultBranch, m.maxInProgressAiIssues, m.executionMode, m.sessionMode, m.machineCpus, m.machineMemoryMb, m.planningEnabled ? 1 : 0, m.planningWorkflowFile, m.autoApprovePlans ? 1 : 0, Object.keys(m.extraEnv).length > 0 ? JSON.stringify(m.extraEnv) : null, m.provider, m.ticketingProvider, JSON.stringify(m.ticketingConfig), m.awsRegion, m.paused ? 1 : 0, m.maxTurns, m.maxIterations, m.maxJobMinutes);
+      insert.run(key, m.owner, m.repo, m.workflowFile, m.defaultBranch, m.maxInProgressAiIssues, m.executionMode, m.sessionMode, m.machineCpus, m.machineMemoryMb, m.planningEnabled ? 1 : 0, m.planningWorkflowFile, m.autoApprovePlans ? 1 : 0, Object.keys(m.extraEnv).length > 0 ? JSON.stringify(m.extraEnv) : null, m.provider, m.ticketingProvider, JSON.stringify(m.ticketingConfig), m.awsRegion, m.paused ? 1 : 0, m.maxTurns, m.maxIterations, m.maxJobMinutes, m.branchPrefix);
     }
     console.log(`[config] Seeded ${Object.keys(SEED_MAPPINGS).length} default mappings`);
   }
@@ -174,7 +180,7 @@ export function initMappingsTable(): void {
 export function getMappings(): Record<string, RepoMapping> {
   const rows = getDb()
     .prepare(
-      "SELECT team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes FROM mappings",
+      "SELECT team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix FROM mappings",
     )
     .all() as Array<{
       team_key: string;
@@ -199,6 +205,7 @@ export function getMappings(): Record<string, RepoMapping> {
       max_turns: number | null;
       max_iterations: number | null;
       max_job_minutes: number | null;
+      branch_prefix: string | null;
     }>;
 
   const result: Record<string, RepoMapping> = {};
@@ -235,6 +242,7 @@ export function getMappings(): Record<string, RepoMapping> {
       maxTurns: row.max_turns,
       maxIterations: row.max_iterations,
       maxJobMinutes: row.max_job_minutes,
+      branchPrefix: row.branch_prefix,
     };
   }
   return result;
@@ -243,7 +251,7 @@ export function getMappings(): Record<string, RepoMapping> {
 export function upsertMapping(teamKey: string, mapping: RepoMapping): void {
   getDb()
     .prepare(
-      "INSERT OR REPLACE INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT OR REPLACE INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     .run(
       teamKey,
@@ -268,6 +276,7 @@ export function upsertMapping(teamKey: string, mapping: RepoMapping): void {
       mapping.maxTurns,
       mapping.maxIterations,
       mapping.maxJobMinutes,
+      mapping.branchPrefix,
     );
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -22,6 +22,8 @@ interface DispatchInputs {
   max_iterations?: string;
   /** Per-project GitHub Actions job timeout in minutes. Only forwarded when set. */
   job_timeout_minutes?: string;
+  /** Per-project branch-name prefix. Only forwarded when set on the mapping. */
+  branch_prefix?: string;
   /** Public base URL the runner should POST results back to. Empty when callback disabled. */
   runner_callback_url?: string;
   /** Signed run token authorizing the runner's callback POST. Empty when callback disabled. */
@@ -97,6 +99,25 @@ export function capRunnerEnv(mapping: RepoMapping): Record<string, string> {
   if (mapping.maxTurns != null) env.AI_IMPLEMENT_MAX_TURNS = String(mapping.maxTurns);
   if (mapping.maxIterations != null) env.AI_IMPLEMENT_MAX_ITERATIONS = String(mapping.maxIterations);
   return env;
+}
+
+/**
+ * Branch-prefix dispatch input for a mapping. Only included when the mapping
+ * configures a prefix, so default repos keep dispatching to workflow templates
+ * that haven't been re-synced with the new input.
+ */
+export function branchPrefixDispatchFields(
+  mapping: RepoMapping,
+): Pick<DispatchInputs, "branch_prefix"> {
+  return mapping.branchPrefix ? { branch_prefix: mapping.branchPrefix } : {};
+}
+
+/**
+ * Branch-prefix env var for the runner process (Fly/local execution modes),
+ * where the prefix arrives via container env rather than a workflow input.
+ */
+export function branchPrefixRunnerEnv(mapping: RepoMapping): Record<string, string> {
+  return mapping.branchPrefix ? { AI_IMPLEMENT_BRANCH_PREFIX: mapping.branchPrefix } : {};
 }
 
 export async function dispatchWorkflow(

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "./config.js";
 import type { RepoMapping } from "./config.js";
 import { isAlreadyDispatched, markDispatched, closeDb, getDispatchedIds, deleteDispatched } from "./dedup.js";
-import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun, providerDispatchFields, capDispatchFields, capRunnerEnv } from "./github.js";
+import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun, providerDispatchFields, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv } from "./github.js";
 import { providerConfigFromEnv, ProviderRegistry } from "./providers/index.js";
 import type { TicketingProvider, IssueLifecycleState } from "./providers/types.js";
 import type { TicketIssue } from "./providers/types.js";
@@ -411,6 +411,7 @@ async function dispatchGitHubActions(
     runner_phase: "implementation",
     ...providerDispatchFields(mapping),
     ...capDispatchFields(mapping),
+    ...branchPrefixDispatchFields(mapping),
     runner_callback_url: runnerCallbackUrl,
     run_token: runToken,
     run_progress_token: runProgressToken,
@@ -745,7 +746,7 @@ async function dispatchFlyMachine(
         tenantId: config.tenantId ?? undefined,
         expectedTtlSeconds: Math.round(SWEEP_MACHINE_MAX_AGE_MS / 1000),
         extraEnv: (() => {
-          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping) };
+          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping), ...branchPrefixRunnerEnv(mapping) };
           return Object.keys(merged).length > 0 ? merged : undefined;
         })(),
       });
@@ -819,7 +820,7 @@ async function dispatchLocalDocker(
         runnerCallbackUrl: runnerCallbackUrl || undefined,
         runToken: runToken || undefined,
         extraEnv: (() => {
-          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping) };
+          const merged = { ...mapping.extraEnv, ...capRunnerEnv(mapping), ...branchPrefixRunnerEnv(mapping) };
           return Object.keys(merged).length > 0 ? merged : undefined;
         })(),
       });

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -36,6 +36,9 @@ export function normalizeBranchPrefix(raw: string | null | undefined): string | 
         "branchPrefix segments may contain only letters, digits, '.', '_', '-' and must each start with a letter or digit",
       );
     }
+    if (segment.endsWith(".") || segment.endsWith(".lock")) {
+      throw new Error("branchPrefix segments must not end with '.' or '.lock'");
+    }
   }
   return value;
 }

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -1,6 +1,6 @@
 const MAX_BRANCH_SUMMARY_LENGTH = 48;
 const MAX_BRANCH_PREFIX_LENGTH = 64;
-const BRANCH_PREFIX_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+const BRANCH_PREFIX_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 function slugify(value: string | undefined, fallback: string): string {
   const slug = (value ?? "")
@@ -30,10 +30,12 @@ export function normalizeBranchPrefix(raw: string | null | undefined): string | 
   if (value.includes("..") || value.includes("//")) {
     throw new Error("branchPrefix must not contain '..' or '//'");
   }
-  if (!BRANCH_PREFIX_PATTERN.test(value)) {
-    throw new Error(
-      "branchPrefix may contain only letters, digits, '.', '_', '-', '/' and must start with a letter or digit",
-    );
+  for (const segment of value.split("/")) {
+    if (!BRANCH_PREFIX_SEGMENT_PATTERN.test(segment)) {
+      throw new Error(
+        "branchPrefix segments may contain only letters, digits, '.', '_', '-' and must each start with a letter or digit",
+      );
+    }
   }
   return value;
 }

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -66,15 +66,12 @@ export function branchMatchesIssueIdentifier(branchRef: string | undefined, issu
     // Legacy bare-identifier branches: "gen-65" or "gen-65/...".
     if (ref === identifier || ref.startsWith(`${identifier}/`)) return true;
 
-    // ai-implement/<identifier>, optionally preceded by a prefix path segment
-    // (e.g. "pr/ai-implement/gen-65-..."). The marker must sit at a segment
-    // boundary and be followed by end, '-' or '/' so "gen-65" never matches
-    // "gen-650".
-    const marker = `ai-implement/${identifier}`;
-    const idx = ref.indexOf(marker);
-    if (idx === -1) return false;
-    if (idx !== 0 && ref[idx - 1] !== "/") return false;
-    const after = ref[idx + marker.length];
-    return after === undefined || after === "-" || after === "/";
+    // ai-implement/<identifier> at a path-segment boundary, optionally preceded
+    // by a prefix path (e.g. "pr/ai-implement/gen-65-..."), followed by end, '-'
+    // or '/' so "gen-65" never matches "gen-650". A regex (rather than
+    // indexOf/lastIndexOf) so a prefix that itself embeds an
+    // "ai-implement/<key>" substring can't shadow the real trailing marker.
+    const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(^|/)ai-implement/${escaped}(-|/|$)`).test(ref);
   });
 }

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -1,4 +1,6 @@
 const MAX_BRANCH_SUMMARY_LENGTH = 48;
+const MAX_BRANCH_PREFIX_LENGTH = 64;
+const BRANCH_PREFIX_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
 
 function slugify(value: string | undefined, fallback: string): string {
   const slug = (value ?? "")
@@ -10,10 +12,44 @@ function slugify(value: string | undefined, fallback: string): string {
   return slug || fallback;
 }
 
-export function buildIssueBranchName(issueIdentifier: string | undefined, issueTitle: string | undefined): string {
+/**
+ * Validates and normalizes a per-project branch prefix.
+ * - Blank/whitespace/undefined -> null (no prefix).
+ * - Strips surrounding slashes.
+ * - Must be a safe git ref path segment: only [A-Za-z0-9._/-], starting with an
+ *   alphanumeric, no "..", no "//", <= 64 chars.
+ * Throws on an invalid (non-blank) value so callers can surface a clear error.
+ */
+export function normalizeBranchPrefix(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  let value = raw.trim().replace(/^\/+|\/+$/g, "");
+  if (value === "") return null;
+  if (value.length > MAX_BRANCH_PREFIX_LENGTH) {
+    throw new Error(`branchPrefix must be ${MAX_BRANCH_PREFIX_LENGTH} characters or fewer`);
+  }
+  if (value.includes("..") || value.includes("//")) {
+    throw new Error("branchPrefix must not contain '..' or '//'");
+  }
+  if (!BRANCH_PREFIX_PATTERN.test(value)) {
+    throw new Error(
+      "branchPrefix may contain only letters, digits, '.', '_', '-', '/' and must start with a letter or digit",
+    );
+  }
+  return value;
+}
+
+export function buildIssueBranchName(
+  issueIdentifier: string | undefined,
+  issueTitle: string | undefined,
+  prefix?: string | null,
+): string {
   const key = slugify(issueIdentifier, "issue");
   const summary = slugify(issueTitle, "implementation");
-  return `ai-implement/${key}-${summary}`;
+  const base = `ai-implement/${key}-${summary}`;
+  // The prefix is already validated upstream (admin API + runner ingest); here we
+  // only trim and strip surrounding slashes so the join stays well-formed.
+  const cleaned = (prefix ?? "").trim().replace(/^\/+|\/+$/g, "");
+  return cleaned ? `${cleaned}/${base}` : base;
 }
 
 export function branchMatchesIssueIdentifier(branchRef: string | undefined, issueIdentifier: string | undefined): boolean {
@@ -24,11 +60,19 @@ export function branchMatchesIssueIdentifier(branchRef: string | undefined, issu
   const slugIdentifier = slugify(issueIdentifier, "");
   const candidates = [...new Set([rawIdentifier, slugIdentifier].filter(Boolean))];
 
-  return candidates.some((identifier) => (
-    ref === identifier ||
-    ref.startsWith(`${identifier}/`) ||
-    ref === `ai-implement/${identifier}` ||
-    ref.startsWith(`ai-implement/${identifier}-`) ||
-    ref.startsWith(`ai-implement/${identifier}/`)
-  ));
+  return candidates.some((identifier) => {
+    // Legacy bare-identifier branches: "gen-65" or "gen-65/...".
+    if (ref === identifier || ref.startsWith(`${identifier}/`)) return true;
+
+    // ai-implement/<identifier>, optionally preceded by a prefix path segment
+    // (e.g. "pr/ai-implement/gen-65-..."). The marker must sit at a segment
+    // boundary and be followed by end, '-' or '/' so "gen-65" never matches
+    // "gen-650".
+    const marker = `ai-implement/${identifier}`;
+    const idx = ref.indexOf(marker);
+    if (idx === -1) return false;
+    if (idx !== 0 && ref[idx - 1] !== "/") return false;
+    const after = ref[idx + marker.length];
+    return after === undefined || after === "-" || after === "/";
+  });
 }

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -146,7 +146,7 @@ function applyWiring(step: YamlStep): StepDefinition {
           repoOwner: ctx.getOutputs("clone").repoOwner,
           repoRepo: ctx.getOutputs("clone").repoRepo,
           githubToken: ctx.getOutputs("clone").githubToken,
-          branchName: buildIssueBranchName(ctx.data.issueIdentifier, ctx.data.issueTitle),
+          branchName: buildIssueBranchName(ctx.data.issueIdentifier, ctx.data.issueTitle, ctx.data.branchPrefix),
           baseBranch: ctx.getOutputs("clone").branch,
           prTitle: `${ctx.data.issueIdentifier}: ${ctx.data.issueTitle}`,
         }),

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -54,6 +54,8 @@ export interface PipelineContextData {
   maxTurns?: number;
   /** Autonomous runner: cap on implement/review iterations (from env). */
   maxIterations?: number;
+  /** Autonomous runner: optional branch-name prefix (from AI_IMPLEMENT_BRANCH_PREFIX). */
+  branchPrefix?: string;
   /** Autonomous runner: WORKFLOW.md hook script paths (relative to repo root). */
   hooks?: { setup?: string; verify?: string; teardown?: string };
 }

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -8,6 +8,7 @@ import { DEFAULT_PIPELINE, createDefaultRunner } from "./pipeline/default-pipeli
 import type { LLMExecutor, LogLevel, PipelineDefinition, StepReporter } from "./pipeline/types.js";
 import { HttpStepReporter, NoopStepReporter, TokenStepReporter } from "./pipeline/reporter.js";
 import { runHookScript } from "./pipeline/steps/hooks.js";
+import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
 import { parseWorkflowMd } from "./workflow-md.js";
 import { fetchPlanningContextFromOrchestrator, postRunnerResult } from "./runner-result.js";
 
@@ -181,6 +182,17 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   };
   const maxTurns = parseEnvInt(process.env.AI_IMPLEMENT_MAX_TURNS, "AI_IMPLEMENT_MAX_TURNS");
   const maxIterations = parseEnvInt(process.env.AI_IMPLEMENT_MAX_ITERATIONS, "AI_IMPLEMENT_MAX_ITERATIONS");
+  const branchPrefix = (() => {
+    try {
+      return normalizeBranchPrefix(process.env.AI_IMPLEMENT_BRANCH_PREFIX) ?? undefined;
+    } catch (err) {
+      // The orchestrator validates the prefix before dispatch, so this only
+      // happens on a manual dispatch with a bad value. Warn rather than fail the
+      // run, and fall back to the default (no prefix).
+      console.warn(`[runner] Ignoring invalid AI_IMPLEMENT_BRANCH_PREFIX: ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
+  })();
 
   const logLevel = resolveLogLevel(process.env.AI_IMPLEMENT_LOG_LEVEL);
   const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir, logLevel);
@@ -218,6 +230,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       provider,
       maxTurns,
       maxIterations,
+      branchPrefix,
       hooks: { setup: setupHook, verify: verifyHook, teardown: teardownHook },
     },
     llmExecutor,

--- a/src/workflow-sync.ts
+++ b/src/workflow-sync.ts
@@ -256,6 +256,10 @@ async function ensureSyncBranch(params: {
   });
 }
 
+// NOTE: this matches only the CURRENT sync branch name. If a project's branchPrefix
+// changes (e.g. "pr" -> none, or "pr" -> "client/pr"), a sync PR previously opened on
+// the old branch name will not be found here and remains open; it must be closed
+// manually. Re-syncing always operates on the branch for the mapping's current prefix.
 async function findSyncPr(
   gh: GitHubClient,
   repo: string,

--- a/src/workflow-sync.ts
+++ b/src/workflow-sync.ts
@@ -246,15 +246,14 @@ async function ensureSyncBranch(params: {
     return;
   }
 
-  const compare = await gh.maybeRequest<{ ahead_by: number }>(
-    `/repos/${repo}/compare/${encodeRefPath(baseBranch)}...${encodeRefPath(syncBranch)}`,
-  );
-  if ((compare?.ahead_by ?? 0) === 0) {
-    await gh.request(`/repos/${repo}/git/refs/heads/${encodeRefPath(syncBranch)}`, {
-      method: "PATCH",
-      body: JSON.stringify({ sha: base.object.sha, force: true }),
-    });
-  }
+  // The sync branch is orchestrator-owned and disposable: always force-reset it to the
+  // current base so each re-sync produces a clean diff (base + freshly regenerated
+  // templates) and never layers onto stale state from a prior sync PR — whether that
+  // branch is ahead of, behind, or lingering after a merge.
+  await gh.request(`/repos/${repo}/git/refs/heads/${encodeRefPath(syncBranch)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ sha: base.object.sha, force: true }),
+  });
 }
 
 async function findSyncPr(

--- a/src/workflow-sync.ts
+++ b/src/workflow-sync.ts
@@ -121,6 +121,11 @@ class GitHubClient {
   }
 }
 
+function buildSyncBranchName(prefix: string | null | undefined): string {
+  const cleaned = (prefix ?? "").trim().replace(/^\/+|\/+$/g, "");
+  return cleaned ? `${cleaned}/sync/ai-implement` : "sync/ai-implement";
+}
+
 function repoPath(mapping: RepoMapping): string {
   return `${mapping.owner}/${mapping.repo}`;
 }
@@ -311,7 +316,7 @@ export async function syncWorkflowTemplates(
 ): Promise<WorkflowSyncResult> {
   const mapping = options.mapping;
   const targetRepo = repoPath(mapping);
-  const syncBranch = options.syncBranch ?? "sync/ai-implement";
+  const syncBranch = options.syncBranch ?? buildSyncBranchName(mapping.branchPrefix);
   const templatesRoot = options.templatesRoot ?? packageRoot();
   const getToken = options.getInstallationTokenImpl ?? getInstallationToken;
   const token = await getToken(options.githubAppId, options.githubAppPrivateKey, mapping.owner);

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -74,6 +74,11 @@ on:
         required: false
         type: string
         default: ""
+      branch_prefix:
+        description: "Optional branch-name prefix prepended as a path segment (empty = no prefix)"
+        required: false
+        type: string
+        default: ""
       runner_callback_url:
         description: "Base URL the orchestrator advertises for /runner/result; empty skips callback"
         required: false
@@ -227,6 +232,7 @@ jobs:
           AWS_REGION: ${{ inputs.aws_region }}
           AI_IMPLEMENT_MAX_TURNS: ${{ inputs.max_turns }}
           AI_IMPLEMENT_MAX_ITERATIONS: ${{ inputs.max_iterations }}
+          AI_IMPLEMENT_BRANCH_PREFIX: ${{ inputs.branch_prefix }}
           AI_IMPLEMENT_LOG_LEVEL: ${{ vars.AI_IMPLEMENT_LOG_LEVEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

### Per-project PR branch prefix
- Adds an optional per-project **branch prefix**. When a project's mapping sets it (e.g. `pr`), implementation branches become `pr/ai-implement/<key>-<summary>` instead of `ai-implement/<key>-<summary>`. Blank (the default) leaves branch names unchanged, so existing projects are byte-for-byte unaffected.
- Threaded end-to-end mirroring the run-caps pattern: `mappings.branch_prefix` column → admin API validation → admin UI field → `branch_prefix` dispatch input (GitHub Actions) / `AI_IMPLEMENT_BRANCH_PREFIX` env (Fly/local), sent only when set → runner re-validates → `buildIssueBranchName` prepends it.
- **Sync Workflows PR branch** is also prefixed: the admin "Sync workflows" action opens its target-repo PR on `pr/sync/ai-implement` instead of `sync/ai-implement`.
- Only the initial orchestrator-driven run is affected; `/ai-implement` comment-triggered gap-fill reuses the existing PR branch and is untouched.
- `branchMatchesIssueIdentifier` made prefix-tolerant (segment-anchored regex) so existing-PR detection still works for prefixed projects without over-matching longer issue keys.
- Validation (shared `normalizeBranchPrefix`): each `/`-segment must start alphanumeric and contain only `[A-Za-z0-9._-]`; no `..`/`//`; ≤ 64 chars. Admin rejects invalid input with 400; runner warns-and-ignores. Injection-safe.

### Sync PR branch refresh
- Fixes "weird things" when re-syncing workflows while an old sync branch still exists. `ensureSyncBranch` now **always force-resets the existing sync branch to the current base** before re-applying templates (previously an ahead-of-base branch was left untouched, so stale state layered onto the reused PR).
- The single canonical sync PR per repo now always shows a clean diff = current base + current templates. Fixes stale open-PR layering, lingering post-merge branches, and wrong/old-base diffs.
- Behavior note: the sync branch is now fully orchestrator-owned/disposable — manual commits on it no longer survive a re-sync (intended; sync PRs are auto-generated).

Specs: `docs/superpowers/specs/2026-06-08-pr-branch-prefix-design.md`, `docs/superpowers/specs/2026-06-08-sync-branch-refresh-design.md`
Plans: `docs/superpowers/plans/2026-06-08-pr-branch-prefix.md`, `docs/superpowers/plans/2026-06-08-sync-branch-refresh.md`

## Test Plan
- [x] `npm run typecheck` clean
- [x] `npm test` — 1253/1253 pass (branch-name normalize/build/match incl. embedded-marker cases, config round-trip + migration, github helpers, admin API validation, sync-branch prefixing + force-reset)
- [x] Canonical and CI workflow copies kept byte-for-byte identical (`workflow-shim-structure.test.ts`)
- [ ] Manual: set a project's Branch Prefix to `pr` in `/admin` (after re-syncing `claude-implement.yml`), dispatch an issue, confirm the PR branch is `pr/ai-implement/...`
- [ ] Manual: tap **Sync workflows** twice without merging; confirm one canonical sync PR that refreshes to a clean diff each time, on `pr/sync/ai-implement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)