### PR TITLE
fix(feedback-loop): include untracked new files in review diff

### DIFF
--- a/src/__tests__/runner-callback.test.ts
+++ b/src/__tests__/runner-callback.test.ts
@@ -8,6 +8,7 @@ import type * as RunnerTokensModule from "../runner-tokens.js";
 import type * as RunnerCallbackModule from "../runner-callback.js";
 import type * as StepLogModule from "../step-log.js";
 import type * as ReviewLedgerStoreModule from "../review-ledger-store.js";
+import { formatFailureComment } from "../runner-callback.js";
 import { FakeProvider } from "./providers/fake.js";
 import type { TicketingProvider } from "../providers/types.js";
 import type { Step } from "../pipeline/types.js";
@@ -707,6 +708,95 @@ describe("handleRunnerResult — expired token", () => {
     });
     expect(res.status).toBe(401);
     expect(res.body.error).toBe("expired");
+  });
+});
+
+// ── formatFailureComment ──────────────────────────────────────────────────────
+
+describe("formatFailureComment", () => {
+  it("returns the raw reason when no failureCode is provided", () => {
+    expect(formatFailureComment(undefined, "tests fail")).toBe("tests fail");
+  });
+
+  it("returns 'unspecified' when both are undefined", () => {
+    expect(formatFailureComment(undefined, undefined)).toBe("unspecified");
+  });
+
+  it("formats SENSITIVE_FILES_BLOCKED with a structured comment", () => {
+    const msg = formatFailureComment("SENSITIVE_FILES_BLOCKED", "Push blocked: 1 sensitive file(s):\n  .env  (.env file)");
+    expect(msg).toContain("🔒");
+    expect(msg).toContain("Blocked by security guardrail");
+    expect(msg).toContain(".env");
+    expect(msg).toContain(".gitignore");
+  });
+
+  it("formats SENSITIVE_FILES_BLOCKED even when failureReason is undefined", () => {
+    const msg = formatFailureComment("SENSITIVE_FILES_BLOCKED", undefined);
+    expect(msg).toContain("🔒");
+    expect(msg).toContain("Blocked by security guardrail");
+  });
+
+  it("passes unknown failure codes through as raw reason", () => {
+    expect(formatFailureComment("SOME_OTHER_CODE", "some error")).toBe("some error");
+  });
+});
+
+describe("handleRunnerResult — SENSITIVE_FILES_BLOCKED failure code", () => {
+  it("formats the comment with the security guardrail message and passes it to markImplementationFailed", async () => {
+    const { token } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const fake = new FakeProvider({ recordCalls: true });
+    const res = await runnerCallback.handleRunnerResult({
+      authorization: `Bearer ${token}`,
+      body: {
+        phase: "implementation",
+        outcome: "failure",
+        failureReason: "Push blocked: 1 sensitive file(s) would be committed:\n  .env  (.env file)",
+        failureCode: "SENSITIVE_FILES_BLOCKED",
+        comments: [],
+      },
+      secret: SECRET,
+      resolveProvider: makeResolve(fake),
+    });
+    expect(res.status).toBe(200);
+    const call = fake.recordedCalls().find((c) => c.method === "markImplementationFailed");
+    expect(call).toBeDefined();
+    const [issueId, comment] = call!.args as [string, string];
+    expect(issueId).toBe("i");
+    expect(comment).toContain("🔒");
+    expect(comment).toContain("Blocked by security guardrail");
+    expect(comment).toContain(".env");
+  });
+
+  it("does not use the security guardrail format for other failures without failureCode", async () => {
+    const { token } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const fake = new FakeProvider({ recordCalls: true });
+    await runnerCallback.handleRunnerResult({
+      authorization: `Bearer ${token}`,
+      body: {
+        phase: "implementation",
+        outcome: "failure",
+        failureReason: "compilation error",
+        comments: [],
+      },
+      secret: SECRET,
+      resolveProvider: makeResolve(fake),
+    });
+    const call = fake.recordedCalls().find((c) => c.method === "markImplementationFailed");
+    const [, comment] = call!.args as [string, string];
+    expect(comment).toBe("compilation error");
+    expect(comment).not.toContain("🔒");
   });
 });
 

