### PR TITLE
feat: per-step + sub-phase timing instrumentation

### DIFF
--- a/src/__tests__/timing.test.ts
+++ b/src/__tests__/timing.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from "vitest";
+import { TimingCollector, formatDuration, formatSummary, runWithTiming, span, TimingStepReporter } from "../pipeline/timing.js";
+import type { Step, StepReporter } from "../pipeline/types.js";
+
+function step(partial: Partial<Step> & { id: string; status: Step["status"] }): Step {
+  return {
+    type: "custom",
+    started_at: "2026-06-09T17:00:00.000Z",
+    ended_at: null,
+    parent_step_id: null,
+    inputs: {},
+    outputs: {},
+    logs_url: null,
+    ...partial,
+  };
+}
+
+describe("formatDuration", () => {
+  it("shows sub-second precision under 10s", () => {
+    expect(formatDuration(312)).toBe("0.3s");
+    expect(formatDuration(2100)).toBe("2.1s");
+  });
+  it("shows minutes and zero-padded seconds at/above 10s", () => {
+    expect(formatDuration(13_000)).toBe("13s");
+    expect(formatDuration(107_000)).toBe("1m47s");
+    expect(formatDuration(744_000)).toBe("12m24s");
+  });
+});
+
+describe("TimingCollector", () => {
+  it("keeps records in insertion order", () => {
+    const c = new TimingCollector("summary");
+    c.record({ label: "clone", parentId: null, ms: 2100, kind: "step" });
+    c.record({ label: "git-push", parentId: "push", ms: 273900, kind: "span" });
+    expect(c.records().map((r) => r.label)).toEqual(["clone", "git-push"]);
+    expect(c.level).toBe("summary");
+  });
+  it("dedupes duplicate step records by label but keeps spans", () => {
+    const c = new TimingCollector("stream");
+    c.record({ label: "push", parentId: null, ms: 100, kind: "step" });
+    c.record({ label: "push", parentId: null, ms: 999, kind: "step" });
+    c.record({ label: "git-push", parentId: "push", ms: 50, kind: "span" });
+    c.record({ label: "git-push", parentId: "push", ms: 60, kind: "span" });
+    expect(c.records().filter((r) => r.kind === "step")).toHaveLength(1);
+    expect(c.records().filter((r) => r.kind === "span")).toHaveLength(2);
+  });
+});
+
+describe("formatSummary", () => {
+  it("nests children under steps, marks the dominant step, and totals top-level steps", () => {
+    const c = new TimingCollector("summary");
+    // Completion order: substeps complete before their parent feedback-loop step.
+    c.record({ label: "clone", parentId: null, ms: 2100, kind: "step" });
+    c.record({ label: "implement.1", parentId: "feedback-loop", ms: 107000, kind: "step" });
+    c.record({ label: "review.1", parentId: "feedback-loop", ms: 13000, kind: "step" });
+    c.record({ label: "feedback-loop", parentId: null, ms: 120000, kind: "step" });
+    c.record({ label: "git-push", parentId: "push", ms: 273900, kind: "span" });
+    c.record({ label: "push", parentId: null, ms: 274600, kind: "step" });
+
+    const out = formatSummary(c, "ACC-465");
+    const lines = out.split("\n");
+
+    // Every line is prefixed and the header carries the identifier + total.
+    expect(lines.every((l) => l.startsWith("[timing]"))).toBe(true);
+    expect(out).toContain("ACC-465");
+    // total = top-level steps only: clone 2.1s + feedback-loop 2m00s + push 4m35s = 6m37s.
+    // (Durations >= 10s render as MmSSs via formatDuration, so 274600ms -> "4m35s".)
+    expect(out).toContain("total 6m37s");
+    // push (4m35s) is the largest top-level step -> dominant marker on its line.
+    expect(out).toMatch(/push\s+4m35s\s+⚠/);
+    // Children appear, indented with a tree branch, under their parent.
+    const pushIdx = lines.findIndex((l) => /\bpush\b/.test(l) && l.includes("4m35s"));
+    const gitPushIdx = lines.findIndex((l) => l.includes("git-push"));
+    expect(pushIdx).toBeGreaterThanOrEqual(0);
+    expect(gitPushIdx).toBeGreaterThan(pushIdx);
+    expect(lines[gitPushIdx]).toMatch(/├|└/);
+  });
+});
+
+describe("TimingStepReporter", () => {
+  it("forwards every report to the inner reporter unchanged", async () => {
+    const seen: Step[] = [];
+    const inner: StepReporter = { report: async (s) => void seen.push(s) };
+    const c = new TimingCollector("summary");
+    const r = new TimingStepReporter(inner, c);
+    const running = step({ id: "push", status: "running" });
+    await r.report(running);
+    expect(seen).toEqual([running]);
+  });
+
+  it("records a step duration only on terminal status, using started_at/ended_at", async () => {
+    const inner: StepReporter = { report: async () => {} };
+    const c = new TimingCollector("summary");
+    const r = new TimingStepReporter(inner, c);
+    await r.report(step({ id: "push", status: "running" }));
+    expect(c.records()).toHaveLength(0);
+    await r.report(
+      step({
+        id: "push",
+        status: "passed",
+        started_at: "2026-06-09T17:00:00.000Z",
+        ended_at: "2026-06-09T17:00:04.600Z",
+      }),
+    );
+    expect(c.records()).toEqual([
+      { label: "push", parentId: null, ms: 4600, kind: "step" },
+    ]);
+  });
+
+  it("forwards skipped/cancelled to inner without recording a duration", async () => {
+    const seen: Step[] = [];
+    const inner: StepReporter = { report: async (s) => void seen.push(s) };
+    const c = new TimingCollector("summary");
+    const r = new TimingStepReporter(inner, c);
+    await r.report(step({ id: "preflight", status: "skipped" }));
+    await r.report(step({ id: "await-ci", status: "cancelled" }));
+    expect(seen).toHaveLength(2);
+    expect(c.records()).toHaveLength(0);
+  });
+});
+
+describe("span", () => {
+  it("records under the current step (set by the reporter) within runWithTiming", async () => {
+    const inner: StepReporter = { report: async () => {} };
+    const c = new TimingCollector("summary");
+    const r = new TimingStepReporter(inner, c);
+    await runWithTiming(c, async () => {
+      await r.report(step({ id: "push", status: "running" }));
+      const result = await span("git-push", async () => 42);
+      expect(result).toBe(42);
+    });
+    const spans = c.records().filter((x) => x.kind === "span");
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.label).toBe("git-push");
+    expect(spans[0]!.parentId).toBe("push");
+    expect(spans[0]!.ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("is a transparent pass-through with no active collector", async () => {
+    expect(await span("orphan", async () => "ok")).toBe("ok");
+  });
+
+  it("records elapsed time then re-throws on rejection", async () => {
+    const c = new TimingCollector("summary");
+    await runWithTiming(c, async () => {
+      await expect(span("boom", async () => {
+        throw new Error("nope");
+      })).rejects.toThrow("nope");
+    });
+    expect(c.records().some((x) => x.label === "boom" && x.kind === "span")).toBe(true);
+  });
+
+  it("emits an inline line at stream level", async () => {
+    const errors: string[] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((msg) => {
+      errors.push(String(msg));
+    });
+    try {
+      const inner: StepReporter = { report: async () => {} };
+      const c = new TimingCollector("stream");
+      const r = new TimingStepReporter(inner, c);
+      await runWithTiming(c, async () => {
+        await r.report(step({ id: "push", status: "running" }));
+        await span("git-push", async () => 0);
+      });
+    } finally {
+      spy.mockRestore();
+    }
+    expect(errors.some((e) => e.includes("git-push") && e.includes("[timing]"))).toBe(true);
+  });
+});

--- a/src/__tests__/timing.test.ts
+++ b/src/__tests__/timing.test.ts
@@ -75,6 +75,22 @@ describe("formatSummary", () => {
     expect(gitPushIdx).toBeGreaterThan(pushIdx);
     expect(lines[gitPushIdx]).toMatch(/├|└/);
   });
+
+  it("omits the dominant marker when there is only one top-level step", () => {
+    const c = new TimingCollector("summary");
+    c.record({ label: "clone", parentId: null, ms: 2100, kind: "step" });
+    const out = formatSummary(c, "ACC-465");
+    expect(out).not.toContain("⚠ dominant");
+    expect(out).toContain("clone");
+  });
+
+  it("emits just a header without throwing when no steps were recorded", () => {
+    const c = new TimingCollector("summary");
+    const out = formatSummary(c, "ACC-465");
+    expect(out.split("\n")).toHaveLength(1);
+    expect(out).toContain("ACC-465");
+    expect(out).toContain("total 0.0s");
+  });
 });
 
 describe("TimingStepReporter", () => {

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -84,59 +84,81 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
       throw new Error(`git push failed (exit ${pushResult.status ?? "null"}): ${stderr}`);
     }
 
-    // Create PR, tolerating 422 (already exists)
-    const prRes = await span("pr-create", async () =>
-      fetch(`https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${githubToken}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          title: prTitle,
-          head: branchName,
-          base: baseBranch,
-          body: prBody,
-        }),
-      }),
+    // Span covers the POST and the 422 list-open-PRs fallback so re-runs (which
+    // hit 422 and pay an extra round-trip) are timed in full, not just the POST.
+    const pr = await span("pr-create", async () =>
+      createOrFindPullRequest({ repoOwner, repoRepo, githubToken, prTitle, branchName, baseBranch, prBody }),
     );
-
-    if (prRes.ok) {
-      const pr = (await prRes.json()) as { html_url?: unknown; number?: unknown };
-      if (typeof pr.html_url !== "string" || typeof pr.number !== "number") {
-        throw new Error("Unexpected PR creation response shape from GitHub API");
-      }
-      return { prUrl: pr.html_url, prNumber: pr.number, branchPushed: true, commitSha };
-    }
-
-    if (prRes.status === 422) {
-      // PR already open — find it
-      const listRes = await fetch(
-        `https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls?head=${repoOwner}:${branchName}&state=open`,
-        { headers: { Authorization: `Bearer ${githubToken}` } },
-      );
-      if (!listRes.ok) {
-        const listBody = await listRes.text().catch(() => "");
-        throw new Error(
-          `PR already exists (422) but listing open PRs failed with HTTP ${listRes.status}: ${listBody}`,
-        );
-      }
-      const prs = (await listRes.json()) as Array<{ html_url?: unknown; number?: unknown }>;
-      if (prs.length > 0) {
-        const existing = prs[0];
-        if (typeof existing.html_url === "string" && typeof existing.number === "number") {
-          return { prUrl: existing.html_url, prNumber: existing.number, branchPushed: true, commitSha };
-        }
-      }
-      throw new Error(
-        `PR already exists (422) but no open PR found for branch ${branchName}`,
-      );
-    }
-
-    const body = await prRes.text().catch(() => "");
-    throw new Error(`PR creation failed with HTTP ${prRes.status}: ${body}`);
+    return { prUrl: pr.url, prNumber: pr.number, branchPushed: true, commitSha };
   },
 };
+
+interface CreatePrInputs {
+  repoOwner: string;
+  repoRepo: string;
+  githubToken: string;
+  prTitle: string;
+  branchName: string;
+  baseBranch: string;
+  prBody: string;
+}
+
+/** Create the PR, tolerating 422 (already exists) by finding the open PR. */
+async function createOrFindPullRequest(
+  { repoOwner, repoRepo, githubToken, prTitle, branchName, baseBranch, prBody }: CreatePrInputs,
+): Promise<{ url: string; number: number }> {
+  const prRes = await fetch(
+    `https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${githubToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: prTitle,
+        head: branchName,
+        base: baseBranch,
+        body: prBody,
+      }),
+    },
+  );
+
+  if (prRes.ok) {
+    const pr = (await prRes.json()) as { html_url?: unknown; number?: unknown };
+    if (typeof pr.html_url !== "string" || typeof pr.number !== "number") {
+      throw new Error("Unexpected PR creation response shape from GitHub API");
+    }
+    return { url: pr.html_url, number: pr.number };
+  }
+
+  if (prRes.status === 422) {
+    // PR already open — find it
+    const listRes = await fetch(
+      `https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls?head=${repoOwner}:${branchName}&state=open`,
+      { headers: { Authorization: `Bearer ${githubToken}` } },
+    );
+    if (!listRes.ok) {
+      const listBody = await listRes.text().catch(() => "");
+      throw new Error(
+        `PR already exists (422) but listing open PRs failed with HTTP ${listRes.status}: ${listBody}`,
+      );
+    }
+    const prs = (await listRes.json()) as Array<{ html_url?: unknown; number?: unknown }>;
+    if (prs.length > 0) {
+      const existing = prs[0];
+      if (typeof existing.html_url === "string" && typeof existing.number === "number") {
+        return { url: existing.html_url, number: existing.number };
+      }
+    }
+    throw new Error(
+      `PR already exists (422) but no open PR found for branch ${branchName}`,
+    );
+  }
+
+  const body = await prRes.text().catch(() => "");
+  throw new Error(`PR creation failed with HTTP ${prRes.status}: ${body}`);
+}
 
 function buildCommitMessage(issueIdentifier: string, issueTitle: string): string {
   const title = (issueTitle || "AI implementation").replace(/\s+/g, " ").trim();

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { formatGitNameStatusSummary } from "../step-utils.js";
+import { span } from "../timing.js";
 
 const LS_REMOTE_MAX_ATTEMPTS = 3;
 const LS_REMOTE_RETRY_DELAYS_MS = [250, 1000];
@@ -63,16 +64,20 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     // stdout/stderr. Token is redacted from any error messages.
     const remote = `https://x-access-token:${githubToken}@github.com/${repoOwner}/${repoRepo}.git`;
     const remoteRef = `refs/heads/${branchName}`;
-    const expectedRemoteSha = resolveRemoteBranchSha(workspaceDir, remote, branchName, githubToken);
-    const pushResult = spawnSync(
-      "git",
-      [
-        "push",
-        remote,
-        `HEAD:${remoteRef}`,
-        `--force-with-lease=${remoteRef}:${expectedRemoteSha ?? ""}`,
-      ],
-      { cwd: workspaceDir, stdio: ["ignore", "pipe", "pipe"] },
+    const expectedRemoteSha = await span("git-ls-remote", async () =>
+      resolveRemoteBranchSha(workspaceDir, remote, branchName, githubToken),
+    );
+    const pushResult = await span("git-push", async () =>
+      spawnSync(
+        "git",
+        [
+          "push",
+          remote,
+          `HEAD:${remoteRef}`,
+          `--force-with-lease=${remoteRef}:${expectedRemoteSha ?? ""}`,
+        ],
+        { cwd: workspaceDir, stdio: ["ignore", "pipe", "pipe"] },
+      ),
     );
     if (pushResult.status !== 0) {
       const stderr = (pushResult.stderr?.toString() ?? "").replace(githubToken, "***");
@@ -80,9 +85,8 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     }
 
     // Create PR, tolerating 422 (already exists)
-    const prRes = await fetch(
-      `https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls`,
-      {
+    const prRes = await span("pr-create", async () =>
+      fetch(`https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${githubToken}`,
@@ -94,7 +98,7 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
           base: baseBranch,
           body: prBody,
         }),
-      },
+      }),
     );
 
     if (prRes.ok) {

--- a/src/pipeline/timing.ts
+++ b/src/pipeline/timing.ts
@@ -1,0 +1,148 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { LogLevel, Step, StepReporter } from "./types.js";
+
+export interface TimingRecord {
+  /** Step id or sub-phase span label. */
+  label: string;
+  /** Parent step id for spans and nested substeps; null for top-level steps. */
+  parentId: string | null;
+  ms: number;
+  kind: "step" | "span";
+}
+
+/** Human duration: sub-second precision below 10s, `MmSSs` at/above. */
+export function formatDuration(ms: number): string {
+  if (ms < 10_000) return `${(ms / 1000).toFixed(1)}s`;
+  const s = Math.round(ms / 1000);
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return m > 0 ? `${m}m${rem.toString().padStart(2, "0")}s` : `${rem}s`;
+}
+
+/** Run-scoped sink for step durations and sub-phase spans. */
+export class TimingCollector {
+  readonly level: LogLevel;
+  private readonly _records: TimingRecord[] = [];
+  private readonly _seenSteps = new Set<string>();
+
+  constructor(level: LogLevel) {
+    this.level = level;
+  }
+
+  record(r: TimingRecord): void {
+    if (r.kind === "step") {
+      // Steps report a terminal status once; guard against a double record.
+      if (this._seenSteps.has(r.label)) return;
+      this._seenSteps.add(r.label);
+    }
+    this._records.push(r);
+  }
+
+  records(): readonly TimingRecord[] {
+    return this._records;
+  }
+}
+
+const PREFIX = "[timing]";
+
+/**
+ * Render the collector as an indented summary. Top-level steps (parentId null)
+ * are listed in completion order — which equals pipeline order, since steps run
+ * sequentially. Each step's children (records whose parentId === step.label) are
+ * listed beneath it, indented, in insertion order. The total counts top-level
+ * steps only (children are already inside their parent's wall-clock).
+ */
+export function formatSummary(collector: TimingCollector, identifier: string): string {
+  const records = collector.records();
+  const topLevel = records.filter((r) => r.kind === "step" && r.parentId === null);
+  const totalMs = topLevel.reduce((sum, r) => sum + r.ms, 0);
+  const dominant = topLevel.reduce<TimingRecord | null>(
+    (max, r) => (max === null || r.ms > max.ms ? r : max),
+    null,
+  );
+
+  const lines: string[] = [
+    `${PREFIX} ── run summary (${identifier}) — total ${formatDuration(totalMs)} ──`,
+  ];
+
+  for (const step of topLevel) {
+    const mark = step === dominant ? "   ⚠ dominant" : "";
+    lines.push(`${PREFIX}   ${step.label.padEnd(18)} ${formatDuration(step.ms).padStart(7)}${mark}`);
+    const children = records.filter((r) => r.parentId === step.label);
+    children.forEach((child, i) => {
+      const branch = i === children.length - 1 ? "└" : "├";
+      lines.push(`${PREFIX}     ${branch} ${child.label.padEnd(16)} ${formatDuration(child.ms).padStart(7)}`);
+    });
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Run-scoped ALS context for span() nesting
+// ---------------------------------------------------------------------------
+
+interface TimingScope {
+  collector: TimingCollector;
+  currentStepId: string | null;
+}
+
+const timingStore = new AsyncLocalStorage<TimingScope>();
+
+/** Establish the run-scoped timing context so span() can find the collector. */
+export function runWithTiming<T>(collector: TimingCollector, fn: () => Promise<T>): Promise<T> {
+  return timingStore.run({ collector, currentStepId: null }, fn);
+}
+
+/**
+ * Time an async sub-phase, recording it under the current step. The active
+ * collector and current step id come from the run scope (set by
+ * TimingStepReporter on each "running" report). A transparent pass-through when
+ * no run scope is active (e.g. a unit test calling a step directly).
+ */
+export async function span<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const scope = timingStore.getStore();
+  if (!scope) return await fn();
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    const ms = performance.now() - start;
+    scope.collector.record({ label, parentId: scope.currentStepId, ms, kind: "span" });
+    if (scope.collector.level === "stream") {
+      console.error(`${PREFIX} ${scope.currentStepId ?? "?"} › ${label}: ${formatDuration(ms)}`);
+    }
+  }
+}
+
+/**
+ * StepReporter decorator: forwards every report to the inner reporter unchanged,
+ * tracks the current step id for span() nesting, and records each step's
+ * duration when it reaches a terminal status.
+ */
+export class TimingStepReporter implements StepReporter {
+  constructor(
+    private readonly inner: StepReporter,
+    private readonly collector: TimingCollector,
+  ) {}
+
+  async report(step: Step): Promise<void> {
+    if (step.status === "running") {
+      const scope = timingStore.getStore();
+      if (scope) scope.currentStepId = step.id;
+    } else if (step.status === "passed" || step.status === "failed") {
+      if (step.ended_at) {
+        const ms = Date.parse(step.ended_at) - Date.parse(step.started_at);
+        if (Number.isFinite(ms) && ms >= 0) {
+          this.collector.record({
+            label: step.id,
+            parentId: step.parent_step_id,
+            ms,
+            kind: "step",
+          });
+        }
+      }
+    }
+    await this.inner.report(step);
+  }
+}

--- a/src/pipeline/timing.ts
+++ b/src/pipeline/timing.ts
@@ -66,7 +66,9 @@ export function formatSummary(collector: TimingCollector, identifier: string): s
   ];
 
   for (const step of topLevel) {
-    const mark = step === dominant ? "   ⚠ dominant" : "";
+    // Only flag a dominant step when there's more than one to compare against;
+    // a single-step run has nothing to be "dominant" over.
+    const mark = topLevel.length > 1 && step === dominant ? "   ⚠ dominant" : "";
     lines.push(`${PREFIX}   ${step.label.padEnd(18)} ${formatDuration(step.ms).padStart(7)}${mark}`);
     const children = records.filter((r) => r.parentId === step.label);
     children.forEach((child, i) => {
@@ -99,6 +101,11 @@ export function runWithTiming<T>(collector: TimingCollector, fn: () => Promise<T
  * collector and current step id come from the run scope (set by
  * TimingStepReporter on each "running" report). A transparent pass-through when
  * no run scope is active (e.g. a unit test calling a step directly).
+ *
+ * Call span() only after the enclosing step has reported "running" (the runner
+ * does this before invoking a step's run()). A span recorded before then has a
+ * null parentId and is silently dropped from formatSummary, which only nests
+ * spans under a known step id.
  */
 export async function span<T>(label: string, fn: () => Promise<T>): Promise<T> {
   const scope = timingStore.getStore();

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -7,6 +7,7 @@ import { PipelineRunner } from "./pipeline/runner.js";
 import { DEFAULT_PIPELINE, createDefaultRunner } from "./pipeline/default-pipeline.js";
 import type { LLMExecutor, LogLevel, PipelineDefinition, StepReporter } from "./pipeline/types.js";
 import { HttpStepReporter, NoopStepReporter, TokenStepReporter } from "./pipeline/reporter.js";
+import { TimingCollector, TimingStepReporter, runWithTiming, formatSummary } from "./pipeline/timing.js";
 import { runHookScript } from "./pipeline/steps/hooks.js";
 import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
 import { parseWorkflowMd } from "./workflow-md.js";
@@ -201,13 +202,16 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   if (orchestratorUrl && !nonce) {
     console.warn("ORCHESTRATOR_URL is set but MACHINE_NONCE is empty — step reports will be rejected (403).");
   }
-  const reporter: StepReporter =
+  const baseReporter: StepReporter =
     opts.reporter ??
     (callbackUrl && progressToken
       ? new TokenStepReporter(callbackUrl, progressToken, { fetchImpl: opts.fetchImpl })
       : orchestratorUrl && nonce
       ? new HttpStepReporter(orchestratorUrl, nonce)
       : new NoopStepReporter());
+
+  const timing = new TimingCollector(logLevel);
+  const reporter: StepReporter = new TimingStepReporter(baseReporter, timing);
 
   const context = new DefaultPipelineContext(
     {
@@ -239,7 +243,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   try {
     const pipeline = opts.pipeline ?? DEFAULT_PIPELINE;
     const runner = opts.runner ?? (await createDefaultRunner());
-    await runner.run(pipeline, context, reporter);
+    await runWithTiming(timing, () => runner.run(pipeline, context, reporter));
     const pushOutputs = context.getOutputs("push");
     await postRunnerResult({
       workspaceDir,
@@ -260,6 +264,13 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     });
     return { exitCode: 1 };
   } finally {
+    try {
+      if (timing.records().length > 0) {
+        console.error(formatSummary(timing, issueIdentifier));
+      }
+    } catch (summaryErr) {
+      console.error(`timing summary failed: ${summaryErr}`);
+    }
     if (teardownHook) {
       try {
         const result = runHookScript("teardown", teardownHook, workspaceDir);


### PR DESCRIPTION
## Summary

Makes where a pipeline run's wall-clock goes visible directly in the runner log, so a slow run is diagnosable without reconstructing it from timestamps. Builds on the stream-json observability foundation and reuses its `AI_IMPLEMENT_LOG_LEVEL` knob.

- **New self-contained module `src/pipeline/timing.ts`:**
  - `TimingCollector` — run-scoped sink for step durations and sub-phase spans.
  - `TimingStepReporter` — a `StepReporter` decorator that forwards every report unchanged and records each step's duration from the `started_at`/`ended_at` the runner already sets (nesting `feedback-loop` substeps via `parent_step_id`).
  - `span(label, fn)` — times an async sub-phase, resolving the active collector via `AsyncLocalStorage` so nothing has to thread through `PipelineContext`; transparent pass-through when no run scope is active (so step unit tests are unaffected).
  - `formatSummary()` — indented summary with a `⚠ dominant` marker.
- **Wired into `src/run-autonomous.ts`** with a minimal, contiguous footprint: construct the collector, wrap the reporter, run inside `runWithTiming(...)`, print the summary in the existing `finally` (success and failure paths).
- **Instrumented the `push` step** with three sub-phase spans — `git-ls-remote`, `git-push`, `pr-create` — which makes "is it `git push`, `ls-remote`, or PR creation?" answerable.

Reuses `AI_IMPLEMENT_LOG_LEVEL ∈ {summary, stream}`: the summary table always prints; inline per-span lines only at `stream`. Capture is decoupled from surface — low verbosity never reintroduces the black box.

Example end-of-run summary (stderr, `[timing]`-prefixed):

```
[timing] ── run summary (ENG-123) — total 11m14s ──
[timing]   clone                 2.1s
[timing]   feedback-loop        2m00s
[timing]     ├ implement.1        1m47s
[timing]     └ review.1             13s
[timing]   push                 4m35s   ⚠ dominant
[timing]     ├ git-ls-remote       0.3s
[timing]     ├ git-push           4m34s
[timing]     └ pr-create           0.4s
[timing]   verify               4m27s
```

Out of scope by design: timing inside the verify/setup/teardown shell hooks (they'd emit their own), persistence to `step_log`, and a GitHub Step Summary panel.

## Test Plan

- [x] `npm test` — 1266/1266 pass (new tests in `src/__tests__/timing.test.ts` cover the collector, formatter, summary nesting/dominant marker, the decorator's forward-and-record behavior incl. skipped/cancelled, and `span` nesting / pass-through / error-rethrow / stream-emit)
- [x] `npm run typecheck` — clean
- [x] Existing `run-autonomous` tests unaffected (decorator forwards 1:1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)