### PR TITLE
feat: reset stranded Planning/Implementing issues that have no live job

### DIFF
--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1244,10 +1244,19 @@ describe("admin issues endpoint", () => {
       scopeKey: "CORE",
       nativeStatus: "Backlog (backlog)",
     };
+    // Two issues sit in-progress; both have live in-flight jobs, so the gated
+    // count is 2. A third in-progress issue with NO job is stranded and must be
+    // excluded — proving the count is gated by the orchestrator's in-flight set.
+    log.appendLog({ issueId: "core-a", issueIdentifier: "CORE-1", issueTitle: "", teamKey: "CORE", repo: "o/r" });
+    log.appendLog({ issueId: "core-b", issueIdentifier: "CORE-2", issueTitle: "", teamKey: "CORE", repo: "o/r" });
     vi.spyOn(provider, "fetchAIImplementSnapshot").mockResolvedValueOnce({
       readyForImplementation: [ready],
       needsPlanning: [needsPlan],
-      inProgressCountsByScope: { CORE: 2 },
+      inProgress: [
+        { issueId: "core-a", scopeKey: "CORE", phase: "implementing" },
+        { issueId: "core-b", scopeKey: "CORE", phase: "implementing" },
+        { issueId: "core-stranded", scopeKey: "CORE", phase: "implementing" },
+      ],
     });
     const token = await login("secret");
     const res = await request("/api/issues", "GET", "secret", undefined, token);
@@ -1343,7 +1352,7 @@ describe("admin blockers endpoint", () => {
     vi.spyOn(provider, "fetchAIImplementSnapshot").mockResolvedValueOnce({
       readyForImplementation: [issue],
       needsPlanning: [],
-      inProgressCountsByScope: {},
+      inProgress: [],
     });
     const token = await login("secret");
     // No mapping for CORE team → should produce a no-mapping blocker

--- a/src/__tests__/poll-selection.test.ts
+++ b/src/__tests__/poll-selection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { selectIssuesToDispatch, selectBlockers } from "../poll-selection.js";
+import { selectIssuesToDispatch, selectBlockers, countInProgressByTeam } from "../poll-selection.js";
 import type { RepoMapping } from "../config.js";
-import type { TicketIssue } from "../providers/types.js";
+import type { InProgressIssue, TicketIssue } from "../providers/types.js";
 
 function makeIssue(id: string, identifier: string, teamKey: string): TicketIssue {
   return {
@@ -36,6 +36,37 @@ function makeMapping(maxInProgressAiIssues = 3): RepoMapping {
     paused: false,
   };
 }
+
+describe("countInProgressByTeam", () => {
+  const ip = (issueId: string, scopeKey: string): InProgressIssue => ({
+    issueId,
+    scopeKey,
+    phase: "implementing",
+  });
+
+  it("counts in-progress issues per scope when all are live", () => {
+    const counts = countInProgressByTeam(
+      [ip("a", "T1"), ip("b", "T1"), ip("c", "T2")],
+      () => true,
+    );
+    expect(counts).toEqual({ T1: 2, T2: 1 });
+  });
+
+  it("excludes issues with no live in-flight job (stranded slots don't count)", () => {
+    // 'b' is stranded in Implementing with no live job — it must not count.
+    const live = new Set(["a", "c"]);
+    const counts = countInProgressByTeam(
+      [ip("a", "T1"), ip("b", "T1"), ip("c", "T2")],
+      (id) => live.has(id),
+    );
+    expect(counts).toEqual({ T1: 1, T2: 1 });
+  });
+
+  it("returns no entry for a scope whose only in-progress issue is stranded", () => {
+    const counts = countInProgressByTeam([ip("a", "T1")], () => false);
+    expect(counts).toEqual({});
+  });
+});
 
 describe("selectIssuesToDispatch", () => {
   it("returns all issues when team has available slots", () => {

--- a/src/__tests__/providers/contract.ts
+++ b/src/__tests__/providers/contract.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
 import type { TicketIssue, TicketingProvider } from "../../providers/types.js";
+import { countInProgressByTeam } from "../../poll-selection.js";
+
+/** Raw per-scope in-progress counts (no in-flight gating) for contract assertions. */
+const countByScope = (snap: { inProgress: Parameters<typeof countInProgressByTeam>[0] }) =>
+  countInProgressByTeam(snap.inProgress, () => true);
 
 export interface ContractFactoryArgs {
   /** Pre-populate the provider's view of the world with these issues. */
@@ -44,7 +49,7 @@ export function runProviderContract(label: string, factory: ContractProviderFact
         await provider.markImplementing("b", "TEAM_A");
         await provider.markImplementing("c", "TEAM_B");
         const snap = await provider.fetchAIImplementSnapshot();
-        expect(snap.inProgressCountsByScope).toEqual({ TEAM_A: 2, TEAM_B: 1 });
+        expect(countByScope(snap)).toEqual({ TEAM_A: 2, TEAM_B: 1 });
       });
     });
 
@@ -67,7 +72,7 @@ export function runProviderContract(label: string, factory: ContractProviderFact
         await provider.markPlanningStarted("a", "TEAM");
         await provider.markPlanningStarted("a", "TEAM");
         const snap = await provider.fetchAIImplementSnapshot();
-        expect(snap.inProgressCountsByScope.TEAM).toBe(1);
+        expect(countByScope(snap).TEAM).toBe(1);
       });
 
       it("markImplementing twice does not double-apply state", async () => {
@@ -76,7 +81,7 @@ export function runProviderContract(label: string, factory: ContractProviderFact
         await provider.markImplementing("a", "TEAM");
         await provider.markImplementing("a", "TEAM");
         const snap = await provider.fetchAIImplementSnapshot();
-        expect(snap.inProgressCountsByScope.TEAM).toBe(1);
+        expect(countByScope(snap).TEAM).toBe(1);
       });
     });
 
@@ -95,7 +100,7 @@ export function runProviderContract(label: string, factory: ContractProviderFact
         await provider.markImplementing("a", "TEAM");
         await provider.clearWorkingState("a");
         const snap = await provider.fetchAIImplementSnapshot();
-        expect(snap.inProgressCountsByScope.TEAM ?? 0).toBe(0);
+        expect((countByScope(snap).TEAM ?? 0)).toBe(0);
       });
     });
 
@@ -109,7 +114,7 @@ export function runProviderContract(label: string, factory: ContractProviderFact
           provider.markPlanningStarted("b", "TEAM"),
         ]);
         const snap = await provider.fetchAIImplementSnapshot();
