### PR TITLE
feat: move issue to Done on PR merge (poll-guaranteed + webhook) — AII-166

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,11 +229,22 @@ The workflow runs `aws-actions/configure-aws-credentials` once before the contai
 
 A Linear **parent issue** tagged `AI-Implement` that has `AI-Implement` children becomes a **feature node**: it owns a long-running branch `ai-implement/feature/<issue-key>`, its labelled children PR **into that branch** (not the repo base), and the tree cascades recursively. A parent's own work is deferred until its children finish, then runs onto its own branch; completed feature branches **roll up** into their parent automatically (internal levels via a direct merge, the top of the tree as a human-reviewed `feature → base` PR).
 
-Key labels: `AI-Implement` (trigger) → `AI-Planning` (planning in flight) → `Plan-Complete` (ready to implement) → `AI-Working` (implementing) → `Ready for Review` (PR open); merging the PR is what moves the issue to Done (Linear's GitHub integration). A parent labelled before its children is left alone until a child is labelled (race guard).
+Key labels: `AI-Implement` (trigger) → `AI-Planning` (planning in flight) → `Plan-Complete` (ready to implement) → `AI-Working` (implementing) → `Ready for Review` (PR open); the orchestrator moves the issue to Done when the PR merges (via poll detector and optional webhook; this complements any native Linear/Jira GitHub integration). A parent labelled before its children is left alone until a child is labelled (race guard).
 
 Parts: classification + roll-up discovery in `src/providers/linear.ts`; `TicketIssue.featureBranchChain` / `FeatureNodeRollUp` in `src/providers/types.ts`; cascade branch creation in `src/feature-branch.ts` (`resolveBaseBranch`); roll-up in `src/merge-up.ts`; GitHub helpers in `src/github.ts`; `Plan-Complete` via `src/runner-callback.ts`; wired into the poll loop in `src/index.ts`. Linear-only (Jira PRs to base). **Full reference: [docs/feature-branch-grouping.md](docs/feature-branch-grouping.md).**
 
 Operational requirements: re-sync `claude-implement.yml` to the target repo (for the `base_branch` input); a **publicly reachable** runner callback (`RUNNER_CALLBACK_BASE_URL` + `RUNNER_TOKEN_SECRET`) so planning auto-advances and the cascade self-drives; and pair the runner image with the orchestrator channel (testing → `SESSION_IMAGE=…:next`).
+
+### Issue completion on PR merge
+
+When an AI-Implement PR merges, the orchestrator moves the tracker issue to a completed state (Linear: the team's `Done` state, else the first completed-type state; Jira: the AI-Implement status field value `Merged`) and clears the `Ready for Review` label. This runs even for paused projects.
+
+Two paths feed the same `reconciliation_queue` → `markMerged` worker:
+
+- **Poll detector (guaranteed):** every tick the orchestrator checks recent dispatches whose PR is not yet reconciled and asks GitHub whether the PR merged. This requires no webhook configuration.
+- **Webhook (optimization):** a `pull_request` `closed`+`merged` delivery to `POST /api/github/webhook` enqueues the same reconciliation immediately, reducing merge→Done latency. If the webhook is unconfigured or a delivery is dropped, the poll detector still completes the issue within one tick.
+
+Jira target repos must add a `Merged` option to their AI-Implement status field.
 
 ## Custom extensions
 

--- a/docs/feature-branch-grouping.md
+++ b/docs/feature-branch-grouping.md
@@ -49,9 +49,10 @@ testing                                  (repo base branch)
 | `AI-Working` | Implementation in flight. Counts against capacity; the issue is skipped while present. | Orchestrator on implementation dispatch |
 | `Ready for Review` | An implementation PR is open. The issue is skipped (waiting on the human to merge). | Orchestrator when the PR is detected |
 
-The merge of a PR moves the issue to **Done** — that's **Linear's GitHub integration**, not
-the orchestrator. The orchestrator only ever sets `Ready for Review`; "Done" is what unblocks
-the next step.
+When a PR merges, the orchestrator moves the issue to **Done** via `markMerged` — driven by
+a poll detector (guaranteed, runs every tick) and optionally accelerated by a webhook delivery
+(optimization, reduces latency). This complements any native Linear/Jira GitHub integration.
+"Done" is what unblocks the next step.
 
 ---
 
@@ -143,10 +144,10 @@ soft per roll-up. It scans only feature nodes completed in a recent window to st
 1. Label the tree `AI-Implement` (whole tree at once is fine — the gates sequence it).
 2. Leaves with no blockers dispatch: **plan → (auto-approve) → implement → PR** into their
    parent's feature branch. The cascade branches are created on the first leaf dispatch.
-3. A human merges each leaf PR → Linear marks the leaf **Done** → any blocked sibling
+3. A human merges each leaf PR → the orchestrator marks the leaf **Done** (via poll detector + webhook) → any blocked sibling
    unblocks and runs.
 4. When a feature node's children are all Done, its **own closing work** dispatches → PR
-   into its own feature branch → human merges → node Done.
+   into its own feature branch → human merges → orchestrator marks node Done.
 5. The **merge-up** rolls each completed feature node's branch up into its parent's branch
    (direct merge). The top node's branch is offered as a `feature → base` PR.
 6. A human reviews and merges that final PR. The whole tree lands on the base branch.

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { dispatchWorkflow, providerDispatchFields, getBranchSha, ensureBranchExists, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv, cancelWorkflowRun } from "../github.js";
+import { dispatchWorkflow, providerDispatchFields, getBranchSha, ensureBranchExists, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv, cancelWorkflowRun, getPullRequestState } from "../github.js";
 import type { RepoMapping } from "../config.js";
 
 function makeMapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
@@ -294,6 +294,22 @@ describe("cancelWorkflowRun", () => {
   it("returns false on 404 without throwing", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({ status: 404, ok: false } as Response);
     await expect(cancelWorkflowRun("token", "owner", "repo", 1)).resolves.toBe(false);
+  });
+});
+
+describe("getPullRequestState", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("returns merged=true for a merged PR", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({ merged: true, state: "closed" }) })));
+    expect(await getPullRequestState("t", "o", "r", 7)).toEqual({ merged: true, state: "closed" });
+  });
+  it("returns merged=false for a closed-unmerged PR", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({ merged: false, state: "closed" }) })));
+    expect(await getPullRequestState("t", "o", "r", 7)).toEqual({ merged: false, state: "closed" });
+  });
+  it("returns null on a non-OK response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 404 })));
+    expect(await getPullRequestState("t", "o", "r", 7)).toBeNull();
   });
 });
 

