### PR TITLE
ci: grant packages:read so container jobs can pull private GHCR runner images

### DIFF
--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -111,6 +111,9 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+  # Lets the implement job's container pull a private runner image from the
+  # same org's GHCR (e.g. ghcr.io/<owner>/...). Public images don't need it.
+  packages: read
 
 jobs:
   validate-runner-image:

--- a/workflows/comment-trigger.yml
+++ b/workflows/comment-trigger.yml
@@ -203,6 +203,9 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      # Lets this job's container pull a private runner image from the same
+      # org's GHCR (e.g. ghcr.io/<owner>/...). Public images don't need it.
+      packages: read
     container:
       image: ${{ needs.check-trigger.outputs.runner_image }}
     steps:


### PR DESCRIPTION
## Problem

`claude-implement.yml` (the `implement` job) and `comment-trigger.yml` (its container job) declare explicit `permissions:` blocks. With an explicit block, every **unlisted** scope defaults to `none` — including `packages`. So when the resolved runner image is a **private** package on the org's GHCR (`ghcr.io/<owner>/...`), the job's token is denied at the container pull, before any step runs:

```
docker login ghcr.io -u <app-bot>
docker pull ghcr.io/<owner>/ai-implement-runner:latest
Error response from daemon: denied
```

## Fix

Add `packages: read` to the permission blocks that govern those container pulls:
- `claude-implement.yml` — workflow-level block (the `implement` job inherits it)
- `comment-trigger.yml` — the container job's own job-level block

Public images (the upstream `ghcr.io/builddownai/...` default) are unaffected — anonymous pulls don't consult this scope. This only enables pulling a private same-org image.

## Notes

`packages: read` is necessary but, for an org-owned private package, not always sufficient: the GitHub App/installation must itself have package read permission and the package must grant the consuming repo read access (Package → Manage Actions access). Those are GHCR/App settings, separate from this YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)