-        expect(snap.inProgressCountsByScope.TEAM).toBe(2);
+        expect(countByScope(snap).TEAM).toBe(2);
       });
     });
 

--- a/src/__tests__/providers/fake.ts
+++ b/src/__tests__/providers/fake.ts
@@ -68,15 +68,15 @@ export class FakeProvider implements TicketingProvider {
     await this.tick("fetchAIImplementSnapshot", []);
     const needsPlanning: TicketIssue[] = [];
     const readyForImplementation: TicketIssue[] = [];
-    const inProgressCountsByScope: Record<string, number> = {};
+    const inProgress: AIImplementSnapshot["inProgress"] = [];
     for (const { issue, phase } of this.issues.values()) {
       if (phase === "needs_planning") needsPlanning.push(issue);
       else if (phase === "plan_complete") readyForImplementation.push(issue);
       if (phase === "planning" || phase === "implementing") {
-        inProgressCountsByScope[issue.scopeKey] = (inProgressCountsByScope[issue.scopeKey] ?? 0) + 1;
+        inProgress.push({ issueId: issue.id, scopeKey: issue.scopeKey, phase });
       }
     }
-    return { needsPlanning, readyForImplementation, inProgressCountsByScope };
+    return { needsPlanning, readyForImplementation, inProgress };
   }
 
   async fetchLifecycleStates(issueIds: string[]): Promise<Map<string, IssueLifecycleState>> {

--- a/src/__tests__/providers/jira.test.ts
+++ b/src/__tests__/providers/jira.test.ts
@@ -347,7 +347,7 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
 
     expect(snap.needsPlanning.map((i) => i.identifier)).toEqual(["P-1"]);
     expect(snap.readyForImplementation.map((i) => i.identifier)).toEqual(["P-2"]);
-    expect(snap.inProgressCountsByScope).toEqual({ "acme/x": 0 });
+    expect(snap.inProgress).toEqual([]);
     expect(snap.readyForImplementation[0].description).toBe("desc");
     expect(snap.needsPlanning[0].nativeStatus).toBe("Ready");
     expect(snap.needsPlanning[0].scopeKey).toBe("acme/x");
@@ -400,7 +400,7 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
     expect(capacityBody.jql).toContain("status in (Planning");
   });
 