--- a/src/__tests__/sensitive-files.test.ts
+++ b/src/__tests__/sensitive-files.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { findSensitiveFiles, formatSensitiveFilesError } from "../pipeline/sensitive-files.js";
+
+// ── findSensitiveFiles ────────────────────────────────────────────────────────
+
+describe("findSensitiveFiles – env files", () => {
+  it("blocks .env at the repo root", () => {
+    expect(findSensitiveFiles([".env"])).toHaveLength(1);
+  });
+
+  it("blocks .env in a subdirectory", () => {
+    expect(findSensitiveFiles(["packages/api/.env"])).toHaveLength(1);
+  });
+
+  it("blocks .env.local / .env.production / .env.staging", () => {
+    expect(findSensitiveFiles([".env.local"])).toHaveLength(1);
+    expect(findSensitiveFiles([".env.production"])).toHaveLength(1);
+    expect(findSensitiveFiles([".env.staging"])).toHaveLength(1);
+  });
+
+  it("blocks suffix variants like prod.env", () => {
+    expect(findSensitiveFiles(["prod.env"])).toHaveLength(1);
+    expect(findSensitiveFiles(["secrets.env"])).toHaveLength(1);
+  });
+});
+
+describe("findSensitiveFiles – private keys and certificates", () => {
+  it("blocks *.pem files", () => {
+    expect(findSensitiveFiles(["server.pem"])).toHaveLength(1);
+    expect(findSensitiveFiles(["certs/ca.pem"])).toHaveLength(1);
+  });
+
+  it("blocks *.key files", () => {
+    expect(findSensitiveFiles(["private.key"])).toHaveLength(1);
+    expect(findSensitiveFiles(["config/server.key"])).toHaveLength(1);
+  });
+
+  it("blocks *.p12 and *.pfx", () => {
+    expect(findSensitiveFiles(["cert.p12"])).toHaveLength(1);
+    expect(findSensitiveFiles(["cert.pfx"])).toHaveLength(1);
+  });
+
+  it("blocks SSH private key names", () => {
+    expect(findSensitiveFiles(["id_rsa"])).toHaveLength(1);
+    expect(findSensitiveFiles(["id_ed25519"])).toHaveLength(1);
+    expect(findSensitiveFiles(["id_dsa"])).toHaveLength(1);
+    expect(findSensitiveFiles(["id_ecdsa"])).toHaveLength(1);
+  });
+
+  it("blocks Java KeyStore files", () => {
+    expect(findSensitiveFiles(["keystore.jks"])).toHaveLength(1);
+    expect(findSensitiveFiles(["app.keystore"])).toHaveLength(1);
+  });
+});
+
+describe("findSensitiveFiles – cloud credentials", () => {
+  it("blocks .aws/credentials wherever it appears", () => {
+    expect(findSensitiveFiles([".aws/credentials"])).toHaveLength(1);
+    expect(findSensitiveFiles(["home/user/.aws/credentials"])).toHaveLength(1);
+  });
+
+  it("blocks GCP service account key files", () => {
+    expect(findSensitiveFiles(["serviceAccountKey.json"])).toHaveLength(1);
+    expect(findSensitiveFiles(["my-service-account.json"])).toHaveLength(1);
+  });
+
+  it("blocks Terraform variable and state files", () => {
+    expect(findSensitiveFiles(["terraform.tfvars"])).toHaveLength(1);
+    expect(findSensitiveFiles(["prod.tfvars"])).toHaveLength(1);
+    expect(findSensitiveFiles(["terraform.tfstate"])).toHaveLength(1);
+    expect(findSensitiveFiles(["terraform.tfstate.backup"])).toHaveLength(1);
+  });
+});
+
+describe("findSensitiveFiles – token and auth files", () => {
+  it("blocks .npmrc at the repo root", () => {
+    expect(findSensitiveFiles([".npmrc"])).toHaveLength(1);
+  });
+
+  it("does not block .npmrc inside node_modules", () => {
+    expect(findSensitiveFiles(["node_modules/foo/.npmrc"])).toHaveLength(0);
+  });
+
+  it("blocks .netrc and netrc", () => {
+    expect(findSensitiveFiles([".netrc"])).toHaveLength(1);
+    expect(findSensitiveFiles(["netrc"])).toHaveLength(1);
+  });
+
+  it("blocks kubeconfig", () => {
+    expect(findSensitiveFiles(["kubeconfig"])).toHaveLength(1);
+  });
+
+  it("blocks secrets.json", () => {
+    expect(findSensitiveFiles(["secrets.json"])).toHaveLength(1);
+  });
+
+  it("blocks Rails master.key and secrets.yml", () => {
+    expect(findSensitiveFiles(["config/master.key"])).toHaveLength(1);
+    expect(findSensitiveFiles(["config/secrets.yml"])).toHaveLength(1);
+  });
+});
+
+describe("findSensitiveFiles – safe files allowed through", () => {
+  it("allows normal source files", () => {
+    expect(findSensitiveFiles(["src/index.ts", "README.md", "package.json"])).toHaveLength(0);
+  });
+
+  it("allows .gitignore and CLAUDE.md", () => {
+    expect(findSensitiveFiles([".gitignore", "CLAUDE.md"])).toHaveLength(0);
+  });
+
+  it("allows files that contain 'key' in their name but are not keys", () => {
+    expect(findSensitiveFiles(["src/hotkeys.ts", "keyboard-shortcut.ts"])).toHaveLength(0);
+  });
+
+  it("allows public SSH key (id_rsa.pub)", () => {
+    // .pub suffix is not blocked; only the bare private key names are
+    expect(findSensitiveFiles(["id_rsa.pub"])).toHaveLength(0);
+  });
+});
+
+describe("findSensitiveFiles – mixed tracked + untracked PR scenario", () => {
+  it("reports sensitive files when mixed with safe changes", () => {
+    const staged = [
+      ".gitignore",          // safe – tracked modification
+      "src/feature.ts",      // safe – new source file
+      ".env",                // SENSITIVE – should be blocked
+      ".claude/settings.json", // safe
+      "private.key",         // SENSITIVE
+    ];
+    const hits = findSensitiveFiles(staged);
+    expect(hits).toHaveLength(2);
+    expect(hits.map((h) => h.file)).toEqual(expect.arrayContaining([".env", "private.key"]));
+  });
+
+  it("passes a clean mixed diff through without error", () => {
+    const staged = [
+      ".gitignore",
+      "src/feature.ts",
+      ".claude/settings.json",
+      "bd-project-setup/SKILL.md",
+      ".mcp.json",
+    ];
+    expect(findSensitiveFiles(staged)).toHaveLength(0);
+  });
+});
+
+describe("findSensitiveFiles – gitignore relaxation scenario", () => {
+  it("blocks a sensitive file that was previously gitignored but is now staged", () => {
+    // Simulate: .gitignore was modified to remove '.env' protection,
+    // then git add -A picks up the pre-existing .env file.
+    const staged = [
+      ".gitignore",   // the modified gitignore (safe on its own)
+      ".env",         // now staged because gitignore no longer ignores it
+    ];
+    const hits = findSensitiveFiles(staged);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].file).toBe(".env");
+  });
+
+  it("blocks multiple secrets exposed by a gitignore relaxation", () => {
+    const staged = [
+      ".gitignore",
+      ".env.production",
+      "config/master.key",
+      "src/unchanged.ts",
+    ];
+    const hits = findSensitiveFiles(staged);
+    expect(hits).toHaveLength(2);
+    expect(hits.map((h) => h.file)).toEqual(
+      expect.arrayContaining([".env.production", "config/master.key"]),
+    );
+  });
+});
+
+// ── formatSensitiveFilesError ─────────────────────────────────────────────────
+
+describe("formatSensitiveFilesError", () => {
+  it("includes the file path and description in the message", () => {
+    const hits = findSensitiveFiles([".env", "server.pem"]);
+    const msg = formatSensitiveFilesError(hits);
+    expect(msg).toContain(".env");
+    expect(msg).toContain("server.pem");
+    expect(msg).toContain("Push blocked");
+    expect(msg).toContain(".gitignore");
+  });
+});