--- a/src/__tests__/poll-merged-prs.test.ts
+++ b/src/__tests__/poll-merged-prs.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+let dbPath: string;
+let dedup: typeof import("../dedup.js");
+let log: typeof import("../log.js");
+let recon: typeof import("../reconciliation.js");
+let mod: typeof import("../poll-merged-prs.js");
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `pollmerged-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  log = await import("../log.js");
+  recon = await import("../reconciliation.js");
+  mod = await import("../poll-merged-prs.js");
+  log.initLogTable();
+  recon.initReconciliationTable();
+});
+afterEach(() => {
+  dedup.closeDb();
+  try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
+});
+
+/**
+ * Seed a dispatch_log row with status='completed' and pr_url ending /pull/<n>.
+ * Uses appendLog (creates the row with status='dispatched') then updateJobStatus
+ * to set it to 'completed' with a prUrl.
+ */
+function seedCompletedJob(prNumber: number) {
+  const jobId = log.appendLog({
+    issueId: "i1",
+    issueIdentifier: "ENG-1",
+    repo: "o/r",
+  });
+  log.updateJobStatus(jobId, "completed", "success", `https://github.com/o/r/pull/${prNumber}`);
+}
+
+describe("prNumberFromUrl", () => {
+  it("parses a standard PR URL", async () => {
+    expect(mod.prNumberFromUrl("https://github.com/o/r/pull/42")).toBe(42);
+  });
+  it("returns null for non-PR URLs", async () => {
+    expect(mod.prNumberFromUrl("https://github.com/o/r/issues/5")).toBeNull();
+  });
+});
+
+describe("detectMergedPrs", () => {
+  it("enqueues a reconciliation for a merged PR", async () => {
+    seedCompletedJob(5);
+    const getPullRequestState = vi.fn(async () => ({ merged: true, state: "closed" as const }));
+    await mod.detectMergedPrs({
+      getPullRequestState,
+      tokenForOwner: async () => "tok",
+      mappingForRepo: () => ({ owner: "o", repo: "r" } as never),
+    });
+    expect(recon.getPendingReconciliations()).toHaveLength(1);
+  });
+  it("tombstones a closed-unmerged PR and does not re-check next tick", async () => {
+    seedCompletedJob(5);
+    const getPullRequestState = vi.fn(async () => ({ merged: false, state: "closed" as const }));
+    const deps = {
+      getPullRequestState,
+      tokenForOwner: async () => "tok",
+      mappingForRepo: () => ({ owner: "o", repo: "r" } as never),
+    };
+    await mod.detectMergedPrs(deps);
+    expect(recon.hasReconciliationForPr("o/r", 5)).toBe(true);
+    expect(recon.getPendingReconciliations()).toHaveLength(0);
+    await mod.detectMergedPrs(deps);
+    expect(getPullRequestState).toHaveBeenCalledTimes(1);
+  });
+  it("leaves an open PR alone", async () => {
+    seedCompletedJob(5);
+    const getPullRequestState = vi.fn(async () => ({ merged: false, state: "open" as const }));
+    await mod.detectMergedPrs({
+      getPullRequestState,
+      tokenForOwner: async () => "tok",
+      mappingForRepo: () => ({ owner: "o", repo: "r" } as never),
+    });
+    expect(recon.hasReconciliationForPr("o/r", 5)).toBe(false);
+  });
+  it("skips rows whose PR already has a queue row", async () => {
+    seedCompletedJob(5);
+    recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "" });
+    const getPullRequestState = vi.fn();
+    await mod.detectMergedPrs({
+      getPullRequestState,
+      tokenForOwner: async () => "tok",
+      mappingForRepo: () => ({ owner: "o", repo: "r" } as never),
+    });
+    expect(getPullRequestState).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/process-reconciliations.test.ts
+++ b/src/__tests__/process-reconciliations.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+let dbPath: string;
+let recon: typeof import("../reconciliation.js");
+let dedup: typeof import("../dedup.js");
+let mod: typeof import("../reconcile-merged.js");
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `procrecon-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  recon = await import("../reconciliation.js");
+  mod = await import("../reconcile-merged.js");
+  recon.initReconciliationTable();
+});
+afterEach(() => {
+  dedup.closeDb();
+  try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
+});
+describe("runReconciliations", () => {
+  it("calls markMerged and marks the row dispatched", async () => {
+    recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha" });
+    const markMerged = vi.fn(async () => {});
+    const resolveProvider = vi.fn(async () => ({ markMerged } as never));
+    const mappingForRepo = vi.fn(() => ({ owner: "o", repo: "r", paused: true } as never));
+    await mod.runReconciliations({ resolveProvider, mappingForRepo });
+    expect(markMerged).toHaveBeenCalledWith("i1");
+    expect(recon.getPendingReconciliations()).toHaveLength(0);
+  });
+  it("skips a row with no mapping", async () => {
+    recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha" });
+    const resolveProvider = vi.fn();
+    await mod.runReconciliations({ resolveProvider, mappingForRepo: () => undefined });
+    expect(resolveProvider).not.toHaveBeenCalled();
+    expect(recon.getPendingReconciliations()).toHaveLength(0);
+  });
+  it("leaves the row pending when markMerged throws", async () => {
+    recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha" });
+    const markMerged = vi.fn(async () => { throw new Error("boom"); });
+    await mod.runReconciliations({
+      resolveProvider: async () => ({ markMerged } as never),
+      mappingForRepo: () => ({ owner: "o", repo: "r", paused: false } as never),
+    });
+    expect(recon.getPendingReconciliations()).toHaveLength(1);
+  });
+});

--- a/src/__tests__/providers/jira-fields.test.ts
+++ b/src/__tests__/providers/jira-fields.test.ts
@@ -112,7 +112,7 @@ describe("STATUS_VALUES", () => {
   it("contains every state in the locked machine", () => {
     expect(Object.values(STATUS_VALUES)).toEqual([
       "Ready", "Planning", "Awaiting Approval", "Plan Approved",
-      "Implementing", "PR Ready", "Planning Failed", "Implementation Failed",
+      "Implementing", "PR Ready", "Merged", "Planning Failed", "Implementation Failed",
     ]);
   });
 });

--- a/src/__tests__/providers/jira.test.ts
+++ b/src/__tests__/providers/jira.test.ts
@@ -257,6 +257,16 @@ describe("JiraProvider lifecycle status setters", () => {
     expectStatusBody(vi.mocked(fetch).mock.calls.at(-1)!, "Plan Approved");
   });
 
+  it("markMerged sets status to Merged (single-mapping shortcut)", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(okEmpty());
+    const p = makeProvider({ cacheScope: "c-merged", mappings: { "acme/x": jiraMapping() } });
+    await p.markMerged("10001");
+    // The last fetch must be a PUT to the issue's field with value "Merged"
+    expectStatusBody(vi.mocked(fetch).mock.calls.at(-1)!, "Merged");
+  });
+
   it("multi-mapping markPlanComplete looks up scopeKey from the issue's repo field", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(FIELDS_RESPONSE) // listFields (first .fields() call)

--- a/src/__tests__/providers/linear.test.ts
+++ b/src/__tests__/providers/linear.test.ts
@@ -776,6 +776,77 @@ describe("LinearProvider.markImplementationFailed", () => {
   });
 });
 
+describe("LinearProvider.markMerged", () => {
+  beforeEach(() => { vi.stubGlobal("fetch", vi.fn()); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("moves a started issue to Done and drops the Ready for Review label", async () => {
+    // 1. fetch issue state, team key, and labels
+    mockJsonOnce({ issue: { state: { type: "started" }, team: { key: "ENG" }, labels: { nodes: [{ id: "L1", name: "Ready for Review" }, { id: "L2", name: "bug" }] } } });
+    // 2. getTeamIdByKey
+    mockJsonOnce({ teams: { nodes: [{ id: "team-uuid", key: "ENG" }] } });
+    // 3. getCompletedStateId: workflowStates query
+    mockJsonOnce({ workflowStates: { nodes: [{ id: "s-rel", name: "Released", type: "completed" }, { id: "s-done", name: "Done", type: "completed" }] } });
+    // 4. issueUpdate: move state + drop label
+    mockJsonOnce({ issueUpdate: { success: true } });
+
+    const p = new LinearProvider({ linearApiKey: "k", linearWorkspaceUrl: "https://linear.app/acme" });
+    await p.markMerged("issue-1");
+
+    expect(fetch).toHaveBeenCalledTimes(4);
+    const updateBody = JSON.parse(vi.mocked(fetch).mock.calls[3][1]?.body as string);
+    expect(updateBody.variables).toMatchObject({ issueId: "issue-1", stateId: "s-done", labelIds: ["L2"] });
+  });
+
+  it("no-ops when the issue is already completed", async () => {
+    mockJsonOnce({ issue: { state: { type: "completed" }, team: { key: "ENG" }, labels: { nodes: [] } } });
+
+    const p = new LinearProvider({ linearApiKey: "k" });
+    await p.markMerged("issue-1");
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when the issue is already canceled", async () => {
+    mockJsonOnce({ issue: { state: { type: "canceled" }, team: { key: "ENG" }, labels: { nodes: [] } } });
+
+    const p = new LinearProvider({ linearApiKey: "k" });
+    await p.markMerged("issue-1");
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the first completed state when none is named Done", async () => {
+    // 1. fetch issue state, team key, labels
+    mockJsonOnce({ issue: { state: { type: "unstarted" }, team: { key: "ENG" }, labels: { nodes: [] } } });
+    // 2. getTeamIdByKey
+    mockJsonOnce({ teams: { nodes: [{ id: "team-uuid", key: "ENG" }] } });
+    // 3. workflowStates — only "Shipped", no "Done"
+    mockJsonOnce({ workflowStates: { nodes: [{ id: "s-shipped", name: "Shipped", type: "completed" }] } });
+    // 4. issueUpdate
+    mockJsonOnce({ issueUpdate: { success: true } });
+
+    const p = new LinearProvider({ linearApiKey: "k" });
+    await p.markMerged("issue-1");
+
+    const updateBody = JSON.parse(vi.mocked(fetch).mock.calls[3][1]?.body as string);
+    expect(updateBody.variables.stateId).toBe("s-shipped");
+  });
+
+  it("keeps all labels except Ready for Review", async () => {
+    mockJsonOnce({ issue: { state: { type: "started" }, team: { key: "ENG" }, labels: { nodes: [{ id: "L1", name: "Ready for Review" }, { id: "L2", name: "bug" }, { id: "L3", name: "AI-Implement" }] } } });
+    mockJsonOnce({ teams: { nodes: [{ id: "team-uuid", key: "ENG" }] } });
+    mockJsonOnce({ workflowStates: { nodes: [{ id: "s-done", name: "Done", type: "completed" }] } });
+    mockJsonOnce({ issueUpdate: { success: true } });
+
+    const p = new LinearProvider({ linearApiKey: "k" });
+    await p.markMerged("issue-1");
+
+    const updateBody = JSON.parse(vi.mocked(fetch).mock.calls[3][1]?.body as string);
+    expect(updateBody.variables.labelIds).toEqual(["L2", "L3"]);
+  });
+});
+
 describe("LinearProvider.issueUrl", () => {
   it("uses linearWorkspaceUrl when provided", () => {
     const p = new LinearProvider({ linearApiKey: "k", linearWorkspaceUrl: "https://linear.app/acme" });

--- a/src/__tests__/reconciliation.test.ts
+++ b/src/__tests__/reconciliation.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+let dbPath: string;
+let recon: typeof import("../reconciliation.js");
+let dedup: typeof import("../dedup.js");
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `recon-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  recon = await import("../reconciliation.js");
+  recon.initReconciliationTable();
+});
+afterEach(() => {
+  dedup.closeDb();
+  try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
+});
+describe("reconciliation pr-dedup", () => {
+  it("hasReconciliationForPr is false until a row exists, then true", () => {
+    expect(recon.hasReconciliationForPr("o/r", 5)).toBe(false);
+    recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha" });
+    expect(recon.hasReconciliationForPr("o/r", 5)).toBe(true);
+    expect(recon.hasReconciliationForPr("o/r", 6)).toBe(false);
+  });
+  it("recordReconciliationTombstone inserts a skipped row that counts for dedup but not pending", () => {
+    recon.recordReconciliationTombstone({ issueId: "i2", issueIdentifier: "ENG-2", prNumber: 9, repo: "o/r" });
+    expect(recon.hasReconciliationForPr("o/r", 9)).toBe(true);
+    expect(recon.getPendingReconciliations()).toHaveLength(0);
+  });
+});

