### PR TITLE
ci: derive runner image org from repo owner instead of hardcoding

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -1,5 +1,6 @@
 # Synced to target repos by sync-workflow.yml.
-# All pipeline logic lives in the runner image (ghcr.io/builddownai/ai-implement-runner).
+# All pipeline logic lives in the runner image (ghcr.io/<owner>/ai-implement-runner,
+# where <owner> is this repository's org).
 # Do not edit in target repos.
 #
 # Required secrets:
@@ -16,7 +17,7 @@
 #
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
-#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
+#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to this repo's own ghcr.io/<owner>/.
 #   AI_IMPLEMENT_RUNNER_LABEL                    - runs-on label for the implement job (default ubuntu-latest); set to a larger-runner label to speed up CPU-bound test suites.
 
 name: Claude AI Implementation
@@ -96,7 +97,7 @@ on:
         type: string
         default: ""
       runner_image:
-        description: "Override the default runner image (must match ghcr.io/builddownai/* or AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES)"
+        description: "Override the default runner image (must match this repo's own ghcr.io/<owner>/* or AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES)"
         required: false
         type: string
         default: ""
@@ -122,12 +123,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Default the runner image to this repository's own org so forks
+          # resolve their own published image instead of a hardcoded one.
+          # Mirrors the owner-derivation already used by build-runner.yml.
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+
           runner_image="${REQUESTED_RUNNER_IMAGE:-}"
           if [ -z "$runner_image" ]; then
             runner_image="${CONFIGURED_RUNNER_IMAGE:-}"
           fi
           if [ -z "$runner_image" ]; then
-            runner_image="ghcr.io/builddownai/ai-implement-runner:latest"
+            runner_image="ghcr.io/${owner}/ai-implement-runner:latest"
           fi
 
           case "$runner_image" in
@@ -137,7 +143,7 @@ jobs:
               ;;
           esac
 
-          allowed_prefixes="ghcr.io/builddownai/"
+          allowed_prefixes="ghcr.io/${owner}/"
           if [ -n "${EXTRA_ALLOWED_PREFIXES:-}" ]; then
             allowed_prefixes="${allowed_prefixes},${EXTRA_ALLOWED_PREFIXES}"
           fi

--- a/.github/workflows/comment-trigger.yml
+++ b/.github/workflows/comment-trigger.yml
@@ -1,5 +1,6 @@
 # Synced to target repos. /ai-implement on a PR → gap-fill run.
-# All pipeline logic lives in the runner image (ghcr.io/builddownai/ai-implement-runner).
+# All pipeline logic lives in the runner image (ghcr.io/<owner>/ai-implement-runner,
+# where <owner> is this repository's org).
 # Do not edit in target repos.
 #
 # Required secrets:
@@ -18,8 +19,8 @@
 #
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
-#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
-# The default runner image uses the public ghcr.io/builddownai/ai-implement-runner:latest tag.
+#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to this repo's own ghcr.io/<owner>/.
+# The default runner image uses this repo's own public ghcr.io/<owner>/ai-implement-runner:latest tag.
 
 name: AI Implementation Comment Trigger
 
@@ -128,9 +129,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Default the runner image to this repository's own org so forks
+          # resolve their own published image instead of a hardcoded one.
+          # Mirrors the owner-derivation already used by build-runner.yml.
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+
           runner_image="${CONFIGURED_RUNNER_IMAGE:-}"
           if [ -z "$runner_image" ]; then
-            runner_image="ghcr.io/builddownai/ai-implement-runner:latest"
+            runner_image="ghcr.io/${owner}/ai-implement-runner:latest"
           fi
 
           case "$runner_image" in
@@ -140,7 +146,7 @@ jobs:
               ;;
           esac
 
-          allowed_prefixes="ghcr.io/builddownai/"
+          allowed_prefixes="ghcr.io/${owner}/"
           if [ -n "${EXTRA_ALLOWED_PREFIXES:-}" ]; then
             allowed_prefixes="${allowed_prefixes},${EXTRA_ALLOWED_PREFIXES}"
           fi