--- a/src/__tests__/sensitive-files.test.ts
+++ b/src/__tests__/sensitive-files.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findSensitiveFiles, formatSensitiveFilesError } from "../pipeline/sensitive-files.js";
+import { findSensitiveFiles, formatSensitiveFilesError, SensitiveFilesError } from "../pipeline/sensitive-files.js";
 
 // ── findSensitiveFiles ────────────────────────────────────────────────────────
 
@@ -183,5 +183,40 @@ describe("formatSensitiveFilesError", () => {
     expect(msg).toContain("server.pem");
     expect(msg).toContain("Push blocked");
     expect(msg).toContain(".gitignore");
+  });
+});
+
+// ── SensitiveFilesError ───────────────────────────────────────────────────────
+
+describe("SensitiveFilesError", () => {
+  it("has code SENSITIVE_FILES_BLOCKED", () => {
+    const hits = findSensitiveFiles([".env"]);
+    const err = new SensitiveFilesError(hits);
+    expect(err.code).toBe("SENSITIVE_FILES_BLOCKED");
+  });
+
+  it("is an instance of Error", () => {
+    const err = new SensitiveFilesError(findSensitiveFiles([".env"]));
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has a human-readable message that includes the blocked file paths", () => {
+    const hits = findSensitiveFiles([".env", "private.key"]);
+    const err = new SensitiveFilesError(hits);
+    expect(err.message).toContain(".env");
+    expect(err.message).toContain("private.key");
+    expect(err.message).toContain("Push blocked");
+  });
+
+  it("exposes the structured files list", () => {
+    const hits = findSensitiveFiles([".env", "server.pem"]);
+    const err = new SensitiveFilesError(hits);
+    expect(err.files).toHaveLength(2);
+    expect(err.files.map((f) => f.file)).toEqual(expect.arrayContaining([".env", "server.pem"]));
+  });
+
+  it("has name SensitiveFilesError", () => {
+    const err = new SensitiveFilesError(findSensitiveFiles([".env"]));
+    expect(err.name).toBe("SensitiveFilesError");
   });
 });

