### PR TITLE
AII-145/collapse repo onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,12 +111,17 @@ All tables live in a single SQLite file at `DEDUP_DB_PATH` (default `/data/dedup
 
 ## Adding a new target repo
 
-1. Install the GitHub App on the target repo **first** — saving the mapping immediately syncs workflows to it.
-2. Add the project mapping in the admin UI at `/admin` (the **New project** stepper, or **Edit** on an existing row). On save, the orchestrator automatically opens or updates a PR in the target repo with the workflow files and starter prompt templates, and the project row shows a **"Workflows synced — PR opened"** link. If the App isn't installed yet (or sync otherwise fails), the mapping still saves and an alert explains why — install the App, then re-save or use the row's **Sync workflows** button.
-3. Merge the PR in the target repo
+1. Add the project mapping in the admin UI at `/admin` — the **New project** stepper (or **Edit** on an existing row). On the **Source** step, enter the owner/repo and click **Check installation**: the stepper probes whether the GitHub App is installed and can see the repo, and links straight to the fix when it can't —
+   - **App not installed** → "Install the App" (GitHub's install flow; org members who aren't owners get GitHub's "request the owner to install" path),
+   - **Repo not selected** → "Add this repo" (same install flow — adjusts the install's selected-repositories set),
+   - **Ready** → green confirmation.
+
+   Use **Re-check** after installing/adding in the opened tab. The check is advisory — you can still save without it.
+2. **Save.** The mapping persists immediately, and the workflow sync runs in the background. The project row's Sync button shows **"Syncing…"**, then polls a status endpoint to a terminal state: **"Workflows synced — PR opened ↗"** (or a transient "Up to date"), or it reverts with an alert naming the failure (App not installed, permission denied, clock skew, …). The mapping is saved regardless of how the sync resolves.
+3. Merge the sync PR in the target repo
 4. Enable "Allow GitHub Actions to create and approve pull requests" in the target repo settings
 
-The **Sync workflows** button on each project row re-runs the sync manually at any time, and `.github/workflows/sync-workflow.yml` remains as a manual/bulk fallback.
+The **Sync workflows** button on each project row re-runs the sync manually at any time, and `.github/workflows/sync-workflow.yml` remains as a manual/bulk fallback. If the orchestrator restarts mid-sync, the poll loop reclaims the orphaned job after a short stale window and finishes it.
 
 The GitHub App must have **Workflows** permission in addition to **Contents** permission. GitHub rejects writes under `.github/workflows/` without it, so the sync will fail (surfaced as a "permission denied" message) before opening or updating the target-repo PR.
 

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -9,7 +9,7 @@ import type * as DedupModule from "../dedup.js";
 import type * as RunnerModeModule from "../runner-mode.js";
 import type * as LogModule from "../log.js";
 import type * as StepLogModule from "../step-log.js";
-import type * as WorkflowSyncModule from "../workflow-sync.js";
+import type * as InstallStateModule from "../github-install-state.js";
 import type * as WorkflowSyncQueueModule from "../workflow-sync-queue.js";
 import { FakeProvider } from "./providers/fake.js";
 import type { TicketIssue } from "../providers/types.js";
@@ -21,6 +21,10 @@ vi.mock("../workflow-sync.js", () => ({
     category: "unknown",
     message: err instanceof Error ? err.message : String(err),
   }),
+}));
+
+vi.mock("../github-install-state.js", () => ({
+  probeInstallState: vi.fn(),
 }));
 
 function makeFakeRegistry(provider: FakeProvider): ProviderRegistry {
@@ -74,7 +78,7 @@ let dedup: typeof DedupModule;
 let runnerMode: typeof RunnerModeModule;
 let log: typeof LogModule;
 let stepLog: typeof StepLogModule;
-let workflowSync: typeof WorkflowSyncModule;
+let installState: typeof InstallStateModule;
 let queue: typeof WorkflowSyncQueueModule;
 let provider: FakeProvider;
 
@@ -89,7 +93,7 @@ beforeEach(async () => {
   runnerMode = await import("../runner-mode.js");
   log = await import("../log.js");
   stepLog = await import("../step-log.js");
-  workflowSync = await import("../workflow-sync.js");
+  installState = await import("../github-install-state.js");
   queue = await import("../workflow-sync-queue.js");
   config.initMappingsTable();
   log.initLogTable();
@@ -1553,5 +1557,35 @@ describe("sync-status endpoint", () => {
       status: "failed",
       error: { message: "App not installed" },
     });
+  });
+});
+
+describe("github-install-state endpoint", () => {
+  it("returns 401 without an auth token", async () => {
+    const res = await request("/api/admin/github-install-state?owner=acme&repo=backend", "GET", "secret");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 when owner or repo is missing", async () => {
+    const token = await login("secret");
+    const res = await request("/api/admin/github-install-state?owner=acme", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 with the probe result", async () => {
+    const token = await login("secret");
+    vi.mocked(installState.probeInstallState).mockResolvedValueOnce({ state: "ready", installationId: 7 });
+
+    const res = await request("/api/admin/github-install-state?owner=acme&repo=backend", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ state: "ready", installationId: 7 });
+  });
+
+  it("returns 500 when the probe throws (e.g. a rethrown credential error)", async () => {
+    const token = await login("secret");
+    vi.mocked(installState.probeInstallState).mockRejectedValueOnce(new Error("bad jwt"));
+
+    const res = await request("/api/admin/github-install-state?owner=acme&repo=backend", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(500);
   });
 });

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -10,6 +10,7 @@ import type * as RunnerModeModule from "../runner-mode.js";
 import type * as LogModule from "../log.js";
 import type * as StepLogModule from "../step-log.js";
 import type * as WorkflowSyncModule from "../workflow-sync.js";
+import type * as WorkflowSyncQueueModule from "../workflow-sync-queue.js";
 import { FakeProvider } from "./providers/fake.js";
 import type { TicketIssue } from "../providers/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
@@ -74,6 +75,7 @@ let runnerMode: typeof RunnerModeModule;
 let log: typeof LogModule;
 let stepLog: typeof StepLogModule;
 let workflowSync: typeof WorkflowSyncModule;
+let queue: typeof WorkflowSyncQueueModule;
 let provider: FakeProvider;
 
 beforeEach(async () => {
@@ -88,6 +90,7 @@ beforeEach(async () => {
   log = await import("../log.js");
   stepLog = await import("../step-log.js");
   workflowSync = await import("../workflow-sync.js");
+  queue = await import("../workflow-sync-queue.js");
   config.initMappingsTable();
   log.initLogTable();
   stepLog.initStepLogTable();
@@ -208,7 +211,7 @@ describe("admin mappings", () => {
   it("creates a mapping with custom maxInProgressAiIssues", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", { teamKey: "APP", owner: "org", repo: "app", maxInProgressAiIssues: 5 }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).maxInProgressAiIssues).toBe(5);
 
     const list = await request("/api/mappings", "GET", "secret", undefined, token);
@@ -218,7 +221,7 @@ describe("admin mappings", () => {
   it("defaults maxInProgressAiIssues to 3 when omitted", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", { teamKey: "API", owner: "org", repo: "api" }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).maxInProgressAiIssues).toBe(3);
   });
 
@@ -256,14 +259,14 @@ describe("admin mappings", () => {
       repo: "app",
       defaultBranch: "development",
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
 
     const update = await requestRaw("/api/mappings", "POST", "secret", {
       teamKey: "DEV",
       owner: "org",
       repo: "app-renamed",
     }, token);
-    expect(update.statusCode).toBe(200);
+    expect(update.statusCode).toBe(202);
 
     const list = await request("/api/mappings", "GET", "secret", undefined, token);
     expect(JSON.parse(list.body).DEV).toMatchObject({
@@ -358,7 +361,7 @@ describe("admin mappings", () => {
       teamKey: "FLY", owner: "org", repo: "fly-repo",
       executionMode: "fly-machines", sessionMode: "hybrid", machineCpus: 4, machineMemoryMb: 8192,
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     const data = JSON.parse(create.body);
     expect(data.executionMode).toBe("fly-machines");
     expect(data.sessionMode).toBe("hybrid");
@@ -374,7 +377,7 @@ describe("admin mappings", () => {
   it("defaults v2 fields when omitted", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", { teamKey: "DEF", owner: "org", repo: "def-repo" }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     const data = JSON.parse(create.body);
     expect(data.executionMode).toBe("github-actions");
     expect(data.sessionMode).toBe("autonomous");
@@ -416,7 +419,7 @@ describe("admin mappings", () => {
       teamKey: "AII", owner: "org", repo: "ai-implement",
       extraEnv: { DEDUP_DB_PATH: "/tmp/dedup.sqlite" },
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).extraEnv).toEqual({ DEDUP_DB_PATH: "/tmp/dedup.sqlite" });
 
     const list = await request("/api/mappings", "GET", "secret", undefined, token);
@@ -426,7 +429,7 @@ describe("admin mappings", () => {
   it("defaults extraEnv to empty object when omitted", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", { teamKey: "DEF", owner: "org", repo: "def" }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).extraEnv).toEqual({});
   });
 
@@ -435,7 +438,7 @@ describe("admin mappings", () => {
     const create = await request("/api/mappings", "POST", "secret", {
       teamKey: "AAP", owner: "org", repo: "aap-repo", autoApprovePlans: false,
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).autoApprovePlans).toBe(false);
 
     const list = await request("/api/mappings", "GET", "secret", undefined, token);
@@ -445,7 +448,7 @@ describe("admin mappings", () => {
   it("defaults autoApprovePlans to true when omitted", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", { teamKey: "AAPD", owner: "org", repo: "aapd-repo" }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).autoApprovePlans).toBe(true);
 
     const list = await request("/api/mappings", "GET", "secret", undefined, token);
@@ -476,7 +479,7 @@ describe("admin mappings", () => {
     const create = await request("/api/mappings", "POST", "secret", {
       teamKey: "DEF", owner: "org", repo: "def",
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     const body = JSON.parse(create.body);
     expect(body.provider).toBe("anthropic");
     expect(body.awsRegion).toBeNull();
@@ -488,7 +491,7 @@ describe("admin mappings", () => {
       teamKey: "BED", owner: "org", repo: "bedrock-repo",
       provider: "bedrock", awsRegion: "us-west-2",
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     const body = JSON.parse(create.body);
     expect(body.provider).toBe("bedrock");
     expect(body.awsRegion).toBe("us-west-2");
@@ -543,7 +546,7 @@ describe("admin mappings", () => {
       teamKey: "CAPS", owner: "org", repo: "caps-repo",
       maxTurns: 40, maxIterations: 2, maxJobMinutes: 30,
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     const body = JSON.parse(create.body);
     expect(body.maxTurns).toBe(40);
     expect(body.maxIterations).toBe(2);
@@ -561,7 +564,7 @@ describe("admin mappings", () => {
     const create = await request("/api/mappings", "POST", "secret", {
       teamKey: "CAPD", owner: "org", repo: "capd-repo",
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     const body = JSON.parse(create.body);
     expect(body.maxTurns).toBeNull();
     expect(body.maxIterations).toBeNull();
@@ -592,7 +595,7 @@ describe("admin mappings", () => {
       teamKey: "CAPN", owner: "org", repo: "capn-repo",
       maxTurns: null,
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).maxTurns).toBeNull();
   });
 
@@ -607,7 +610,7 @@ describe("admin mappings", () => {
         repoFieldValue: "org/jira-app",
       },
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     const list = await request("/api/mappings", "GET", "secret", undefined, token);
     expect(list.statusCode).toBe(200);
     const entry = JSON.parse(list.body).JIRA1;
@@ -638,7 +641,7 @@ describe("admin mappings", () => {
     const create = await request("/api/mappings", "POST", "secret", {
       teamKey: "PFX", owner: "org", repo: "app", branchPrefix: "pr",
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).branchPrefix).toBe("pr");
 
     const list = await request("/api/mappings", "GET", "secret", undefined, token);
@@ -650,7 +653,7 @@ describe("admin mappings", () => {
     const create = await request("/api/mappings", "POST", "secret", {
       teamKey: "PFX2", owner: "org", repo: "app", branchPrefix: "/pr/",
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).branchPrefix).toBe("pr");
   });
 
@@ -659,7 +662,7 @@ describe("admin mappings", () => {
     const create = await request("/api/mappings", "POST", "secret", {
       teamKey: "PFX3", owner: "org", repo: "app", branchPrefix: "  ",
     }, token);
-    expect(create.statusCode).toBe(200);
+    expect(create.statusCode).toBe(202);
     expect(JSON.parse(create.body).branchPrefix).toBeNull();
   });
 
@@ -1458,45 +1461,97 @@ describe("classifyTemplate", () => {
   });
 });
 
-describe("auto-sync on mapping upsert", () => {
-  it("returns sync.ok with the result on success and persists the mapping", async () => {
+describe("async sync on mapping upsert", () => {
+  it("returns 202 with a syncJobId, no inline sync field, and persists the mapping", async () => {
     const token = await login("secret");
-    vi.mocked(workflowSync.syncWorkflowTemplates).mockResolvedValueOnce({
-      status: "pr-opened",
-      targetRepo: "org/app",
-      baseBranch: "main",
-      syncBranch: "sync/ai-implement",
-      changedFiles: [".github/workflows/claude-implement.yml"],
-      prNumber: 42,
-      prUrl: "https://github.com/org/app/pull/42",
-    });
-
     const res = await request("/api/mappings", "POST", "secret",
       { teamKey: "SYNCOK", owner: "org", repo: "app", defaultBranch: "main" }, token);
 
-    expect(res.statusCode).toBe(200);
+    // The save no longer waits on the sync — it returns 202 (Accepted) with a job id to poll.
+    expect(res.statusCode).toBe(202);
     const body = JSON.parse(res.body);
     expect(body.teamKey).toBe("SYNCOK");
-    expect(body.sync.ok).toBe(true);
-    expect(body.sync.result.prUrl).toBe("https://github.com/org/app/pull/42");
+    expect(typeof body.syncJobId).toBe("number");
+    expect(body.sync).toBeUndefined(); // the old inline blocking result is gone
 
     const list = JSON.parse((await request("/api/mappings", "GET", "secret", undefined, token)).body);
-    expect(list.SYNCOK).toBeDefined();
+    expect(list.SYNCOK).toBeDefined(); // mapping persisted regardless of the (background) sync outcome
   });
 
-  it("is non-fatal when sync throws: 200, sync.ok false, mapping still persisted", async () => {
+  it("manual sync-workflows returns 202 with a syncJobId", async () => {
     const token = await login("secret");
-    vi.mocked(workflowSync.syncWorkflowTemplates).mockRejectedValueOnce(new Error("App not installed"));
+    await request("/api/mappings", "POST", "secret",
+      { teamKey: "MAN", owner: "org", repo: "app", defaultBranch: "main" }, token);
 
-    const res = await request("/api/mappings", "POST", "secret",
-      { teamKey: "SYNCFAIL", owner: "org", repo: "app", defaultBranch: "main" }, token);
+    const res = await request("/api/mappings/MAN/sync-workflows", "POST", "secret", undefined, token);
+    expect(res.statusCode).toBe(202);
+    expect(typeof JSON.parse(res.body).syncJobId).toBe("number");
+  });
 
+  it("manual sync-workflows returns 404 for an unknown team", async () => {
+    const token = await login("secret");
+    const res = await request("/api/mappings/NOPE/sync-workflows", "POST", "secret", undefined, token);
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("sync-status endpoint", () => {
+  it("returns 401 without an auth token", async () => {
+    const res = await request("/api/mappings/ENG/sync-status/1", "GET", "secret");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 404 for an unknown job id", async () => {
+    const token = await login("secret");
+    const res = await request("/api/mappings/ENG/sync-status/99999", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 404 when the job id belongs to a different team", async () => {
+    const token = await login("secret");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    // Same id, wrong team in the path -> the row-ownership guard rejects it.
+    const res = await request(`/api/mappings/OTHER/sync-status/${id}`, "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("reflects a completed job with its result (200, not an error status)", async () => {
+    const token = await login("secret");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(id, "completed", {
+      result: {
+        status: "pr-opened",
+        targetRepo: "org/app",
+        baseBranch: "main",
+        syncBranch: "sync/ai-implement",
+        changedFiles: [".github/workflows/claude-implement.yml"],
+        prNumber: 42,
+        prUrl: "https://github.com/org/app/pull/42",
+      },
+    });
+
+    const res = await request(`/api/mappings/ENG/sync-status/${id}`, "GET", "secret", undefined, token);
     expect(res.statusCode).toBe(200);
-    const body = JSON.parse(res.body);
-    expect(body.sync.ok).toBe(false);
-    expect(body.sync.error.message).toBe("App not installed");
+    expect(JSON.parse(res.body)).toMatchObject({
+      id,
+      status: "completed",
+      result: { prUrl: "https://github.com/org/app/pull/42" },
+    });
+  });
 
-    const list = JSON.parse((await request("/api/mappings", "GET", "secret", undefined, token)).body);
-    expect(list.SYNCFAIL).toBeDefined();
+  it("reflects a failed job with its error as data (still 200)", async () => {
+    const token = await login("secret");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(id, "failed", {
+      error: { category: "app-not-installed", message: "App not installed" },
+    });
+
+    const res = await request(`/api/mappings/ENG/sync-status/${id}`, "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      id,
+      status: "failed",
+      error: { message: "App not installed" },
+    });
   });
 });

--- a/src/__tests__/github-app-auth.test.ts
+++ b/src/__tests__/github-app-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { getInstallationToken, clearTokenCache } from "../github-app-auth.js";
+import { getInstallationToken, getInstallation, getAppSlug, installationIncludesRepo, clearTokenCache } from "../github-app-auth.js";
 
 // Generate a real RSA key pair for tests so JWT signing works correctly
 const { privateKey } = generateKeyPairSync("rsa", {
@@ -170,5 +170,125 @@ describe("getInstallationToken", () => {
     const escapedKey = pkcs1Key.replace(/\n/g, "\\n");
     const token = await getInstallationToken(APP_ID, escapedKey, "my-org");
     expect(token).toBe("ghs_pkcs1_esc");
+  });
+});
+
+describe("getInstallation", () => {
+  it("returns the token plus the install's repository selection", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 55, repository_selection: "selected" } },
+      { ok: true, json: { token: "ghs_inst", expires_at: "" } },
+    ]));
+
+    const result = await getInstallation(APP_ID, privateKey, "my-org");
+
+    expect(result).toEqual({
+      token: "ghs_inst",
+      installationId: 55,
+      repositorySelection: "selected",
+    });
+  });
+
+  it("normalizes 'all' selection and falls back to the user endpoint", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: false, status: 404, text: "Not Found" }, // org endpoint 404 -> fall back
+      { ok: true, json: { id: 56, repository_selection: "all" } },
+      { ok: true, json: { token: "ghs_user_inst", expires_at: "" } },
+    ]));
+
+    const result = await getInstallation(APP_ID, privateKey, "my-user");
+
+    expect(result).toMatchObject({ installationId: 56, repositorySelection: "all" });
+  });
+
+  it("defaults repositorySelection to 'selected' when GitHub omits it", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 57 } }, // no repository_selection
+      { ok: true, json: { token: "ghs_x", expires_at: "" } },
+    ]));
+
+    const result = await getInstallation(APP_ID, privateKey, "my-org");
+
+    expect(result).toMatchObject({ repositorySelection: "selected" });
+  });
+
+  it("is uncached — every call re-resolves and re-mints", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 1, repository_selection: "all", account: { type: "Organization" } } },
+      { ok: true, json: { token: "t1", expires_at: "" } },
+      { ok: true, json: { id: 1, repository_selection: "all", account: { type: "Organization" } } },
+      { ok: true, json: { token: "t2", expires_at: "" } },
+    ]));
+
+    await getInstallation(APP_ID, privateKey, "my-org");
+    await getInstallation(APP_ID, privateKey, "my-org");
+
+    expect(fetch).toHaveBeenCalledTimes(4); // 2 requests each, no cache (unlike getInstallationToken)
+  });
+});
+
+describe("getAppSlug", () => {
+  it("reads GET /app and caches the slug for subsequent calls", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { slug: "ai-implement" } },
+    ]));
+
+    const slug1 = await getAppSlug(APP_ID, privateKey);
+    const slug2 = await getAppSlug(APP_ID, privateKey);
+
+    expect(slug1).toBe("ai-implement");
+    expect(slug2).toBe("ai-implement");
+    expect(fetch).toHaveBeenCalledTimes(1); // cached — GET /app hit once across both calls
+
+    const [appUrl] = vi.mocked(fetch).mock.calls[0];
+    expect(appUrl).toBe("https://api.github.com/app");
+  });
+});
+
+describe("installationIncludesRepo", () => {
+  it("returns true when the repo is on the first page (single request)", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { total_count: 2, repositories: [{ name: "frontend" }, { name: "backend" }] } },
+    ]));
+
+    expect(await installationIncludesRepo("ghs_x", "backend")).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches case-insensitively", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { total_count: 1, repositories: [{ name: "Backend" }] } },
+    ]));
+
+    expect(await installationIncludesRepo("ghs_x", "backend")).toBe(true);
+  });
+
+  it("returns false without paginating when total_count <= 100", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { total_count: 2, repositories: [{ name: "frontend" }, { name: "api" }] } },
+    ]));
+
+    expect(await installationIncludesRepo("ghs_x", "backend")).toBe(false);
+    expect(fetch).toHaveBeenCalledTimes(1); // no needless page 2
+  });
+
+  it("paginates when total_count > 100 and finds the repo on a later page", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({ name: "repo" + i }));
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { total_count: 101, repositories: fullPage } },
+      { ok: true, json: { total_count: 101, repositories: [{ name: "backend" }] } },
+    ]));
+
+    expect(await installationIncludesRepo("ghs_x", "backend")).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a GitHubApiError on a non-ok response", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: false, status: 403, text: "Forbidden" },
+    ]));
+
+    await expect(installationIncludesRepo("ghs_x", "backend"))
+      .rejects.toThrow("Failed to list installation repositories");
   });
 });

--- a/src/__tests__/github-install-state.test.ts
+++ b/src/__tests__/github-install-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GitHubApiError } from "../github-errors.js";
+
+// Mock the github-app-auth boundary so the probe's branching logic is tested in isolation — no real
+// GitHub calls, no JWT signing. Each test drives getInstallation / installationIncludesRepo / getAppSlug.
+vi.mock("../github-app-auth.js", () => ({
+  getInstallation: vi.fn(),
+  installationIncludesRepo: vi.fn(),
+  getAppSlug: vi.fn(),
+}));
+
+import { probeInstallState } from "../github-install-state.js";
+import { getInstallation, installationIncludesRepo, getAppSlug } from "../github-app-auth.js";
+
+const PARAMS = { appId: "123", privateKey: "key", owner: "acme", repo: "backend" };
+const INSTALL_URL = "https://github.com/apps/ai-implement/installations/new";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("probeInstallState", () => {
+  it("app-not-installed: maps a 404 from getInstallation to the install-flow URL", async () => {
+    vi.mocked(getInstallation).mockRejectedValueOnce(
+      new GitHubApiError({ status: 404, path: "/users/acme/installation", bodyText: "", message: "not installed" }),
+    );
+    vi.mocked(getAppSlug).mockResolvedValueOnce("ai-implement");
+
+    const result = await probeInstallState(PARAMS);
+
+    expect(result).toEqual({ state: "app-not-installed", installUrl: INSTALL_URL });
+    expect(installationIncludesRepo).not.toHaveBeenCalled();
+  });
+
+  it("rethrows a non-404 error instead of mislabeling it as not-installed", async () => {
+    vi.mocked(getInstallation).mockRejectedValueOnce(
+      new GitHubApiError({ status: 401, path: "/orgs/acme/installation", bodyText: "", message: "bad jwt" }),
+    );
+
+    await expect(probeInstallState(PARAMS)).rejects.toThrow("bad jwt");
+  });
+
+  it("ready: an 'all' install short-circuits without listing repos", async () => {
+    vi.mocked(getInstallation).mockResolvedValueOnce({
+      token: "ghs_x",
+      installationId: 7,
+      repositorySelection: "all",
+    });
+
+    const result = await probeInstallState(PARAMS);
+
+    expect(result).toEqual({ state: "ready" });
+    expect(installationIncludesRepo).not.toHaveBeenCalled(); // "all" never needs the repo-listing call
+  });
+
+  it("ready: a 'selected' install that includes the repo", async () => {
+    vi.mocked(getInstallation).mockResolvedValueOnce({
+      token: "ghs_x",
+      installationId: 8,
+      repositorySelection: "selected",
+    });
+    vi.mocked(installationIncludesRepo).mockResolvedValueOnce(true);
+
+    const result = await probeInstallState(PARAMS);
+
+    expect(result).toEqual({ state: "ready" });
+    expect(installationIncludesRepo).toHaveBeenCalledWith("ghs_x", "backend");
+  });
+
+  it("repo-not-selected: a selected install missing the repo -> the same install-flow URL", async () => {
+    vi.mocked(getInstallation).mockResolvedValueOnce({
+      token: "ghs_x",
+      installationId: 9,
+      repositorySelection: "selected",
+    });
+    vi.mocked(installationIncludesRepo).mockResolvedValueOnce(false);
+    vi.mocked(getAppSlug).mockResolvedValueOnce("ai-implement");
+
+    const result = await probeInstallState(PARAMS);
+
+    expect(result).toEqual({ state: "repo-not-selected", installUrl: INSTALL_URL });
+  });
+});

--- a/src/__tests__/workflow-sync-queue.test.ts
+++ b/src/__tests__/workflow-sync-queue.test.ts
@@ -197,4 +197,50 @@ describe("runWorkflowSync executor", () => {
     expect(job?.status).toBe("failed");
     expect(job?.error?.message).toMatch(/deleted/i);
   });
+
+  it("bails without re-running when the job is already running and fresh (dedup guard)", async () => {
+    seedMapping("ENG");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(id, "running"); // an in-flight sync owns this job
+
+    // A rapid re-enqueue dedups to the same id and the handler fires runWorkflowSync again — the guard
+    // must keep it from double-firing the sync.
+    await queue.runWorkflowSync(id, CREDS);
+
+    expect(workflowSync.syncWorkflowTemplates).not.toHaveBeenCalled();
+    expect(queue.getWorkflowSyncById(id)?.status).toBe("running"); // left untouched for the live runner
+  });
+});
+
+describe("processPendingWorkflowSyncs (crash-recovery safety net)", () => {
+  it("re-runs pending and stale-running jobs but leaves a fresh running job alone", async () => {
+    seedMapping("A");
+    seedMapping("B");
+    seedMapping("C");
+    vi.mocked(workflowSync.syncWorkflowTemplates).mockResolvedValue(RESULT);
+
+    const a = queue.enqueueWorkflowSync("A"); // pending — orphaned before its runner started
+
+    const b = queue.enqueueWorkflowSync("B"); // running but stale — runner died mid-sync
+    queue.updateWorkflowSyncStatus(b.id, "running");
+    dedup
+      .getDb()
+      .prepare("UPDATE workflow_sync_queue SET updated_at = ? WHERE id = ?")
+      .run(Date.now() - queue.STALE_RUNNING_MS - 1000, b.id);
+
+    const c = queue.enqueueWorkflowSync("C"); // running and fresh — a live runner owns it
+    queue.updateWorkflowSyncStatus(c.id, "running");
+
+    await queue.processPendingWorkflowSyncs(CREDS);
+
+    expect(queue.getWorkflowSyncById(a.id)?.status).toBe("completed");
+    expect(queue.getWorkflowSyncById(b.id)?.status).toBe("completed"); // stale -> reclaimed
+    expect(queue.getWorkflowSyncById(c.id)?.status).toBe("running"); // fresh -> untouched
+    expect(workflowSync.syncWorkflowTemplates).toHaveBeenCalledTimes(2); // A + B only, never C
+  });
+
+  it("is a no-op when nothing is pending or stale", async () => {
+    await queue.processPendingWorkflowSyncs(CREDS);
+    expect(workflowSync.syncWorkflowTemplates).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/workflow-sync-queue.test.ts
+++ b/src/__tests__/workflow-sync-queue.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type * as DedupModule from "../dedup.js";
+import type * as ConfigModule from "../config.js";
+import type * as WorkflowSyncQueueModule from "../workflow-sync-queue.js";
+import type * as WorkflowSyncModule from "../workflow-sync.js";
+import { DEFAULT_TICKETING_CONFIG } from "../providers/ticketing-config.js";
+
+// runWorkflowSync (the executor) imports syncWorkflowTemplates from this module; mock it so the
+// executor tests below are deterministic and never reach GitHub. classifySyncError mirrors the real
+// shape so a thrown error still becomes a { category, message } pair. The lifecycle tests don't touch it.
+vi.mock("../workflow-sync.js", () => ({
+  syncWorkflowTemplates: vi.fn(),
+  classifySyncError: (err: unknown) => ({
+    category: "unknown",
+    message: err instanceof Error ? err.message : String(err),
+  }),
+}));
+
+let dbPath: string;
+let dedup: typeof DedupModule;
+let config: typeof ConfigModule;
+let queue: typeof WorkflowSyncQueueModule;
+let workflowSync: typeof WorkflowSyncModule;
+
+const CREDS = { githubAppId: "test-app-id", githubAppPrivateKey: "test-key" };
+
+const RESULT: WorkflowSyncModule.WorkflowSyncResult = {
+  status: "pr-opened",
+  targetRepo: "org/app",
+  baseBranch: "main",
+  syncBranch: "sync/ai-implement",
+  changedFiles: [".github/workflows/claude-implement.yml"],
+  prNumber: 42,
+  prUrl: "https://github.com/org/app/pull/42",
+};
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks(); // the factory's vi.fn() persists across tests; clear its call history each test
+  dbPath = path.join(
+    os.tmpdir(),
+    `workflow-sync-queue-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  config = await import("../config.js");
+  queue = await import("../workflow-sync-queue.js");
+  workflowSync = await import("../workflow-sync.js");
+  dedup.getDb(); // creates workflow_sync_queue (its DDL lives in getDb)
+  config.initMappingsTable(); // executor tests seed a mapping
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+  vi.restoreAllMocks();
+});
+
+// runWorkflowSync reads the mapping back via getMappings(); seed a complete, valid one so the row
+// isn't dropped on read (getMappings discards rows whose ticketing_config fails to parse).
+function seedMapping(teamKey: string): void {
+  config.upsertMapping(teamKey, {
+    owner: "org",
+    repo: "app",
+    workflowFile: "claude-implement.yml",
+    defaultBranch: "main",
+    maxInProgressAiIssues: 3,
+    executionMode: "github-actions",
+    sessionMode: "autonomous",
+    machineCpus: 2,
+    machineMemoryMb: 4096,
+    planningEnabled: true,
+    planningWorkflowFile: "claude-plan.yml",
+    autoApprovePlans: true,
+    extraEnv: {},
+    provider: "anthropic",
+    ticketingProvider: "linear",
+    ticketingConfig: DEFAULT_TICKETING_CONFIG,
+    awsRegion: null,
+    paused: false,
+    maxTurns: null,
+    maxIterations: null,
+    maxJobMinutes: null,
+    branchPrefix: null,
+  });
+}
+
+describe("workflow sync queue — lifecycle & dedup", () => {
+  it("enqueues a pending job and reads it back by id", () => {
+    const { id, deduped } = queue.enqueueWorkflowSync("ENG");
+    expect(deduped).toBe(false);
+    expect(queue.getWorkflowSyncById(id)).toMatchObject({
+      id,
+      teamKey: "ENG",
+      status: "pending",
+      result: null,
+      error: null,
+    });
+  });
+
+  it("collapses a second enqueue onto the same row (one row per team)", () => {
+    const first = queue.enqueueWorkflowSync("ENG");
+    const second = queue.enqueueWorkflowSync("ENG");
+    expect(second.id).toBe(first.id); // UNIQUE(team_key) — same row
+    expect(queue.getPendingWorkflowSyncs().map((j) => j.id)).toEqual([first.id]); // not duplicated
+  });
+
+  it("reuses a running, fresh job instead of resetting it (prevents a double-fire)", () => {
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(id, "running");
+    const again = queue.enqueueWorkflowSync("ENG");
+    expect(again).toEqual({ id, deduped: true });
+    expect(queue.getWorkflowSyncById(id)?.status).toBe("running"); // left untouched
+  });
+
+  it("re-queues a terminal job back to pending and clears the prior result", () => {
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(id, "completed", { result: RESULT });
+    const again = queue.enqueueWorkflowSync("ENG");
+    expect(again).toEqual({ id, deduped: false }); // same row, re-queued
+    expect(queue.getWorkflowSyncById(id)).toMatchObject({ status: "pending", result: null, error: null });
+  });
+
+  it("round-trips result and error JSON through updateWorkflowSyncStatus", () => {
+    const { id } = queue.enqueueWorkflowSync("ENG");
+
+    queue.updateWorkflowSyncStatus(id, "completed", { result: RESULT });
+    expect(queue.getWorkflowSyncById(id)?.result).toEqual(RESULT);
+
+    queue.updateWorkflowSyncStatus(id, "failed", {
+      error: { category: "permission-denied", message: "no perms" },
+    });
+    const job = queue.getWorkflowSyncById(id);
+    expect(job?.status).toBe("failed");
+    expect(job?.error).toEqual({ category: "permission-denied", message: "no perms" });
+    expect(job?.result).toBeNull(); // update writes both columns every call, so the stale result is cleared
+  });
+
+  it("getPendingWorkflowSyncs returns only pending jobs", () => {
+    queue.enqueueWorkflowSync("A");
+    const b = queue.enqueueWorkflowSync("B");
+    queue.updateWorkflowSyncStatus(b.id, "running");
+    expect(queue.getPendingWorkflowSyncs().map((j) => j.teamKey)).toEqual(["A"]);
+  });
+
+  it("getStaleRunningWorkflowSyncs honors the staleness boundary", () => {
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(id, "running"); // updated_at = now -> fresh
+    expect(queue.getStaleRunningWorkflowSyncs()).toEqual([]);
+
+    // Age the row past the window by rewriting updated_at directly, then it should surface.
+    dedup
+      .getDb()
+      .prepare("UPDATE workflow_sync_queue SET updated_at = ? WHERE id = ?")
+      .run(Date.now() - queue.STALE_RUNNING_MS - 1000, id);
+    expect(queue.getStaleRunningWorkflowSyncs().map((j) => j.id)).toEqual([id]);
+  });
+});
+
+describe("runWorkflowSync executor", () => {
+  it("marks the job completed with the sync result on success", async () => {
+    seedMapping("ENG");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    vi.mocked(workflowSync.syncWorkflowTemplates).mockResolvedValueOnce(RESULT);
+
+    await queue.runWorkflowSync(id, CREDS);
+
+    expect(workflowSync.syncWorkflowTemplates).toHaveBeenCalledOnce();
+    expect(queue.getWorkflowSyncById(id)).toMatchObject({ status: "completed", result: RESULT, error: null });
+  });
+
+  it("marks the job failed with a classified error when the sync throws", async () => {
+    seedMapping("ENG");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    vi.mocked(workflowSync.syncWorkflowTemplates).mockRejectedValueOnce(new Error("App not installed"));
+
+    await queue.runWorkflowSync(id, CREDS);
+
+    const job = queue.getWorkflowSyncById(id);
+    expect(job?.status).toBe("failed");
+    expect(job?.error?.message).toBe("App not installed");
+  });
+
+  it("fails the job without calling sync when the mapping was deleted before the run", async () => {
+    const { id } = queue.enqueueWorkflowSync("GONE"); // no seedMapping — mapping does not exist
+    await queue.runWorkflowSync(id, CREDS);
+
+    expect(workflowSync.syncWorkflowTemplates).not.toHaveBeenCalled();
+    const job = queue.getWorkflowSyncById(id);
+    expect(job?.status).toBe("failed");
+    expect(job?.error?.message).toMatch(/deleted/i);
+  });
+});

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -200,30 +200,6 @@ export const projectsScript = `
   let pendingJiraRepoFieldValue = '';
   let jiraFieldsLoaded = false;
 
-  // Ephemeral, in-memory record of the most recent auto-sync result per team
-  // - written when a mapping is created/edited AND syncing was successful
-  // - cleared on page refresh, so the row reverts to the normal button.
-  let recentSync = {};
-  window.noteSyncResult = function (teamKey, sync) {
-    if (sync && sync.ok && sync.result && sync.result.prUrl) {
-      recentSync[teamKey] = { prUrl: sync.result.prUrl, status: sync.result.status };
-    }
-  };
-  // Transiently label a project row's Sync button (mirrors the manual button's label-then-revert),
-  // - used after a create/edit that returned up-to-date (i.e. no PR to link to)
-  window.flashRowSyncStatus = function (teamKey, label) {
-    const buttons = document.querySelectorAll('#mappings-body button[data-sync-btn]');
-    for (const btn of buttons) {
-      if (btn.dataset.key !== teamKey) continue;
-      const original = btn.textContent;
-      btn.textContent = label;
-      btn.disabled = true;
-      setTimeout(function () { btn.textContent = original; btn.disabled = false; }, 4000);
-      break;
-    }
-  };
-
-
   async function loadMappings() {
     const res = await window.api('/api/mappings');
     mappingsData = await res.json();
@@ -654,7 +630,7 @@ export const projectsScript = `
 
     const saveBtn = document.getElementById('md-save');
     const origSaveLabel = saveBtn ? saveBtn.textContent : '';
