### PR TITLE
feat(workflow): make the implement job runner configurable (AI_IMPLEMENT_RUNNER_LABEL)

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -17,6 +17,7 @@
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
 #   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
+#   AI_IMPLEMENT_RUNNER_LABEL                    - runs-on label for the implement job (default ubuntu-latest); set to a larger-runner label to speed up CPU-bound test suites.
 
 name: Claude AI Implementation
 
@@ -172,7 +173,10 @@ jobs:
 
   implement:
     needs: validate-runner-image
-    runs-on: ubuntu-latest
+    # Default GitHub-hosted runners are 2 vCPU; the test suites Claude runs are
+    # CPU-bound and scale ~linearly with cores. Set AI_IMPLEMENT_RUNNER_LABEL to
+    # a larger-runner label (e.g. ubuntu-latest-4-cores) to speed those up.
+    runs-on: ${{ vars.AI_IMPLEMENT_RUNNER_LABEL || 'ubuntu-latest' }}
     timeout-minutes: ${{ inputs.job_timeout_minutes && fromJSON(inputs.job_timeout_minutes) || 90 }}
     container:
       image: ${{ needs.validate-runner-image.outputs.runner_image }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,12 @@ The prefix only affects the **initial orchestrator-driven run** — `/ai-impleme
 
 Set it as a repository or organization **variable** (Settings → Secrets and variables → Actions → Variables), mirroring `AI_IMPLEMENT_PROVIDER`. It is read inside the runner container, so it applies to both orchestrator-initiated and `/ai-implement` comment-triggered runs **after the target repo has re-synced `claude-implement.yml`**. It is not a per-project admin field and not a dispatch input.
 
+### Runner label (GHA mode)
+
+`AI_IMPLEMENT_RUNNER_LABEL` overrides the `runs-on` label for the `implement` job, defaulting to `ubuntu-latest`. Default GitHub-hosted runners are 2 vCPU; the test suites Claude runs during implement (and the verify-hook gauntlet) are CPU-bound and scale ~linearly with cores, so pointing this at a larger-runner label (e.g. `ubuntu-latest-4-cores`) roughly halves the implement job's wall-clock.
+
+Set it as a repository or organization **variable** (Settings → Secrets and variables → Actions → Variables), like `AI_IMPLEMENT_LOG_LEVEL`. It only affects the GitHub Actions execution mode and only after the target repo has re-synced `claude-implement.yml`. It takes a single label string, not a label array. Granting write access to this variable lets the holder retarget the job to an arbitrary (e.g. self-hosted) runner that would see the job's secrets — the same threat model as any org-variable-controlled `runs-on`.
+
 `workflows/claude-plan.yml` is the planning workflow synced to target repos. It runs read-only codebase analysis and posts structured planning comments to Linear when dispatched. It supports:
 - **PLANNING.md** — per-repo Claude prompt template; front matter carries `model:` (same rules as WORKFLOW.md)
 

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -17,6 +17,7 @@
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
 #   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
+#   AI_IMPLEMENT_RUNNER_LABEL                    - runs-on label for the implement job (default ubuntu-latest); set to a larger-runner label to speed up CPU-bound test suites.
 
 name: Claude AI Implementation
 
@@ -172,7 +173,10 @@ jobs:
 
   implement:
     needs: validate-runner-image
-    runs-on: ubuntu-latest
+    # Default GitHub-hosted runners are 2 vCPU; the test suites Claude runs are
+    # CPU-bound and scale ~linearly with cores. Set AI_IMPLEMENT_RUNNER_LABEL to
+    # a larger-runner label (e.g. ubuntu-latest-4-cores) to speed those up.
+    runs-on: ${{ vars.AI_IMPLEMENT_RUNNER_LABEL || 'ubuntu-latest' }}
     timeout-minutes: ${{ inputs.job_timeout_minutes && fromJSON(inputs.job_timeout_minutes) || 90 }}
     container:
       image: ${{ needs.validate-runner-image.outputs.runner_image }}


### PR DESCRIPTION
## Summary

The `implement` job runs on `ubuntu-latest` (2 vCPU). The test suites Claude runs during implement — and the verify-hook gauntlet — are CPU-bound and scale ~linearly with cores (measured: a 251-file vitest suite is 26s on 10 cores, ~82s on 2). This adds an `AI_IMPLEMENT_RUNNER_LABEL` repo/org variable to override `runs-on`, defaulting to `ubuntu-latest`:

```yaml
runs-on: ${{ vars.AI_IMPLEMENT_RUNNER_LABEL || 'ubuntu-latest' }}
```

Operators with larger GitHub-hosted (or self-hosted) runners can point at a bigger label (e.g. `ubuntu-latest-4-cores`) to roughly halve the implement job's wall-clock, with no change for anyone who leaves it unset. The `validate-runner-image` job stays on `ubuntu-latest` (trivial). Documented alongside the other `AI_IMPLEMENT_*` variables in the workflow header.

## Test Plan

- [x] `actionlint workflows/claude-implement.yml` — clean
- [x] Default unchanged when the variable is unset (`|| 'ubuntu-latest'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)