### PR TITLE
feat(push): optional GIT_TRACE2 perf trace for diagnosing slow git push

### DIFF
--- a/src/__tests__/push.test.ts
+++ b/src/__tests__/push.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildGitPushInvocation } from "../pipeline/steps/push.js";
+
+const REMOTE = "https://x-access-token:secret@github.com/o/r.git";
+const REF = "refs/heads/feature";
+
+describe("buildGitPushInvocation", () => {
+  it("builds a plain push without tracing", () => {
+    const { args, env } = buildGitPushInvocation(REMOTE, REF, "abc123", false);
+    expect(args).toEqual([
+      "push",
+      REMOTE,
+      `HEAD:${REF}`,
+      `--force-with-lease=${REF}:abc123`,
+    ]);
+    expect(args).not.toContain("--verbose");
+    expect(env.GIT_TRACE2_PERF).toBeUndefined();
+  });
+
+  it("adds --verbose and GIT_TRACE2_PERF when tracing", () => {
+    const { args, env } = buildGitPushInvocation(REMOTE, REF, "abc123", true);
+    expect(args[0]).toBe("push");
+    expect(args[1]).toBe("--verbose");
+    expect(args).toEqual([
+      "push",
+      "--verbose",
+      REMOTE,
+      `HEAD:${REF}`,
+      `--force-with-lease=${REF}:abc123`,
+    ]);
+    expect(env.GIT_TRACE2_PERF).toBe("1");
+  });
+
+  it("uses an empty lease target when the remote branch does not exist yet", () => {
+    const { args } = buildGitPushInvocation(REMOTE, REF, null, false);
+    expect(args).toContain(`--force-with-lease=${REF}:`);
+  });
+});

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -404,4 +404,53 @@ describe("pushStep", () => {
     ).rejects.toThrow(/Refusing to push implementation branch/);
     expect(spawnSync).not.toHaveBeenCalled();
   });
+
+  it("logs a token-redacted push trace at stream log level", async () => {
+    const prev = process.env.AI_IMPLEMENT_LOG_LEVEL;
+    process.env.AI_IMPLEMENT_LOG_LEVEL = "stream";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Trace output echoes the tokenized remote URL on both streams; stdout has
+      // no trailing newline so the separator fix is exercised too.
+      const tokenizedUrl = `https://x-access-token:gh-token@github.com/acme/app.git`;
+      vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+        const gitArgs = args as string[];
+        if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
+        if (gitArgs[0] === "rev-parse") return spawnResult(0, "abc123\n");
+        if (gitArgs[0] === "show") return spawnResult(0, "M\tsrc/app.ts\n");
+        if (gitArgs[0] === "ls-remote") {
+          return spawnResult(0, "beadfeed\trefs/heads/ai-implement/eng-42-feature\n");
+        }
+        if (gitArgs[0] === "push") {
+          return spawnResult(
+            0,
+            `Pushing to ${tokenizedUrl}`,
+            `region_enter send-pack ${tokenizedUrl}\n`,
+          );
+        }
+        return spawnResult(0);
+      });
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ html_url: "https://github.com/acme/app/pull/7", number: 7 }),
+        text: async () => "",
+      } as Response);
+
+      await pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+      const traceCall = errorSpy.mock.calls
+        .map((c) => String(c[0]))
+        .find((msg) => msg.includes("[git-push trace]"));
+      expect(traceCall).toBeDefined();
+      expect(traceCall).not.toContain("gh-token");
+      expect(traceCall).toContain("***");
+      // stdout and stderr are separated by a newline, not run together.
+      expect(traceCall).toMatch(/Pushing to[^\n]*\nregion_enter/);
+    } finally {
+      errorSpy.mockRestore();
+      if (prev === undefined) delete process.env.AI_IMPLEMENT_LOG_LEVEL;
+      else process.env.AI_IMPLEMENT_LOG_LEVEL = prev;
+    }
+  });
 });

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -85,9 +85,13 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
       // Diagnostic for slow pushes: GIT_TRACE2_PERF region timings (pack-objects
       // vs send-pack vs server wait) + --verbose object counts. Redact the token
       // with replaceAll — the tokenized remote URL can recur many times here.
-      const trace = `${pushResult.stdout?.toString() ?? ""}${pushResult.stderr?.toString() ?? ""}`
-        .replaceAll(githubToken, "***")
-        .trim();
+      // Trim each stream and join with a newline so partial-line stdout doesn't
+      // run onto the first byte of stderr.
+      const trace = [pushResult.stdout?.toString() ?? "", pushResult.stderr?.toString() ?? ""]
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .join("\n")
+        .replaceAll(githubToken, "***");
       if (trace) console.error(`[git-push trace]\n${trace}`);
     }
     if (pushResult.status !== 0) {
@@ -248,7 +252,7 @@ function summarizeCommittedChanges(workspaceDir: string, githubToken: string): s
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.status !== 0) {
-    const stderr = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    const stderr = (result.stderr?.toString() ?? "").replaceAll(githubToken, "***");
     throw new Error(`git show failed (exit ${result.status ?? "null"}): ${stderr}`);
   }
 
@@ -266,7 +270,7 @@ function runGit(
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.status !== 0) {
-    const stderr = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    const stderr = (result.stderr?.toString() ?? "").replaceAll(githubToken, "***");
     throw new Error(`${label} failed (exit ${result.status ?? "null"}): ${stderr}`);
   }
 }