--- a/src/__tests__/webhook.test.ts
+++ b/src/__tests__/webhook.test.ts
@@ -337,6 +337,41 @@ describe("reconciliation enqueue", () => {
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).queued).toBe(true);
   });
+
+  it("does not enqueue a second reconciliation row on a redelivered merged-PR webhook", async () => {
+    log.appendLog({ issueId: "issue-4", issueIdentifier: "AII-77", repo: "org/repo" });
+
+    const payload = {
+      action: "closed",
+      pull_request: {
+        number: 77,
+        merged: true,
+        html_url: "https://github.com/org/repo/pull/77",
+        head: { ref: "AII-77/add-feature" },
+        merge_commit_sha: "sha-dedup",
+      },
+      repository: { full_name: "org/repo" },
+    };
+
+    // First delivery — should enqueue
+    const { req: req1, res: res1 } = makeRequest(SECRET, "pull_request", payload);
+    webhook.handleGitHubWebhook(req1 as never, res1 as never, SECRET);
+    await res1.done;
+    expect(res1.statusCode).toBe(200);
+    expect(JSON.parse(res1.body).queued).toBe(true);
+    expect(reconciliation.getPendingReconciliations()).toHaveLength(1);
+
+    // Second delivery (redelivery) — should be ignored, no new row
+    const { req: req2, res: res2 } = makeRequest(SECRET, "pull_request", payload);
+    webhook.handleGitHubWebhook(req2 as never, res2 as never, SECRET);
+    await res2.done;
+    expect(res2.statusCode).toBe(200);
+    const body2 = JSON.parse(res2.body);
+    expect(body2.ignored).toBe(true);
+    expect(body2.reason).toBe("already queued");
+    // Queue must still have exactly one row
+    expect(reconciliation.getPendingReconciliations()).toHaveLength(1);
+  });
 });
 
 // ---------- Reconciliation queue ----------

