### PR TITLE
[ai-implement] Feature branch ready for review — AII-189 (top-of-tree completion)

### DIFF
--- a/docs/feature-branch-grouping.md
+++ b/docs/feature-branch-grouping.md
@@ -125,10 +125,20 @@ dispatch so a parent's own work clones a branch that already contains its childr
   parent issue and mark it **Done on merge — before the parent's own work runs**. A plain
   merge commit gives Linear nothing to link, so the parent's lifecycle stays correct.
 - **Top of the tree** (no feature-node parent) → an open `feature → base` **PR for human
-  review**, never auto-merged.
+  review**, never auto-merged. **Completion is detected by the PR's *merged state***
+  (`findPullRequestByBranches` in `src/github.ts`), **not** by git ancestry — a **squash** or
+  **rebase** merge creates new commits on base, so the branch's own commits are never
+  ancestors and an ancestry check would misread the merge as "still unmerged" and re-open an
+  identical PR every poll (the AII-188 bug). When the top-of-tree PR is found **merged** (any
+  method — squash, rebase, or merge-commit), the orchestrator **deletes the feature branch**
+  (`deleteBranch`) and idempotently marks the node Done (`markMerged`, wired via
+  `MergeUpDeps.finalizeMerged`). An **open** PR is left alone; only when no PR exists is one
+  opened (gated on the branch being ahead).
 
-The step is idempotent (a branch already merged — 0 commits ahead — is skipped) and fails
-soft per roll-up. It scans only feature nodes completed in a recent window to stay cheap.
+The step is idempotent (a branch already merged — 0 commits ahead — is skipped; and once the
+top-of-tree branch is deleted, `compareBranches` returns null so the node is skipped forever)
+and fails soft per roll-up. It scans only feature nodes completed in a recent window to stay
+cheap.
 
 > ⚠️ **Auto-roll-up needs the runner callback.** A feature node only completes when its
 > closing-work PR merges and Linear marks it Done; the roll-up keys off that completed
@@ -150,7 +160,15 @@ soft per roll-up. It scans only feature nodes completed in a recent window to st
    into its own feature branch → human merges → orchestrator marks node Done.
 5. The **merge-up** rolls each completed feature node's branch up into its parent's branch
    (direct merge). The top node's branch is offered as a `feature → base` PR.
-6. A human reviews and merges that final PR. The whole tree lands on the base branch.
+6. A human reviews and merges that final PR **by any merge method** (squash, rebase, or
+   merge-commit). The orchestrator detects the merge from the PR's merged state, deletes the
+   feature branch, and keeps the node Done — it does **not** re-open the PR. The whole tree
+   lands on the base branch.
+
+> **Operator note (pre-deploy window):** until an orchestrator carrying this fix is deployed,
+> merge grouped top-of-tree PRs with `--delete-branch` (or a real merge commit), never
+> squash-and-leave — an un-fixed orchestrator re-opens the PR and flips the parent to In
+> Progress (AII-188).
 
 ---
 
@@ -162,8 +180,8 @@ soft per roll-up. It scans only feature nodes completed in a recent window to st
 | Shared types (`featureBranchChain`, `FeatureNodeRollUp`) | `src/providers/types.ts` |
 | Branch names | `src/pipeline/branch-name.ts` (`buildFeatureBranchName`) |
 | Cascade branch creation + PR-base resolution | `src/feature-branch.ts` (`resolveBaseBranch`) |
-| Roll-up (direct merge / human PR) | `src/merge-up.ts` (`runMergeUps`) |
-| GitHub helpers (branch/compare/merge/PR) | `src/github.ts` (`ensureBranchExists`, `compareBranches`, `mergeBranch`, `createPullRequest`, `findOpenPullRequest`) |
+| Roll-up (direct merge / human PR); top-of-tree merged-state completion + branch delete + finalize | `src/merge-up.ts` (`runMergeUps`) |
+| GitHub helpers (branch/compare/merge/PR; branch delete; merged-PR lookup) | `src/github.ts` (`ensureBranchExists`, `compareBranches`, `mergeBranch`, `createPullRequest`, `findOpenPullRequest`, `deleteBranch`, `findPullRequestByBranches`) |
 | Plan-Complete transition | `src/runner-callback.ts` → `markPlanComplete` |
 | Poll-loop wiring (roll-up before dispatch; base resolved per issue) | `src/index.ts` |
 