--- a/src/__tests__/workflow-shim-structure.test.ts
+++ b/src/__tests__/workflow-shim-structure.test.ts
@@ -156,7 +156,9 @@ describe("GHA workflow shims", () => {
       expect(yaml).toMatch(/validate-runner-image:/);
       expect(yaml).toMatch(/needs:\s*validate-runner-image/);
       expect(yaml).toMatch(/image:\s*\$\{\{\s*needs\.validate-runner-image\.outputs\.runner_image\s*\}\}/);
-      expect(yaml).toMatch(/ghcr\.io\/builddownai\/ai-implement-runner:latest/);
+      // The default runner image is derived from the repo owner, not hardcoded.
+      expect(yaml).toContain('owner="${GITHUB_REPOSITORY_OWNER,,}"');
+      expect(yaml).toMatch(/ghcr\.io\/\$\{owner\}\/ai-implement-runner:latest/);
       expect(yaml).toMatch(/invalid characters for a container image reference/);
       expect(yaml).toMatch(/AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES=<prefix>/);
     });
@@ -199,7 +201,9 @@ describe("GHA workflow shims", () => {
     expect(yaml).toMatch(/runner_image:\s*\$\{\{\s*steps\.runner-image\.outputs\.runner_image\s*\}\}/);
     expect(yaml).toMatch(/image:\s*\$\{\{\s*needs\.check-trigger\.outputs\.runner_image\s*\}\}/);
     expect(yaml).toMatch(/AI_IMPLEMENT_RUNNER_IMAGE/);
-    expect(yaml).toMatch(/ghcr\.io\/builddownai\/ai-implement-runner:latest/);
+    // The default runner image is derived from the repo owner, not hardcoded.
+    expect(yaml).toContain('owner="${GITHUB_REPOSITORY_OWNER,,}"');
+    expect(yaml).toMatch(/ghcr\.io\/\$\{owner\}\/ai-implement-runner:latest/);
     expect(yaml).toMatch(/invalid characters for a container image reference/);
     expect(yaml).toMatch(/AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES=<prefix>/);
   });

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -1,5 +1,6 @@
 # Synced to target repos by sync-workflow.yml.
-# All pipeline logic lives in the runner image (ghcr.io/builddownai/ai-implement-runner).
+# All pipeline logic lives in the runner image (ghcr.io/<owner>/ai-implement-runner,
+# where <owner> is this repository's org).
 # Do not edit in target repos.
 #
 # Required secrets:
@@ -16,7 +17,7 @@
 #
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
-#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
+#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to this repo's own ghcr.io/<owner>/.
 #   AI_IMPLEMENT_RUNNER_LABEL                    - runs-on label for the implement job (default ubuntu-latest); set to a larger-runner label to speed up CPU-bound test suites.
 
 name: Claude AI Implementation
@@ -96,7 +97,7 @@ on:
         type: string
         default: ""
       runner_image:
-        description: "Override the default runner image (must match ghcr.io/builddownai/* or AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES)"
+        description: "Override the default runner image (must match this repo's own ghcr.io/<owner>/* or AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES)"
         required: false
         type: string
         default: ""
@@ -122,12 +123,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Default the runner image to this repository's own org so forks
+          # resolve their own published image instead of a hardcoded one.
+          # Mirrors the owner-derivation already used by build-runner.yml.
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+
           runner_image="${REQUESTED_RUNNER_IMAGE:-}"
           if [ -z "$runner_image" ]; then
             runner_image="${CONFIGURED_RUNNER_IMAGE:-}"
           fi
           if [ -z "$runner_image" ]; then
-            runner_image="ghcr.io/builddownai/ai-implement-runner:latest"
+            runner_image="ghcr.io/${owner}/ai-implement-runner:latest"
           fi
 
           case "$runner_image" in
@@ -137,7 +143,7 @@ jobs:
               ;;
           esac
 
