### PR TITLE
chore(bd-setup): wire linear-eudoxus tracker for AII team

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "mcpServers": {
+    "linear-eudoxus": { "type": "http", "url": "https://mcp.linear.app/mcp" },
+    "github": { "type": "http", "url": "https://api.githubcopilot.com/mcp/" }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,23 @@
 
 A Node.js service that polls Linear for issues labeled "AI-Implement" and dispatches GitHub Actions workflows that run Claude Code to implement them. It also provides an admin UI and manages workflow templates synced to target repos.
 
+## Issue tracker — Linear (BuildDown skills)
+
+Bindings for the BuildDown skills (bd-build-up, bd-build-down, bd-summit-push, etc.):
+
+- tracker.kind: linear
+- MCP server: `linear-eudoxus` (project `.mcp.json`; pre-approved in `.claude/settings.json`)
+- Workspace: `eudoxus` (bound at OAuth time)
+- Team: `AII`  ← issues filed/listed/searched against this team
+- Team URL: https://linear.app/eudoxus/team/AII/overview
+- GitHub repo (PRs land here): `BuildDownAI/AI-Implement`
+- Implement label: `AI-Implement` (orchestrator pickup trigger)
+- Agent mention (PR comment re-trigger): `/ai-implement`
+
+> Note: a separate global `claude.ai Linear` connector is authenticated to the **oolidata** workspace.
+> `linear-eudoxus` is a distinctly-named project server with its own token on **eudoxus**, so the two
+> never collide.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## What

Wires the BuildDown skills to this repo's own Linear tracker (workspace **eudoxus**, team **AII**) via a project-scoped MCP server.

- **`.mcp.json`** (new) — defines `linear-eudoxus` (`https://mcp.linear.app/mcp`) and `github` MCP servers. Endpoints only; OAuth tokens live in the local credential store, never in this file.
- **`CLAUDE.md`** — adds an *Issue tracker — Linear (BuildDown skills)* section binding tracker.kind, workspace `eudoxus`, team `AII`, repo, implement label `AI-Implement`, and the `/ai-implement` mention.

## Why

`linear-eudoxus` is a distinctly-named server with its own OAuth token on **eudoxus**, kept separate from the global `claude.ai Linear` connector (which is authenticated to the unrelated **oolidata** test-target workspace). This lets `AII-*` issues (e.g. AII-141) resolve without disturbing the oolidata connection.

Pre-approval already exists in `.claude/settings.json` (`enabledMcpjsonServers`), so a fresh clone trusts the server automatically.

## Notes

- `github` MCP currently fails to connect (needs its own auth) — intentionally left for a follow-up.
- A Claude Code session must reload after merge/pull to pick up the new `.mcp.json` server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)