--- a/docs/plans/2026-07-01-aii-188-feature-node-completion-design.md
+++ b/docs/plans/2026-07-01-aii-188-feature-node-completion-design.md
@@ -1,0 +1,114 @@
+# Feature-node top-of-tree completion — Design Decisions
+
+> Bug fix for AII-188 (re-open of the top-of-tree PR after a human/squash merge),
+> grouped with AII-187 (multi-level roll-up verification) under one feature node.
+
+## Objective
+
+Make top-of-tree feature-node completion robust to **human merges via any merge
+method** (squash, rebase, merge-commit). Today the grouping decides "merged" by git
+ancestry (`compareBranches`), which a squash/rebase breaks, so the orchestrator
+re-opens an identical `feature → base` PR every poll and Linear flips the parent issue
+back to In Progress. Fix: detect completion via the **PR's merged state**, delete the
+feature branch, and reuse AII-166's `markMerged` to idempotently finalize the parent.
+
+## Scope
+
+**In v1:**
+- Detect the top-of-tree `feature → base` PR's **merged** state (not ancestry), covering
+  squash, rebase, and merge-commit.
+- On detection: **delete the feature branch** and **`markMerged(parentIssueId)`** (AII-166
+  verb — idempotent no-op if already Done), so the PR is never re-opened and the parent
+  stays Done.
+- Multi-level verification (AII-187): lock in that the internal roll-up (direct-merge,
+  no-PR) mitigation holds and that top-of-tree completion works at the top of a ≥2-level
+  tree.
+- Docs: update `docs/feature-branch-grouping.md` §5/§6 to describe merged-state completion.
+
+**Deferred (explicit follow-up, NOT in this build-up):**
+- **True no-native-integration self-finalize.** Because `fetchFeatureNodeRollUps` only
+  returns nodes already in `completed` state, our detection point only fires when Linear's
+  GitHub integration already marked the parent Done. Repos *without* that integration never
+  enter the roll-up set, so the grouping can't self-complete the top of the tree there. Truly
+  covering that needs detection independent of the completed-state (persist the top PR +
+  poll its merged state, à la AII-166's `detectMergedPrs`). Filed as a separate issue; the
+  repos that actually hit AII-188 all have native integration.
+
+**Out of scope:**
+- Internal roll-up mechanics (direct merge, no PR) — unchanged; only *verified* (AII-187).
+- Jira grouping (Linear-only feature).
+- AII-152's broader grouping work (Cameron, In Progress) — coordinate, don't absorb.
+
+## Decisions
+
+- **Detection mechanism:** In `merge-up.ts` `rollUpOne`, top-of-tree path, replace the
+  ancestry-only gate with a **PR lookup by (head, base) across all states**. New/generalized
+  GitHub helper returns `{ number, state, merged }`. Branch by result:
+  - **merged** → `deleteBranch(feature)` + `finalizeMerged(parentIssueId)` (→ `markMerged`),
+    then return. Fixes all three merge methods.
+  - **open** → return (awaiting human review).
+  - **none / closed-unmerged** → if `compareBranches` ahead > 0, `createPullRequest`
+    (unchanged behavior).
+- **Reuse AII-166:** `finalizeMerged` is wired in `index.ts` to the Linear provider's
+  `markMerged(issueId)` — idempotent (no-op on completed/canceled), drops `Ready for Review`.
+  No new "move to Done" logic.
+- **Carry the UUID:** `FeatureNodeRollUp` gains `issueId` (the Linear UUID) so `markMerged`
+  can be called without a second lookup. `fetchFeatureNodeRollUps` selects `id`.
+- **New GitHub helpers:** `deleteBranch(token, owner, repo, branch)` (DELETE ref; **404 =
+  already gone = success**, idempotent) and a merged-aware PR finder
+  (`findPullRequestByBranches`, or generalize `findOpenPullRequest` to `state=all`).
+- **Ordering:** detection runs inside the existing merge-up step (already runs each poll
+  before dispatch), so no new poll wiring. Branch deletion makes it durably idempotent:
+  once deleted, `compareBranches` returns null and the node is skipped forever.
+- **Grouping structure (dogfood):** a new **parent feature node** owns
+  `ai-implement/feature/<parent-key>`; **AII-188** (the fix) and **AII-187** (verification)
+  are its labelled children. Parent's own closing work = the docs update, `Blocked by` both
+  children. Running this tree through the pipeline exercises the fixed top-of-tree path.
+
+- **Trust boundaries:** none new. All calls are orchestrator→GitHub App (already
+  authenticated) and orchestrator→Linear (already authenticated). `deleteBranch` only ever
+  targets an `ai-implement/feature/*` branch the orchestrator owns.
+- **Failure modes:**
+  - PR finder returns null / API error → fall through to existing behavior (fail-open, as
+    grouping already does).
+  - `deleteBranch` 404 → treat as success (branch already gone).
+  - `deleteBranch` other error → log, do **not** re-open (avoid the bug); markMerged still
+    runs. Next poll retries deletion.
+  - `markMerged` throws (e.g. no completed state) → logged, per-rollup soft-fail; branch
+    already deleted so no re-open.
+- **Rollout:** pure code; no migration/flag. Takes effect when the testing orchestrator
+  redeploys off `testing`. Operator workaround until deployed (from the issue): merge grouped
+  top-of-tree PRs with `--delete-branch` or a real merge commit.
+- **Testing:** unit tests via the existing `vi.mock("../github.js")` seam in
+  `merge-up.test.ts`: merged→delete+markMerged (squash/rebase/merge-commit), open→no-op,
+  unmerged→create, deleteBranch-404 tolerance, idempotent second poll. AII-187 adds
+  multi-level assertions.
+- **Observability:** existing `[merge-up]` console logs; add explicit lines for
+  "detected merged top PR → deleted branch + finalized" and "deleteBranch failed".
+
+## Overlap & Reconciliation
+
+- **AII-166** "Mark issue done on PR merge" — **Dependency (shipped, merged to `testing`
+  via PR #89).** Action: **reuse** `markMerged` + the merged-state checking style. Already
+  merged into this branch. No duplication.
+- **AII-152** "Feature-branch support + auto-merge" (Cameron, In Progress) — **Adjacent.**
+  GitHub scan (2026-07-01): **no open PR/branch touches `merge-up.ts` or grouping yet**, so
+  no immediate collision. Action: **flag for coordination** — John to sync with Cameron
+  before the tree is labelled `AI-Implement`; sequence AII-188 vs AII-152 to avoid a
+  `merge-up.ts` / `linear.ts` conflict. Not blocked in the tracker pending that conversation.
+- **AII-187** "Verify merge-up false-Done holds for multi-level trees" — **Adjacent →
+  absorbed as a sibling child.** Action: reparent under the new feature node alongside
+  AII-188; do both in one feature branch (per operator decision).
+- **AII-134** "Auto-Merge into feature branches" — **Stale / superseded** by the shipped
+  grouping + AII-152. Action: **ignore** for this build-up (not this bug's job; not touched).
+
+## Open Questions
+
+- **Parent-node own work:** default = the docs update is the parent's closing work
+  (`Blocked by` both children). If preferred, the docs can instead ride on the AII-188 child
+  and the parent carries no own work (pure container). Default: docs = parent closing work.
+- **AII-188 code split:** default = one deep-and-targeted child issue (helpers + merge-up
+  detection + tests are tightly coupled and small). Alternative: split helpers (github.ts)
+  from the merge-up consumer. Default: single issue.
+- **Deferred no-integration follow-up:** file now (Backlog) or hold? Default: file a Backlog
+  issue so it isn't lost.

--- a/docs/plans/2026-07-01-aii-188-feature-node-completion-plan.md
+++ b/docs/plans/2026-07-01-aii-188-feature-node-completion-plan.md
@@ -1,0 +1,593 @@
+# Feature-node top-of-tree completion — Implementation Plan
+
+> **For AI-Implement:** Each task below maps to a tracker issue. Steps use checkbox syntax.
+> The pipeline picks up each issue independently — task descriptions are self-contained.
+
+**Goal:** Make top-of-tree feature-node completion detect the `feature → base` PR's **merged
+state** (not git ancestry), delete the feature branch, and idempotently finalize the parent —
+so a human squash/rebase/merge-commit merge never re-opens the PR or flips the parent to In
+Progress.
+
+**Architecture:** Two new `github.ts` helpers (`deleteBranch`, `findPullRequestByBranches`)
+feed a reworked top-of-tree branch in `merge-up.ts` `rollUpOne`; on a merged top PR it deletes
+the branch and calls `finalizeMerged` (wired in `index.ts` to the Linear provider's `markMerged`
+from AII-166). `FeatureNodeRollUp` carries the parent's Linear UUID so no extra lookup is needed.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Node, Vitest. REST for GitHub,
+GraphQL for Linear.
+
+**Tracker Container:** AII-189 (feature node) — children AII-188 (this fix), AII-187
+(verification); parent closing work = docs (Task 3).
+
+**Grouping:** parent AII-189 owns `ai-implement/feature/aii-189`; AII-188 + AII-187 PR into it;
+Task 3 (docs) is AII-189's deferred closing work, `Blocked by` both children.
+
+---
+
+## Task 1 — AII-188: Merged-state top-of-tree completion (the fix)
+
+**Shape:** deep-and-targeted (the reasoning is concentrated in `merge-up.ts`; the rest is
+mechanical plumbing that exists only to serve it, so it lands as one coherent change).
+**Migration / backfill?** no
+
+**Files:**
+- Modify: `src/github.ts` — add `deleteBranch`, `findPullRequestByBranches` (after
+  `findOpenPullRequest`, ~`:406`)
+- Modify: `src/providers/types.ts` — add `issueId` to `FeatureNodeRollUp` (`:48-60`)
+- Modify: `src/providers/linear.ts` — select `id` in `fetchFeatureNodeRollUps` and set
+  `issueId` (`:333-386`)
+- Modify: `src/merge-up.ts` — add `finalizeMerged` to `MergeUpDeps`; rework the top-of-tree
+  branch of `rollUpOne`
+- Modify: `src/index.ts` — call `runMergeUps` per-provider, wiring
+  `finalizeMerged: (id) => provider.markMerged(id)` (`:255-273`)
+- Test: `src/__tests__/github.test.ts` — `deleteBranch` + `findPullRequestByBranches`
+- Test: `src/__tests__/merge-up.test.ts` — merged/open/unmerged top-of-tree cases
+
+**Parallel-safe with:** none in this tree (AII-187 is `Blocked by` this; Task 3 is `Blocked by`
+this). External: AII-152 touches the same files — coordinate before labelling (see Notes).
+**Blocked by:** none.
+
+**Rubric:**
+- Pattern anchor: `src/github.ts` `compareBranches`/`findOpenPullRequest` (same `fetch` +
+  `ghHeaders` + `GitHubApiError` style); `src/merge-up.ts` `rollUpOne` itself.
+- Test fixture: `src/__tests__/merge-up.test.ts` (`vi.mock("../github.js")`) and
+  `src/__tests__/github.test.ts` (`vi.stubGlobal("fetch", …)`).
+- Trust boundary: none new — orchestrator→GitHub App (authenticated). `deleteBranch` only ever
+  targets orchestrator-owned `ai-implement/feature/*` branches.
+- Rollback path: mechanical, no flag; revert PR. Operator workaround until deployed: merge
+  grouped top-of-tree PRs with `--delete-branch`.
+- Observability: `[merge-up]` logs — "Top-of-tree PR #N … merged; deleted … + finalized";
+  `[github] deleteBranch(...) failed`.
+- Parallel-safety verified: within the tree, no peer edits these files concurrently
+  (AII-187 uses a *separate* test file and is `Blocked by` this).
+
+- [ ] **Step 1: Write failing helper tests** (`src/__tests__/github.test.ts`)
+
+Append (the file already `vi.stubGlobal("fetch", …)`; add these `describe`s):
+
+```ts
+import { deleteBranch, findPullRequestByBranches } from "../github.js";
+
+describe("deleteBranch", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("returns true on 204 (deleted)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 204, ok: true })));
+    expect(await deleteBranch("t", "o", "r", "ai-implement/feature/aii-1")).toBe(true);
+  });
+  it("returns true on 404 (already gone — idempotent)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 404, ok: false, text: async () => "" })));
+    expect(await deleteBranch("t", "o", "r", "ai-implement/feature/aii-1")).toBe(true);
+  });
+  it("returns false on other errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 403, ok: false, text: async () => "no" })));
+    expect(await deleteBranch("t", "o", "r", "ai-implement/feature/aii-1")).toBe(false);
+  });
+});
+
+describe("findPullRequestByBranches", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("reports a merged PR", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [{ number: 5, html_url: "u", state: "closed", merged_at: "2026-07-01T00:00:00Z" }],
+    })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base"))
+      .toEqual({ number: 5, url: "u", state: "closed", merged: true });
+  });
+  it("prefers a merged PR when several exist for the pair", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { number: 9, html_url: "u9", state: "open", merged_at: null },
+        { number: 5, html_url: "u5", state: "closed", merged_at: "2026-07-01T00:00:00Z" },
+      ],
+    })));
+    expect((await findPullRequestByBranches("t", "o", "r", "feat", "base"))?.number).toBe(5);
+  });
+  it("reports an open unmerged PR", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [{ number: 7, html_url: "u", state: "open", merged_at: null }],
+    })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base"))
+      .toEqual({ number: 7, url: "u", state: "open", merged: false });
+  });
+  it("returns null when no PR exists", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => [] })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base")).toBeNull();
+  });
+  it("returns null on a non-OK response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500 })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail** — `npx vitest run src/__tests__/github.test.ts`
+  → FAIL (`deleteBranch`/`findPullRequestByBranches` not exported).
+
+- [ ] **Step 3: Implement the helpers** (`src/github.ts`, after `findOpenPullRequest`)
+
+```ts
+/**
+ * Deletes a git ref (branch). Idempotent: 204 (deleted) and 404 (already gone) both return
+ * true. Only ever called on orchestrator-owned `ai-implement/feature/*` branches.
+ */
+export async function deleteBranch(
+  token: string,
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<boolean> {
+  const enc = branch.split("/").map(encodeURIComponent).join("/");
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${enc}`,
+    { method: "DELETE", headers: ghHeaders(token) },
+  );
+  if (res.status === 204 || res.status === 404) return true;
+  const body = await res.text().catch(() => "");
+  console.error(`[github] deleteBranch(${branch}) failed: HTTP ${res.status}: ${body}`);
+  return false;
+}
+
+/**
+ * Finds the PR for the given head→base pair in ANY state, reporting whether it merged.
+ * GitHub's pulls list returns `merged_at` (null unless merged). Prefers a merged PR when
+ * several exist for the pair (e.g. a prior buggy re-open). Returns null when none exists
+ * or on a non-OK response (callers fall back to existing behavior).
+ */
+export async function findPullRequestByBranches(
+  token: string,
+  owner: string,
+  repo: string,
+  head: string,
+  base: string,
+): Promise<{ number: number; url: string; state: "open" | "closed"; merged: boolean } | null> {
+  const url =
+    `https://api.github.com/repos/${owner}/${repo}/pulls` +
+    `?head=${encodeURIComponent(`${owner}:${head}`)}&base=${encodeURIComponent(base)}` +
+    `&state=all&sort=updated&direction=desc&per_page=10`;
+  const res = await fetch(url, { headers: ghHeaders(token) });
+  if (!res.ok) return null;
+  const prs = (await res.json()) as Array<{
+    number: number; html_url: string; state: string; merged_at: string | null;
+  }>;
+  if (prs.length === 0) return null;
+  const chosen = prs.find((p) => p.merged_at !== null) ?? prs[0];
+  return {
+    number: chosen.number,
+    url: chosen.html_url,
+    state: chosen.state === "open" ? "open" : "closed",
+    merged: chosen.merged_at !== null,
+  };
+}
+```
+
+- [ ] **Step 4: Run helper tests** — `npx vitest run src/__tests__/github.test.ts` → PASS.
+
+- [ ] **Step 5: Carry the parent UUID** (`src/providers/types.ts`, in `FeatureNodeRollUp`)
+
+```ts
+  /** The feature node's Linear issue UUID — used to finalize (markMerged) without a
+   *  second lookup when its top-of-tree PR merges. */
+  issueId: string;
+```
+
+And in `src/providers/linear.ts` `fetchFeatureNodeRollUps`: add `id` to the node selection
+and set it. Change the query's `nodes { identifier …` to `nodes { id identifier …` (add `id`
+to the typed shape too), then:
+
+```ts
+      rollUps.push({
+        identifier: node.identifier,
+        issueId: node.id,
+        scopeKey: node.team.key,
+        parentIdentifier: parentIsFeatureNode ? node.parent!.identifier : null,
+      });
+```
+
+(Update the local generic type `nodes: Array<{ identifier: string; … }>` to include
+`id: string;`.)
+
+- [ ] **Step 6: Rework `merge-up.ts`** — add the dep + import, restructure `rollUpOne`
+
+Imports (extend the existing `./github.js` import):
+
+```ts
+import { compareBranches, createPullRequest, deleteBranch, findPullRequestByBranches, mergeBranch } from "./github.js";
+```
+
+`MergeUpDeps`:
+
+```ts
+export interface MergeUpDeps {
+  githubAppId: string;
+  githubAppPrivateKey: string;
+  resolveMapping: (scopeKey: string) => RepoMapping | null;
+  /** Finalize a feature node whose top-of-tree PR merged: idempotently mark its issue Done
+   *  (drops Ready for Review). Wired to the Linear provider's markMerged (AII-166). */
+  finalizeMerged: (issueId: string) => Promise<void>;
+}
+```
+
+Replace `rollUpOne`'s body from the `compareBranches` line onward with:
+
+```ts
+  const branch = buildFeatureBranchName(rollUp.identifier);
+  const target = rollUp.parentIdentifier
+    ? buildFeatureBranchName(rollUp.parentIdentifier)
+    : mapping.defaultBranch;
+
+  if (rollUp.parentIdentifier !== null) {
+    // Internal roll-up → direct merge, no PR (ancestry-gated; unchanged).
+    const ahead = await compareBranches(ghToken, owner, repo, target, branch);
+    if (ahead === null || ahead === 0) return; // branch missing, or already fully merged
+    const result = await mergeBranch(
+      ghToken,
+      owner,
+      repo,
+      target,
+      branch,
+      "[ai-implement] Automated feature-branch roll-up",
+    );
+    if (result === "conflict") {
+      console.warn(
+        `[merge-up] Conflict rolling up ${branch} → ${target} (${rollUp.identifier}) — needs a manual merge`,
+      );
+    } else if (result === "merged") {
+      console.log(`[merge-up] Rolled up ${branch} → ${target} (${rollUp.identifier})`);
+    }
+    return;
+  }
+
+  // Top of the tree. Detect completion by the feature → base PR's MERGED state (robust to
+  // squash/rebase/merge-commit — git ancestry alone misreads squash/rebase as "unmerged").
+  const pr = await findPullRequestByBranches(ghToken, owner, repo, branch, target);
+  if (pr?.merged) {
+    await deleteBranch(ghToken, owner, repo, branch);
+    await deps.finalizeMerged(rollUp.issueId);
+    console.log(
+      `[merge-up] Top-of-tree PR #${pr.number} for ${rollUp.identifier} merged; deleted ${branch} + finalized`,
+    );
+    return;
+  }
+  if (pr?.state === "open") return; // awaiting human review
+
+  // No PR yet (or a closed-unmerged one) — open it only if the branch has commits to offer.
+  const ahead = await compareBranches(ghToken, owner, repo, target, branch);
+  if (ahead === null || ahead === 0) return;
+  const created = await createPullRequest(ghToken, owner, repo, {
+    head: branch,
+    base: target,
+    title: "[ai-implement] Feature branch ready for review",
+    body:
+      "Automated feature-branch grouping: this feature branch's work is complete and ready " +
+      "to merge into the base branch. Opened for human review.",
+  });
+  console.log(`[merge-up] Opened feature→base PR ${created.url} for ${rollUp.identifier} (awaiting human merge)`);
+```
+
+(Remove the now-unused `findOpenPullRequest` import if the compiler flags it.)
+
+- [ ] **Step 7: Wire `finalizeMerged` per-provider** (`src/index.ts`, ~`:255-273`)
+
+Replace the flatten-then-single-`runMergeUps` block with a per-provider loop so
+`finalizeMerged` binds to the provider that produced the roll-ups:
+
+```ts
+    if (providers.length > 0) {
+      for (const provider of providers) {
+        try {
+          const rollUps = await provider
+            .fetchFeatureNodeRollUps()
+            .catch((err) => {
+              console.error("[merge-up] Provider fetchFeatureNodeRollUps failed:", err);
+              return [] as FeatureNodeRollUp[];
+            });
+          if (rollUps.length > 0) {
+            await runMergeUps(rollUps, {
+              githubAppId: config.githubAppId,
+              githubAppPrivateKey: config.githubAppPrivateKey,
+              resolveMapping: (scopeKey) => teamRepoMap[scopeKey] ?? null,
+              finalizeMerged: (issueId) => provider.markMerged(issueId),
+            });
+          }
+        } catch (err) {
+          console.error("[merge-up] roll-up step failed:", err);
+        }
+      }
+    }
+```
+
+- [ ] **Step 8: Merge-up behavior tests** (`src/__tests__/merge-up.test.ts`)
+
+Extend the `vi.mock("../github.js")` factory with `deleteBranch` + `findPullRequestByBranches`,
+add `finalizeMerged: vi.fn()` to the `deps` helper, and add:
+
+```ts
+// in vi.mock("../github.js") factory:
+//   deleteBranch: vi.fn(async () => true),
+//   findPullRequestByBranches: vi.fn(async () => null),
+import { deleteBranch, findPullRequestByBranches } from "../github.js";
+
+const depsF = (resolve: (k: string) => RepoMapping | null, finalizeMerged = vi.fn(async () => {})) => ({
+  githubAppId: "1", githubAppPrivateKey: "k", resolveMapping: resolve, finalizeMerged,
+});
+
+describe("runMergeUps — top-of-tree merged-state completion", () => {
+  const topRollUp = () => rollUp({ identifier: "OOL-106", issueId: "uuid-106", parentIdentifier: null });
+
+  it("deletes the branch and finalizes when the top PR merged (squash/rebase/merge-commit)", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 8, url: "u", state: "closed", merged: true });
+    const finalizeMerged = vi.fn(async () => {});
+    await runMergeUps([topRollUp()], depsF(() => mapping(), finalizeMerged));
+    expect(vi.mocked(deleteBranch)).toHaveBeenCalledWith("tok", "jodwyer", "alpacaWheel", "ai-implement/feature/ool-106");
+    expect(finalizeMerged).toHaveBeenCalledWith("uuid-106");
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the top PR is still open", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 8, url: "u", state: "open", merged: false });
+    await runMergeUps([topRollUp()], depsF(() => mapping()));
+    expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+  });
+
+  it("opens the PR when none exists and the branch is ahead", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+    vi.mocked(compareBranches).mockResolvedValue(3);
+    await runMergeUps([topRollUp()], depsF(() => mapping()));
+    expect(vi.mocked(createPullRequest)).toHaveBeenCalled();
+  });
+
+  it("is idempotent: once the branch is gone, compareBranches null → no re-open", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+    vi.mocked(compareBranches).mockResolvedValue(null); // branch deleted
+    await runMergeUps([topRollUp()], depsF(() => mapping()));
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+  });
+});
+```
+
+(Add `deleteBranch`/`findPullRequestByBranches` resets to the existing `beforeEach`:
+`vi.mocked(findPullRequestByBranches).mockResolvedValue(null); vi.mocked(deleteBranch).mockResolvedValue(true);`)
+
+- [ ] **Step 9: Full suite + typecheck** — `npm run typecheck && npm test` → PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/github.ts src/merge-up.ts src/providers/types.ts src/providers/linear.ts src/index.ts src/__tests__/github.test.ts src/__tests__/merge-up.test.ts
+git commit -m "fix(merge-up): finalize top-of-tree by PR merged-state, delete branch (AII-188)"
+```
+
+## Acceptance Criteria (AII-188)
+- [ ] A merged top-of-tree `feature → base` PR (squash, rebase, **and** merge-commit) causes
+      the branch to be deleted and `finalizeMerged` (markMerged) called — no new PR opened.
+- [ ] An open top-of-tree PR is left untouched (awaiting human review).
+- [ ] With no PR and the branch ahead, the PR is opened as before.
+- [ ] Once the branch is deleted, subsequent polls do not re-open a PR.
+- [ ] `npm test` + `tsc --noEmit` pass.
+
+---
+
+## Task 2 — AII-187: Automated multi-level roll-up tests
+
+**Shape:** deep-and-targeted (test logic).
+**Migration / backfill?** no
+
+**Files:**
+- Create: `src/__tests__/merge-up-multilevel.test.ts` (sibling to
+  `src/__tests__/merge-up.test.ts` — same `vi.mock("../github.js")` harness)
+
+**Parallel-safe with:** Task 3 (different files).
+**Blocked by:** AII-188 (asserts the post-fix top-of-tree behavior; uses a *separate* test
+file to avoid colliding with AII-188's edits to `merge-up.test.ts`).
+
+**Rubric:**
+- Pattern anchor: `src/__tests__/merge-up.test.ts` (copy its mock factory + `mapping`/`rollUp`
+  helpers verbatim into the new file).
+- Test fixture: same file.
+- Trust boundary: none.
+- Rollback path: test-only.
+- Observability: n/a.
+- Parallel-safety verified: new dedicated file; no shared edits.
+
+- [ ] **Step 1: Create the multi-level test file** — copy the mock factory and helpers from
+  `merge-up.test.ts`, then assert the multi-level contract:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runMergeUps } from "../merge-up.js";
+import type { RepoMapping } from "../config.js";
+import type { FeatureNodeRollUp } from "../providers/types.js";
+
+vi.mock("../github-app-auth.js", () => ({ getInstallationToken: vi.fn(async () => "tok") }));
+vi.mock("../github.js", () => ({
+  compareBranches: vi.fn(async () => 2),
+  createPullRequest: vi.fn(async () => ({ number: 7, url: "u" })),
+  mergeBranch: vi.fn(async () => "merged"),
+  deleteBranch: vi.fn(async () => true),
+  findPullRequestByBranches: vi.fn(async () => null),
+}));
+import { compareBranches, createPullRequest, mergeBranch, findPullRequestByBranches } from "../github.js";
+
+function mapping(o: Partial<RepoMapping> = {}): RepoMapping {
+  return { owner: "jodwyer", repo: "alpacaWheel", workflowFile: "claude-implement.yml",
+    defaultBranch: "testing", maxInProgressAiIssues: 3, executionMode: "github-actions",
+    sessionMode: "autonomous", machineCpus: 2, machineMemoryMb: 4096, planningEnabled: false,
+    planningWorkflowFile: "", autoApprovePlans: true, extraEnv: {}, provider: "anthropic",
+    ticketingProvider: "linear", ticketingConfig: { kind: "linear" }, awsRegion: null, paused: false, ...o };
+}
+const deps = (finalizeMerged = vi.fn(async () => {})) => ({
+  githubAppId: "1", githubAppPrivateKey: "k", resolveMapping: () => mapping(), finalizeMerged });
+const node = (o: Partial<FeatureNodeRollUp>): FeatureNodeRollUp =>
+  ({ identifier: "OOL-107", issueId: "u-107", scopeKey: "OOL", parentIdentifier: "OOL-106", ...o });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(compareBranches).mockResolvedValue(2);
+  vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+});
+
+describe("multi-level roll-up (AII-187)", () => {
+  it("internal roll-up uses a direct git merge, never a PR", async () => {
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps());
+    expect(vi.mocked(mergeBranch)).toHaveBeenCalledWith(
+      "tok", "jodwyer", "alpacaWheel",
+      "ai-implement/feature/ool-106", "ai-implement/feature/ool-107", expect.any(String));
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+  });
+
+  it("the internal roll-up commit carries no issue identifier (no Linear false-Done link)", async () => {
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps());
+    const msg = vi.mocked(mergeBranch).mock.calls[0][5];
+    expect(msg).not.toMatch(/OOL-10[67]/);
+  });
+
+  it("does NOT finalize (markMerged) an internal node — only the top of the tree finalizes", async () => {
+    const finalizeMerged = vi.fn(async () => {});
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps(finalizeMerged));
+    expect(finalizeMerged).not.toHaveBeenCalled();
+  });
+
+  it("only the top-of-tree (parentIdentifier null) opens a feature→base PR", async () => {
+    await runMergeUps([node({ identifier: "OOL-106", parentIdentifier: null })], deps());
+    expect(vi.mocked(createPullRequest)).toHaveBeenCalledWith(
+      "tok", "jodwyer", "alpacaWheel",
+      expect.objectContaining({ base: "testing", head: "ai-implement/feature/ool-106" }));
+  });
+
+  it("a two-level tree in one pass: internal merges + top opens exactly one PR", async () => {
+    await runMergeUps([
+      node({ identifier: "OOL-107", parentIdentifier: "OOL-106" }), // internal
+      node({ identifier: "OOL-106", parentIdentifier: null }),      // top
+    ], deps());
+    expect(vi.mocked(mergeBranch)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createPullRequest)).toHaveBeenCalledTimes(1);
+  });
+
+  it("internal roll-up skips when the branch is already merged (0 ahead) — idempotent", async () => {
+    vi.mocked(compareBranches).mockResolvedValue(0);
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps());
+    expect(vi.mocked(mergeBranch)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an internal conflict without throwing", async () => {
+    vi.mocked(mergeBranch).mockResolvedValue("conflict");
+    await expect(runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps()))
+      .resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run** — `npx vitest run src/__tests__/merge-up-multilevel.test.ts` → PASS
+  (behavior already implemented by AII-188 + the pre-existing internal roll-up).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/merge-up-multilevel.test.ts
+git commit -m "test(merge-up): lock in multi-level roll-up + no-false-Done contract (AII-187)"
+```
+
+## Acceptance Criteria (AII-187)
+- [ ] Internal roll-ups assert direct git merge (no PR) with an identifier-free commit message.
+- [ ] Internal nodes are not finalized; only the top of the tree opens a PR / finalizes.
+- [ ] Idempotency (0 ahead → skip) and the conflict path are covered.
+- [ ] `npm test` + `tsc --noEmit` pass.
+
+## Notes (AII-187)
+The live-sandbox verification in the original AII-187 body (build a real 2+ level tree, run
+the orchestrator) remains a **manual operator step** post-merge — it can't be a pipeline PR.
+This child codifies the *automatable* part. The manual run is captured in Task 3's notes.
+
+---
+
+## Task 3 — AII-189 closing work: Docs for merged-state completion
+
+**Shape:** wide-and-shallow (docs only).
+**Migration / backfill?** no
+
+**Files:**
+- Modify: `docs/feature-branch-grouping.md` — §5 (Roll-up) and §6 (lifecycle step 6) to
+  describe merged-state top-of-tree completion + branch deletion + finalize; §7 table row for
+  `deleteBranch`/`findPullRequestByBranches`.
+
+**Parallel-safe with:** Task 2 (different files).
+**Blocked by:** AII-188 **and** AII-187 (parent closing work defers until both children are
+terminal — feature-node grouping rule).
+
+**Rubric:**
+- Pattern anchor: `docs/feature-branch-grouping.md` existing §5/§6/§7 prose + table style.
+- Test fixture: n/a (docs).
+- Trust boundary: none.
+- Rollback path: revert.
+- Observability: n/a.
+- Parallel-safety verified: only doc file; no overlap.
+
+- [ ] **Step 1: Update §5 (Roll-up).** Replace the "top of the tree → open a PR … never
+  auto-merged" bullet's completion description: the top-of-tree node completes when its
+  `feature → base` PR **merges** (any method — squash/rebase/merge-commit), detected via the
+  PR's merged state (`findPullRequestByBranches`), on which the orchestrator **deletes the
+  feature branch** and idempotently marks the node Done (`markMerged`). Note this replaces the
+  old git-ancestry heuristic that misread squash/rebase merges and re-opened the PR (AII-188).
+
+- [ ] **Step 2: Update §6 step 6** to state that a human merge of the final PR — by any merge
+  method — finalizes the tree (branch deleted, node stays Done, no re-open).
+
+- [ ] **Step 3: Update the §7 table** — add `deleteBranch` / `findPullRequestByBranches`
+  (`src/github.ts`) and note `merge-up.ts` now detects top-of-tree completion by PR merged
+  state. Add an operational note: until the fix is deployed to the running orchestrator, merge
+  grouped top-of-tree PRs with `--delete-branch`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/feature-branch-grouping.md
+git commit -m "docs: merged-state top-of-tree completion + branch deletion (AII-189)"
+```
+
+## Acceptance Criteria (AII-189 closing work)
+- [ ] §5/§6/§7 describe merged-state completion, branch deletion, and markMerged finalize.
+- [ ] The ancestry-heuristic description is removed/replaced.
+- [ ] Operator workaround noted for the pre-deploy window.
+
+---
+
+## Self-Review Notes
+
+- **Decision coverage:** design doc → Task 1 (detection/delete/finalize + helpers + UUID +
+  wiring), Task 2 (multi-level verification), Task 3 (docs). Deferred no-integration follow-up
+  is out of this tree (separate Backlog issue).
+- **Naming consistency:** `findPullRequestByBranches`, `deleteBranch`, `finalizeMerged`,
+  `FeatureNodeRollUp.issueId` used identically across Task 1 code + Task 1/2 tests.
+- **Shape check:** Task 1 concentrates reasoning in `merge-up.ts` (deep) with mechanical
+  plumbing; Task 2 is isolated test logic; Task 3 is docs. No task is wide-and-deep.
+- **Parallel-safety:** AII-187 uses a *new* test file and is `Blocked by` AII-188; Task 3 is
+  `Blocked by` both. No two concurrently-runnable tasks share a file.
+- **External overlap (AII-152):** same files (`merge-up.ts`, `linear.ts`); no GitHub code yet.
+  Coordinate before labelling the tree `AI-Implement`.
+- **Bootstrapping wrinkle:** the AII-189 tree's own top-of-tree PR is merged by a human while
+  the *running* orchestrator may not yet have this fix — merge it with `--delete-branch` until
+  the fix deploys.

--- a/docs/plans/2026-07-01-aii-188-feature-node-completion-plan.md
+++ b/docs/plans/2026-07-01-aii-188-feature-node-completion-plan.md
@@ -321,56 +321,83 @@ Replace the flatten-then-single-`runMergeUps` block with a per-provider loop so
 
 - [ ] **Step 8: Merge-up behavior tests** (`src/__tests__/merge-up.test.ts`)
 
-Extend the `vi.mock("../github.js")` factory with `deleteBranch` + `findPullRequestByBranches`,
-add `finalizeMerged: vi.fn()` to the `deps` helper, and add:
+> **The rework REMOVES `findOpenPullRequest` from the top-of-tree path**, so the existing test
+> harness must be migrated, not just extended — otherwise the existing "does not re-open …"
+> test throws (the symbol is gone) and CI goes red. This is validated: all changes below make
+> `npm test` pass (1518 tests).
+
+**8a. Update the `vi.mock("../github.js")` factory** — drop `findOpenPullRequest`, add the two new helpers:
 
 ```ts
-// in vi.mock("../github.js") factory:
-//   deleteBranch: vi.fn(async () => true),
-//   findPullRequestByBranches: vi.fn(async () => null),
-import { deleteBranch, findPullRequestByBranches } from "../github.js";
+vi.mock("../github.js", () => ({
+  compareBranches: vi.fn(),
+  createPullRequest: vi.fn(async () => ({ number: 7, url: "https://gh/pr/7" })),
+  mergeBranch: vi.fn(async () => "merged"),
+  deleteBranch: vi.fn(async () => true),
+  findPullRequestByBranches: vi.fn(async () => null),
+}));
+import { compareBranches, createPullRequest, mergeBranch, deleteBranch, findPullRequestByBranches } from "../github.js";
+```
 
-const depsF = (resolve: (k: string) => RepoMapping | null, finalizeMerged = vi.fn(async () => {})) => ({
+**8b. Update the shared `deps` and `rollUp` helpers** (`finalizeMerged` on deps, `issueId` on rollUp):
+
+```ts
+const deps = (
+  resolve: (k: string) => RepoMapping | null,
+  finalizeMerged: (id: string) => Promise<void> = vi.fn(async () => {}),
+) => ({
   githubAppId: "1", githubAppPrivateKey: "k", resolveMapping: resolve, finalizeMerged,
 });
 
-describe("runMergeUps — top-of-tree merged-state completion", () => {
-  const topRollUp = () => rollUp({ identifier: "OOL-106", issueId: "uuid-106", parentIdentifier: null });
-
-  it("deletes the branch and finalizes when the top PR merged (squash/rebase/merge-commit)", async () => {
-    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 8, url: "u", state: "closed", merged: true });
-    const finalizeMerged = vi.fn(async () => {});
-    await runMergeUps([topRollUp()], depsF(() => mapping(), finalizeMerged));
-    expect(vi.mocked(deleteBranch)).toHaveBeenCalledWith("tok", "jodwyer", "alpacaWheel", "ai-implement/feature/ool-106");
-    expect(finalizeMerged).toHaveBeenCalledWith("uuid-106");
-    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
-  });
-
-  it("does nothing when the top PR is still open", async () => {
-    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 8, url: "u", state: "open", merged: false });
-    await runMergeUps([topRollUp()], depsF(() => mapping()));
-    expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
-    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
-  });
-
-  it("opens the PR when none exists and the branch is ahead", async () => {
-    vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
-    vi.mocked(compareBranches).mockResolvedValue(3);
-    await runMergeUps([topRollUp()], depsF(() => mapping()));
-    expect(vi.mocked(createPullRequest)).toHaveBeenCalled();
-  });
-
-  it("is idempotent: once the branch is gone, compareBranches null → no re-open", async () => {
-    vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
-    vi.mocked(compareBranches).mockResolvedValue(null); // branch deleted
-    await runMergeUps([topRollUp()], depsF(() => mapping()));
-    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
-  });
+const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
+  identifier: "OOL-107", issueId: "u-107", scopeKey: "OOL", parentIdentifier: "OOL-106", ...o,
 });
 ```
 
-(Add `deleteBranch`/`findPullRequestByBranches` resets to the existing `beforeEach`:
-`vi.mocked(findPullRequestByBranches).mockResolvedValue(null); vi.mocked(deleteBranch).mockResolvedValue(true);`)
+**8c. Update `beforeEach`** — reset the new mocks (drop the `findOpenPullRequest` reset):
+
+```ts
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+  vi.mocked(deleteBranch).mockResolvedValue(true);
+  vi.mocked(createPullRequest).mockResolvedValue({ number: 7, url: "https://gh/pr/7" });
+  vi.mocked(mergeBranch).mockResolvedValue("merged");
+});
+```
+
+**8d. REWRITE the existing "does not re-open the top-level PR when one already exists" test**
+(it referenced `findOpenPullRequest`) and add the merged/idempotent cases:
+
+```ts
+  it("does not re-open the top-level PR when one is already open", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 42, url: "https://gh/pr/42", state: "open", merged: false });
+    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping()));
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+  });
+
+  it("deletes the branch and finalizes when the top-of-tree PR merged (any method)", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 8, url: "u", state: "closed", merged: true });
+    const finalizeMerged = vi.fn(async () => {});
+    await runMergeUps([rollUp({ identifier: "OOL-106", issueId: "u-106", parentIdentifier: null })], deps(() => mapping(), finalizeMerged));
+    expect(vi.mocked(deleteBranch)).toHaveBeenCalledWith("tok", "jodwyer", "alpacaWheel", "ai-implement/feature/ool-106");
+    expect(finalizeMerged).toHaveBeenCalledWith("u-106");
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+    expect(vi.mocked(compareBranches)).not.toHaveBeenCalled(); // merged short-circuits before ancestry
+  });
+
+  it("is idempotent after deletion: no PR + compareBranches null → no re-open", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+    vi.mocked(compareBranches).mockResolvedValue(null);
+    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping()));
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+    expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
+  });
+```
+
+> The existing "opens a human PR … for the top-level feature→base roll-up" test (compareBranches
+> = 3) still passes unchanged: `findPullRequestByBranches` defaults to null → falls through to
+> `compareBranches` → `createPullRequest`.
 
 - [ ] **Step 9: Full suite + typecheck** — `npm run typecheck && npm test` → PASS.
 

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { dispatchWorkflow, providerDispatchFields, getBranchSha, ensureBranchExists, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv, skillsRepoDispatchFields, skillsRepoRunnerEnv, cancelWorkflowRun, getPullRequestState } from "../github.js";
+import { dispatchWorkflow, providerDispatchFields, getBranchSha, ensureBranchExists, capDispatchFields, capRunnerEnv, branchPrefixDispatchFields, branchPrefixRunnerEnv, skillsRepoDispatchFields, skillsRepoRunnerEnv, cancelWorkflowRun, getPullRequestState, deleteBranch, findPullRequestByBranches } from "../github.js";
 import type { RepoMapping } from "../config.js";
 
 function makeMapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
@@ -361,5 +361,59 @@ describe("skillsRepoRunnerEnv", () => {
     expect(skillsRepoRunnerEnv(makeMapping({ skillsRepo: "org/skills" }))).toEqual({
       AI_IMPLEMENT_SKILLS_REPO: "org/skills",
     });
+  });
+});
+
+describe("deleteBranch", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("returns true on 204 (deleted)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 204, ok: true })));
+    expect(await deleteBranch("t", "o", "r", "ai-implement/feature/aii-1")).toBe(true);
+  });
+  it("returns true on 404 (already gone — idempotent)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 404, ok: false, text: async () => "" })));
+    expect(await deleteBranch("t", "o", "r", "ai-implement/feature/aii-1")).toBe(true);
+  });
+  it("returns false on other errors", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 403, ok: false, text: async () => "no" })));
+    expect(await deleteBranch("t", "o", "r", "ai-implement/feature/aii-1")).toBe(false);
+  });
+});
+
+describe("findPullRequestByBranches", () => {
+  afterEach(() => vi.unstubAllGlobals());
+  it("reports a merged PR", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [{ number: 5, html_url: "u", state: "closed", merged_at: "2026-07-01T00:00:00Z" }],
+    })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base"))
+      .toEqual({ number: 5, url: "u", state: "closed", merged: true });
+  });
+  it("prefers a merged PR when several exist for the pair", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { number: 9, html_url: "u9", state: "open", merged_at: null },
+        { number: 5, html_url: "u5", state: "closed", merged_at: "2026-07-01T00:00:00Z" },
+      ],
+    })));
+    expect((await findPullRequestByBranches("t", "o", "r", "feat", "base"))?.number).toBe(5);
+  });
+  it("reports an open unmerged PR", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [{ number: 7, html_url: "u", state: "open", merged_at: null }],
+    })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base"))
+      .toEqual({ number: 7, url: "u", state: "open", merged: false });
+  });
+  it("returns null when no PR exists", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => [] })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base")).toBeNull();
+  });
+  it("returns null on a non-OK response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500 })));
+    expect(await findPullRequestByBranches("t", "o", "r", "feat", "base")).toBeNull();
   });
 });