-          allowed_prefixes="ghcr.io/builddownai/"
+          allowed_prefixes="ghcr.io/${owner}/"
           if [ -n "${EXTRA_ALLOWED_PREFIXES:-}" ]; then
             allowed_prefixes="${allowed_prefixes},${EXTRA_ALLOWED_PREFIXES}"
           fi

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -1,5 +1,6 @@
 # Synced to target repos. /ai-implement on a PR → gap-fill run.
-# All pipeline logic lives in the runner image (ghcr.io/builddownai/ai-implement-runner).
+# All pipeline logic lives in the runner image (ghcr.io/<owner>/ai-implement-runner,
+# where <owner> is this repository's org).
 # Do not edit in target repos.
 #
 # Required secrets:
@@ -18,8 +19,8 @@
 #
 # Optional repository or organization variables:
 #   AI_IMPLEMENT_RUNNER_IMAGE                    - Default runner image for this repo/org.
-#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to ghcr.io/builddownai/.
-# The default runner image uses the public ghcr.io/builddownai/ai-implement-runner:latest tag.
+#   AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES   - Comma-separated image prefixes allowed in addition to this repo's own ghcr.io/<owner>/.
+# The default runner image uses this repo's own public ghcr.io/<owner>/ai-implement-runner:latest tag.
 
 name: AI Implementation Comment Trigger
 
@@ -128,9 +129,14 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Default the runner image to this repository's own org so forks
+          # resolve their own published image instead of a hardcoded one.
+          # Mirrors the owner-derivation already used by build-runner.yml.
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+
           runner_image="${CONFIGURED_RUNNER_IMAGE:-}"
           if [ -z "$runner_image" ]; then
-            runner_image="ghcr.io/builddownai/ai-implement-runner:latest"
+            runner_image="ghcr.io/${owner}/ai-implement-runner:latest"
           fi
 
           case "$runner_image" in
@@ -140,7 +146,7 @@ jobs:
               ;;
           esac
 
-          allowed_prefixes="ghcr.io/builddownai/"
+          allowed_prefixes="ghcr.io/${owner}/"
           if [ -n "${EXTRA_ALLOWED_PREFIXES:-}" ]; then
             allowed_prefixes="${allowed_prefixes},${EXTRA_ALLOWED_PREFIXES}"
           fi


### PR DESCRIPTION
## What

The `claude-implement.yml` and `comment-trigger.yml` workflows hardcoded `ghcr.io/builddownai/ai-implement-runner` in two places:

- the **default** runner image (used when no `runner_image` input / `AI_IMPLEMENT_RUNNER_IMAGE` var is set), and
- the **allowed-prefix** check in `validate-runner-image`.

This change derives the org from `GITHUB_REPOSITORY_OWNER` (lowercased for GHCR), so a repository's workflows default to *that repository's own* published runner image and allow it by default.

```sh
owner="${GITHUB_REPOSITORY_OWNER,,}"
...
runner_image="ghcr.io/${owner}/ai-implement-runner:latest"
...
allowed_prefixes="ghcr.io/${owner}/"
```

This mirrors the owner-derivation pattern `build-runner.yml` already uses to publish the image.

## Why

Forks that publish their own runner image currently have to patch these two workflows (and re-sync them to every target repo) just to change the org. Deriving the owner removes that divergence: the same workflow files work unmodified in any fork.

## Compatibility

- **`builddownai/AI-Implement`: no behavior change** — `GITHUB_REPOSITORY_OWNER` resolves to `builddownai`, producing the same default image and allowed prefix as before.
- Explicit overrides are unchanged: the `runner_image` dispatch input, the `AI_IMPLEMENT_RUNNER_IMAGE` repo/org variable, and `AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES` all behave exactly as before.
- Both the canonical `.github/workflows/` copies and the synced `workflows/` templates are updated together, preserving the byte-for-byte parity enforced by `workflow-shim-structure.test.ts`.

## Tests

- Updated `workflow-shim-structure.test.ts` to assert the owner-derived form instead of the hardcoded literal.
- `npm run typecheck` and the full `vitest` suite pass (1278 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)