-    if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = 'Syncing...'; }
+    if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = 'Saving...'; }
 
     const res = await window.api('/api/mappings', { method: 'POST', body: JSON.stringify(body) });
     let data = {};
@@ -665,17 +641,9 @@ export const projectsScript = `
       errEl.classList.remove('hidden');
       return;
     }
-    if (window.noteSyncResult) window.noteSyncResult(teamKey, data.sync);
     closeMappingDialog();
     await loadMappings();
-    if (data.sync && data.sync.ok && !(data.sync.result && data.sync.result.prUrl)) {
-      if (window.flashRowSyncStatus) window.flashRowSyncStatus(teamKey, 'Up to date');
-    }
-    if (data.sync && data.sync.ok === false) {
-      setTimeout(function () {
-        alert('Mapping saved, but workflow sync did not complete: ' + ((data.sync.error && data.sync.error.message) || 'unknown error') + ' Retry with the Sync workflows button on the project row.');
-      }, 100);
-    }
+    pollSyncStatus(teamKey, data.syncJobId);
   }
   window.saveMappingDialog = saveMappingDialog;
 
@@ -704,44 +672,106 @@ export const projectsScript = `
   }
   window.togglePause = togglePause;
 
+  let recentSync = {};
+  let syncPollTimers = {};
+  const SYNC_POLL_MS = 2000;
+  const SYNC_POLL_MAX_ATTEMPTS = 60; // ~2 min, then hand off to the background safety net
+
+  // Poll GET /api/mappings/:teamKey/sync-status/:jobId until the job is terminal
+  function pollSyncStatus(teamKey, jobId) {
+    if (!jobId) return;
+    stopSyncPoll(teamKey); // never run two pollers for one row
+
+    const initialBtn = findSyncBtn(teamKey);
+    if (initialBtn) { initialBtn.disabled = true; initialBtn.textContent = 'Syncing...'; }
+
+    let inFlight = false;
+    let attempts = 0;
+    syncPollTimers[teamKey] = setInterval(async function () {
+      if (inFlight) return; // a slow tick must not overlap the next one
+      inFlight = true;
+      try {
+        attempts++;
+        if (attempts > SYNC_POLL_MAX_ATTEMPTS) {
+          stopSyncPoll(teamKey);
+          await loadMappings();
+          flashRowSyncStatus(teamKey, 'Still syncing…');
+          return;
+        }
+        const res = await window.api('/api/mappings/' + encodeURIComponent(teamKey) + '/sync-status/' + jobId);
+        if (res.status === 404) { stopSyncPoll(teamKey); await loadMappings(); return; }
+        if (!res.ok) return; // transient server hiccup — retry next tick
+        const job = await res.json();
+        if (job.status === 'pending' || job.status === 'running') return; // keep waiting
+
+        stopSyncPoll(teamKey);
+        if (job.status === 'completed') {
+          noteSyncResult(teamKey, { ok: true, result: job.result });
+          await loadMappings();
+          if (!(job.result && job.result.prUrl)) flashRowSyncStatus(teamKey, 'Up to date');
+        } else { // failed
+          await loadMappings();
+          const msg = (job.error && job.error.message) || 'Workflow sync did not complete.';
+          alert(msg + ' Retry with the Sync workflows button on the project row.');
+        }
+      } catch (_) {
+        // network blip — leave the timer running for the next tick
+      } finally {
+        inFlight = false;
+      }
+    }, SYNC_POLL_MS);
+  }
+  window.pollSyncStatus = pollSyncStatus;
+  
   async function syncWorkflows(button) {
     const key = button.dataset.key;
-    const original = button.textContent;
     button.disabled = true;
     button.textContent = 'Syncing...';
     try {
-      const res = await window.api('/api/mappings/' + encodeURIComponent(key) + '/sync-workflows', {
-        method: 'POST',
-      });
+      const res = await window.api('/api/mappings/' + encodeURIComponent(key) + '/sync-workflows', { method: 'POST' });
       let data = {};
       try { data = await res.json(); } catch (_) {}
-      if (!res.ok) {
-        throw new Error(data.error || 'Failed to sync workflows');
-      }
-      const labels = {
-        'up-to-date': 'Up to date',
-        'pr-existing': 'PR exists',
-        'pr-opened': 'PR opened',
-        'pr-updated': 'PR updated',
-      };
-      button.textContent = labels[data.status] || 'Synced';
-      if (data.prUrl) {
-        button.dataset.prUrl = data.prUrl;
-        button.title = data.prUrl;
-        window.open(data.prUrl, '_blank', 'noopener,noreferrer');
-      }
-      setTimeout(function () {
-        button.textContent = original;
-        button.disabled = false;
-      }, 4000);
+      if (!res.ok) { throw new Error(data.error || 'Failed to start sync'); }
+      pollSyncStatus(key, data.syncJobId);
     } catch (err) {
       button.textContent = 'Sync failed';
       button.disabled = false;
       alert(err && err.message ? err.message : String(err));
-      setTimeout(function () { button.textContent = original; }, 4000);
+      setTimeout(function () { button.textContent = 'Sync workflows'; }, 4000);
     }
   }
   window.syncWorkflows = syncWorkflows;