--- a/src/__tests__/merge-up-multilevel.test.ts
+++ b/src/__tests__/merge-up-multilevel.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runMergeUps } from "../merge-up.js";
+import type { RepoMapping } from "../config.js";
+import type { FeatureNodeRollUp } from "../providers/types.js";
+
+vi.mock("../github-app-auth.js", () => ({ getInstallationToken: vi.fn(async () => "tok") }));
+vi.mock("../github.js", () => ({
+  compareBranches: vi.fn(async () => 2),
+  createPullRequest: vi.fn(async () => ({ number: 7, url: "u" })),
+  mergeBranch: vi.fn(async () => "merged"),
+  deleteBranch: vi.fn(async () => true),
+  findPullRequestByBranches: vi.fn(async () => null),
+}));
+import { compareBranches, createPullRequest, mergeBranch, findPullRequestByBranches } from "../github.js";
+
+function mapping(o: Partial<RepoMapping> = {}): RepoMapping {
+  return { owner: "jodwyer", repo: "alpacaWheel", workflowFile: "claude-implement.yml",
+    defaultBranch: "testing", maxInProgressAiIssues: 3, executionMode: "github-actions",
+    sessionMode: "autonomous", machineCpus: 2, machineMemoryMb: 4096, planningEnabled: false,
+    planningWorkflowFile: "", autoApprovePlans: true, extraEnv: {}, provider: "anthropic",
+    ticketingProvider: "linear", ticketingConfig: { kind: "linear" }, awsRegion: null, paused: false, ...o };
+}
+const deps = (finalizeMerged = vi.fn(async () => {})) => ({
+  githubAppId: "1", githubAppPrivateKey: "k", resolveMapping: () => mapping(), finalizeMerged });
+const node = (o: Partial<FeatureNodeRollUp>): FeatureNodeRollUp =>
+  ({ identifier: "OOL-107", issueId: "u-107", scopeKey: "OOL", parentIdentifier: "OOL-106", ...o });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(compareBranches).mockResolvedValue(2);
+  vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+});
+
+describe("multi-level roll-up (AII-187)", () => {
+  it("internal roll-up uses a direct git merge, never a PR", async () => {
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps());
+    expect(vi.mocked(mergeBranch)).toHaveBeenCalledWith(
+      "tok", "jodwyer", "alpacaWheel",
+      "ai-implement/feature/ool-106", "ai-implement/feature/ool-107", expect.any(String));
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+  });
+
+  it("the internal roll-up commit carries no issue identifier (no Linear false-Done link)", async () => {
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps());
+    const msg = vi.mocked(mergeBranch).mock.calls[0][5];
+    expect(msg).not.toMatch(/OOL-10[67]/);
+  });
+
+  it("does NOT finalize (markMerged) an internal node — only the top of the tree finalizes", async () => {
+    const finalizeMerged = vi.fn(async () => {});
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps(finalizeMerged));
+    expect(finalizeMerged).not.toHaveBeenCalled();
+  });
+
+  it("only the top-of-tree (parentIdentifier null) opens a feature→base PR", async () => {
+    await runMergeUps([node({ identifier: "OOL-106", parentIdentifier: null })], deps());
+    expect(vi.mocked(createPullRequest)).toHaveBeenCalledWith(
+      "tok", "jodwyer", "alpacaWheel",
+      expect.objectContaining({ base: "testing", head: "ai-implement/feature/ool-106" }));
+  });
+
+  it("a two-level tree in one pass: internal merges + top opens exactly one PR", async () => {
+    await runMergeUps([
+      node({ identifier: "OOL-107", parentIdentifier: "OOL-106" }), // internal
+      node({ identifier: "OOL-106", parentIdentifier: null }),      // top
+    ], deps());
+    expect(vi.mocked(mergeBranch)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createPullRequest)).toHaveBeenCalledTimes(1);
+  });
+
+  it("internal roll-up skips when the branch is already merged (0 ahead) — idempotent", async () => {
+    vi.mocked(compareBranches).mockResolvedValue(0);
+    await runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps());
+    expect(vi.mocked(mergeBranch)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an internal conflict without throwing", async () => {
+    vi.mocked(mergeBranch).mockResolvedValue("conflict");
+    await expect(runMergeUps([node({ identifier: "OOL-107", parentIdentifier: "OOL-106" })], deps()))
+      .resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/merge-up.test.ts
+++ b/src/__tests__/merge-up.test.ts
@@ -8,12 +8,13 @@ vi.mock("../github-app-auth.js", () => ({
 }));
 vi.mock("../github.js", () => ({
   compareBranches: vi.fn(),
-  findOpenPullRequest: vi.fn(async () => null),
   createPullRequest: vi.fn(async () => ({ number: 7, url: "https://gh/pr/7" })),
   mergeBranch: vi.fn(async () => "merged"),
+  deleteBranch: vi.fn(async () => true),
+  findPullRequestByBranches: vi.fn(async () => null),
 }));
 
-import { compareBranches, createPullRequest, mergeBranch, findOpenPullRequest } from "../github.js";
+import { compareBranches, createPullRequest, mergeBranch, deleteBranch, findPullRequestByBranches } from "../github.js";
 
 function mapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
   return {
@@ -26,17 +27,21 @@ function mapping(overrides: Partial<RepoMapping> = {}): RepoMapping {
   };
 }
 
-const deps = (resolve: (k: string) => RepoMapping | null) => ({
-  githubAppId: "1", githubAppPrivateKey: "k", resolveMapping: resolve,
+const deps = (
+  resolve: (k: string) => RepoMapping | null,
+  finalizeMerged: (id: string) => Promise<void> = vi.fn(async () => {}),
+) => ({
+  githubAppId: "1", githubAppPrivateKey: "k", resolveMapping: resolve, finalizeMerged,
 });
 
 const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
-  identifier: "OOL-107", scopeKey: "OOL", parentIdentifier: "OOL-106", ...o,
+  identifier: "OOL-107", issueId: "u-107", scopeKey: "OOL", parentIdentifier: "OOL-106", ...o,
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(findOpenPullRequest).mockResolvedValue(null);
+  vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+  vi.mocked(deleteBranch).mockResolvedValue(true);
   vi.mocked(createPullRequest).mockResolvedValue({ number: 7, url: "https://gh/pr/7" });
   vi.mocked(mergeBranch).mockResolvedValue("merged");
 });
@@ -86,11 +91,28 @@ describe("runMergeUps", () => {
     expect(`${arg.title} ${arg.body}`).not.toMatch(/OOL-\d+/i);
   });
 
-  it("does not re-open the top-level PR when one already exists", async () => {
-    vi.mocked(compareBranches).mockResolvedValue(1);
-    vi.mocked(findOpenPullRequest).mockResolvedValue({ number: 42, url: "https://gh/pr/42" });
+  it("does not re-open the top-level PR when one is already open", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 42, url: "https://gh/pr/42", state: "open", merged: false });
     await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping()));
     expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+  });