--- a/src/github.ts
+++ b/src/github.ts
@@ -324,6 +324,22 @@ export async function findPrForRun(
   return prs.length > 0 ? prs[0].html_url : null;
 }
 
+export async function getPullRequestState(
+  token: string,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<{ merged: boolean; state: "open" | "closed" } | null> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`;
+  const res = await fetch(url, { headers: ghHeaders(token) });
+  if (!res.ok) return null;
+  const data = (await res.json()) as { merged?: boolean; state?: string };
+  return {
+    merged: data.merged === true,
+    state: data.state === "open" ? "open" : "closed",
+  };
+}
+
 // ---------- Feature-branch roll-up (merge-up) helpers ----------
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ import { createMachine, getMachine, listMachines, destroyMachine, generateSessio
 import { safeDestroyMachine, sweepOrphanedMachines, SWEEP_MACHINE_MAX_AGE_MS } from "./reaper.js";
 import { getRunnerMode, getFlySecretsMinVersion, initSettingsTable, resolveExecutionPath } from "./runner-mode.js";
 import { handleGitHubWebhook } from "./webhook.js";
-import { initReconciliationTable, getPendingReconciliations, updateReconciliationStatus } from "./reconciliation.js";
+import { initReconciliationTable } from "./reconciliation.js";
+import { runReconciliations } from "./reconcile-merged.js";
 import { resolveSessionImage, resolveDefaultRunnerImage, selectRunnerImageInput, type SessionImageStatus } from "./repo-image.js";
 import { getStepRecord, initStepLogTable } from "./step-log.js";
 import { getOrchestratorSettings } from "./orchestrator-settings.js";
@@ -364,7 +365,7 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
   });
 
   // Process any pending reconciliation jobs triggered by merged PRs
-  await processReconciliations(config);
+  await processReconciliations(config, registry);
 
   // Process pending late review feedback that arrived after the original run.
   await processReviewFixQueue(config);
@@ -1596,79 +1597,15 @@ async function startupReconciliation(config: AppConfig, registry: ProviderRegist
 // ---------- Reconciliation ----------
 
 /**
- * Processes pending reconciliation jobs enqueued by the webhook handler.
- * For each pending job, dispatches a gap-fill run of claude-implement.yml
- * with the merged PR number so Claude can review what still needs to be done.
+ * Thin wrapper: adapts registry + mappings to runReconciliations.
  */
-async function processReconciliations(config: AppConfig): Promise<void> {
-  const pending = getPendingReconciliations();
-  if (pending.length === 0) return;
-
-  console.log(`[reconcile] Processing ${pending.length} pending reconciliation(s)`);
-
+async function processReconciliations(_config: AppConfig, registry: ProviderRegistry): Promise<void> {
   const teamRepoMap = getMappings();
-
-  for (const job of pending) {
-    try {
-      const mapping = Object.values(teamRepoMap).find(
-        (m) => `${m.owner}/${m.repo}` === job.repo,
-      );
-
-      if (!mapping) {
-        console.warn(
-          `[reconcile] No mapping found for repo ${job.repo}, skipping reconciliation #${job.id}`,
-        );
-        updateReconciliationStatus(job.id, "skipped");
-        continue;
-      }
-
-      if (mapping.paused) {
-        console.log(
-          `[reconcile] Project ${mapping.owner}/${mapping.repo} is paused, skipping reconciliation #${job.id}`,
-        );
-        updateReconciliationStatus(job.id, "skipped");
-        continue;
-      }
-
-      const [owner] = job.repo.split("/");
-      const ghToken = await getInstallationToken(
-        config.githubAppId,
-        config.githubAppPrivateKey,
-        owner,
-      );
-
-      // Dispatch a gap-fill run using the existing claude-implement.yml workflow,
-      // passing the merged PR number so Claude checks out the right branch.
-      // Reconciliation/gap-fill and review-fix re-dispatches always go through
-      // GitHub Actions (this dispatchWorkflow path), so caps ride capDispatchFields
-      // here — there is no Fly/local gap-fill path needing capRunnerEnv.
-      const runnerImage = await resolveDispatchRunnerImage(config, mapping, ghToken);
-      const result = await dispatchWorkflow(ghToken, mapping, {
-        issue_id: job.issueId,
-        issue_identifier: job.issueIdentifier ?? job.issueId,
-        issue_title: `Reconciliation for PR #${job.prNumber}`,
-        issue_description: `Gap-fill after PR #${job.prNumber} was merged (${job.mergeCommitSha})`,
-        pr_number: String(job.prNumber),
-        runner_phase: "gap-analysis",
-        ...providerDispatchFields(mapping),
-        ...capDispatchFields(mapping),
-        ...(runnerImage ? { runner_image: runnerImage } : {}),
-      });
-
-      if (result.success) {
-        updateReconciliationStatus(job.id, "dispatched");
-        console.log(
-          `[reconcile] Dispatched gap-fill for ${job.issueIdentifier} (PR #${job.prNumber} in ${job.repo}, image: ${runnerImage ?? "workflow-default"})`,
-        );
-      } else {
-        console.error(
-          `[reconcile] Failed to dispatch reconciliation #${job.id}: ${result.status} ${result.error}`,
-        );
-      }
-    } catch (err) {
-      console.error(`[reconcile] Error processing reconciliation #${job.id}:`, err);
-    }
-  }
+  await runReconciliations({
+    mappingForRepo: (repo) =>
+      Object.values(teamRepoMap).find((m) => `${m.owner}/${m.repo}` === repo),
+    resolveProvider: (mapping) => registry.forMapping(mapping),
+  });
 }
 
 // ---------- Late Review Fix Queue ----------

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from "./config.js";
 import type { RepoMapping } from "./config.js";
 import { isAlreadyDispatched, markDispatched, closeDb, getDispatchedIds, deleteDispatched } from "./dedup.js";
