### PR TITLE
fix(runner): never commit the transient ai-output/ scratch dir (AII-162)

### DIFF
--- a/src/__tests__/scratch-exclude.test.ts
+++ b/src/__tests__/scratch-exclude.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { prepareScratchExclusion, SCRATCH_PATHS } from "../pipeline/scratch-exclude.js";
+
+function git(cwd: string, args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  return { status: r.status, stdout: r.stdout.toString(), stderr: r.stderr.toString() };
+}
+
+function initRepo(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scratch-exclude-"));
+  git(dir, ["init", "-q"]);
+  git(dir, ["config", "user.email", "t@example.com"]);
+  git(dir, ["config", "user.name", "Test"]);
+  return dir;
+}
+
+function writeScratch(dir: string): void {
+  fs.mkdirSync(path.join(dir, "ai-output", "comments"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "ai-output", "comments", "01-summary.md"), "scratch output");
+}
+
+describe("prepareScratchExclusion", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = initRepo();
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("keeps untracked ai-output/ out of the staged set after git add -A", () => {
+    writeScratch(dir);
+    fs.writeFileSync(path.join(dir, "real.ts"), "export const x = 1;");
+
+    prepareScratchExclusion(dir);
+    git(dir, ["add", "-A"]);
+
+    const staged = git(dir, ["diff", "--cached", "--name-only"]).stdout;
+    expect(staged).toContain("real.ts");
+    expect(staged).not.toContain("ai-output");
+  });
+
+  it("untracks ai-output/ that a previous run already committed", () => {
+    writeScratch(dir);
+    git(dir, ["add", "-A"]);
+    git(dir, ["commit", "-q", "-m", "leaked scratch"]);
+    // sanity: the scratch file is tracked before we run
+    expect(git(dir, ["ls-files"]).stdout).toContain("ai-output/comments/01-summary.md");
+
+    prepareScratchExclusion(dir);
+
+    // a subsequent run's add must not re-track it
+    fs.writeFileSync(path.join(dir, "real.ts"), "export const x = 1;");
+    git(dir, ["add", "-A"]);
+
+    expect(git(dir, ["ls-files"]).stdout).not.toContain("ai-output");
+    expect(git(dir, ["diff", "--cached", "--name-only"]).stdout).toContain("real.ts");
+  });
+
+  it("is idempotent — does not duplicate the exclude entry across runs", () => {
+    prepareScratchExclusion(dir);
+    prepareScratchExclusion(dir);
+
+    const exclude = fs.readFileSync(path.join(dir, ".git", "info", "exclude"), "utf-8");
+    const occurrences = exclude.split("\n").filter((l) => l.trim() === SCRATCH_PATHS[0]).length;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/src/__tests__/scratch-exclude.test.ts
+++ b/src/__tests__/scratch-exclude.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -59,6 +59,22 @@ describe("prepareScratchExclusion", () => {
 
     expect(git(dir, ["ls-files"]).stdout).not.toContain("ai-output");
     expect(git(dir, ["diff", "--cached", "--name-only"]).stdout).toContain("real.ts");
+  });
+
+  it("logs a warning when git rm --cached fails instead of swallowing it", () => {
+    // A directory that is not a valid git repo: the exclude file still gets
+    // seeded, but `git rm --cached` fails — which must not be silent.
+    const nonRepo = fs.mkdtempSync(path.join(os.tmpdir(), "scratch-nonrepo-"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      prepareScratchExclusion(nonRepo);
+
+      expect(warn).toHaveBeenCalled();
+      expect(warn.mock.calls.flat().join(" ")).toMatch(/scratch-exclude/);
+    } finally {
+      warn.mockRestore();
+      fs.rmSync(nonRepo, { recursive: true, force: true });
+    }
   });
 
   it("is idempotent — does not duplicate the exclude entry across runs", () => {

--- a/src/__tests__/steps-clone.test.ts
+++ b/src/__tests__/steps-clone.test.ts
@@ -13,8 +13,14 @@ vi.mock("node:fs", () => ({
   },
 }));
 
+vi.mock("../pipeline/scratch-exclude.js", () => ({
+  prepareScratchExclusion: vi.fn(),
+  SCRATCH_PATHS: ["ai-output/"],
+}));
+
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { prepareScratchExclusion } from "../pipeline/scratch-exclude.js";
 
 function mockSpawn(calls: Array<{ status: number; stdout?: string; stderr?: string }>) {
   let call = 0;
@@ -117,6 +123,24 @@ describe("cloneStep", () => {
     await expect(
       cloneStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
     ).rejects.toThrow(/git rev-parse HEAD failed/);
+  });
+
+  it("seeds scratch exclusion for the workspace on a fresh clone", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    mockSpawn([{ status: 0 }, { status: 0, stdout: "sha1\n" }]);
+
+    await cloneStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    expect(prepareScratchExclusion).toHaveBeenCalledWith("/tmp/workspace");
+  });
+
+  it("seeds scratch exclusion for the workspace on an incremental fetch", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    mockSpawn([{ status: 0 }, { status: 0 }, { status: 0, stdout: "sha2\n" }]);
+
+    await cloneStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    expect(prepareScratchExclusion).toHaveBeenCalledWith("/tmp/workspace");
   });
 
   it("passes through repoOwner, repoRepo, branch, githubToken in outputs", async () => {

--- a/src/pipeline/scratch-exclude.ts
+++ b/src/pipeline/scratch-exclude.ts
@@ -44,12 +44,21 @@ export function prepareScratchExclusion(workspaceDir: string): void {
   }
 
   // Untrack scratch paths a prior run committed; `--ignore-unmatch` makes this a
-  // no-op when nothing matches, so it's safe to run unconditionally.
+  // no-op when nothing matches, so it's safe to run unconditionally. A non-zero
+  // exit means a real failure (bad repo state, wrong cwd) left the files tracked
+  // — non-fatal (the exclude above still blocks re-staging) but never silent.
   for (const p of SCRATCH_PATHS) {
     const pathspec = p.replace(/\/$/, "");
-    spawnSync("git", ["rm", "-r", "--cached", "--ignore-unmatch", pathspec], {
+    const result = spawnSync("git", ["rm", "-r", "--cached", "--ignore-unmatch", pathspec], {
       cwd: workspaceDir,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    if (result.status !== 0) {
+      const stderr = (result.stderr?.toString() ?? "").trim();
+      console.warn(
+        `[scratch-exclude] git rm --cached ${pathspec} exited ${result.status ?? "null"}; ` +
+          `previously-committed files may remain tracked: ${stderr}`,
+      );
+    }
   }
 }

--- a/src/pipeline/scratch-exclude.ts
+++ b/src/pipeline/scratch-exclude.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Workspace-relative paths the orchestrator/runner writes as transient scratch
+ * (e.g. `ai-output/comments/*.md`, which the runner-callback reads and posts to
+ * the ticket) and must NEVER commit into the target repo. Gitignore-style
+ * patterns, with a trailing slash for directories.
+ */
+export const SCRATCH_PATHS = ["ai-output/"] as const;
+
+/**
+ * Make orchestrator scratch paths uncommittable in a freshly-prepared workspace.
+ *
+ * Two deterministic guards, applied once after the working tree exists so every
+ * downstream `git add -A` (initial push, post-push review/fix loop, gap-fill)
+ * honors them without per-call-site changes:
+ *
+ *  1. Seed the repo-local `.git/info/exclude` (never committed; unlike the target
+ *     repo's `.gitignore` it doesn't mutate their tree) so untracked scratch
+ *     files are never staged.
+ *  2. Untrack any scratch path a previous run already committed to the branch
+ *     (`git rm --cached`), self-healing branches that leaked it before this fix.
+ *
+ * Idempotent: safe to call on every run, including incremental re-use of a
+ * workspace.
+ */
+export function prepareScratchExclusion(workspaceDir: string): void {
+  const excludePath = path.join(workspaceDir, ".git", "info", "exclude");
+  fs.mkdirSync(path.dirname(excludePath), { recursive: true });
+
+  let existing = "";
+  try {
+    existing = fs.readFileSync(excludePath, "utf-8");
+  } catch {
+    existing = "";
+  }
+  const present = new Set(existing.split("\n").map((line) => line.trim()));
+  const missing = SCRATCH_PATHS.filter((p) => !present.has(p));
+  if (missing.length > 0) {
+    const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+    fs.appendFileSync(excludePath, `${separator}${missing.join("\n")}\n`);
+  }
+
+  // Untrack scratch paths a prior run committed; `--ignore-unmatch` makes this a
+  // no-op when nothing matches, so it's safe to run unconditionally.
+  for (const p of SCRATCH_PATHS) {
+    const pathspec = p.replace(/\/$/, "");
+    spawnSync("git", ["rm", "-r", "--cached", "--ignore-unmatch", pathspec], {
+      cwd: workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  }
+}

--- a/src/pipeline/steps/clone.ts
+++ b/src/pipeline/steps/clone.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
+import { prepareScratchExclusion } from "../scratch-exclude.js";
 
 interface CloneInputs extends Record<string, unknown> {
   repoOwner: string;
@@ -69,6 +70,10 @@ export const cloneStep: StepModule<CloneInputs, CloneOutputs> = {
 
       cloneMethod = "fresh";
     }
+
+    // Working tree now exists (fresh or incremental). Make orchestrator scratch
+    // paths (e.g. ai-output/) uncommittable before any downstream `git add`.
+    prepareScratchExclusion(workspaceDir);
 
     const revResult = spawnSync("git", ["rev-parse", "HEAD"], {
       cwd: workspaceDir,


### PR DESCRIPTION
## Summary

The runner writes Claude's structured comments to `ai-output/comments/*.md` in the workspace; the runner-callback (`collectRunnerComments()`) reads them and posts them to the ticket. They're an orchestration **side-channel** and must never land in the target repo — but `git add -A` in the push and post-push-review steps was sweeping them into PRs. Example leak: [Forecast-it/repositus-maximus#6981](https://github.com/Forecast-it/repositus-maximus/pull/6981/files).

Fixes **[AII-162](https://linear.app/eudoxus/issue/AII-162/runner-commits-the-transient-ai-output-folder-into-target-repo-prs)**.

## Approach

There are two `git add -A` sites (`push.ts`, `post-push-review.ts`), so the exclusion is enforced at the **single chokepoint** they all flow through — the clone step — rather than patched per call-site.

New `prepareScratchExclusion(workspaceDir)` (`src/pipeline/scratch-exclude.ts`), called once from the clone step after the working tree exists (both fresh-clone and incremental-fetch paths):

1. Seeds repo-local `.git/info/exclude` with `ai-output/` — never committed, and (unlike adding to the target repo's `.gitignore`) doesn't mutate their tree. Every downstream `git add -A` then skips it deterministically.
2. `git rm -r --cached --ignore-unmatch ai-output` to self-heal branches that already committed the folder before this fix (the staged deletion is the desired cleanup).

Idempotent; the excluded set is a named constant (`SCRATCH_PATHS`) for easy extension. `collectRunnerComments()` is unchanged — the files still live on disk, they're just never staged.

## Test plan

- [x] `src/__tests__/scratch-exclude.test.ts` — behavioral tests against a **real** temp git repo: untracked `ai-output/` is excluded from `git add -A`; an already-committed `ai-output/` is untracked; idempotent (no duplicate exclude entries).
- [x] `src/__tests__/steps-clone.test.ts` — clone seeds the exclusion on both fresh and incremental paths.
- [x] `npm test` — 1277 passed. `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)