+
+  it("deletes the branch and finalizes when the top-of-tree PR merged (any method)", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({ number: 8, url: "u", state: "closed", merged: true });
+    const finalizeMerged = vi.fn(async () => {});
+    await runMergeUps([rollUp({ identifier: "OOL-106", issueId: "u-106", parentIdentifier: null })], deps(() => mapping(), finalizeMerged));
+    expect(vi.mocked(deleteBranch)).toHaveBeenCalledWith("tok", "jodwyer", "alpacaWheel", "ai-implement/feature/ool-106");
+    expect(finalizeMerged).toHaveBeenCalledWith("u-106");
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+    expect(vi.mocked(compareBranches)).not.toHaveBeenCalled(); // merged short-circuits before ancestry
+  });
+
+  it("is idempotent after deletion: no PR + compareBranches null → no re-open", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
+    vi.mocked(compareBranches).mockResolvedValue(null);
+    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping()));
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+    expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
   });
 
   it("warns (does not crash) when the internal merge conflicts", async () => {

--- a/src/github.ts
+++ b/src/github.ts
@@ -404,6 +404,59 @@ export async function compareBranches(
   return typeof data.ahead_by === "number" ? data.ahead_by : 0;
 }
 
+/**
+ * Deletes a git ref (branch). Idempotent: 204 (deleted) and 404 (already gone) both return
+ * true. Only ever called on orchestrator-owned `ai-implement/feature/*` branches.
+ */
+export async function deleteBranch(
+  token: string,
+  owner: string,
+  repo: string,
+  branch: string,
+): Promise<boolean> {
+  const enc = branch.split("/").map(encodeURIComponent).join("/");
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${enc}`,
+    { method: "DELETE", headers: ghHeaders(token) },
+  );
+  if (res.status === 204 || res.status === 404) return true;
+  const body = await res.text().catch(() => "");
+  console.error(`[github] deleteBranch(${branch}) failed: HTTP ${res.status}: ${body}`);
+  return false;
+}
+
+/**
+ * Finds the PR for the given head→base pair in ANY state, reporting whether it merged.
+ * GitHub's pulls list returns `merged_at` (null unless merged). Prefers a merged PR when
+ * several exist for the pair (e.g. a prior buggy re-open). Returns null when none exists
+ * or on a non-OK response (callers fall back to existing behavior).
+ */
+export async function findPullRequestByBranches(
+  token: string,
+  owner: string,
+  repo: string,
+  head: string,
+  base: string,
+): Promise<{ number: number; url: string; state: "open" | "closed"; merged: boolean } | null> {
+  const url =
+    `https://api.github.com/repos/${owner}/${repo}/pulls` +
+    `?head=${encodeURIComponent(`${owner}:${head}`)}&base=${encodeURIComponent(base)}` +
+    `&state=all&sort=updated&direction=desc&per_page=10`;
+  const res = await fetch(url, { headers: ghHeaders(token) });
+  if (!res.ok) return null;
+  const prs = (await res.json()) as Array<{
+    number: number; html_url: string; state: string; merged_at: string | null;
+  }>;
+  if (prs.length === 0) return null;
+  const chosen = prs.find((p) => p.merged_at !== null) ?? prs[0];
+  return {
+    number: chosen.number,
+    url: chosen.html_url,
+    state: chosen.state === "open" ? "open" : "closed",
+    merged: chosen.merged_at !== null,
+  };
+}
+
 /** Finds an open PR for the given head→base pair; returns its number/url or null. */
 export async function findOpenPullRequest(
   token: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,26 +254,25 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
     // dispatch so a parent's own closing work clones a branch that already contains its
     // children's merged work. Best-effort — never blocks the poll.
     if (providers.length > 0) {
-      try {
-        const rollUps = (
-          await Promise.all(
-            providers.map((p) =>
-              p.fetchFeatureNodeRollUps().catch((err) => {
-                console.error("[merge-up] Provider fetchFeatureNodeRollUps failed:", err);
-                return [] as FeatureNodeRollUp[];
-              }),
-            ),
-          )
-        ).flat();
-        if (rollUps.length > 0) {
-          await runMergeUps(rollUps, {
-            githubAppId: config.githubAppId,
-            githubAppPrivateKey: config.githubAppPrivateKey,
-            resolveMapping: (scopeKey) => teamRepoMap[scopeKey] ?? null,
+      // Per-provider so finalizeMerged binds markMerged to the provider that produced the
+      // roll-ups (a merged top-of-tree PR moves that provider's issue Done).
+      for (const provider of providers) {
+        try {
+          const rollUps = await provider.fetchFeatureNodeRollUps().catch((err) => {
+            console.error("[merge-up] Provider fetchFeatureNodeRollUps failed:", err);
+            return [] as FeatureNodeRollUp[];
           });
+          if (rollUps.length > 0) {
+            await runMergeUps(rollUps, {
+              githubAppId: config.githubAppId,
+              githubAppPrivateKey: config.githubAppPrivateKey,
+              resolveMapping: (scopeKey) => teamRepoMap[scopeKey] ?? null,
+              finalizeMerged: (issueId) => provider.markMerged(issueId),
+            });
+          }
+        } catch (err) {
+          console.error("[merge-up] roll-up step failed:", err);
         }
-      } catch (err) {
-        console.error("[merge-up] roll-up step failed:", err);
       }
     }
 

--- a/src/merge-up.ts
+++ b/src/merge-up.ts
@@ -2,7 +2,7 @@ import type { RepoMapping } from "./config.js";
 import type { FeatureNodeRollUp } from "./providers/types.js";
 import { getInstallationToken } from "./github-app-auth.js";
 import { buildFeatureBranchName } from "./pipeline/branch-name.js";
-import { compareBranches, createPullRequest, findOpenPullRequest, mergeBranch } from "./github.js";
+import { compareBranches, createPullRequest, deleteBranch, findPullRequestByBranches, mergeBranch } from "./github.js";
 
 /**
  * Feature-branch roll-up (the merge-up half of feature-branch grouping).
@@ -28,6 +28,9 @@ export interface MergeUpDeps {
   githubAppPrivateKey: string;
   /** Resolve the repo mapping for a scope/team key, or null when unmapped/paused. */
   resolveMapping: (scopeKey: string) => RepoMapping | null;
+  /** Finalize a feature node whose top-of-tree PR merged: idempotently mark its issue Done
+   *  (drops Ready for Review). Wired to the Linear provider's markMerged (AII-166). */
+  finalizeMerged: (issueId: string) => Promise<void>;
 }
 
 export async function runMergeUps(rollUps: FeatureNodeRollUp[], deps: MergeUpDeps): Promise<void> {
@@ -52,12 +55,11 @@ async function rollUpOne(rollUp: FeatureNodeRollUp, deps: MergeUpDeps): Promise<
     ? buildFeatureBranchName(rollUp.parentIdentifier)
     : mapping.defaultBranch;
 
-  const ahead = await compareBranches(ghToken, owner, repo, target, branch);
-  if (ahead === null || ahead === 0) return; // branch missing, or already fully merged
-
   if (rollUp.parentIdentifier !== null) {
     // Internal roll-up → direct merge, no PR (avoids Linear linking the roll-up to the
     // parent issue). Commit message is intentionally free of issue identifiers / magic words.
+    const ahead = await compareBranches(ghToken, owner, repo, target, branch);
+    if (ahead === null || ahead === 0) return; // branch missing, or already fully merged
     const result = await mergeBranch(
       ghToken,
       owner,
@@ -76,10 +78,23 @@ async function rollUpOne(rollUp: FeatureNodeRollUp, deps: MergeUpDeps): Promise<
     return;
   }
 
-  // Top of the tree → feature → base PR for human review. Opened once, never auto-merged.
-  const existing = await findOpenPullRequest(ghToken, owner, repo, branch, target);
-  if (existing) return;
-  const pr = await createPullRequest(ghToken, owner, repo, {
+  // Top of the tree. Detect completion by the feature → base PR's MERGED state (robust to
+  // squash/rebase/merge-commit — git ancestry alone misreads squash/rebase as "unmerged").
+  const pr = await findPullRequestByBranches(ghToken, owner, repo, branch, target);
+  if (pr?.merged) {
+    await deleteBranch(ghToken, owner, repo, branch);
+    await deps.finalizeMerged(rollUp.issueId);
+    console.log(
+      `[merge-up] Top-of-tree PR #${pr.number} for ${rollUp.identifier} merged; deleted ${branch} + finalized`,
+    );
+    return;
+  }
+  if (pr?.state === "open") return; // awaiting human review
+
+  // No PR yet (or a closed-unmerged one) — open it only if the branch has commits to offer.
+  const ahead = await compareBranches(ghToken, owner, repo, target, branch);
+  if (ahead === null || ahead === 0) return;
+  const created = await createPullRequest(ghToken, owner, repo, {
     head: branch,
     base: target,
     title: "[ai-implement] Feature branch ready for review",
@@ -87,5 +102,5 @@ async function rollUpOne(rollUp: FeatureNodeRollUp, deps: MergeUpDeps): Promise<
       "Automated feature-branch grouping: this feature branch's work is complete and ready " +
       "to merge into the base branch. Opened for human review.",
   });
-  console.log(`[merge-up] Opened feature→base PR ${pr.url} for ${rollUp.identifier} (awaiting human merge)`);
+  console.log(`[merge-up] Opened feature→base PR ${created.url} for ${rollUp.identifier} (awaiting human merge)`);
 }

--- a/src/providers/linear.ts
+++ b/src/providers/linear.ts
@@ -341,6 +341,7 @@ export class LinearProvider implements TicketingProvider {
     const data = await this.linearMutation<{
       issues: {
         nodes: Array<{
+          id: string;
           identifier: string;
           team: { key: string };
           children: { nodes: Array<{ labels: { nodes: Array<{ name: string }> } }> };
@@ -358,6 +359,7 @@ export class LinearProvider implements TicketingProvider {
           }
         ) {
           nodes {
+            id
             identifier
             team { key }
             children(first: 50) { nodes { labels { nodes { name } } } }
@@ -378,6 +380,7 @@ export class LinearProvider implements TicketingProvider {
         !!node.parent && (node.parent.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL);
       rollUps.push({
         identifier: node.identifier,
+        issueId: node.id,
         scopeKey: node.team.key,
         parentIdentifier: parentIsFeatureNode ? node.parent!.identifier : null,
       });

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -48,6 +48,9 @@ export interface AIImplementSnapshot {
 export interface FeatureNodeRollUp {
   /** The feature node's identifier → branch `ai-implement/feature/<identifier>`. */
   identifier: string;
+  /** The feature node's Linear issue UUID — used to finalize (markMerged) without a
+   *  second lookup when its top-of-tree PR merges. */
+  issueId: string;
   /** Capacity/scope bucket (team key) — used to resolve the repo mapping. */
   scopeKey: string;
   /**


### PR DESCRIPTION
Feature-branch delivery for the **AII-189** tree — makes top-of-tree feature-node completion robust to human merges by any method. Opened for **human review** (the top-of-tree gate); do not expect auto-merge.

## What's in this feature branch

| Commit | Issue | Change |
|--------|-------|--------|
| `fix(merge-up)` | [AII-188](https://linear.app/eudoxus/issue/AII-188) | Detect top-of-tree `feature → base` completion by the PR's **merged state** (`findPullRequestByBranches`) instead of git ancestry; on merged → `deleteBranch` + `finalizeMerged` (reuses AII-166 `markMerged`). Covers squash/rebase/merge-commit. |
| `test(merge-up)` | [AII-187](https://linear.app/eudoxus/issue/AII-187) | Automated multi-level roll-up contract tests (internal direct-merge no-PR, no false-Done, top-of-tree opens one PR). |
| `docs` | [AII-189](https://linear.app/eudoxus/issue/AII-189) | `docs/feature-branch-grouping.md` §5/§6/§7 describe merged-state completion + branch deletion. |

Plan/design artifacts also included: `docs/plans/2026-07-01-aii-188-feature-node-completion-{design,plan}.md`.

## Root cause (AII-188)

`merge-up.ts` decided "merged" by ancestry (`compareBranches`); a squash/rebase leaves the branch's commits non-ancestors, so it read as "unmerged" → re-opened an identical top-of-tree PR each poll → the re-opened PR auto-linked via the branch-name key and flipped the parent to In Progress. Now completion keys off the PR's merged state and the branch is deleted, so it can never re-open.

## Verification

- `tsc --noEmit` clean
- `npm test` — **1518 passing** (102 files; +17 new tests here)

## Notes

- **Base is `testing`** (repo base for grouping), not `main`.
- Delivered by hand on the feature branch (validated implementation) rather than via the live pipeline, because the running orchestrator doesn't yet carry this fix (the bootstrapping wrinkle this very change fixes). Merge with **`--delete-branch`** to be safe until an orchestrator with the fix is deployed.

Generated with bd-super-build-down (autonomous session 2026-07-01).