-import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun, providerDispatchFields, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv } from "./github.js";
+import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun, providerDispatchFields, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv, getPullRequestState } from "./github.js";
 import { providerConfigFromEnv, ProviderRegistry } from "./providers/index.js";
 import type { TicketingProvider, IssueLifecycleState, FeatureNodeRollUp } from "./providers/types.js";
 import type { TicketIssue } from "./providers/types.js";
@@ -45,6 +45,7 @@ import { resolveBaseBranch } from "./feature-branch.js";
 import { runMergeUps } from "./merge-up.js";
 import { getPendingReviewFixes, recordReviewFixDispatch, updateReviewFixStatus } from "./review-fix-queue.js";
 import { listOpenReviewFindings } from "./review-ledger-store.js";
+import { detectMergedPrs } from "./poll-merged-prs.js";
 
 // ---------- Configuration ----------
 
@@ -362,6 +363,16 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
       if (provider) await postSessionLogs(config, provider, job, context);
     },
     findPrForIssue: (repo, issueIdentifier) => findPrForIssue(config, repo, issueIdentifier),
+  });
+
+  // Guaranteed (webhook-independent) merge detector: enqueue reconciliations
+  // for merged PRs the webhook may have missed.
+  await detectMergedPrs({
+    mappingForRepo: (repo) =>
+      Object.values(getMappings()).find((m) => `${m.owner}/${m.repo}` === repo),
+    tokenForOwner: (owner) =>
+      getInstallationToken(config.githubAppId, config.githubAppPrivateKey, owner),
+    getPullRequestState,
   });
 
   // Process any pending reconciliation jobs triggered by merged PRs