@@ -277,7 +281,7 @@ function hasWorkingTreeChanges(workspaceDir: string, githubToken: string): boole
     stdio: ["ignore", "pipe", "pipe"],
   });
   if (result.status !== 0) {
-    const stderr = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    const stderr = (result.stderr?.toString() ?? "").replaceAll(githubToken, "***");
     throw new Error(`git status failed (exit ${result.status ?? "null"}): ${stderr}`);
   }
   return result.stdout.toString().trim().length > 0;
@@ -315,7 +319,7 @@ function resolveRemoteBranchSha(
       return line.split("\t")[0] || null;
     }
 
-    lastError = (result.stderr?.toString() ?? "").replace(githubToken, "***");
+    lastError = (result.stderr?.toString() ?? "").replaceAll(githubToken, "***");
     if (attempt < LS_REMOTE_MAX_ATTEMPTS) {
       sleepSync(LS_REMOTE_RETRY_DELAYS_MS[attempt - 1] ?? 1000);
     }

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -67,20 +67,31 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     const expectedRemoteSha = await span("git-ls-remote", async () =>
       resolveRemoteBranchSha(workspaceDir, remote, branchName, githubToken),
     );
-    const pushResult = await span("git-push", async () =>
-      spawnSync(
-        "git",
-        [
-          "push",
-          remote,
-          `HEAD:${remoteRef}`,
-          `--force-with-lease=${remoteRef}:${expectedRemoteSha ?? ""}`,
-        ],
-        { cwd: workspaceDir, stdio: ["ignore", "pipe", "pipe"] },
-      ),
+    const tracePush = process.env.AI_IMPLEMENT_LOG_LEVEL === "stream";
+    const { args: pushArgs, env: pushEnv } = buildGitPushInvocation(
+      remote,
+      remoteRef,
+      expectedRemoteSha,
+      tracePush,
     );
+    const pushResult = await span("git-push", async () =>
+      spawnSync("git", pushArgs, {
+        cwd: workspaceDir,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: pushEnv,
+      }),
+    );
+    if (tracePush) {
+      // Diagnostic for slow pushes: GIT_TRACE2_PERF region timings (pack-objects
+      // vs send-pack vs server wait) + --verbose object counts. Redact the token
+      // with replaceAll — the tokenized remote URL can recur many times here.
+      const trace = `${pushResult.stdout?.toString() ?? ""}${pushResult.stderr?.toString() ?? ""}`
+        .replaceAll(githubToken, "***")
+        .trim();
+      if (trace) console.error(`[git-push trace]\n${trace}`);
+    }
     if (pushResult.status !== 0) {
-      const stderr = (pushResult.stderr?.toString() ?? "").replace(githubToken, "***");
+      const stderr = (pushResult.stderr?.toString() ?? "").replaceAll(githubToken, "***");
       throw new Error(`git push failed (exit ${pushResult.status ?? "null"}): ${stderr}`);
     }
 
@@ -158,6 +169,29 @@ async function createOrFindPullRequest(
 
   const body = await prRes.text().catch(() => "");
   throw new Error(`PR creation failed with HTTP ${prRes.status}: ${body}`);
+}
+
+/**
+ * Build the `git push` argv and spawn env. When `trace` is true (driven by
+ * AI_IMPLEMENT_LOG_LEVEL=stream), it adds `--verbose` and `GIT_TRACE2_PERF=1`
+ * so a slow push can be diagnosed — region timings (pack-objects vs send-pack
+ * vs server wait) plus object counts land on the captured stderr.
+ */
+export function buildGitPushInvocation(
+  remote: string,
+  remoteRef: string,
+  expectedRemoteSha: string | null,
+  trace: boolean,
+): { args: string[]; env: NodeJS.ProcessEnv } {
+  const args = [
+    "push",
+    ...(trace ? ["--verbose"] : []),
+    remote,
+    `HEAD:${remoteRef}`,
+    `--force-with-lease=${remoteRef}:${expectedRemoteSha ?? ""}`,
+  ];
+  const env = trace ? { ...process.env, GIT_TRACE2_PERF: "1" } : process.env;
+  return { args, env };
 }
 
 function buildCommitMessage(issueIdentifier: string, issueTitle: string): string {


### PR DESCRIPTION
## Summary

Adds an opt-in diagnostic for slow `git push` in the push step. With the per-step + sub-phase timing (#80) we can now see that on some runs `git-push` dominates (4+ minutes for a tiny commit) while `git-ls-remote` and `pr-create` are sub-second — i.e. auth/network round-trips are fine, so the cost is inside the push transfer/negotiation. This makes that visible.

When `AI_IMPLEMENT_LOG_LEVEL=stream`, the push runs with:
- `--verbose` — object enumeration/compression/write counts + remote messages
- `GIT_TRACE2_PERF=1` — per-region timings (pack-objects vs send-pack vs server wait)

and the captured output is printed under `[git-push trace]`. Default (`summary`) behavior is unchanged — no trace, no extra output.

**Security:** the captured trace is redacted with `replaceAll(githubToken, "***")` (not `.replace`), because the tokenized remote URL can recur many times in a trace; the existing error-path redaction is upgraded to `replaceAll` for the same reason.

The push argv/env construction is extracted into a pure, tested `buildGitPushInvocation()` helper.

## Test Plan

- [x] `npm test` — 1271/1271 pass (new `src/__tests__/push.test.ts` covers args/env with trace on/off and the empty-lease case)
- [x] `npm run typecheck` — clean
- [x] Default path unchanged (trace only when `AI_IMPLEMENT_LOG_LEVEL=stream`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)