--- a/src/__tests__/steps-feedback-loop-diff.test.ts
+++ b/src/__tests__/steps-feedback-loop-diff.test.ts
@@ -93,3 +93,54 @@ describe("getDiff generated-file exclusion", () => {
     expect(diff).not.toContain("generated/types.ts");
   });
 });
+
+describe("getDiff untracked-file inclusion", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), "diff-untracked-test-"));
+    git(repo, ["init", "-q"]);
+    git(repo, ["config", "user.email", "t@t.com"]);
+    git(repo, ["config", "user.name", "t"]);
+    writeFileSync(join(repo, ".gitignore"), "settings.local.json\n");
+    git(repo, ["add", "-A"]);
+    git(repo, ["commit", "-qm", "seed"]);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("includes newly created untracked files as additions", () => {
+    // Simulate Claude creating a new file that has never been committed
+    mkdirSync(join(repo, "bd-project-setup"), { recursive: true });
+    writeFileSync(join(repo, "bd-project-setup/SKILL.md"), "# New skill\n");
+    const diff = getDiff(repo);
+    expect(diff).toContain("bd-project-setup/SKILL.md");
+    expect(diff).toContain("New skill");
+  });
+
+  it("includes untracked .mcp.json as an addition", () => {
+    writeFileSync(join(repo, ".mcp.json"), '{"mcpServers":{}}\n');
+    const diff = getDiff(repo);
+    expect(diff).toContain(".mcp.json");
+    expect(diff).toContain("mcpServers");
+  });
+
+  it("includes untracked files in nested directories alongside tracked changes", () => {
+    // Mix of tracked modification + untracked new file (the real BDS-2 scenario)
+    writeFileSync(join(repo, ".gitignore"), "settings.local.json\n*.log\n");
+    mkdirSync(join(repo, ".claude"), { recursive: true });
+    writeFileSync(join(repo, ".claude/settings.json"), '{"enabledMcpjsonServers":["linear"]}\n');
+    const diff = getDiff(repo);
+    expect(diff).toContain(".gitignore");         // tracked modification
+    expect(diff).toContain(".claude/settings.json"); // new untracked file
+    expect(diff).toContain("enabledMcpjsonServers");
+  });
+
+  it("does not include gitignored files", () => {
+    writeFileSync(join(repo, "settings.local.json"), '{"secret":"value"}\n');
+    const diff = getDiff(repo);
+    expect(diff).not.toContain("settings.local.json");
+  });
+});

--- a/src/__tests__/steps-feedback-loop-diff.test.ts
+++ b/src/__tests__/steps-feedback-loop-diff.test.ts
@@ -127,15 +127,35 @@ describe("getDiff untracked-file inclusion", () => {
     expect(diff).toContain("mcpServers");
   });
 