--- a/src/poll-merged-prs.ts
+++ b/src/poll-merged-prs.ts
@@ -1,0 +1,73 @@
+import type { RepoMapping } from "./config.js";
+import { listLog } from "./log.js";
+import type { JobStatus } from "./log.js";
+import {
+  enqueueReconciliation,
+  hasReconciliationForPr,
+  recordReconciliationTombstone,
+} from "./reconciliation.js";
+
+const CANDIDATE_STATUSES = new Set<JobStatus>(["completed", "review_failed"]);
+
+export interface DetectDeps {
+  mappingForRepo: (repo: string) => RepoMapping | undefined;
+  tokenForOwner: (owner: string) => Promise<string>;
+  getPullRequestState: (
+    token: string,
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ) => Promise<{ merged: boolean; state: "open" | "closed" } | null>;
+}
+
+/** Parse the PR number from a stored html PR URL ending in /pull/<n>. */
+export function prNumberFromUrl(url: string): number | null {
+  const m = /\/pull\/(\d+)(?:$|[/?#])/.exec(url);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Guaranteed (webhook-independent) path: scans recent dispatches whose PR is
+ * not yet reconciled, asks GitHub whether each PR merged, and enqueues a
+ * reconciliation (merged) or a tombstone (closed-unmerged). Open PRs are
+ * re-checked next tick.
+ */
+export async function detectMergedPrs(deps: DetectDeps): Promise<void> {
+  for (const job of listLog(500)) {
+    if (!job.repo || !job.prUrl) continue;
+    if (!CANDIDATE_STATUSES.has(job.status)) continue;
+    const prNumber = prNumberFromUrl(job.prUrl);
+    if (prNumber === null) continue;
+    if (hasReconciliationForPr(job.repo, prNumber)) continue;
+    const mapping = deps.mappingForRepo(job.repo);
+    if (!mapping) continue;
+    const [owner] = job.repo.split("/");
+    let token: string;
+    try {
+      token = await deps.tokenForOwner(owner);
+    } catch (err) {
+      console.error(`[merge-poll] token error for ${job.repo}:`, err);
+      continue;
+    }
+    const state = await deps.getPullRequestState(token, mapping.owner, mapping.repo, prNumber);
+    if (!state) continue;
+    if (state.merged) {
+      enqueueReconciliation({
+        issueId: job.issueId,
+        issueIdentifier: job.issueIdentifier,
+        prNumber,
+        repo: job.repo,
+        mergeCommitSha: "",
+      });
+      console.log(`[merge-poll] Detected merge of PR #${prNumber} in ${job.repo}; queued reconciliation`);
+    } else if (state.state === "closed") {
+      recordReconciliationTombstone({
+        issueId: job.issueId,
+        issueIdentifier: job.issueIdentifier,
+        prNumber,
+        repo: job.repo,
+      });
+      console.log(`[merge-poll] PR #${prNumber} in ${job.repo} closed unmerged; tombstoned`);
+    }
+  }
+}

--- a/src/providers/jira-fields.ts
+++ b/src/providers/jira-fields.ts
@@ -74,6 +74,7 @@ export const STATUS_VALUES = {
   APPROVED: "Plan Approved",
   IMPLEMENTING: "Implementing",
   PR_READY: "PR Ready",
+  MERGED: "Merged",
   PLANNING_FAILED: "Planning Failed",
   IMPLEMENTATION_FAILED: "Implementation Failed",
 } as const;

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -266,6 +266,10 @@ export class JiraProvider implements TicketingProvider {
     const scopeKey = await this.scopeKeyForIssue(issueId);
     await this.setStatus(issueId, scopeKey, STATUS_VALUES.APPROVED);
   }
+  async markMerged(issueId: string): Promise<void> {
+    const scopeKey = await this.scopeKeyForIssue(issueId);
+    await this.setStatus(issueId, scopeKey, STATUS_VALUES.MERGED);
+  }
   async postComment(issueId: string, body: string): Promise<void> {
     await this.client.addComment(issueId, adfParagraph(body));
   }

--- a/src/providers/linear.ts
+++ b/src/providers/linear.ts
@@ -60,6 +60,7 @@ export class LinearProvider implements TicketingProvider {
   private readyForReviewLabelId: string | null = null;
   private teamIdByKey = new Map<string, string>();
   private inProgressStateByTeamKey = new Map<string, string>();
+  private completedStateByTeamKey = new Map<string, string>();
 
   constructor(config: ProviderConfig) {
     if (!config.linearApiKey) {
@@ -532,6 +533,30 @@ export class LinearProvider implements TicketingProvider {
     return state.id;
   }
 
+  private async getCompletedStateId(teamKey: string): Promise<string> {
+    const cached = this.completedStateByTeamKey.get(teamKey);
+    if (cached) return cached;
+    const teamId = await this.getTeamIdByKey(teamKey);
+    const data = await this.linearMutation<{
+      workflowStates: { nodes: Array<{ id: string; name: string; type: string }> };
+    }>(
+      `query($teamId: ID!) {
+        workflowStates(filter: { team: { id: { eq: $teamId } }, type: { eq: "completed" } }) {
+          nodes { id name type }
+        }
+      }`,
+      { teamId },
+    );
+    const state =
+      data.workflowStates.nodes.find((s) => s.name.toLowerCase() === "done") ??
+      data.workflowStates.nodes[0];
+    if (!state) {
+      throw new Error(`No "completed" workflow state found for team ${teamId}`);
+    }
+    this.completedStateByTeamKey.set(teamKey, state.id);
+    return state.id;
+  }
+
   private async updateIssueState(issueId: string, stateId: string): Promise<void> {
     await this.linearMutation<{ issueUpdate: { success: boolean } }>(
       `mutation($issueId: String!, $stateId: String!) {
@@ -690,6 +715,40 @@ export class LinearProvider implements TicketingProvider {
     );
 
     await this.postComment(issueId, `AI implementation PR: ${prUrl}`);
+  }
+
+  async markMerged(issueId: string): Promise<void> {
+    const data = await this.linearMutation<{
+      issue: {
+        state: { type: string };
+        team: { key: string };
+        labels: { nodes: Array<{ id: string; name: string }> };
+      } | null;
+    }>(
+      `query($id: String!) {
+        issue(id: $id) {
+          state { type }
+          team { key }
+          labels { nodes { id name } }
+        }
+      }`,
+      { id: issueId },
+    );
+    const issue = data.issue;
+    if (!issue) return;
+    if (issue.state.type === "completed" || issue.state.type === "canceled") return;
+    const stateId = await this.getCompletedStateId(issue.team.key);
+    const labelIds = issue.labels.nodes
+      .filter((l) => l.name !== "Ready for Review")
+      .map((l) => l.id);
+    await this.linearMutation<{ issueUpdate: { success: boolean } }>(
+      `mutation($issueId: String!, $stateId: String!, $labelIds: [String!]!) {
+        issueUpdate(id: $issueId, input: { stateId: $stateId, labelIds: $labelIds }) {
+          success
+        }
+      }`,
+      { issueId, stateId, labelIds },
+    );
   }
 
   async markImplementationFailed(issueId: string, reason: string): Promise<void> {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -81,6 +81,9 @@ export interface TicketingProvider {
   markPrReady(issueId: string, prUrl: string): Promise<void>;
   markImplementationFailed(issueId: string, reason: string): Promise<void>;
   clearWorkingState(issueId: string): Promise<void>;
+  /** Move the issue to a completed state after its PR merged. Idempotent:
+   *  no-op when the issue is already completed/cancelled. */
+  markMerged(issueId: string): Promise<void>;
 
   // Communication
   postComment(issueId: string, body: string): Promise<void>;

--- a/src/reconcile-merged.ts
+++ b/src/reconcile-merged.ts
@@ -1,0 +1,35 @@
+import type { RepoMapping } from "./config.js";
+import type { TicketingProvider } from "./providers/types.js";
+import { getPendingReconciliations, updateReconciliationStatus } from "./reconciliation.js";
+
+export interface ReconcileDeps {
+  mappingForRepo: (repo: string) => RepoMapping | undefined;
+  resolveProvider: (mapping: RepoMapping) => Promise<TicketingProvider>;
+}
+
+/**
+ * Drains the reconciliation queue by moving each merged PR's issue to Done.
+ * Runs even for paused projects (bookkeeping only). On provider error the row
+ * is left pending so the next tick retries it.
+ */
+export async function runReconciliations(deps: ReconcileDeps): Promise<void> {
+  const pending = getPendingReconciliations();
+  if (pending.length === 0) return;
+  console.log(`[reconcile] Processing ${pending.length} pending reconciliation(s)`);
+  for (const job of pending) {
+    try {
+      const mapping = deps.mappingForRepo(job.repo);
+      if (!mapping) {
+        console.warn(`[reconcile] No mapping for repo ${job.repo}, skipping #${job.id}`);
+        updateReconciliationStatus(job.id, "skipped");
+        continue;
+      }
+      const provider = await deps.resolveProvider(mapping);
+      await provider.markMerged(job.issueId);
+      updateReconciliationStatus(job.id, "dispatched");
+      console.log(`[reconcile] Marked ${job.issueIdentifier ?? job.issueId} Done (PR #${job.prNumber} in ${job.repo})`);
+    } catch (err) {
+      console.error(`[reconcile] Error processing reconciliation #${job.id} (left pending):`, err);
+    }
+  }
+}

--- a/src/reconciliation.ts
+++ b/src/reconciliation.ts
@@ -50,6 +50,27 @@ export function enqueueReconciliation(entry: {
   return Number(result.lastInsertRowid);
 }
 
+export function hasReconciliationForPr(repo: string, prNumber: number): boolean {
+  const row = getDb()
+    .prepare("SELECT 1 FROM reconciliation_queue WHERE repo = ? AND pr_number = ? LIMIT 1")
+    .get(repo, prNumber);
+  return row !== undefined;
+}
+
+export function recordReconciliationTombstone(entry: {
+  issueId: string;
+  issueIdentifier: string | null;
+  prNumber: number;
+  repo: string;
+}): number {
+  const result = getDb()
+    .prepare(
+      "INSERT INTO reconciliation_queue (issue_id, issue_identifier, pr_number, repo, merge_commit_sha, status, created_at) VALUES (?, ?, ?, ?, '', 'skipped', ?)",
+    )
+    .run(entry.issueId, entry.issueIdentifier ?? null, entry.prNumber, entry.repo, Date.now());
+  return Number(result.lastInsertRowid);
+}
+
 export function getPendingReconciliations(): ReconciliationJob[] {
   return (
     getDb()

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import http from "node:http";
 import { listLog } from "./log.js";
-import { enqueueReconciliation } from "./reconciliation.js";
+import { enqueueReconciliation, hasReconciliationForPr } from "./reconciliation.js";
 import { branchMatchesIssueIdentifier } from "./pipeline/branch-name.js";
 import { enqueueReviewFix } from "./review-fix-queue.js";
 import { AI_IMPLEMENT_NATIVE_REVIEW_MARKER, extractClaudeSummaryFindings } from "./pipeline/review-ledger.js";
@@ -217,6 +217,12 @@ export async function handleGitHubWebhook(
     // Not an AI-created PR — ignore silently
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ ignored: true, reason: "no matching dispatch" }));
+    return;
+  }
+
+  if (hasReconciliationForPr(repoFullName, prNumber)) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ignored: true, reason: "already queued" }));
     return;
   }
 