+
+  // Ephemeral, in-memory record of the most recent auto-sync result per team
+  // - written when a mapping is created/edited AND syncing was successful
+  // - cleared on page refresh, so the row reverts to the normal button.
+  function noteSyncResult(teamKey, sync) {
+    if (sync && sync.ok && sync.result && sync.result.prUrl) {
+      recentSync[teamKey] = { prUrl: sync.result.prUrl, status: sync.result.status };
+    }
+  }
+
+  // Transiently label a project row's Sync button
+  // - used after a create/edit that returned up-to-date (i.e. no PR to link to)
+  function flashRowSyncStatus(teamKey, label) {
+    const syncButton = findSyncBtn(teamKey);
+    if (syncButton) {
+      const originalText = syncButton.textContent;
+      syncButton.textContent = label;
+      syncButton.disabled = true;
+      setTimeout(function () { syncButton.textContent = originalText; syncButton.disabled = false; }, 4000);
+    }
+  }
+
+  function findSyncBtn(teamKey) {
+    const buttons = document.querySelectorAll('#mappings-body button[data-sync-btn]');
+    for (const btn of buttons) { if (btn.dataset.key === teamKey) return btn; }
+    return null;
+  }
+
+  function stopSyncPoll(teamKey) {
+    if (syncPollTimers[teamKey]) { clearInterval(syncPollTimers[teamKey]); delete syncPollTimers[teamKey]; }
+  }
 
   async function showSecrets(teamKey) {
     currentSecretsTeam = teamKey;

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -485,7 +485,8 @@ export const stepperScript = `
     } else if (step === 2) {
       const ow = (document.getElementById('np-owner') || {}).value || '';
       const rp = (document.getElementById('np-repo') || {}).value || '';
-      if (!ow.trim() || !rp.trim()) ok = false;
+      const br = (document.getElementById('np-defaultBranch') || {}).value || '';
+      if (!ow.trim() || !rp.trim() || !br.trim()) ok = false;
       resetInstallState();
     }
     if (ok) nextBtn.removeAttribute('disabled');

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -966,7 +966,7 @@ export const stepperScript = `
 
     const createBtn = document.getElementById('np-create');
     const origCreateLabel = createBtn ? createBtn.textContent : '';
-    if (createBtn) { createBtn.disabled = true; createBtn.textContent = 'Syncing...'; }
+    if (createBtn) { createBtn.disabled = true; createBtn.textContent = 'Creating...'; }
     
     const res = await window.api('/api/mappings', { method: 'POST', body: JSON.stringify(body) });
     let resData = {};
@@ -992,18 +992,12 @@ export const stepperScript = `
       }
     }
 
-    if (window.noteSyncResult) window.noteSyncResult(teamKey, resData.sync);
     closeNewProjectStepper();
     if (window.loadMappings) await window.loadMappings();
-    if (resData.sync && resData.sync.ok && !(resData.sync.result && resData.sync.result.prUrl)) {
-      if (window.flashRowSyncStatus) window.flashRowSyncStatus(teamKey, 'Up to date');
-    }
+    if (window.pollSyncStatus) window.pollSyncStatus(teamKey, resData.syncJobId);
 
-    // Project was created but some portions failed — warn but don't block
+    // Project was created but some secrets failed — warn but don't block.
     const notices = [];
-    if (resData.sync && resData.sync.ok === false) {
-      notices.push('Workflow sync did not complete: ' + ((resData.sync.error && resData.sync.error.message) || 'unknown error') + ' Retry with the Sync workflows button on the project row.');
-    }
     if (secretFailures > 0) {
       notices.push(secretFailures + ' secret(s) failed to save. Add them via the Secrets button on the Projects page.');
     }

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -80,7 +80,11 @@ export const stepperHtml = `
           <div class="alert-icon">&#8505;</div>
           <div style="flex:1">
             <div class="alert-title">GitHub App required</div>
-            <div class="alert-desc">Make sure the AI-Implement GitHub App is installed on the target repository before creating this project.</div>
+            <div class="alert-desc">The AI-Implement GitHub App must be installed on the target repo before it can sync. Enter the owner and repo, then check the installation.</div>
+            <div id="np-install-state" style="margin-top:10px;font-size:12px"></div>
+            <div class="alert-actions" style="margin-top:10px">
+              <button type="button" class="btn btn-sm" id="np-install-check" onclick="checkInstallState()">Check installation</button>
+            </div>
           </div>
         </div>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
@@ -482,9 +486,63 @@ export const stepperScript = `
       const ow = (document.getElementById('np-owner') || {}).value || '';
       const rp = (document.getElementById('np-repo') || {}).value || '';
       if (!ow.trim() || !rp.trim()) ok = false;
+      resetInstallState();
     }
     if (ok) nextBtn.removeAttribute('disabled');
     else nextBtn.setAttribute('disabled', '');
+  }
+
+  async function checkInstallState() {
+    const owner = ((document.getElementById('np-owner') || {}).value || '').trim();
+    const repo = ((document.getElementById('np-repo') || {}).value || '').trim();
+    const out = document.getElementById('np-install-state');
+    const btn = document.getElementById('np-install-check');
+    if (!out || !btn) return;
+    if (!owner || !repo) {
+      out.innerHTML = '<span style="color:var(--fg-tertiary)">Enter owner and repo first.</span>';
+      return;
+    }
+    btn.disabled = true;
+    btn.textContent = 'Checking…';
+    out.innerHTML = '';
+    try {
+      const res = await window.api('/api/admin/github-install-state?owner=' + encodeURIComponent(owner) + '&repo=' + encodeURIComponent(repo));
+      const data = await res.json();
+      if (!res.ok) {
+        out.innerHTML = '<span style="color:var(--st-fail-fg)">Could not check: ' + window.esc(data.error || 'unknown error') + '</span>';
+        return;
+      }
+      out.innerHTML = renderInstallState(data);
+    } catch (_) {
+      out.innerHTML = '<span style="color:var(--st-fail-fg)">Could not check installation.</span>';
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Re-check';
+    }
+  }
+  
+  function renderInstallState(data) {
+    const state = data.state;
+    if (state === 'ready') {
+      return '<span class="badge success">Ready</span> The App is installed and can access this repo.';
+    }
+    if (state === 'app-not-installed') {
+      return '<span class="badge warn">Action needed</span> The App is not installed on this owner. '
+        + '<a class="text-accent" href="' + window.esc(data.installUrl) + '" target="_blank" rel="noopener noreferrer">Install the App &#8599;</a> then Re-check.';
+    }
+    if (state === 'repo-not-selected') {
+      return '<span class="badge warn">Action needed</span> The App is installed, but this repo is not in its selected repositories. '
+      + '<a class="text-accent" href="' + window.esc(data.installUrl) + '" target="_blank" rel="noopener noreferrer">Add this repo &#8599;</a> then Re-check.';
+    }
+    return '';
+  }
+
+  // Clears a stale probe result when owner/repo change, so a "Ready" for the old repo can't linger.
+  function resetInstallState() {
+    const out = document.getElementById('np-install-state');
+    const btn = document.getElementById('np-install-check');
+    if (out) out.innerHTML = '';
+    if (btn) btn.textContent = 'Check installation';
   }
 
   function stepperBack() {
@@ -1020,5 +1078,6 @@ export const stepperScript = `
   window.onStepperRepoFieldChange = onStepperRepoFieldChange;
   window.stepperValidateJql = stepperValidateJql;
   window.updateStepperNextButton = updateStepperNextButton;
+  window.checkInstallState = checkInstallState;
 })();
 `;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -39,7 +39,7 @@ import { listCustomizations } from "./customizations.js";
 import { inspectPipelinesAndSteps } from "./inspect-pipeline-graph.js";
 import { validateTicketingConfig, type TicketingMappingConfig } from "./providers/ticketing-config.js";
 import { JiraClient, JiraFieldNotSelectError } from "./providers/jira-client.js";
-import { syncWorkflowTemplates, classifySyncError, type WorkflowSyncResult, type ClassifiedSyncError } from "./workflow-sync.js";
+import { enqueueWorkflowSync, runWorkflowSync, getWorkflowSyncById } from "./workflow-sync-queue.js";
 import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -173,12 +173,19 @@ export function handleAdminRequest(
     const workflowSyncMatch = url.match(/^\/api\/mappings\/([^/]+)\/sync-workflows$/);
     if (workflowSyncMatch && method === "POST") {
       const teamKey = decodeURIComponent(workflowSyncMatch[1]);
-      handleSyncWorkflows(res, config, teamKey).catch((err) => {
-        console.error(`[admin] workflow sync failed for ${teamKey}:`, err);
-        if (!res.headersSent) {
-          json(res, 500, { error: err instanceof Error ? err.message : String(err) });
-        }
-      });
+      handleSyncWorkflows(res, config, teamKey)
+      return true;
+    }
+
+    const syncStatusMatch = url.match(/^\/api\/mappings\/([^/]+)\/sync-status\/(\d+)$/);
+    if (syncStatusMatch && method === "GET") {
+      const teamKey = decodeURIComponent(syncStatusMatch[1]);
+      const jobId = Number.parseInt(syncStatusMatch[2], 10);
+      const job = getWorkflowSyncById(jobId);
+
+      // Require the job to belong to the team in the URL — so one team's status id can't be read via another team's path.
+      if (!job || job.teamKey !== teamKey) { json(res, 404, { error: "sync job not found" }); return true; }
+      json(res, 200, { id: job.id, status: job.status, result: job.result, error: job.error });
       return true;
     }
 
@@ -618,29 +625,22 @@ async function handlePatchMapping(
   }
 }
 
-async function handleSyncWorkflows(
+function handleSyncWorkflows(
   res: http.ServerResponse,
   config: AdminConfig,
   teamKey: string,
-): Promise<void> {
+): void {
   const mappings = getMappings();
   const mapping = mappings[teamKey];
   if (!mapping) {
     json(res, 404, { error: "Team not found" });
     return;
   }
-  try {
-    const result = await syncWorkflowTemplates({
-      mapping,
-      githubAppId: config.githubAppId,
-      githubAppPrivateKey: config.githubAppPrivateKey,
-    });
-    json(res, 200, result);
-  } catch (err) {
-    console.error(`[admin] workflow sync failed for ${teamKey}:`, err);
-    const { category, message } = classifySyncError(err);
-    json(res, 500, { error: message, category });
-  }
+  const { id } = enqueueWorkflowSync(teamKey);
+  void runWorkflowSync(id, config).catch((err) =>
+    console.error(`[admin] workflow sync failed for ${teamKey}:`, err)
+  );
+  json(res, 202, { teamKey, syncJobId: id });
 }
 
 async function handleListSecrets(
@@ -1137,22 +1137,15 @@ async function handleUpsertMapping(
     upsertMapping(body.teamKey, mapping);
     registry.invalidate();
 
-    // Auto-sync workflow templates to the target repo. Blocking but non-fatal:
-    // - the mapping is already persisted above, so a sync failure still returns 200 with the saved mapping
-    // - the categorized error rides along in `sync` for the UI to surface.
-    let sync: { ok: true; result: WorkflowSyncResult } | { ok: false; error: ClassifiedSyncError };
-    try {
-      const result = await syncWorkflowTemplates({
-        mapping,
-        githubAppId: config.githubAppId,
-        githubAppPrivateKey: config.githubAppPrivateKey,
-      });
-      sync = { ok: true, result };
-    } catch (err) {
-      console.error(`[admin] workflow sync failed for ${body.teamKey}:`, err);
-      sync = { ok: false, error: classifySyncError(err) };
-    }
-    json(res, 200, { teamKey: body.teamKey, ...mapping, sync });
+    // Kick the workflow sync off in the background and return immediately
+    // - the client polls GET /api/mappings/:teamKey/sync-status/:id for the outcome
+    // - the mapping is already persisted above, so the save itself succeeds regardless of how the sync resolves
+    const { id } = enqueueWorkflowSync(body.teamKey);
+    void runWorkflowSync(id, config).catch((err) =>
+      console.error(`[admin] workflow sync failed for ${body.teamKey}:`, err),
+    );
+
+    json(res, 202, { teamKey: body.teamKey, ...mapping, syncJobId: id });
   } catch {
     json(res, 400, { error: "Invalid request body" });
   }

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -35,6 +35,7 @@ import { selectBlockers } from "./poll-selection.js";
 import { adminHtml } from "./admin-html.js";
 import { getOrchestratorSettings, setOrchestratorSetting } from "./orchestrator-settings.js";
 import { getInstallationToken } from "./github-app-auth.js";
+import { probeInstallState } from "./github-install-state.js";
 import { listCustomizations } from "./customizations.js";
 import { inspectPipelinesAndSteps } from "./inspect-pipeline-graph.js";
 import { validateTicketingConfig, type TicketingMappingConfig } from "./providers/ticketing-config.js";
@@ -361,6 +362,11 @@ export function handleAdminRequest(
         runnerCallback: !!(process.env.RUNNER_CALLBACK_BASE_URL && process.env.RUNNER_TOKEN_SECRET),
         gapFillTrigger: !!process.env.GAP_FILL_TRIGGER_SECRET,
       });
+      return true;
+    }
+
+    if (url.startsWith("/api/admin/github-install-state") && method === "GET") {
+      handleGithubInstallState(req, res, config);
       return true;
     }
 
@@ -1229,6 +1235,32 @@ async function handleListJiraFieldOptions(
       json(res, 200, []);
       return;
     }
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleGithubInstallState(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  config: AdminConfig,
+): Promise<void> {
+  const query = new URL(req.url ?? "", "http://localhost").searchParams;
+  const owner = query.get("owner");
+  const repo = query.get("repo");
+  if (!owner || !repo) {
+    json(res, 400, { error: "owner and repo query params are required" });
+    return;
+  }
+  try {
+    const result = await probeInstallState({
+      appId: config.githubAppId,
+      privateKey: config.githubAppPrivateKey,
+      owner,
+      repo,
+    });
+    json(res, 200, result);
+  } catch (err) {
+    console.error(`[admin] install-state probe failed for ${owner}/${repo}:`, err);
     json(res, 500, { error: err instanceof Error ? err.message : String(err) });
   }
 }

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -184,6 +184,18 @@ export function getDb(): Database.Database {
     `);
     db.exec(`CREATE INDEX IF NOT EXISTS idx_review_fix_dispatches_pr ON review_fix_dispatches(repo, pr_number, created_at)`);
     db.exec(`
+      CREATE TABLE IF NOT EXISTS workflow_sync_queue (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        team_key TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL DEFAULT 'pending',
+        result_json TEXT,
+        error_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `)
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_workflow_sync_queue_status ON workflow_sync_queue(status, created_at)`);
+    db.exec(`
       CREATE TABLE IF NOT EXISTS admin_sessions (
         token TEXT PRIMARY KEY,
         expires_at INTEGER NOT NULL

--- a/src/github-app-auth.ts
+++ b/src/github-app-auth.ts
@@ -1,8 +1,15 @@
 import crypto from "node:crypto";
 import { GitHubApiError } from "./github-errors.js";
 
+export interface InstallationDetails {
+  token: string;
+  installationId: number; // Currently inert — no caller reads this yet. Reserved for an OAuth follow-up (if approved), which will add a repo to a "selected repositories" install via the API and needs the installation id to target it
+  repositorySelection: "all" | "selected";
+}
+
 // Cache: org → { token, expiresAt }
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+let cachedAppSlug: string | null = null;
 
 /**
  * Wraps raw bytes in an ASN.1 TLV (tag-length-value) structure.
@@ -76,39 +83,31 @@ function createAppJwt(appId: string, privateKey: string): string {
   return `${signing}.${sig}`;
 }
 
-/**
- * Returns a cached installation access token for the given owner.
- * Tokens are valid for 1 hour; we cache for 50 minutes.
- *
- * The GitHub App must be installed on the target owner. The owner can be
- * either an organisation or a personal user account; GitHub uses separate
- * REST endpoints for each, so we try the org endpoint first and fall back
- * to the user endpoint on 404.
- */
-export async function getInstallationToken(
-  appId: string,
-  privateKey: string,
-  owner: string,
-): Promise<string> {
-  const cached = tokenCache.get(owner);
-  if (cached && Date.now() < cached.expiresAt) {
-    return cached.token;
-  }
-
-  // Normalize PEM key — handle \n literals from env vars
-  const normalizedKey = privateKey.replace(/\\n/g, "\n");
-  const jwt = createAppJwt(appId, normalizedKey);
-
-  const headers = {
-    Authorization: `Bearer ${jwt}`,
+function githubAppHeaders(authValue: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${authValue}`,
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
     "User-Agent": "ai-implement",
   };
+}
 
-  // Resolve installation ID for the owner (org or user account).
-  // GitHub's `/orgs/{org}/installation` endpoint 404s on user accounts and
-  // vice versa; try org first since that's the more common deployment shape.
+/**
+ * Resolves the GitHub App installation for an owner and mints an installation token, returning both
+ * the token and the install metadata (repo selection + account type) the install-state probe needs.
+ * The org endpoint 404s on user accounts and vice versa, so try org first and fall back to user.
+ * 
+ * Uncached — getInstallationToken is the cached, token-only view.
+ */
+export async function getInstallation(
+  appId: string,
+  privateKey: string,
+  owner: string,
+): Promise<InstallationDetails> {
+  const normalizedKey = privateKey.replace(/\\n/g, "\n"); // handle \n literals from env vars
+  const jwt = createAppJwt(appId, normalizedKey);
+  const headers = githubAppHeaders(jwt);
+
   let installPath = `/orgs/${owner}/installation`;
   let installRes = await fetch(`https://api.github.com${installPath}`, { headers });
   if (installRes.status === 404) {
@@ -117,8 +116,7 @@ export async function getInstallationToken(
   }
   if (!installRes.ok) {
     const body = await installRes.text();
-    // `path` (…/installation) lets classifySyncError tell a 404-not-installed from a 404-repo-not-found
-    // `message` keeps the original wording so existing consumers are unchanged.
+    // `path` (…/installation) lets classifySyncError tell a 404-not-installed from a 404-repo-not-found.
     throw new GitHubApiError({
       status: installRes.status,
       path: installPath,
@@ -126,9 +124,11 @@ export async function getInstallationToken(
       message: `GitHub App not installed for owner "${owner}" (${installRes.status}): ${body}`,
     });
   }
-  const install = await installRes.json() as { id: number };
+  const install = (await installRes.json()) as {
+    id: number;
+    repository_selection?: "all" | "selected";
+  };
 
-  // Exchange for an installation access token
   const tokenPath = `/app/installations/${install.id}/access_tokens`;
   const tokenRes = await fetch(`https://api.github.com${tokenPath}`, { method: "POST", headers });
   if (!tokenRes.ok) {
@@ -140,10 +140,93 @@ export async function getInstallationToken(
       message: `Failed to get installation token for owner "${owner}" (${tokenRes.status}): ${body}`,
     });
   }
-  const tokenData = await tokenRes.json() as { token: string; expires_at: string };
+  const tokenData = (await tokenRes.json()) as { token: string };
 
-  tokenCache.set(owner, { token: tokenData.token, expiresAt: Date.now() + 50 * 60 * 1000 });
-  return tokenData.token;
+  return {
+    token: tokenData.token,
+    installationId: install.id,
+    repositorySelection: install.repository_selection === "all" ? "all" : "selected",
+  };
+}
+
+/**
+ * Whether the installation can see a given repo. Only meaningful when repositorySelection === "selected"
+ * (an "all" install sees everything, so the caller skips this). 
+ * 
+ * Pages through GET /installation/repositories with the install token, short-circuiting as soon as the repo is found.
+ */
+export async function installationIncludesRepo(token: string, repoName: string): Promise<boolean> {
+  const headers = githubAppHeaders(token);
+  const perPage = 100;
+  const target = repoName.toLowerCase();
+
+  for (let page = 1; ; page++) {
+    const path = `/installation/repositories?per_page=${perPage}&page=${page}`;
+    const res = await fetch(`https://api.github.com${path}`, { headers });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new GitHubApiError({
+        status: res.status,
+        path,
+        bodyText: body,
+        message: `Failed to list installation repositories (${res.status}): ${body}`,
+      });
+    }
+
+    const data = (await res.json()) as { total_count: number; repositories: Array<{ name: string }> };
+    if (data.repositories.some((r) => r.name.toLowerCase() === target)) return true;
+    // Stop once this page was short (the last page) or we've already covered total_count.
+    if (data.repositories.length < perPage || page * perPage >= data.total_count) return false;
+  }
+}
+
+/**
+ * The GitHub App's slug (the name in github.com/apps/<slug>/...). Immutable per app, so cached for the
+ * process lifetime. Authenticates as the app (JWT) and reads GET /app
+ * 
+ * Derived from the credentials the orchestrator already needs, so no extra config and zero new secrets.
+ */
+export async function getAppSlug(appId: string, privateKey: string): Promise<string> {
+  if (cachedAppSlug) return cachedAppSlug;
+
+  const normalizedKey = privateKey.replace(/\\n/g, "\n");
+  const jwt = createAppJwt(appId, normalizedKey);
+  const path = "/app";
+  const res = await fetch(`https://api.github.com${path}`, { headers: githubAppHeaders(jwt) });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new GitHubApiError({
+      status: res.status,
+      path,
+      bodyText: body,
+      message: `Failed to read GitHub App metadata (${res.status}): ${body}`,
+    });
+  }
+
+  const data = (await res.json()) as { slug: string };
+  cachedAppSlug = data.slug;
+  return cachedAppSlug;
+}
+
+/**
+ * Returns a cached installation access token for the given owner.
+ * Tokens are valid for 1 hour; we cache for 50 minutes.
+ * 
+ * Thin caching layer over getInstallation — the hot dispatch path only needs the token.
+ */
+export async function getInstallationToken(
+  appId: string,
+  privateKey: string,
+  owner: string,
+): Promise<string> {
+  const cached = tokenCache.get(owner);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.token;
+  }
+  const { token } = await getInstallation(appId, privateKey, owner);
+  tokenCache.set(owner, { token, expiresAt: Date.now() + 50 * 60 * 1000 });
+  return token;
 }
 
 /** Clears the token cache (useful for testing). */

--- a/src/github-install-state.ts
+++ b/src/github-install-state.ts
@@ -1,0 +1,50 @@
+import { getInstallation, installationIncludesRepo, getAppSlug, type InstallationDetails } from "./github-app-auth.js";
+import { GitHubApiError } from "./github-errors.js";
+
+export type InstallState =
+  | { state: "app-not-installed"; installUrl: string }
+  | { state: "repo-not-selected"; installUrl: string }
+  | { state: "ready" };
+
+export interface ProbeInstallStateParams {
+  appId: string;
+  privateKey: string;
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Determines whether the GitHub App is ready to sync to owner/repo, and if not, the exact next action:
+ *   - app-not-installed: the App isn't on this owner -> deep-link to install it
+ *   - repo-not-selected: installed with "selected repositories" but this repo isn't included -> deep-link to add it
+ *   - ready: installed and can see the repo ("all repositories", or this repo is selected)
+ */
+export async function probeInstallState(params: ProbeInstallStateParams): Promise<InstallState> {
+  const { appId, privateKey, owner, repo } = params;
+  const slug = await getAppSlug(appId, privateKey);
+  const installUrl = `https://github.com/apps/${slug}/installations/new`;
+
+  let install: InstallationDetails;
+  try {
+    install = await getInstallation(appId, privateKey, owner);
+  } catch (err) {
+    // Only a 404 (no installation on this owner) means "not installed". A 401/403 is a credential or
+    // permission failure, not an install state — rethrow it rather than telling the user to install an
+    // App that may already be there.
+    if (err instanceof GitHubApiError && err.status === 404) {
+      return { state: "app-not-installed", installUrl };
+    }
+    throw err;
+  }
+
+  // Whether the installation can see this repo:
+  // an "all" install sees everything; a "selected" install sees it only if the repo was explicitly added
+  const repoVisible = install.repositorySelection === "all" ? true : await installationIncludesRepo(install.token, repo);
+  if (repoVisible) {
+    return { state: "ready" };
+  }
+
+  // Same install-flow URL as app-not-installed: GitHub's install entry lets owners add the repo and
+  // routes non-owners through the "request the owner to install" flow.
+  return { state: "repo-not-selected", installUrl };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ import { branchMatchesIssueIdentifier } from "./pipeline/branch-name.js";
 import { resolveBaseBranch } from "./feature-branch.js";
 import { runMergeUps } from "./merge-up.js";
 import { getPendingReviewFixes, recordReviewFixDispatch, updateReviewFixStatus } from "./review-fix-queue.js";
-import { getPendingWorkflowSyncs, getStaleRunningWorkflowSyncs, runWorkflowSync } from "./workflow-sync-queue.js";
+import { processPendingWorkflowSyncs } from "./workflow-sync-queue.js";
 import { listOpenReviewFindings } from "./review-ledger-store.js";
 
 // ---------- Configuration ----------
@@ -2017,20 +2017,6 @@ async function processReviewFixQueue(config: AppConfig): Promise<void> {
     } catch (err) {
       console.error(`[review-fix] Error processing review fix #${fix.id}:`, err);
     }
-  }
-}
-
-async function processPendingWorkflowSyncs(config: AppConfig): Promise<void> {
-  // pending = orphaned before their runner started; stale-running = runner died mid-sync.
-  const jobs = [...getPendingWorkflowSyncs(), ...getStaleRunningWorkflowSyncs()];
-  if (jobs.length === 0) return;
-
-  console.log(`[workflow-sync] Re-running ${jobs.length} orphaned/stale sync job(s)`);
-
-  // Sequential, not Promise.all: bound the safety net to one sync at a time
-  // so a backlog can't fan out into a burst of concurrent GitHub round-trips.
-  for (const job of jobs) {
-    await runWorkflowSync(job.id, config);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { branchMatchesIssueIdentifier } from "./pipeline/branch-name.js";
 import { resolveBaseBranch } from "./feature-branch.js";
 import { runMergeUps } from "./merge-up.js";
 import { getPendingReviewFixes, recordReviewFixDispatch, updateReviewFixStatus } from "./review-fix-queue.js";
+import { getPendingWorkflowSyncs, getStaleRunningWorkflowSyncs, runWorkflowSync } from "./workflow-sync-queue.js";
 import { listOpenReviewFindings } from "./review-ledger-store.js";
 
 // ---------- Configuration ----------
@@ -370,6 +371,10 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
 
   // Process pending late review feedback that arrived after the original run.
   await processReviewFixQueue(config);
+
+  // Crash-recovery safety net for workflow syncs. (NOT the primary trigger. the admin handlers fire runWorkflowSync immediately on save) 
+  // this only re-runs jobs that lost their runner to a restart or a wedge.
+  await processPendingWorkflowSyncs(config);
 
   } finally {
     pollInProgress = false;
@@ -2012,6 +2017,20 @@ async function processReviewFixQueue(config: AppConfig): Promise<void> {
     } catch (err) {
       console.error(`[review-fix] Error processing review fix #${fix.id}:`, err);
     }
+  }
+}
+
+async function processPendingWorkflowSyncs(config: AppConfig): Promise<void> {
+  // pending = orphaned before their runner started; stale-running = runner died mid-sync.
+  const jobs = [...getPendingWorkflowSyncs(), ...getStaleRunningWorkflowSyncs()];
+  if (jobs.length === 0) return;
+
+  console.log(`[workflow-sync] Re-running ${jobs.length} orphaned/stale sync job(s)`);
+
+  // Sequential, not Promise.all: bound the safety net to one sync at a time
+  // so a backlog can't fan out into a burst of concurrent GitHub round-trips.
+  for (const job of jobs) {
+    await runWorkflowSync(job.id, config);
   }
 }
 

--- a/src/workflow-sync-queue.ts
+++ b/src/workflow-sync-queue.ts
@@ -104,7 +104,11 @@ export function updateWorkflowSyncStatus(
 export async function runWorkflowSync(jobId: number, creds: WorkflowSyncCreds): Promise<void> {
   const job = getWorkflowSyncById(jobId);
   if (!job) return; // row vanished — nothing to run
+  // A fresh `running` row means a live runner already owns this job. Bail rather than double-fire the sync.
+  // A `running` row past the stale window is fair game (the safety net reclaims a crashed run).
+  if (job.status === "running" && Date.now() - job.updatedAt < STALE_RUNNING_MS) return;
 
+  
   updateWorkflowSyncStatus(jobId, "running");
 
   // Re-read the mapping at RUN time, not enqueue time: 
@@ -128,6 +132,21 @@ export async function runWorkflowSync(jobId: number, creds: WorkflowSyncCreds): 
   } catch (err) {
     console.error(`[workflow-sync] sync failed for ${job.teamKey}:`, err);
     updateWorkflowSyncStatus(jobId, "failed", { error: classifySyncError(err) });
+  }
+}
+
+// Crash-recovery safety net: re-run jobs orphaned by a restart (pending) or wedged past the stale window (running).
+// NOT the primary trigger — the admin handlers fire runWorkflowSync immediately on save; this is the backstop, driven by the poll loop.
+export async function processPendingWorkflowSyncs(creds: WorkflowSyncCreds): Promise<void> {
+  const jobs = [...getPendingWorkflowSyncs(), ...getStaleRunningWorkflowSyncs()];
+  if (jobs.length === 0) return;
+
+  console.log(`[workflow-sync] Re-running ${jobs.length} orphaned/stale sync job(s)`);
+
+  // Sequential, not Promise.all: bound the safety net to one sync at a time so a backlog can't fan out
+  // into a burst of concurrent GitHub round-trips. Latency is not a concern on this path.
+  for (const job of jobs) {
+    await runWorkflowSync(job.id, creds);
   }
 }
 

--- a/src/workflow-sync-queue.ts
+++ b/src/workflow-sync-queue.ts
@@ -1,0 +1,153 @@
+import { getDb } from "./dedup.js";
+import { getMappings } from "./config.js";
+import { syncWorkflowTemplates, classifySyncError, type WorkflowSyncResult, type ClassifiedSyncError } from "./workflow-sync.js";
+
+export type WorkflowSyncStatus = "pending" | "running" | "completed" | "failed";
+
+export interface WorkflowSyncCreds {
+  githubAppId: string;
+  githubAppPrivateKey: string;
+}
+
+export interface WorkflowSyncJob {
+  id: number;
+  teamKey: string;
+  status: WorkflowSyncStatus;
+  result: WorkflowSyncResult | null;
+  error: ClassifiedSyncError | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface WorkflowSyncRow {
+  id: number;
+  team_key: string;
+  status: WorkflowSyncStatus;
+  result_json: string | null;
+  error_json: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+// How long a `running` row may sit without an update before
+// the poll-loop safety net assumes the orchestrator crashed mid-sync and re-runs it. 
+export const STALE_RUNNING_MS = 5 * 60 * 1000;
+
+// At most one in-flight sync per team.
+export function enqueueWorkflowSync(teamKey: string): { id: number; deduped: boolean } {
+  const db = getDb();
+  const now = Date.now();
+  
+  const existing = db
+  .prepare("SELECT id, status, updated_at FROM workflow_sync_queue WHERE team_key = ?")
+  .get(teamKey) as { id: number; status: WorkflowSyncStatus; updated_at: number } | undefined;
+  
+  // If a `running` row is fresh, reuse it (don't reset it to pending — that would let the safety net double-fire).
+  if (existing && existing.status === "running" && now - existing.updated_at < STALE_RUNNING_MS) {
+    return { id: existing.id, deduped: true };
+  }
+  
+  // Otherwise (re)queue it as pending (for a new team, or an existing terminal/stale row).
+  db.prepare(`
+    INSERT INTO workflow_sync_queue (team_key, status, result_json, error_json, created_at, updated_at)
+    VALUES (@teamKey, 'pending', NULL, NULL, @now, @now)
+    ON CONFLICT (team_key) DO UPDATE SET
+      status = 'pending',
+      result_json = NULL,
+      error_json = NULL,
+      updated_at = excluded.updated_at
+  `).run({ teamKey, now });
+
+  const row = db.prepare("SELECT id FROM workflow_sync_queue WHERE team_key = ?").get(teamKey) as { id: number };
+  return { id: row.id, deduped: false };
+}
+
+export function getWorkflowSyncById(id: number): WorkflowSyncJob | null {
+  const row = getDb().prepare("SELECT * FROM workflow_sync_queue WHERE id = ?").get(id) as WorkflowSyncRow | undefined;
+  return row ? mapRow(row) : null;
+}
+
+export function getPendingWorkflowSyncs(limit = 20): WorkflowSyncJob[] {
+  const rows = getDb()
+    .prepare("SELECT * FROM workflow_sync_queue WHERE status = 'pending' ORDER BY created_at ASC, id ASC LIMIT ?")
+    .all(limit) as WorkflowSyncRow[];
+  return rows.map(mapRow);
+}
+
+export function getStaleRunningWorkflowSyncs(olderThanMs = STALE_RUNNING_MS, limit = 20): WorkflowSyncJob[] {
+  const cutoff = Date.now() - olderThanMs;
+  const rows = getDb()
+    .prepare("SELECT * FROM workflow_sync_queue WHERE status = 'running' AND updated_at < ? ORDER BY updated_at ASC, id ASC LIMIT ?")
+    .all(cutoff, limit) as WorkflowSyncRow[];
+  return rows.map(mapRow);
+}
+
+export function updateWorkflowSyncStatus(
+  id: number,
+  status: WorkflowSyncStatus,
+  payload: { result?: WorkflowSyncResult | null; error?: ClassifiedSyncError | null } = {},
+): void {
+  getDb().prepare(
+    "UPDATE workflow_sync_queue SET status = ?, result_json = ?, error_json = ?, updated_at = ? WHERE id = ?",
+  ).run(
+    status,
+    payload.result ? JSON.stringify(payload.result) : null,
+    payload.error ? JSON.stringify(payload.error) : null,
+    Date.now(),
+    id,
+  );
+}
+
+// Shared executor: drives one queued job to a terminal state. Two callers:
+//   1. fire-immediately from the admin handlers — `void runWorkflowSync(id, creds).catch(...)`
+//   2. the poll-loop safety net — re-runs jobs orphaned by a restart
+export async function runWorkflowSync(jobId: number, creds: WorkflowSyncCreds): Promise<void> {
+  const job = getWorkflowSyncById(jobId);
+  if (!job) return; // row vanished — nothing to run
+
+  updateWorkflowSyncStatus(jobId, "running");
+
+  // Re-read the mapping at RUN time, not enqueue time: 
+  // it may have been edited or deleted in between (the safety net can fire minutes after enqueue).
+  // A deleted mapping is a terminal failure here, not an error to retry — there's nothing left to sync to.
+  const mapping = getMappings()[job.teamKey];
+  if (!mapping) {
+    updateWorkflowSyncStatus(jobId, "failed", {
+      error: { category: "unknown", message: "Mapping was deleted before the sync ran." },
+    });
+    return;
+  }
+
+  try {
+    const result = await syncWorkflowTemplates({
+      mapping,
+      githubAppId: creds.githubAppId,
+      githubAppPrivateKey: creds.githubAppPrivateKey,
+    });
+    updateWorkflowSyncStatus(jobId, "completed", { result });
+  } catch (err) {
+    console.error(`[workflow-sync] sync failed for ${job.teamKey}:`, err);
+    updateWorkflowSyncStatus(jobId, "failed", { error: classifySyncError(err) });
+  }
+}
+
+function mapRow(row: WorkflowSyncRow): WorkflowSyncJob {
+  return {
+    id: row.id,
+    teamKey: row.team_key,
+    status: row.status,
+    result: parseJson<WorkflowSyncResult>(row.result_json),
+    error: parseJson<ClassifiedSyncError>(row.error_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function parseJson<T>(raw: string | null): T | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
# AII-145 — Collapse repo onboarding to one step

## Summary

Onboarding a target repo is now a single admin-UI step: create the project mapping. Two workstreams get it there.

**(A) Async, status-polled workflow sync.** Saving a mapping (`POST /api/mappings`) returns **202 + a `syncJobId`** immediately; the sync to the target repo runs in the background and the admin UI polls a status endpoint, driving the existing project-row feedback. A `workflow_sync_queue` table (one row per team) holds the job lifecycle; the immediate fire-off is the trigger and the 60s poll loop is a crash-recovery safety net. One async sync path, one status endpoint.

**(B) Proactive GitHub App install-state probe.** The New-project stepper's **Source** step checks, before save, whether the App is installed and can see the repo — surfacing one of three states (`app-not-installed` / `repo-not-selected` / `ready`) with a GitHub deep-link to the exact fix. Zero new secrets or config (the App slug is read from `GET /app` and cached).

**Status:** code complete and verified — typecheck clean, full unit suite green (95 files / 1361 tests, +45 new), both workstreams live-integration tested against a sandbox orchestrator + target repo (async save → poll → PR link; crash-recovery reclaim after a restart; all three probe states and their deep-links). Branch is stacked on AII-94 - PR #91; rebase onto `testing` once that merges.

## What changed

**Async sync (A)**
- **New `workflow_sync_queue` table** (`src/dedup.ts` DDL) — one row per `team_key` (`UNIQUE` + `ON CONFLICT`), a `pending`/`running`/`completed`/`failed` lifecycle, modeled on the review-fix-queue pattern. Module `src/workflow-sync-queue.ts` holds enqueue-with-dedup, the status accessors, and the `runWorkflowSync` executor (shared by the fire-off and the poll loop).
- **Endpoints return 202** — `handleUpsertMapping` and the manual `/sync-workflows` handler enqueue a job, fire `runWorkflowSync` in the background (`void … .catch()`), and return `202 { …, syncJobId }`. New read-only `GET /api/mappings/:teamKey/sync-status/:id` returns `{ id, status, result, error }`; a failed sync is **200 with the error as data**, not an HTTP error.
- **Crash-recovery safety net** — the 60s poll loop (`src/index.ts`) re-runs orphaned `pending` jobs and `running` jobs past a 5-min stale window. The immediate fire-off is the real trigger; the poll is the backstop.
- **UI polling** — `src/admin-ui/pages/projects.ts` gains `pollSyncStatus` (a `setInterval` modeled on the job-drawer poller); the three submit paths (stepper, edit dialog, manual Sync button) hand off to it. The project-row feedback (PR link / "Up to date" / error alert) is preserved, now poll-driven; the create/edit modals close immediately on submit.

**Install-state probe (B)**
- **`getInstallation` companion** (`src/github-app-auth.ts`) over the existing App-auth plumbing — returns the install token plus `repository_selection`; `getInstallationToken` becomes a thin cached wrapper over it. Adds `installationIncludesRepo` (paginated repo-membership check) and `getAppSlug` (`GET /app`, cached). Shared `githubAppHeaders` helper.
- **Three-state probe** (`src/github-install-state.ts`) — `probeInstallState` composes the above into `app-not-installed` / `repo-not-selected` / `ready`. Only a 404 maps to not-installed; 401/403 rethrow, so a credential failure isn't mislabeled as "not installed."
- **Endpoint + UI** — `GET /api/admin/github-install-state?owner=&repo=`; stepper Source-step UI with **Check installation** / **Re-check** and the deep-links.

**Tests (+45):** queue lifecycle/dedup/stale boundary + `runWorkflowSync` executor; admin 202 + status-endpoint contract; probe three-branch + rethrow; `getInstallation` / `getAppSlug` / `installationIncludesRepo`; install-state endpoint contract.

**Docs:** CLAUDE.md "Adding a new target repo" — single-step onboarding (probe-guided install + async sync/poll).

## Design decisions

- **Async fully replaces the inline sync** — one sync path, one status endpoint. The sync queue is one row per `team_key`; an in-flight `running` row is never reset (prevents the safety net double-firing).
- **The safety net reclaims a crashed `running` job only after a 5-min stale window** — the orchestrator can't distinguish "crashed" from "legitimately in-flight," and the window also avoids double-firing a peer poll's live work. Trade-off: up to ~5-min reclaim lag after a restart (the UI poller shows "Still syncing…", then it completes server-side).
- **Both probe action states deep-link to the App install-flow URL `github.com/apps/<slug>/installations/new`** (differing only in messaging). The settings URLs are dead ends for non-owners: installation management is **org-owner-only**, and the App Manager role governs app *registrations*, not third-party *installations*. The install-flow URL is the only one that works for everyone — owners configure directly, non-owners get GitHub's "request the owner to install" flow. (`/installations/select_target` is the account-picker sub-step it routes through.)
- **Zero new secrets/config** — the App slug comes from `GET /app` (cached), not a new env var.

## Follow-ups (out of scope)

- **Startup reclaim** — on a cold start every `running` row is definitionally orphaned, so startup could reclaim them immediately while the periodic poll keeps the stale heuristic, cutting post-restart reclaim lag to ~0.
- **OAuth authorize-during-install** — let the orchestrator add a repo to a "selected repositories" install itself (needs a user OAuth token plus the installation id, which `InstallationDetails` already carries — inert today, reserved for this).
- **Install-state probe on the projects row / edit dialog** — this block scopes the probe to the New-project stepper.
- **Bulk sync on workflow-template change** — fan-out enqueue across all mappings + a throttled drain; the queue + status-poll infrastructure already supports it, only the trigger is missing.
- **Installation-token cache TTL** — derive it from the `/access_tokens` `expires_at` rather than the hardcoded 50-min margin (App-auth hardening, alongside the GitHub App JWT forward-skew fix carried from AII-94).
- **Page teardown hook** — the admin router (`registerPage`) is init-once with no leave/teardown callback, so per-page resources aren't released on navigation (e.g. `pollSyncStatus`'s `syncPollTimers` keep firing against the hidden Projects page until they self-terminate at the ~2-min poll cap). A general teardown hook would let any page clean up timers/listeners on leave, rather than a per-page workaround.