-  it("counts capacity from the in-flight query", async () => {
+  it("reports in-progress issues (id + phase) from the in-flight query", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(FIELDS_RESPONSE)
       .mockResolvedValueOnce(searchOk([]))
@@ -417,7 +417,11 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
     });
     const snap = await p.fetchAIImplementSnapshot();
 
-    expect(snap.inProgressCountsByScope).toEqual({ "acme/x": 3 });
+    expect(snap.inProgress).toEqual([
+      { issueId: "20001", scopeKey: "acme/x", phase: "planning" },
+      { issueId: "20002", scopeKey: "acme/x", phase: "implementing" },
+      { issueId: "20003", scopeKey: "acme/x", phase: "planning" },
+    ]);
     expect(snap.needsPlanning).toEqual([]);
     expect(snap.readyForImplementation).toEqual([]);
   });

--- a/src/__tests__/providers/linear.test.ts
+++ b/src/__tests__/providers/linear.test.ts
@@ -226,7 +226,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
 
     expect(snap.readyForImplementation.map((i) => i.id)).toEqual(["a"]);
     expect(snap.needsPlanning.map((i) => i.id)).toEqual(["b"]);
-    expect(snap.inProgressCountsByScope).toEqual({});
+    expect(snap.inProgress).toEqual([]);
     expect(snap.readyForImplementation[0].scopeKey).toBe("ENG");
     expect(snap.readyForImplementation[0].nativeStatus).toBe("Todo (unstarted)");
   });
@@ -349,7 +349,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
     });
   });
 