-  it("includes untracked files in nested directories alongside tracked changes", () => {
-    // Mix of tracked modification + untracked new file (the real BDS-2 scenario)
+  it("includes both tracked modifications and untracked new files in the same diff", () => {
+    // This is the BDS-2 failure scenario: Claude modifies a tracked file AND creates
+    // several new files in the same pass. Before the git add -N fix, only the tracked
+    // modification appeared; the new files were invisible, causing the reviewer to
+    // reject every iteration with "files are not committed".
+
+    // Tracked modification: .gitignore already exists in HEAD
     writeFileSync(join(repo, ".gitignore"), "settings.local.json\n*.log\n");
+
+    // Untracked new files: never committed, not in HEAD at all
     mkdirSync(join(repo, ".claude"), { recursive: true });
     writeFileSync(join(repo, ".claude/settings.json"), '{"enabledMcpjsonServers":["linear"]}\n');
+    writeFileSync(join(repo, ".mcp.json"), '{"mcpServers":{"linear":{"type":"http","url":"https://mcp.linear.app/sse"}}}\n');
+    mkdirSync(join(repo, "bd-project-setup"), { recursive: true });
+    writeFileSync(join(repo, "bd-project-setup/SKILL.md"), "# BD Project Setup\n\nSets up the project.\n");
+
     const diff = getDiff(repo);
-    expect(diff).toContain(".gitignore");         // tracked modification
-    expect(diff).toContain(".claude/settings.json"); // new untracked file
+
+    // Tracked file must appear as a modification
+    expect(diff).toContain(".gitignore");
+    expect(diff).toContain("*.log");
+
+    // Each untracked file must appear as a new-file addition
+    expect(diff).toContain(".claude/settings.json");
     expect(diff).toContain("enabledMcpjsonServers");
+    expect(diff).toContain(".mcp.json");
+    expect(diff).toContain("mcp.linear.app");
+    expect(diff).toContain("bd-project-setup/SKILL.md");
+    expect(diff).toContain("BD Project Setup");
   });
 
   it("does not include gitignored files", () => {

--- a/src/pipeline/sensitive-files.ts
+++ b/src/pipeline/sensitive-files.ts
@@ -1,0 +1,123 @@
+import path from "node:path";
+
+/**
+ * File patterns that must never be committed by the pipeline.
+ *
+ * Each entry is checked against both the full repo-relative path and the
+ * basename so path-agnostic names (e.g. `.env`) are caught wherever they
+ * appear in the tree.
+ *
+ * Pattern types used here:
+ *   exact   – literal string equality against basename
+ *   suffix  – file extension check (e.g. ".pem")
+ *   segment – substring of the full path (e.g. "/.aws/credentials")
+ */
+
+interface SensitivePattern {
+  /** Human-readable description surfaced in the error message. */
+  description: string;
+  match: (filePath: string, basename: string) => boolean;
+}
+
+const SENSITIVE_PATTERNS: SensitivePattern[] = [
+  // ── Environment / config files ──────────────────────────────────────────
+  { description: ".env file",
+    match: (_, b) => b === ".env" },
+  { description: ".env.* variant",
+    match: (_, b) => b.startsWith(".env.") },
+  { description: "*.env file",
+    match: (_, b) => b !== ".env" && b.endsWith(".env") },
+  { description: "Rails master.key",
+    match: (_, b) => b === "master.key" },
+  { description: "Rails secrets.yml / secrets.yaml",
+    match: (_, b) => b === "secrets.yml" || b === "secrets.yaml" },
+  { description: "secrets.json",
+    match: (_, b) => b === "secrets.json" },
+  { description: "Rails config/credentials.yml.enc",
+    match: (f) => f === "config/credentials.yml.enc" || f.endsWith("/config/credentials.yml.enc") },
+
+  // ── Private keys and certificates ────────────────────────────────────────
+  { description: "PEM file (*.pem)",
+    match: (_, b) => b.endsWith(".pem") },
+  { description: "private key file (*.key)",
+    match: (_, b) => b.endsWith(".key") },
+  { description: "PKCS#12 bundle (*.p12)",
+    match: (_, b) => b.endsWith(".p12") },
+  { description: "PFX bundle (*.pfx)",
+    match: (_, b) => b.endsWith(".pfx") },
+  { description: "DER certificate (*.der)",
+    match: (_, b) => b.endsWith(".der") },
+  { description: "Java KeyStore (*.jks / *.keystore)",
+    match: (_, b) => b.endsWith(".jks") || b.endsWith(".keystore") },
+  { description: "SSH private key (id_rsa / id_ed25519 / id_dsa / id_ecdsa)",
+    match: (_, b) => ["id_rsa", "id_ed25519", "id_dsa", "id_ecdsa"].includes(b) },
+  { description: "ASC armored key (*.asc)",
+    match: (_, b) => b.endsWith(".asc") },
+
+  // ── Cloud provider credentials ───────────────────────────────────────────
+  { description: "AWS credentials file",
+    match: (f) => f.includes("/.aws/credentials") || f === ".aws/credentials" },
+  { description: "GCP service account key (*-service-account*.json or serviceAccountKey.json)",
+    match: (_, b) => b === "serviceAccountKey.json" || /service.?account/i.test(b) },
+  { description: "Terraform variable file (*.tfvars)",
+    match: (_, b) => b.endsWith(".tfvars") },
+  { description: "Terraform state file (*.tfstate)",
+    match: (_, b) => b.endsWith(".tfstate") || b.endsWith(".tfstate.backup") },
+
+  // ── Database credentials ─────────────────────────────────────────────────
+  { description: "PostgreSQL password file (.pgpass / pgpass)",
+    match: (_, b) => b === ".pgpass" || b === "pgpass" },
+  { description: "Rails database.yml",
+    match: (_, b) => b === "database.yml" },
+
+  // ── Token / auth files ───────────────────────────────────────────────────
+  { description: ".npmrc (can contain registry auth tokens)",
+    match: (f, b) => b === ".npmrc" && !f.startsWith("node_modules/") },
+  { description: ".pypirc (PyPI credentials)",
+    match: (_, b) => b === ".pypirc" },
+  { description: ".netrc / netrc (generic host credentials)",
+    match: (_, b) => b === ".netrc" || b === "netrc" },
+  { description: "generic token file (*.token)",
+    match: (_, b) => b.endsWith(".token") },
+  { description: "kubeconfig (Kubernetes credentials)",
+    match: (_, b) => b === "kubeconfig" },
+  { description: ".htpasswd (basic-auth password file)",
+    match: (_, b) => b === ".htpasswd" || b.endsWith(".htpasswd") },
+];
+
+export interface SensitiveFileMatch {
+  file: string;
+  description: string;
+}
+
+/**
+ * Returns every staged file that matches a sensitive pattern.
+ * `stagedFiles` is a list of repo-relative paths (output of
+ * `git diff --cached --name-only`).
+ */
+export function findSensitiveFiles(stagedFiles: string[]): SensitiveFileMatch[] {
+  const hits: SensitiveFileMatch[] = [];
+  for (const file of stagedFiles) {
+    const basename = path.basename(file);
+    for (const pattern of SENSITIVE_PATTERNS) {
+      if (pattern.match(file, basename)) {
+        hits.push({ file, description: pattern.description });
+        break; // one match per file is enough
+      }
+    }
+  }
+  return hits;
+}
+
+/**
+ * Formats a human-readable error message for sensitive files found in the
+ * staged set.
+ */
+export function formatSensitiveFilesError(hits: SensitiveFileMatch[]): string {
+  const lines = hits.map((h) => `  ${h.file}  (${h.description})`);
+  return (
+    `Push blocked: ${hits.length} sensitive file(s) would be committed:\n` +
+    lines.join("\n") +
+    "\n\nRemove these files from the working tree or add them to .gitignore."
+  );
+}

--- a/src/pipeline/sensitive-files.ts
+++ b/src/pipeline/sensitive-files.ts
@@ -91,6 +91,22 @@ export interface SensitiveFileMatch {
 }
 
 /**
+ * Thrown by the push step when one or more staged files match a sensitive
+ * pattern. The `code` property lets callers (e.g. the runner result handler)
+ * distinguish this from generic pipeline failures programmatically.
+ */
+export class SensitiveFilesError extends Error {
+  readonly code = "SENSITIVE_FILES_BLOCKED" as const;
+  readonly files: SensitiveFileMatch[];
+
+  constructor(hits: SensitiveFileMatch[]) {
+    super(formatSensitiveFilesError(hits));
+    this.name = "SensitiveFilesError";
+    this.files = hits;
+  }
+}
+
+/**
  * Returns every staged file that matches a sensitive pattern.
  * `stagedFiles` is a list of repo-relative paths (output of
  * `git diff --cached --name-only`).

--- a/src/pipeline/steps/feedback-loop.ts
+++ b/src/pipeline/steps/feedback-loop.ts
@@ -68,6 +68,16 @@ const REVIEW_DIFF_EXCLUDES = [
 ];
 
 export function getDiff(workspaceDir: string): string {
+  // Mark all untracked files as "intent to add" so git diff HEAD includes them
+  // as new-file additions. Without this, untracked files (e.g. newly created
+  // .mcp.json, .claude/settings.json) are invisible to the diff and the reviewer
+  // falsely rejects the implementation as "uncommitted". The push step runs
+  // git add -A unconditionally, so leaving intent-to-add markers is harmless.
+  spawnSync("git", ["add", "-N", "."], {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
   const result = spawnSync(
     "git",
     ["diff", "HEAD", "--", ".", ...REVIEW_DIFF_EXCLUDES],

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { formatGitNameStatusSummary } from "../step-utils.js";
 import { span } from "../timing.js";
-import { findSensitiveFiles, formatSensitiveFilesError } from "../sensitive-files.js";
+import { findSensitiveFiles, SensitiveFilesError } from "../sensitive-files.js";
 
 const LS_REMOTE_MAX_ATTEMPTS = 3;
 const LS_REMOTE_RETRY_DELAYS_MS = [250, 1000];
@@ -63,7 +63,7 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     const stagedFiles = stagedResult.stdout.toString().split("\n").map((f) => f.trim()).filter(Boolean);
     const sensitiveHits = findSensitiveFiles(stagedFiles);
     if (sensitiveHits.length > 0) {
-      throw new Error(formatSensitiveFilesError(sensitiveHits));
+      throw new SensitiveFilesError(sensitiveHits);
     }
     runGit(workspaceDir, ["commit", "-m", buildCommitMessage(issueIdentifier, issueTitle)], githubToken, "git commit");
     const commitSha = resolveCommitSha(workspaceDir);

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { formatGitNameStatusSummary } from "../step-utils.js";
 import { span } from "../timing.js";
+import { findSensitiveFiles, formatSensitiveFilesError } from "../sensitive-files.js";
 
 const LS_REMOTE_MAX_ATTEMPTS = 3;
 const LS_REMOTE_RETRY_DELAYS_MS = [250, 1000];
@@ -55,6 +56,15 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
       "git config user.email",
     );
     runGit(workspaceDir, ["add", "-A"], githubToken, "git add");
+    const stagedResult = spawnSync("git", ["diff", "--cached", "--name-only"], {
+      cwd: workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stagedFiles = stagedResult.stdout.toString().split("\n").map((f) => f.trim()).filter(Boolean);
+    const sensitiveHits = findSensitiveFiles(stagedFiles);
+    if (sensitiveHits.length > 0) {
+      throw new Error(formatSensitiveFilesError(sensitiveHits));
+    }
     runGit(workspaceDir, ["commit", "-m", buildCommitMessage(issueIdentifier, issueTitle)], githubToken, "git commit");
     const commitSha = resolveCommitSha(workspaceDir);
     const changedFilesSummary = summarizeCommittedChanges(workspaceDir, githubToken);

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -12,6 +12,7 @@ import { runHookScript } from "./pipeline/steps/hooks.js";
 import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
 import { parseWorkflowMd } from "./workflow-md.js";
 import { fetchPlanningContextFromOrchestrator, postRunnerResult } from "./runner-result.js";
+import { SensitiveFilesError } from "./pipeline/sensitive-files.js";
 
 export interface RunAutonomousOptions {
   workspaceDir?: string;
@@ -260,6 +261,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       phase: runnerPhase,
       outcome: "failure",
       failureReason: err instanceof Error ? err.message : String(err),
+      failureCode: err instanceof SensitiveFilesError ? err.code : undefined,
       fetchImpl: opts.fetchImpl,
     });
     return { exitCode: 1 };

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -12,6 +12,8 @@ export interface RunnerResultBody {
   phase: RunnerPhase;
   outcome: "success" | "failure";
   failureReason?: string;
+  /** Machine-readable error code set when a known guardrail trips (e.g. "SENSITIVE_FILES_BLOCKED"). */
+  failureCode?: string;
   comments: Array<{ body: string }>;
   prUrl?: string;
 }
@@ -46,6 +48,20 @@ export interface HandleRunnerPlanningContextInput {
 
 function bad(status: number, error: string): HandleRunnerResultOutput {
   return { status, body: { error } };
+}
+
+/**
+ * Formats the failure reason for the ticket comment. When the runner reports a
+ * known `failureCode`, uses a structured description so the ticket reader has
+ * actionable context. Falls back to the raw `failureReason` string for all
+ * other failures.
+ */
+export function formatFailureComment(failureCode: string | undefined, failureReason: string | undefined): string {
+  if (failureCode === "SENSITIVE_FILES_BLOCKED") {
+    const detail = failureReason ?? "sensitive files detected in staged changes";
+    return `🔒 Blocked by security guardrail\n\n${detail}\n\nRemove these files from the implementation or ensure they are excluded via .gitignore before re-running.`;
+  }
+  return failureReason ?? "unspecified";
 }
 
 function parseBearerToken(authorization: string | undefined): string | null {
@@ -174,7 +190,7 @@ export async function handleRunnerResult(
       try {
         await provider.markImplementationFailed(
           claims.issueId,
-          input.body.failureReason ?? "unspecified",
+          formatFailureComment(input.body.failureCode, input.body.failureReason),
         );
       } catch (err) {
         warn("markImplementationFailed", err);

--- a/src/runner-result.ts
+++ b/src/runner-result.ts
@@ -44,6 +44,8 @@ export async function postRunnerResult(params: {
   outcome: "success" | "failure";
   prUrl?: string;
   failureReason?: string;
+  /** Machine-readable code set when a known guardrail trips (e.g. "SENSITIVE_FILES_BLOCKED"). */
+  failureCode?: string;
   fetchImpl?: typeof fetch;
 }): Promise<void> {
   const callbackUrl = process.env.RUNNER_CALLBACK_URL;
@@ -62,6 +64,7 @@ export async function postRunnerResult(params: {
   const body: Record<string, unknown> = { phase: params.phase, outcome: params.outcome, comments };
   if (params.prUrl) body.prUrl = params.prUrl;
   if (params.failureReason) body.failureReason = params.failureReason;
+  if (params.failureCode) body.failureCode = params.failureCode;
   const fetchFn = params.fetchImpl ?? fetch;
   try {
     const res = await fetchFn(`${callbackUrl.replace(/\/$/, "")}/runner/result`, {


### PR DESCRIPTION
## Summary

**Commit 1 — fix(feedback-loop): include untracked new files in review diff**
- `getDiff()` used `git diff HEAD` which only shows changes to *tracked* files — newly created (untracked) files were invisible to the reviewer
- The reviewer received an empty/incomplete diff, concluded "files are not committed", and rejected every iteration; since push is gated on \`approved=true\`, no PR was ever created
- Fix: run \`git add -N .\` (intent-to-add) before diffing so untracked files appear as new-file additions; the push step's \`git add -A\` runs unconditionally afterward so the markers are harmless
- Added 4 explicit tests including the mixed tracked-modification + untracked-new-file scenario (the exact BDS-2 failure pattern)

**Commit 2 — test(feedback-loop): explicit mixed tracked+untracked diff coverage**
- Replaces a vague test with one that matches the exact BDS-2 failure: modifies a tracked file *and* creates several new untracked files in the same pass

**Commit 3 — feat(push): block sensitive files from being committed**
- Guardrail in \`push.ts\` runs after \`git add -A\` but before \`git commit\`; lists staged files via \`git diff --cached --name-only\` and throws if any match ~25 high-signal patterns
- Patterns: \`.env\`/\`.env.*\`/\`*.env\`, private keys (\`*.pem\`, \`*.key\`, \`*.p12\`, \`id_rsa\`, …), cloud credentials (\`.aws/credentials\`, \`*.tfvars\`, service-account JSON), auth files (\`.npmrc\`, \`.netrc\`, \`kubeconfig\`), framework secrets (Rails \`master.key\`, \`secrets.yml\`)
- Also catches the **gitignore-relaxation** scenario: if Claude removes a \`.gitignore\` protection line and the now-unignored secret file gets staged, the guardrail blocks the push regardless of why it was staged
- 27 new tests cover every category, mixed safe+sensitive diffs, and the gitignore relaxation scenario

## Test plan
- [ ] \`npm test\` passes (1390 tests)
- [ ] Validated end-to-end: BDS-2 in the skills repo produced [PR #13](https://github.com/BuildDownAI/skills/pull/13) after the getDiff fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)