### PR DESCRIPTION
Implements [AII-166](https://linear.app/eudoxus/issue/AII-166/mark-issue-done-on-pr-merge): when an AI-Implement PR merges, the orchestrator moves the tracker issue to a completed state and clears the `Ready for Review` label — instead of depending solely on the native GitHub→Linear/Jira integration.

## What changed
A new `markMerged(issueId)` provider verb performs the status transition. Two paths feed the existing `reconciliation_queue`, drained by a worker that calls `markMerged`:

- **Poll detector (guaranteed):** every tick, `detectMergedPrs` scans recent dispatches whose PR isn't yet reconciled and asks GitHub whether the PR merged. Requires no webhook configuration.
- **Webhook (optimization):** a `pull_request` `closed`+`merged` delivery enqueues the same reconciliation immediately, reducing merge→Done latency.

Dedup/tombstoning live entirely in `reconciliation_queue` (no `dispatch_log` migration). Runs even for paused projects (bookkeeping only). `markMerged` is idempotent — a no-op when the issue is already completed/canceled — so the two paths racing is safe.

## Provider behavior
- **Linear:** moves a non-terminal issue to the team's completed state (prefers `Done`, else first completed-type) and drops only the `Ready for Review` label, in one `issueUpdate`.
- **Jira:** sets the AI-Implement status field to `Merged`. *(Jira target repos must add a `Merged` option to that field.)*

## Commits (TDD, one task per commit)
1. `markMerged` verb on `TicketingProvider` + Jira `Merged` status
2. Linear `markMerged`
3. `getPullRequestState` GitHub helper
4. `reconciliation`: `hasReconciliationForPr` + tombstone helper
5. Rewire worker → `markMerged` (extracted to `src/reconcile-merged.ts`); old gap-fill-on-merge path removed
6. `src/poll-merged-prs.ts` poll detector, wired into the poll tick
7. Docs (CLAUDE.md)
- plus final-review fixes: corrected stale `docs/feature-branch-grouping.md` lifecycle claim; added a webhook dedup guard so GitHub redeliveries don't create duplicate queue rows

## Testing
`npm run typecheck` clean; `npm test` → **1337 passing (96 files)**. Each task was implemented test-first and independently reviewed; a final whole-branch review (cross-task integration, idempotency/race, rate-limit, dead-code) passed with fixes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)