-  it("counts AI-Working / AI-Planning issues by scope and excludes them from buckets", async () => {
+  it("reports AI-Working / AI-Planning issues as in-progress (with phase) and excludes them from buckets", async () => {
     mockSinglePage([
       makeIssue({ id: "a", teamKey: "T1", labels: ["AI-Implement", "AI-Working"] }),
       makeIssue({ id: "b", teamKey: "T2", labels: ["AI-Implement", "AI-Planning"] }),
@@ -358,7 +358,10 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
     const p = new LinearProvider({ linearApiKey: "k" });
     const snap = await p.fetchAIImplementSnapshot();
 
-    expect(snap.inProgressCountsByScope).toEqual({ T1: 1, T2: 1 });
+    expect(snap.inProgress).toEqual([
+      { issueId: "a", scopeKey: "T1", phase: "implementing" },
+      { issueId: "b", scopeKey: "T2", phase: "planning" },
+    ]);
     expect(snap.needsPlanning).toEqual([]);
     expect(snap.readyForImplementation).toEqual([]);
   });
@@ -374,7 +377,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
 
     expect(snap.needsPlanning.map((i) => i.id)).toEqual(["b"]);
     expect(snap.readyForImplementation).toEqual([]);
-    expect(snap.inProgressCountsByScope).toEqual({});
+    expect(snap.inProgress).toEqual([]);
   });
 
   it("skips issues blocked by an open issue, includes ones whose blocker is completed", async () => {

--- a/src/__tests__/stranded-reset.test.ts
+++ b/src/__tests__/stranded-reset.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { resetStrandedIssues } from "../stranded-reset.js";
+import { FakeProvider } from "./providers/fake.js";
+import type { AIImplementSnapshot, InProgressIssue } from "../providers/types.js";
+
+function snapshot(inProgress: InProgressIssue[]): AIImplementSnapshot {
+  return { needsPlanning: [], readyForImplementation: [], inProgress };
+}
+
+const never = () => false;
+
+describe("resetStrandedIssues", () => {
+  it("marks a stranded implementing issue failed (no live job, no dedup)", async () => {
+    const provider = new FakeProvider({ recordCalls: true });
+    await resetStrandedIssues(
+      [snapshot([{ issueId: "a", scopeKey: "T1", phase: "implementing" }])],
+      [provider],
+      { isLive: never, isDispatched: never },
+    );
+    const call = provider.recordedCalls().find((c) => c.method === "markImplementationFailed");
+    expect(call?.args[0]).toBe("a");
+    expect(String(call?.args[1])).toContain("no active job");
+  });
+
+  it("marks a stranded planning issue failed via the planning verb", async () => {
+    const provider = new FakeProvider({ recordCalls: true });
+    await resetStrandedIssues(
+      [snapshot([{ issueId: "b", scopeKey: "T1", phase: "planning" }])],
+      [provider],
+      { isLive: never, isDispatched: never },
+    );
+    const calls = provider.recordedCalls();
+    expect(calls.find((c) => c.method === "markPlanningFailed")?.args[0]).toBe("b");
+    expect(calls.find((c) => c.method === "markImplementationFailed")).toBeUndefined();
+  });
+
+  it("leaves an issue with a live in-flight job alone", async () => {
+    const provider = new FakeProvider({ recordCalls: true });
+    await resetStrandedIssues(
+      [snapshot([{ issueId: "a", scopeKey: "T1", phase: "implementing" }])],
+      [provider],
+      { isLive: (id) => id === "a", isDispatched: never },
+    );
+    expect(provider.recordedCalls().some((c) => c.method.includes("Failed"))).toBe(false);
+  });
+
+  it("leaves an issue that still has a dedup entry alone (fresh dispatch guard)", async () => {
+    const provider = new FakeProvider({ recordCalls: true });
+    await resetStrandedIssues(
+      [snapshot([{ issueId: "a", scopeKey: "T1", phase: "implementing" }])],
+      [provider],
+      { isLive: never, isDispatched: (id) => id === "a" },
+    );
+    expect(provider.recordedCalls().some((c) => c.method.includes("Failed"))).toBe(false);
+  });
+
+  it("resets only the stranded issues in a mixed batch", async () => {
+    const provider = new FakeProvider({ recordCalls: true });
+    const live = new Set(["live"]);
+    const dispatched = new Set(["fresh"]);
+    await resetStrandedIssues(
+      [
+        snapshot([
+          { issueId: "live", scopeKey: "T1", phase: "implementing" },
+          { issueId: "fresh", scopeKey: "T1", phase: "planning" },
+          { issueId: "stranded", scopeKey: "T2", phase: "implementing" },
+        ]),
+      ],
+      [provider],
+      { isLive: (id) => live.has(id), isDispatched: (id) => dispatched.has(id) },
+    );
+    const failed = provider
+      .recordedCalls()
+      .filter((c) => c.method.includes("Failed"))
+      .map((c) => c.args[0]);
+    expect(failed).toEqual(["stranded"]);
+  });
+});

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -26,12 +26,12 @@ import {
 } from "./runner-mode.js";
 import { getDb, listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
 import { getLastSweepAt } from "./reaper.js";
-import { listLog, getInFlightJobs, updateJobStatus, getJobById, getPulls } from "./log.js";
+import { listLog, getInFlightJobs, getInFlightIssueIds, updateJobStatus, getJobById, getPulls } from "./log.js";
 import { getStepsByJobId } from "./step-log.js";
 import { listMachines, destroyMachine, listAppSecrets, setAppSecrets, unsetAppSecret } from "./fly-machines.js";
 import type { TicketIssue, AIImplementSnapshot } from "./providers/types.js";
 import type { ProviderRegistry } from "./providers/registry.js";
-import { selectBlockers } from "./poll-selection.js";
+import { selectBlockers, countInProgressByTeam } from "./poll-selection.js";
 import { adminHtml } from "./admin-html.js";
 import { getOrchestratorSettings, setOrchestratorSetting } from "./orchestrator-settings.js";
 import { getInstallationToken } from "./github-app-auth.js";
@@ -380,18 +380,13 @@ async function fetchMergedSnapshot(registry: ProviderRegistry): Promise<AIImplem
   const allMappings = Object.values(getMappings());
   const providers = await registry.forAllMappings(allMappings);
   if (providers.length === 0) {
-    return { needsPlanning: [], readyForImplementation: [], inProgressCountsByScope: {} };
+    return { needsPlanning: [], readyForImplementation: [], inProgress: [] };
   }
   const snapshots = await Promise.all(providers.map((p) => p.fetchAIImplementSnapshot()));
   return {
     needsPlanning: snapshots.flatMap((s) => s.needsPlanning),
     readyForImplementation: snapshots.flatMap((s) => s.readyForImplementation),
-    inProgressCountsByScope: snapshots.reduce<Record<string, number>>((acc, s) => {
-      for (const [k, v] of Object.entries(s.inProgressCountsByScope)) {
-        acc[k] = (acc[k] ?? 0) + v;
-      }
-      return acc;
-    }, {}),
+    inProgress: snapshots.flatMap((s) => s.inProgress),
   };
 }
 
@@ -404,10 +399,13 @@ async function handleListBlockers(
     const allIssues = [...snapshot.readyForImplementation, ...snapshot.needsPlanning];
     const teamRepoMap = getMappings();
     const dispatchedSet = new Set(getDispatchedIds());
+    // Gate the capacity count by live in-flight jobs, mirroring the poll loop,
+    // so issues stranded in Planning/Implementing don't show a phantom cap.
+    const inFlight = getInFlightIssueIds();
     const blockers = selectBlockers(
       allIssues,
       teamRepoMap,
-      snapshot.inProgressCountsByScope,
+      countInProgressByTeam(snapshot.inProgress, (id) => inFlight.has(id)),
       (id) => dispatchedSet.has(id),
     );
     const teams = new Set(blockers.map((b) => b.teamKey));
@@ -432,9 +430,10 @@ async function handleListIssues(
       ...snapshot.readyForImplementation.map((i) => shapeIssue(i, "ready")),
       ...snapshot.needsPlanning.map((i) => shapeIssue(i, "needs-planning")),
     ].sort((a, b) => a.identifier.localeCompare(b.identifier));
+    const inFlight = getInFlightIssueIds();
     json(res, 200, {
       issues,
-      inProgressCountsByTeam: snapshot.inProgressCountsByScope,
+      inProgressCountsByTeam: countInProgressByTeam(snapshot.inProgress, (id) => inFlight.has(id)),
     });
   } catch (err) {
     json(res, 502, { error: err instanceof Error ? err.message : String(err) });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import { dispatchWorkflow, findWorkflowRunId, getWorkflowRunStatus, findPrForRun
 import { providerConfigFromEnv, ProviderRegistry } from "./providers/index.js";
 import type { TicketingProvider, IssueLifecycleState, FeatureNodeRollUp } from "./providers/types.js";
 import type { TicketIssue } from "./providers/types.js";
-import { selectIssuesToDispatch } from "./poll-selection.js";
+import { selectIssuesToDispatch, countInProgressByTeam } from "./poll-selection.js";
+import { resetStrandedIssues } from "./stranded-reset.js";
 import { notify, notifyCompletion } from "./notify.js";
 import { remediateStuckJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
@@ -222,13 +223,20 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
 
     const needsPlanning = snapshots.flatMap((s) => s.needsPlanning);
     const readyForImplementation = snapshots.flatMap((s) => s.readyForImplementation);
-    const inProgressCountsByScope = snapshots.reduce<Record<string, number>>((acc, s) => {
-      for (const [k, v] of Object.entries(s.inProgressCountsByScope)) {
-        acc[k] = (acc[k] ?? 0) + v;
-      }
-      return acc;
-    }, {});
-    const inProgressCountsByTeam = inProgressCountsByScope;
+
+    // Reset issues stranded in Planning/Implementing with no live job behind
+    // them (e.g. a run that died before its terminal callback), then gate the
+    // capacity count by the orchestrator's in-flight set so phantom slots don't
+    // block dispatch. Runs before selection so freed slots are usable this poll.
+    const inFlightIssueIds = getInFlightIssueIds();
+    await resetStrandedIssues(snapshots, providers, {
+      isLive: (id) => inFlightIssueIds.has(id),
+      isDispatched: (id) => isAlreadyDispatched(id),
+    });
+    const inProgressCountsByTeam = countInProgressByTeam(
+      snapshots.flatMap((s) => s.inProgress),
+      (id) => inFlightIssueIds.has(id),
+    );
     console.log(`[poll] Found ${needsPlanning.length} needing planning, ${readyForImplementation.length} ready for implementation`);
 
     // Build the dispatch view of mappings: hide paused ones so the poller
@@ -279,7 +287,8 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
     const allCandidates = [...readyForImplementation, ...needsPlanning];
     const needsPlanningIds = new Set(needsPlanning.map((i) => i.id));
 
-    const inFlightIssueIds = getInFlightIssueIds();
+    // Reuses inFlightIssueIds captured above — no dispatch happens in between,
+    // so the in-flight set is unchanged.
     const isDispatchBlocked = (issueId: string) =>
       isAlreadyDispatched(issueId) || inFlightIssueIds.has(issueId);
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -253,6 +253,11 @@ export function getInFlightJobs(): Job[] {
   );
 }
 
+/**
+ * Returns the issue IDs of every in-flight (dispatched/running) job. Used by the
+ * poll loop to tell which provider-reported in-progress issues actually have a
+ * live job behind them, versus ones stranded in that state with no run.
+ */
 export function getInFlightIssueIds(): Set<string> {
   const rows = getDb()
     .prepare(

--- a/src/poll-selection.ts
+++ b/src/poll-selection.ts
@@ -1,5 +1,29 @@
 import type { RepoMapping } from "./config.js";
-import type { TicketIssue } from "./providers/types.js";
+import type { InProgressIssue, TicketIssue } from "./providers/types.js";
+
+/**
+ * Collapse the provider-reported in-progress issues into a per-team count,
+ * keeping only those the orchestrator still has a live job for (`isLive`).
+ *
+ * The providers report a slot as occupied purely from ticket state (Jira
+ * Planning/Implementing status, Linear AI-Planning/AI-Working labels). A run
+ * that ends without a clean terminal transition strands the ticket in that
+ * state, where it would otherwise consume a concurrency slot forever. Gating by
+ * the orchestrator's in-flight set means only issues *both* sides agree are
+ * active count toward the cap — robust to a stale ticket (not live → dropped)
+ * and a stale local job (not in the ticket query → dropped).
+ */
+export function countInProgressByTeam(
+  inProgress: InProgressIssue[],
+  isLive: (issueId: string) => boolean,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const ip of inProgress) {
+    if (!isLive(ip.issueId)) continue;
+    counts[ip.scopeKey] = (counts[ip.scopeKey] ?? 0) + 1;
+  }
+  return counts;
+}
 
 export interface Blocker {
   issueId: string;

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -1,6 +1,7 @@
 import type {
   AIImplementSnapshot,
   FeatureNodeRollUp,
+  InProgressIssue,
   IssueLifecycleState,
   ProviderConfig,
   TicketIssue,
@@ -135,7 +136,7 @@ export class JiraProvider implements TicketingProvider {
 
     const needsPlanning: TicketIssue[] = [];
     const readyForImplementation: TicketIssue[] = [];
-    const inProgressCountsByScope: Record<string, number> = {};
+    const inProgress: InProgressIssue[] = [];
 
     for (const [scopeKey, m] of jiraEntries) {
       if (m.ticketingConfig.kind !== "jira") continue;
@@ -177,12 +178,23 @@ export class JiraProvider implements TicketingProvider {
         // else: orchestrator picked it up between query and our processing; skip.
       }
 
+      // Fetch the in-progress issues' IDs and status (not just a count) so the
+      // orchestrator can cross-check each against its live jobs and reset any
+      // that are stranded in Planning/Implementing with no run behind them.
       const capacityJql = `(${cfg.jql}) AND ${statusJqlField} in (Planning, Implementing)`;
-      const capacityIssues = await this.client.searchJql(capacityJql, ["summary"]);
-      inProgressCountsByScope[scopeKey] = capacityIssues.length;
+      const capacityIssues = await this.client.searchJql(capacityJql, [fieldIds.statusFieldId]);
+      for (const raw of capacityIssues) {
+        const statusValue =
+          (raw.fields[fieldIds.statusFieldId] as { value?: string } | null)?.value ?? "";
+        inProgress.push({
+          issueId: raw.id,
+          scopeKey,
+          phase: statusValue === STATUS_VALUES.PLANNING ? "planning" : "implementing",
+        });
+      }
     }
 
-    return { needsPlanning, readyForImplementation, inProgressCountsByScope };
+    return { needsPlanning, readyForImplementation, inProgress };
   }
 
   private toTicketIssue(

--- a/src/providers/linear.ts
+++ b/src/providers/linear.ts
@@ -247,16 +247,22 @@ export class LinearProvider implements TicketingProvider {
       }
     } while (cursor !== null);
 
-    const inProgressCountsByScope: Record<string, number> = {};
+    const inProgress: AIImplementSnapshot["inProgress"] = [];
     const needsPlanning: AIImplementSnapshot["needsPlanning"] = [];
     const readyForImplementation: AIImplementSnapshot["readyForImplementation"] = [];
 
     for (const issue of allNodes) {
       const labelNames = new Set(issue.labels?.nodes?.map((l) => l.name) ?? []);
 
-      // AI-Working or AI-Planning = slot is occupied; count against capacity
+      // AI-Working or AI-Planning = slot is occupied; count against capacity.
+      // Record the issue identity + phase so the orchestrator can detect a slot
+      // stranded with no live job behind it (AI-Planning → planning).
       if (labelNames.has("AI-Working") || labelNames.has("AI-Planning")) {
-        inProgressCountsByScope[issue.team.key] = (inProgressCountsByScope[issue.team.key] ?? 0) + 1;
+        inProgress.push({
+          issueId: issue.id,
+          scopeKey: issue.team.key,
+          phase: labelNames.has("AI-Working") ? "implementing" : "planning",
+        });
         continue;
       }
 
@@ -327,7 +333,7 @@ export class LinearProvider implements TicketingProvider {
       }
     }
 
-    return { needsPlanning, readyForImplementation, inProgressCountsByScope };
+    return { needsPlanning, readyForImplementation, inProgress };
   }
 
   async fetchFeatureNodeRollUps(): Promise<FeatureNodeRollUp[]> {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -34,10 +34,28 @@ export interface TicketIssue {
   featureBranchChain?: string[];
 }
 
+/**
+ * An issue the provider currently reports as occupying a capacity slot —
+ * i.e. in a "Planning" or "Implementing" state. The orchestrator cross-checks
+ * these against its own in-flight jobs: an entry with no live job is stranded
+ * (a run that ended without a clean terminal transition) and must neither count
+ * toward the concurrency cap nor sit in that state forever.
+ */
+export interface InProgressIssue {
+  issueId: string;
+  scopeKey: string;
+  phase: "planning" | "implementing";
+}
+
 export interface AIImplementSnapshot {
   needsPlanning: TicketIssue[];
   readyForImplementation: TicketIssue[];
-  inProgressCountsByScope: Record<string, number>;
+  /**
+   * Issues the provider sees as occupying a slot. The raw length is NOT the
+   * concurrency count — the orchestrator gates these by its in-flight jobs (see
+   * countInProgressByTeam) so stranded states don't permanently fill the cap.
+   */
+  inProgress: InProgressIssue[];
 }
 
 /**

--- a/src/stranded-reset.ts
+++ b/src/stranded-reset.ts
@@ -1,0 +1,58 @@
+import type { AIImplementSnapshot, TicketingProvider } from "./providers/types.js";
+
+export interface StrandedResetDeps {
+  /** True if the orchestrator has a live in-flight job for this issue. */
+  isLive: (issueId: string) => boolean;
+  /** True if the issue still has a (recent) dedup entry. */
+  isDispatched: (issueId: string) => boolean;
+}
+
+const STRANDED_REASON =
+  "Orchestrator has no active job for this run — it likely ended without reporting back. " +
+  "Resetting so the issue stops holding a concurrency slot; re-trigger if the work is incomplete.";
+
+/**
+ * Reset issues a provider reports as Planning/Implementing that the orchestrator
+ * has no record of running — neither a live in-flight job nor a dedup entry.
+ *
+ * These are runs that ended without a clean terminal transition (a failed
+ * status callback, a crashed/timed-out run, a lost machine). Left alone they sit
+ * in that state forever and the capacity query keeps counting them, permanently
+ * filling the concurrency cap. Marking them failed (matching the stuck phase)
+ * clears the slot and surfaces an explanatory comment for a human to re-trigger.
+ *
+ * The "no live job AND no dedup entry" gate cannot fire on a fresh dispatch:
+ * markDispatched() + the job row are written before the ticket is moved to
+ * Planning/Implementing, so an in-flight issue is always recorded on both sides.
+ * Best-effort and idempotent — once reset, the ticket drops out of the query.
+ *
+ * `snapshots[i]` must correspond to `providers[i]` so each issue is reset
+ * through the provider that reported it.
+ */
+export async function resetStrandedIssues(
+  snapshots: AIImplementSnapshot[],
+  providers: TicketingProvider[],
+  deps: StrandedResetDeps,
+): Promise<void> {
+  await Promise.all(
+    providers.map(async (provider, i) => {
+      const snapshot = snapshots[i];
+      if (!snapshot) return;
+      for (const ip of snapshot.inProgress) {
+        if (deps.isLive(ip.issueId) || deps.isDispatched(ip.issueId)) continue;
+        try {
+          if (ip.phase === "planning") {
+            await provider.markPlanningFailed(ip.issueId, STRANDED_REASON);
+          } else {
+            await provider.markImplementationFailed(ip.issueId, STRANDED_REASON);
+          }
+          console.warn(
+            `[reconcile] Reset stranded ${ip.phase} issue ${ip.issueId} (scope ${ip.scopeKey}): no live job`,
+          );
+        } catch (err) {
+          console.error(`[reconcile] Failed to reset stranded issue ${ip.issueId}:`, err);
+        }
+      }
+    }),
+  );
+}


### PR DESCRIPTION
## Problem

A run that ends without a clean terminal transition — a failed status callback, a crashed or timed-out run, a lost machine — leaves its ticket stuck in **Planning** or **Implementing**. The capacity query keeps counting that ticket, so a *phantom slot* fills the per-team concurrency cap forever and silently blocks new dispatches for that team.

The existing reaper and the stuck-job watchdog both act on a run the orchestrator already knows about (a job row / machine). Neither catches a ticket the orchestrator has **no record of at all** — exactly the case that strands a slot.

## What this does

A poll-time reconcile that cross-checks each provider-reported in-progress issue against the orchestrator's in-flight jobs:

- **`AIImplementSnapshot.inProgress: InProgressIssue[]`** replaces the opaque `inProgressCountsByScope` count. Each entry carries `{ issueId, scopeKey, phase }`, so the orchestrator can identify individual stranded issues rather than just a number. Both providers populate it (Jira status query, Linear label scan).
- **`resetStrandedIssues`** marks failed (matching the stuck phase) any in-progress issue with **neither** a live in-flight job **nor** a dedup entry, posting an explanatory comment so a human can re-trigger. The "no live job AND no dedup entry" gate cannot fire on a fresh dispatch (both are written before the ticket moves to Planning/Implementing), so it never races a just-started run. Best-effort and idempotent.
- **`countInProgressByTeam`** gates the capacity count by the in-flight set, so stranded slots stop counting toward the cap. Applied in both the poll loop and the admin blockers/issues endpoints.
- Reset runs **before** selection, so a freed slot is usable on the same poll.

This is complementary to the stuck-job watchdog: the watchdog cancels runs that take too long; this reclaims slots whose run is already gone.

## Tests

- New `stranded-reset.test.ts` (live job / dedup guards, planning vs implementing verb, mixed batch).
- New `countInProgressByTeam` cases in `poll-selection.test.ts`.
- Provider contract + Jira/Linear/fake/admin tests updated for the `inProgress` shape; admin test proves the count is gated by the in-flight set.

Full suite green (`npm run typecheck` + `npm test`).
