### PR TITLE
[ai-implement] Feature branch ready for review — AII-191 multi-issue grouping

### DIFF
--- a/docs/feature-branch-grouping.md
+++ b/docs/feature-branch-grouping.md
@@ -13,28 +13,30 @@ This is the operator/developer reference. The decision history lives in
 
 A Linear issue tree maps onto a tree of git branches:
 
-- A **parent issue** that carries the `AI-Implement` label *and* has at least one
-  `AI-Implement` child becomes a **feature node**. It owns a long-running feature branch
-  `ai-implement/feature/<issue-key>`.
-- Its **labelled children** are worked on and open PRs **into that feature branch**, not
-  into the repo's base branch.
+- A **parent issue** that carries the `AI-Implement` label *and* has **two or more**
+  `AI-Implement` children becomes a **grouping node**. It owns a shared branch named from
+  its children: `ai-implement/multi-issue/<sorted child slugs>`. The grouping node carries
+  **no implementation work of its own** and is never dispatched.
+- A parent with **exactly one** `AI-Implement` child is **not** a grouping node — that lone
+  child PRs directly to the repo base branch (or the nearest grouping ancestor) as if the
+  parent didn't exist.
+- The **labelled children** open PRs **into the shared grouping branch**, not into the
+  repo's base branch.
 - Unlabelled children are ignored until they too get the `AI-Implement` label — so you can
   roll a tree out incrementally.
-- The tree is **recursive**: a child that is itself a feature node gets its own branch cut
-  from its parent's branch, and so on.
-- When a feature node's children are all done, the node's **own work** runs (a parent
-  can carry work that isn't done in any child — e.g. a final cleanup), committed onto its
-  own feature branch.
-- Completed feature branches **roll up** into their parent's branch automatically; the
-  single top-of-tree `feature → base` merge is left as a human-reviewed PR.
+- The tree is **recursive**: a child that is itself a grouping node gets its own shared
+  branch cut from its parent's branch, and so on.
+- When **all** AI-Implement children reach a terminal state (completed or cancelled), the
+  grouping branch **rolls up** automatically. Internal levels roll up via a direct merge;
+  the single top-of-tree roll-up is offered as a human-reviewed `multi-issue → base` PR.
 
 ```
-testing                                  (repo base branch)
-└─ ai-implement/feature/PROJ-100         parent PROJ-100 (feature node)
-   ├─ ai-implement/feature/PROJ-101      child PROJ-101 (also a feature node)
-   │   ├─ PR: PROJ-103 (leaf) ─────────► feature/PROJ-101
-   │   └─ PR: PROJ-104 (leaf) ─────────► feature/PROJ-101
-   └─ PR: PROJ-102 (leaf) ─────────────► feature/PROJ-100
+testing                                           (repo base branch)
+└─ ai-implement/multi-issue/aii-100-aii-101       grouping node AII-99
+   ├─ ai-implement/multi-issue/aii-103-aii-104    grouping node AII-100
+   │   ├─ PR: AII-103 (leaf) ──────────────────► multi-issue/aii-103-aii-104
+   │   └─ PR: AII-104 (leaf) ──────────────────► multi-issue/aii-103-aii-104
+   └─ PR: AII-101 (leaf) ──────────────────────► multi-issue/aii-100-aii-101
 ```
 
 ---
@@ -67,10 +69,18 @@ classifies each one (`src/providers/linear.ts`, `fetchAIImplementSnapshot`):
 | `AI-Working` or `AI-Planning` present | in-progress | counted for capacity, skipped |
 | `Ready for Review` present | in review | skipped |
 | blocked by an open "blocks" relation | blocked | skipped |
-| **no children** | **leaf** | dispatched; PR targets the nearest feature-node ancestor branch (or base) |
-| **≥1 `AI-Implement` child, not all terminal** | **feature node (waiting)** | skipped — its branch is cut lazily when the first child dispatches |
-| **≥1 `AI-Implement` child, all terminal** | **feature node (ready)** | dispatched; its own closing work lands on its own feature branch |
+| **no children** | **leaf** | dispatched; PR targets the nearest grouping-node ancestor branch (or base) |
+| **exactly 1 `AI-Implement` child** | **single-child parent** | skipped — not a grouping node; the lone child PRs to base as a leaf |
+| **≥2 `AI-Implement` children, not all terminal** | **grouping node (waiting)** | skipped — its branch is cut lazily when the first child dispatches |
+| **≥2 `AI-Implement` children, all terminal** | **grouping node (roll-up ready)** | roll-up fires; grouping node is NOT dispatched |
 | **has children but none `AI-Implement` yet** | **waiting parent** | skipped — race guard (see below) |
+
+### The ≥2 gate
+
+Two or more AI-Implement children are required to form a grouping node. A parent with
+exactly one AI-Implement child is treated the same as a non-parent: the orchestrator skips
+it and the lone child dispatches as a leaf toward the base branch. Only at ≥2 children does
+the parent become a passive grouping container.
 
 ### The race guard
 
@@ -80,24 +90,24 @@ a child gets labelled. This is what lets you label a whole tree at once (or top-
 without the parent being worked prematurely. Log line:
 `Skipping <key>: parent labeled but no child has AI-Implement set yet`.
 
-### Parent closing work is deferred
-
-A feature node is **not** implemented while any of its `AI-Implement` children are still
-in flight (`Skipping <key>: feature-node parent waiting on in-flight AI-Implement
-children`). Only once **all** its labelled children reach a terminal state does its own
-work dispatch — onto its own feature branch. "Terminal" means completed *or* cancelled, so
-a cancelled child doesn't block the parent forever.
-
 ---
 
-## 4. Feature branches: naming and the cascade
+## 4. Branch naming and the cascade
 
-- Branch name: `ai-implement/feature/<issue-key-slug>` (`buildFeatureBranchName` in
-  `src/pipeline/branch-name.ts`).
-- The provider attaches an ordered `featureBranchChain` (base-most first) to each
-  dispatchable issue (`TicketIssue.featureBranchChain` in `src/providers/types.ts`). For a
-  leaf it ends at the nearest feature-node ancestor; for a ready feature node it ends at
-  the node itself.
+- Branch name: `ai-implement/multi-issue/<sorted child slugs>` (`buildMultiIssueBranchName`
+  in `src/pipeline/branch-name.ts`). Each child identifier is slugified (lowercased;
+  non-alphanumeric runs replaced by hyphens), the slugs are sorted, and the first three are
+  joined with hyphens. When there are more than three children, a `-plus{N}` suffix records
+  the count of omitted children. Examples:
+  - 2 children AII-101 and AII-102 → `ai-implement/multi-issue/aii-101-aii-102`
+  - 5 children AII-101 through AII-105 → `ai-implement/multi-issue/aii-101-aii-102-aii-103-plus2`
+- The parent's own key is **excluded** from the branch name by design. The name is a stable
+  label; the grouping truth lives in the Linear hierarchy. Nothing parses the name back into
+  a set of issues.
+- The provider attaches an ordered `featureBranchChain` (base-most first) carrying **branch
+  name strings** to each dispatchable issue (`TicketIssue.featureBranchChain` in
+  `src/providers/types.ts`). Only grouping ancestors with ≥2 AI children appear in the
+  chain; single-AI-child ancestors are dropped so the lone child reaches the base.
 - At dispatch time, `resolveBaseBranch` (`src/feature-branch.ts`) walks the chain and
   **creates each branch that doesn't exist, cut from the previous one** (or from the repo
   base for the first), returning the branch the PR should target. Branch creation is
@@ -114,31 +124,33 @@ grouping**.
 
 ## 5. Roll-up (the merge-up)
 
-When a feature-node issue completes, its branch is merged into its parent's branch
-(`src/merge-up.ts`, fed by `LinearProvider.fetchFeatureNodeRollUps`, run each poll **before**
-dispatch so a parent's own work clones a branch that already contains its children's work):
+When **all** of a grouping node's AI-Implement children reach a terminal state (completed
+or cancelled), `fetchFeatureNodeRollUps` surfaces the node and the roll-up fires
+(`src/merge-up.ts`, run each poll **before** dispatch). The grouping node itself is **never
+dispatched** — it has no implementation work and does not need a runner callback to advance.
 
-- **Internal level** (the parent is itself a feature node) → a **direct git merge**
+- **Internal level** (the parent is itself a grouping node) → a **direct git merge**
   (`POST /merges`, `mergeBranch` in `src/github.ts`), **not** a pull request, with a commit
-  message that carries no issue identifier. *Why no PR:* a roll-up PR's base branch name and
-  title encode the parent's key, so Linear's GitHub integration would auto-link the PR to the
-  parent issue and mark it **Done on merge — before the parent's own work runs**. A plain
-  merge commit gives Linear nothing to link, so the parent's lifecycle stays correct.
-- **Top of the tree** (no feature-node parent) → an open `feature → base` **PR for human
-  review**, never auto-merged.
+  message that carries no issue identifier. *Why no PR:* a roll-up PR's base branch name
+  and title would encode the parent's key, giving Linear's GitHub integration a signal to
+  mark the parent Done before the tree is finalized. A plain merge commit gives Linear
+  nothing to link.
+- **Top of the tree** (no grouping-node parent) → an open `multi-issue → base` **PR for
+  human review**, never auto-merged.
 
-The step is **idempotent** and **fails soft** per roll-up — one failure never aborts the others or the poll loop. It scans only feature nodes completed in a recent window to stay cheap.
+The step is **idempotent** and **fails soft** per roll-up — one failure never aborts the
+others or the poll loop.
 
 Idempotency is handled differently per path:
-- **Internal level:** `compareBranches` returning 0 (branch already merged into parent) or `null` (branch missing) causes an early return.
-- **Top of the tree:** `findPullRequestByBranches` is checked first. If the `feature → base` PR is **merged** — by any method (merge-commit, squash, or rebase) — the orchestrator deletes the feature branch (`deleteBranch`) and calls `markMerged` to idempotently finalize the parent node in the tracker. If the PR is still open, the step returns and awaits the human. Only when no PR exists is a new one opened (guarded by an ahead-check so a missing branch exits early). This replaces the old git-ancestry heuristic (`compareBranches` alone at the top-of-tree path), which misread squash/rebase merges as "still ahead" and re-opened the PR on each poll tick ([AII-188](https://linear.app/eudoxus/issue/AII-188)).
-
-> ⚠️ **Auto-roll-up needs the runner callback.** A feature node only completes when its
-> closing-work PR merges and Linear marks it Done; the roll-up keys off that completed
-> state. Planning's `Plan-Complete` transition is delivered by the runner callback
-> (`RUNNER_CALLBACK_BASE_URL` + `RUNNER_TOKEN_SECRET`, which must be **publicly reachable**).
-> With the callback disabled, planning stalls at `AI-Planning` and the cascade can't advance
-> on its own.
+- **Internal level:** `compareBranches` returning 0 (branch already merged into parent) or
+  `null` (branch missing) causes an early return.
+- **Top of the tree:** `findPullRequestByBranches` is checked first. If the
+  `multi-issue → base` PR is **merged** — by any method (merge-commit, squash, or rebase)
+  — the orchestrator deletes the grouping branch (`deleteBranch`) and calls `markMerged` to
+  finalize the grouping node in the tracker. **This path self-finalizes without requiring
+  native Linear/GitHub integration** — the PR merged-state check is the only signal needed.
+  If the PR is still open, the step returns and awaits the human. Only when no PR exists is
+  a new one opened (guarded by an ahead-check so a missing branch exits early).
 
 ---
 
@@ -146,14 +158,15 @@ Idempotency is handled differently per path:
 
 1. Label the tree `AI-Implement` (whole tree at once is fine — the gates sequence it).
 2. Leaves with no blockers dispatch: **plan → (auto-approve) → implement → PR** into their
-   parent's feature branch. The cascade branches are created on the first leaf dispatch.
-3. A human merges each leaf PR → the orchestrator marks the leaf **Done** (via poll detector + webhook) → any blocked sibling
-   unblocks and runs.
-4. When a feature node's children are all Done, its **own closing work** dispatches → PR
-   into its own feature branch → human merges → orchestrator marks node Done.
-5. The **merge-up** rolls each completed feature node's branch up into its parent's branch
-   (direct merge). The top node's branch is offered as a `feature → base` PR.
-6. A human reviews and merges that final PR **by any merge method** (merge-commit, squash, or rebase). On the next poll tick the orchestrator detects the merged PR state, deletes the feature branch, and calls `markMerged` to finalize the top node Done — the tree lands on the base branch and the PR is never re-opened.
+   parent's grouping branch. The cascade branches are created on the first leaf dispatch.
+3. A human merges each leaf PR → the orchestrator marks the leaf **Done** (via poll
+   detector + webhook) → any blocked sibling unblocks and runs.
+4. When all of a grouping node's AI-Implement children are Done (or cancelled), the
+   **roll-up** fires automatically: the shared grouping branch merges into its parent's
+   branch (internal levels) or is offered as a `multi-issue → base` PR (top of tree).
+5. A human reviews and merges that final PR **by any merge method** (merge-commit, squash,
+   or rebase). On the next poll tick the orchestrator detects the merged PR state, deletes
+   the grouping branch, and calls `markMerged` to finalize the top grouping node Done.
 
 ---
 
@@ -162,11 +175,11 @@ Idempotency is handled differently per path:
 | Concern | File |
 |---------|------|
 | Label query, classification, roll-up discovery | `src/providers/linear.ts` (`fetchAIImplementSnapshot`, `fetchFeatureNodeRollUps`) |
-| Shared types (`featureBranchChain`, `FeatureNodeRollUp`) | `src/providers/types.ts` |
-| Branch names | `src/pipeline/branch-name.ts` (`buildFeatureBranchName`) |
+| Shared types (`featureBranchChain` carries branch name strings; `FeatureNodeRollUp`) | `src/providers/types.ts` |
+| Branch names | `src/pipeline/branch-name.ts` (`buildMultiIssueBranchName`); `fetchFeatureNodeRollUps` surfaces grouping nodes on children-all-terminal |
 | Cascade branch creation + PR-base resolution | `src/feature-branch.ts` (`resolveBaseBranch`) |
 | Roll-up (direct merge / human PR) | `src/merge-up.ts` (`runMergeUps`) |
-| GitHub helpers (branch/compare/merge/PR/merged-state) | `src/github.ts` (`ensureBranchExists`, `compareBranches`, `mergeBranch`, `createPullRequest`, `findOpenPullRequest`, `findPullRequestByBranches`, `deleteBranch`) — `findPullRequestByBranches` detects the top-of-tree PR's merged state (robust to any merge method); `deleteBranch` removes the feature branch after merge |
+| GitHub helpers (branch/compare/merge/PR/merged-state) | `src/github.ts` (`ensureBranchExists`, `compareBranches`, `mergeBranch`, `createPullRequest`, `findOpenPullRequest`, `findPullRequestByBranches`, `deleteBranch`) — `findPullRequestByBranches` detects the top-of-tree PR's merged state (robust to any merge method); `deleteBranch` removes the grouping branch after merge |
 | Plan-Complete transition | `src/runner-callback.ts` → `markPlanComplete` |
 | Poll-loop wiring (roll-up before dispatch; base resolved per issue) | `src/index.ts` |
 
@@ -188,7 +201,20 @@ and no `featureBranchChain`, so its issues always PR to the base branch.
   `SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:next`; otherwise a GitHub Actions
   run falls back to the `:latest` runner, which may be incompatible with the current
   workflow/entrypoint.
-- **Top-of-tree PR merge method:** any method (merge-commit, squash, rebase) works correctly — the orchestrator detects completion via the PR's merged state, not git ancestry. On orchestrator versions before AII-188 shipped, squash/rebase merges left the feature branch appearing "ahead" of base, causing the PR to be re-opened each poll tick. If running a pre-fix orchestrator, use merge-commit with **Delete branch** checked as a temporary workaround.
+- **Top-of-tree PR merge method:** any method (merge-commit, squash, rebase) works
+  correctly — the orchestrator detects completion via the PR's merged state, not git
+  ancestry.
+- **Child-set mutation hazard:** the grouping branch name is derived from the child set at
+  the time the branch is first created. If a child is added to or removed from a grouping
+  node while the branch is in flight, `buildMultiIssueBranchName` will compute a different
+  name for the current child set, and the orchestrator will create a second branch —
+  orphaning the first. **Drain all in-flight `ai-implement/multi-issue/*` groups before
+  mutating their child sets.**
+- **Migration from old `ai-implement/feature/*` branches:** teams upgrading from the
+  pre-AII-152 model (where grouping branches used `ai-implement/feature/<parent-key>`)
+  should drain any in-flight `ai-implement/feature/*` groups before deploying. After
+  deploy, new groups use the `ai-implement/multi-issue/…` form; the old form will no longer
+  be created.
 - **Don't restart the orchestrator mid-run.** A restart drops in-flight job tracking,
   leaving dispatched issues stuck with `AI-Working` plus a dedup row. Recover by removing
   `AI-Working` in Linear and deleting the dedup entry (`DELETE /api/dedup/<issue-uuid>`).

--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { branchMatchesIssueIdentifier, buildIssueBranchName, buildFeatureBranchName, normalizeBranchPrefix } from "../pipeline/branch-name.js";
+import { branchMatchesIssueIdentifier, buildIssueBranchName, buildFeatureBranchName, buildMultiIssueBranchName, normalizeBranchPrefix } from "../pipeline/branch-name.js";
 
 describe("buildIssueBranchName", () => {
   it("builds issue-scoped branch names from issue metadata", () => {
@@ -33,6 +33,46 @@ describe("buildFeatureBranchName", () => {
 
   it("falls back defensively for empty identifiers", () => {
     expect(buildFeatureBranchName(undefined)).toBe("ai-implement/feature/parent");
+  });
+});
+
+describe("buildMultiIssueBranchName", () => {
+  it("produces sorted, order-independent names", () => {
+    expect(buildMultiIssueBranchName(["AII-200", "AII-100"])).toBe(
+      buildMultiIssueBranchName(["AII-100", "AII-200"]),
+    );
+  });
+
+  it("always starts with ai-implement/multi-issue/", () => {
+    expect(buildMultiIssueBranchName(["AII-1", "AII-2"])).toMatch(/^ai-implement\/multi-issue\//);
+  });
+
+  it("does not append a suffix when exactly 3 keys", () => {
+    expect(buildMultiIssueBranchName(["AII-1", "AII-2", "AII-3"])).toBe(
+      "ai-implement/multi-issue/aii-1-aii-2-aii-3",
+    );
+  });
+
+  it("caps at 3 and appends -plus1 for 4 keys", () => {
+    expect(buildMultiIssueBranchName(["AII-4", "AII-1", "AII-2", "AII-3"])).toBe(
+      "ai-implement/multi-issue/aii-1-aii-2-aii-3-plus1",
+    );
+  });
+
+  it("appends -plus3 for 6 keys", () => {
+    expect(buildMultiIssueBranchName(["AII-6", "AII-5", "AII-4", "AII-1", "AII-2", "AII-3"])).toBe(
+      "ai-implement/multi-issue/aii-1-aii-2-aii-3-plus3",
+    );
+  });
+
+  it("handles a single identifier (degenerate case, no cap suffix)", () => {
+    expect(buildMultiIssueBranchName(["AII-100"])).toBe("ai-implement/multi-issue/aii-100");
+  });
+
+  it("slugifies mixed-case identifiers", () => {
+    expect(buildMultiIssueBranchName(["OOL-78", "OOL-96"])).toBe(
+      "ai-implement/multi-issue/ool-78-ool-96",
+    );
   });
 });
 

--- a/src/__tests__/feature-branch.test.ts
+++ b/src/__tests__/feature-branch.test.ts
@@ -43,43 +43,54 @@ describe("resolveBaseBranch", () => {
   beforeEach(() => { vi.stubGlobal("fetch", vi.fn()); });
   afterEach(() => { vi.restoreAllMocks(); });
 
-  it("returns the feature branch and ensures it from defaultBranch for a single-entry chain", async () => {
+  it("returns the branch name directly from a single-entry chain and ensures it from defaultBranch", async () => {
     vi.mocked(fetch)
-      .mockResolvedValueOnce({ ok: false, status: 404 } as Response)                               // feature branch missing
+      .mockResolvedValueOnce({ ok: false, status: 404 } as Response)                               // branch missing
       .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "base-sha" } }) } as Response) // base head
       .mockResolvedValueOnce({ ok: true, status: 201 } as Response);                                // create ref
 
-    const base = await resolveBaseBranch({ ghToken: "t", issue: makeIssue(["OOL-78"]), mapping: makeMapping() });
+    const base = await resolveBaseBranch({
+      ghToken: "t",
+      issue: makeIssue(["ai-implement/multi-issue/ool-96-ool-97"]),
+      mapping: makeMapping(),
+    });
 
-    expect(base).toBe("ai-implement/feature/ool-78");
+    expect(base).toBe("ai-implement/multi-issue/ool-96-ool-97");
     const createBody = JSON.parse((vi.mocked(fetch).mock.calls[2][1] as RequestInit).body as string);
-    expect(createBody).toEqual({ ref: "refs/heads/ai-implement/feature/ool-78", sha: "base-sha" });
+    expect(createBody).toEqual({ ref: "refs/heads/ai-implement/multi-issue/ool-96-ool-97", sha: "base-sha" });
   });
 
   it("cascades a multi-entry chain: each branch cut from the previous one", async () => {
     vi.mocked(fetch)
-      // ensure OOL-78 (missing → cut from testing)
+      // ensure first branch (missing → cut from testing)
       .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
       .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "testing-sha" } }) } as Response)
       .mockResolvedValueOnce({ ok: true, status: 201 } as Response)
-      // ensure OOL-96 (missing → cut from OOL-78 branch)
+      // ensure second branch (missing → cut from first)
       .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
-      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "f78-sha" } }) } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "first-sha" } }) } as Response)
       .mockResolvedValueOnce({ ok: true, status: 201 } as Response);
 
     const base = await resolveBaseBranch({
       ghToken: "t",
-      issue: makeIssue(["OOL-78", "OOL-96"]),
+      issue: makeIssue([
+        "ai-implement/multi-issue/ool-96-ool-97",
+        "ai-implement/multi-issue/ool-100-ool-99",
+      ]),
       mapping: makeMapping(),
     });
 
-    expect(base).toBe("ai-implement/feature/ool-96");
-    // The OOL-78 branch is read from refs/heads/testing; the OOL-96 branch is cut from the OOL-78 branch head.
-    const f78Sha = JSON.parse((vi.mocked(fetch).mock.calls[2][1] as RequestInit).body as string).sha;
-    expect(f78Sha).toBe("testing-sha");
-    const f96Sha = JSON.parse((vi.mocked(fetch).mock.calls[5][1] as RequestInit).body as string).sha;
-    expect(f96Sha).toBe("f78-sha");
-    expect(vi.mocked(fetch).mock.calls[4][0]).toContain("ai-implement/feature/ool-78");
+    expect(base).toBe("ai-implement/multi-issue/ool-100-ool-99");
+    // First branch cut from testing
+    const first = JSON.parse((vi.mocked(fetch).mock.calls[2][1] as RequestInit).body as string);
+    expect(first.sha).toBe("testing-sha");
+    expect(first.ref).toBe("refs/heads/ai-implement/multi-issue/ool-96-ool-97");
+    // Second branch cut from first
+    const second = JSON.parse((vi.mocked(fetch).mock.calls[5][1] as RequestInit).body as string);
+    expect(second.sha).toBe("first-sha");
+    expect(second.ref).toBe("refs/heads/ai-implement/multi-issue/ool-100-ool-99");
+    // The head read for the second cut was the first branch URL
+    expect(vi.mocked(fetch).mock.calls[4][0]).toContain("ai-implement/multi-issue/ool-96-ool-97");
   });
 
   it("returns defaultBranch and creates nothing when there is no chain", async () => {
@@ -92,7 +103,11 @@ describe("resolveBaseBranch", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500, text: async () => "boom" } as Response);
 
-    const base = await resolveBaseBranch({ ghToken: "t", issue: makeIssue(["OOL-78"]), mapping: makeMapping() });
+    const base = await resolveBaseBranch({
+      ghToken: "t",
+      issue: makeIssue(["ai-implement/multi-issue/ool-96-ool-97"]),
+      mapping: makeMapping(),
+    });
 
     expect(base).toBe("testing");
     expect(warn).toHaveBeenCalled();

--- a/src/__tests__/merge-up-multilevel.test.ts
+++ b/src/__tests__/merge-up-multilevel.test.ts
@@ -39,7 +39,13 @@ const deps = (resolve: (k: string) => RepoMapping | null, finalizeMerged = vi.fn
 });
 
 const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
-  issueId: "issue-uuid-1", identifier: "AII-101", scopeKey: "AII", parentIdentifier: "AII-102", ...o,
+  issueId: "issue-uuid-1",
+  identifier: "AII-101",
+  scopeKey: "AII",
+  parentIdentifier: "AII-102",
+  branch: "ai-implement/feature/aii-101",
+  target: "ai-implement/feature/aii-102",
+  ...o,
 });
 
 beforeEach(() => {
@@ -91,7 +97,7 @@ describe("runMergeUps — multi-level feature trees", () => {
     await runMergeUps(
       [
         rollUp({ issueId: "uuid-101", identifier: "AII-101", parentIdentifier: "AII-102" }),
-        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null }),
+        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null, branch: "ai-implement/feature/aii-102", target: null }),
       ],
       deps(() => mapping(), finalizeMerged),
     );
@@ -109,7 +115,7 @@ describe("runMergeUps — multi-level feature trees", () => {
     await runMergeUps(
       [
         rollUp({ issueId: "uuid-101", identifier: "AII-101", parentIdentifier: "AII-102" }),
-        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null }),
+        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null, branch: "ai-implement/feature/aii-102", target: null }),
       ],
       deps(() => mapping(), finalizeMerged),
     );
@@ -147,7 +153,7 @@ describe("runMergeUps — multi-level feature trees", () => {
     vi.mocked(compareBranches).mockResolvedValue(0);
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
-      [rollUp({ identifier: "AII-102", parentIdentifier: null })],
+      [rollUp({ identifier: "AII-102", parentIdentifier: null, branch: "ai-implement/feature/aii-102", target: null })],
       deps(() => mapping(), finalizeMerged),
     );
 

--- a/src/__tests__/merge-up.test.ts
+++ b/src/__tests__/merge-up.test.ts
@@ -33,7 +33,13 @@ const deps = (resolve: (k: string) => RepoMapping | null, finalizeMerged = vi.fn
 });
 
 const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
-  issueId: "issue-uuid-1", identifier: "OOL-107", scopeKey: "OOL", parentIdentifier: "OOL-106", ...o,
+  issueId: "issue-uuid-1",
+  identifier: "OOL-107",
+  scopeKey: "OOL",
+  parentIdentifier: "OOL-106",
+  branch: "ai-implement/feature/ool-107",
+  target: "ai-implement/feature/ool-106",
+  ...o,
 });
 
 beforeEach(() => {
@@ -81,7 +87,10 @@ describe("runMergeUps", () => {
   it("opens a human PR (no direct merge) for the top-level feature→base roll-up", async () => {
     vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
     vi.mocked(compareBranches).mockResolvedValue(3);
-    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping()));
+    await runMergeUps(
+      [rollUp({ identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })],
+      deps(() => mapping()),
+    );
 
     expect(vi.mocked(createPullRequest)).toHaveBeenCalledWith("tok", "jodwyer", "alpacaWheel", expect.objectContaining({
       head: "ai-implement/feature/ool-106",
@@ -98,7 +107,10 @@ describe("runMergeUps", () => {
       number: 42, url: "https://gh/pr/42", state: "open", merged: false,
     });
     const finalizeMerged = vi.fn();
-    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping(), finalizeMerged));
+    await runMergeUps(
+      [rollUp({ identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })],
+      deps(() => mapping(), finalizeMerged),
+    );
     expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
     expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
     expect(finalizeMerged).not.toHaveBeenCalled();
@@ -110,7 +122,7 @@ describe("runMergeUps", () => {
     });
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
-      [rollUp({ issueId: "uuid-parent", identifier: "OOL-106", parentIdentifier: null })],
+      [rollUp({ issueId: "uuid-parent", identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })],
       deps(() => mapping(), finalizeMerged),
     );
 
@@ -125,7 +137,10 @@ describe("runMergeUps", () => {
     vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
     vi.mocked(compareBranches).mockResolvedValue(null);
     const finalizeMerged = vi.fn();
-    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping(), finalizeMerged));
+    await runMergeUps(
+      [rollUp({ identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })],
+      deps(() => mapping(), finalizeMerged),
+    );
     expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
     expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
     expect(finalizeMerged).not.toHaveBeenCalled();
@@ -138,7 +153,7 @@ describe("runMergeUps", () => {
     vi.mocked(deleteBranch).mockResolvedValue(true); // 404 treated as success → true
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
-      [rollUp({ issueId: "uuid-p", identifier: "OOL-106", parentIdentifier: null })],
+      [rollUp({ issueId: "uuid-p", identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })],
       deps(() => mapping(), finalizeMerged),
     );
     expect(finalizeMerged).toHaveBeenCalledWith("uuid-p");

--- a/src/__tests__/providers/linear.test.ts
+++ b/src/__tests__/providers/linear.test.ts
@@ -154,7 +154,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
   afterEach(() => { vi.restoreAllMocks(); });
 
   type Ancestor = { identifier: string; labels?: string[]; parent?: Ancestor | null };
-  type Child = { labels?: string[]; stateType?: string };
+  type Child = { labels?: string[]; stateType?: string; identifier?: string };
 
   function labelNodes(names: string[] | undefined) {
     return { nodes: (names ?? []).map((name) => ({ name })) };
@@ -192,7 +192,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
       inverseRelations: { nodes: overrides.inverseRelations ?? [] },
       children: {
         nodes: (overrides.children ?? []).map((c, i) => ({
-          identifier: `${overrides.identifier ?? "ENG-1"}-c${i}`,
+          identifier: c.identifier ?? `${overrides.identifier ?? "ENG-1"}-c${i}`,
           state: { type: c.stateType ?? "unstarted" },
           labels: labelNodes(c.labels),
         })),
@@ -252,8 +252,19 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
   });
 
   describe("feature-branch grouping", () => {
-    it("a leaf under a labeled parent targets the parent's feature-branch chain", async () => {
+    it("a leaf under a grouping parent (≥2 AI children) gets the multi-issue branch name in its chain", async () => {
       mockSinglePage([
+        // Grouping container in allNodes with ≥2 AI children
+        makeIssue({
+          id: "parent",
+          identifier: "OOL-78",
+          labels: ["AI-Implement"],
+          children: [
+            { labels: ["AI-Implement"], identifier: "OOL-96" },
+            { labels: ["AI-Implement"], identifier: "OOL-97" },
+          ],
+        }),
+        // Leaf whose parent is OOL-78
         makeIssue({
           id: "leaf",
           identifier: "OOL-96",
@@ -262,8 +273,36 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
         }),
       ]);
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+      // Parent (OOL-78) is never dispatched — grouping container
+      expect(snap.needsPlanning.some((i) => i.id === "parent")).toBe(false);
+      expect(snap.readyForImplementation.some((i) => i.id === "parent")).toBe(false);
+      // Leaf gets the multi-issue branch name (sorted: ool-96, ool-97)
       const leaf = snap.readyForImplementation.find((i) => i.id === "leaf")!;
-      expect(leaf.featureBranchChain).toEqual(["OOL-78"]);
+      expect(leaf.featureBranchChain).toEqual(["ai-implement/multi-issue/ool-96-ool-97"]);
+    });
+
+    it("a leaf under a single-AI-child parent gets no chain (PRs to base)", async () => {
+      mockSinglePage([
+        makeIssue({
+          id: "parent",
+          identifier: "OOL-78",
+          labels: ["AI-Implement"],
+          children: [{ labels: ["AI-Implement"], identifier: "OOL-96" }],
+        }),
+        makeIssue({
+          id: "leaf",
+          identifier: "OOL-96",
+          labels: ["AI-Implement", "Plan-Complete"],
+          parent: { identifier: "OOL-78", labels: ["AI-Implement"] },
+        }),
+      ]);
+      const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+      // Parent with 1 AI child is skipped
+      expect(snap.needsPlanning.some((i) => i.id === "parent")).toBe(false);
+      expect(snap.readyForImplementation.some((i) => i.id === "parent")).toBe(false);
+      // Leaf has no chain (PRs to base; no grouping parent)
+      const leaf = snap.readyForImplementation.find((i) => i.id === "leaf")!;
+      expect(leaf.featureBranchChain).toBeUndefined();
     });
 
     it("a leaf under an UNlabeled parent gets no chain (PRs to base)", async () => {
@@ -280,8 +319,30 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
       expect(leaf.featureBranchChain).toBeUndefined();
     });
 
-    it("cascades the chain through labeled grandparents", async () => {
+    it("cascades the chain through labeled grouping grandparents (both must be in allNodes with ≥2 AI children)", async () => {
+      // Grandparent OOL-78 has AI children OOL-96 and OOL-97 → branch ool-96-ool-97
+      // Parent OOL-96 has AI children OOL-99 and OOL-100 → branch ool-100-ool-99 (sorted)
+      // Leaf OOL-99 under OOL-96 (under OOL-78) → chain is base-most first
       mockSinglePage([
+        makeIssue({
+          id: "grandparent",
+          identifier: "OOL-78",
+          labels: ["AI-Implement"],
+          children: [
+            { labels: ["AI-Implement"], identifier: "OOL-96" },
+            { labels: ["AI-Implement"], identifier: "OOL-97" },
+          ],
+        }),
+        makeIssue({
+          id: "parent",
+          identifier: "OOL-96",
+          labels: ["AI-Implement"],
+          parent: { identifier: "OOL-78", labels: ["AI-Implement"] },
+          children: [
+            { labels: ["AI-Implement"], identifier: "OOL-99" },
+            { labels: ["AI-Implement"], identifier: "OOL-100" },
+          ],
+        }),
         makeIssue({
           id: "leaf",
           identifier: "OOL-99",
@@ -295,11 +356,14 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
       ]);
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
       const leaf = snap.needsPlanning.find((i) => i.id === "leaf")!;
-      // base-most first
-      expect(leaf.featureBranchChain).toEqual(["OOL-78", "OOL-96"]);
+      // Grandparent branch (base-most first), then parent branch
+      expect(leaf.featureBranchChain).toEqual([
+        "ai-implement/multi-issue/ool-96-ool-97",
+        "ai-implement/multi-issue/ool-100-ool-99",
+      ]);
     });
 
-    it("skips a feature-node parent while any AI-Implement child is in flight", async () => {
+    it("skips a grouping parent (≥2 AI children) regardless of child state", async () => {
       mockSinglePage([
         makeIssue({
           id: "parent",
@@ -307,7 +371,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
           labels: ["AI-Implement"],
           children: [
             { labels: ["AI-Implement"], stateType: "completed" },
-            { labels: ["AI-Implement"], stateType: "started" }, // still in flight
+            { labels: ["AI-Implement"], stateType: "started" },
           ],
         }),
       ]);
@@ -316,7 +380,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
       expect(snap.readyForImplementation).toEqual([]);
     });
 
-    it("dispatches a feature-node parent once all AI-Implement children are terminal, onto its own branch", async () => {
+    it("skips a grouping parent even when all AI children are terminal (never dispatches)", async () => {
       mockSinglePage([
         makeIssue({
           id: "parent",
@@ -325,13 +389,27 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
           children: [
             { labels: ["AI-Implement"], stateType: "completed" },
             { labels: ["AI-Implement"], stateType: "canceled" },
-            { labels: ["Improvement"], stateType: "started" }, // non-AI child does not gate
+            { labels: ["Improvement"], stateType: "started" }, // non-AI child never gates
           ],
         }),
       ]);
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
-      const parent = snap.needsPlanning.find((i) => i.id === "parent")!;
-      expect(parent.featureBranchChain).toEqual(["OOL-78"]);
+      expect(snap.needsPlanning).toEqual([]);
+      expect(snap.readyForImplementation).toEqual([]);
+    });
+
+    it("skips a parent with exactly 1 AI-Implement child", async () => {
+      mockSinglePage([
+        makeIssue({
+          id: "parent",
+          identifier: "OOL-78",
+          labels: ["AI-Implement"],
+          children: [{ labels: ["AI-Implement"], stateType: "completed" }],
+        }),
+      ]);
+      const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+      expect(snap.needsPlanning).toEqual([]);
+      expect(snap.readyForImplementation).toEqual([]);
     });
 
     it("skips a labeled parent whose children are not yet AI-Implement (race guard)", async () => {
@@ -346,6 +424,21 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
       expect(snap.needsPlanning).toEqual([]);
       expect(snap.readyForImplementation).toEqual([]);
+    });
+
+    it("a leaf whose labeled ancestor is not in allNodes (e.g. already terminal) gets no chain", async () => {
+      // OOL-78 is not in allNodes → groupingBranchFor("OOL-78") = null → no chain
+      mockSinglePage([
+        makeIssue({
+          id: "leaf",
+          identifier: "OOL-96",
+          labels: ["AI-Implement", "Plan-Complete"],
+          parent: { identifier: "OOL-78", labels: ["AI-Implement"] },
+        }),
+      ]);
+      const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+      const leaf = snap.readyForImplementation.find((i) => i.id === "leaf")!;
+      expect(leaf.featureBranchChain).toBeUndefined();
     });
   });
 
@@ -411,33 +504,117 @@ describe("LinearProvider.fetchFeatureNodeRollUps", () => {
       json: async () => ({ data: { issues: { nodes } } }),
     } as Response);
   }
-  const labels = (...names: string[]) => ({ nodes: names.map((name) => ({ name })) });
-
-  it("returns feature nodes with parent target; non-feature parent → null (base)", async () => {
-    mockResponse([
-      { identifier: "OOL-107", team: { key: "OOL" },
-        children: { nodes: [{ labels: labels("AI-Implement") }] },
-        parent: { identifier: "OOL-106", labels: labels("AI-Implement") } },
-      { identifier: "OOL-106", team: { key: "OOL" },
-        children: { nodes: [{ labels: labels("AI-Implement") }] },
-        parent: null },
-    ]);
-    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
-    expect(rollUps).toEqual([
-      { identifier: "OOL-107", scopeKey: "OOL", parentIdentifier: "OOL-106" },
-      { identifier: "OOL-106", scopeKey: "OOL", parentIdentifier: null },
-    ]);
+  const lbl = (...names: string[]) => ({ nodes: names.map((name) => ({ name })) });
+  const child = (identifier: string, type: string, ...labelNames: string[]) => ({
+    identifier, state: { type }, labels: lbl(...labelNames),
   });
 
-  it("excludes completed issues that are not feature nodes (no AI-Implement child)", async () => {
+  it("surfaces an active grouping parent when all AI-Implement children are terminal; computes branch and null target", async () => {
+    mockResponse([{
+      id: "parent-id",
+      identifier: "OOL-78",
+      team: { key: "OOL" },
+      children: { nodes: [
+        child("OOL-96", "completed", "AI-Implement"),
+        child("OOL-97", "canceled", "AI-Implement"),
+        child("OOL-extra", "started"), // non-AI child, ignored
+      ]},
+      parent: null,
+    }]);
+    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
+    expect(rollUps).toHaveLength(1);
+    expect(rollUps[0]).toMatchObject({
+      issueId: "parent-id",
+      identifier: "OOL-78",
+      scopeKey: "OOL",
+      parentIdentifier: null,
+      branch: "ai-implement/multi-issue/ool-96-ool-97",
+      target: null,
+    });
+  });
+
+  it("does not surface a grouping parent when some AI children are still in-flight", async () => {
+    mockResponse([{
+      id: "parent-id",
+      identifier: "OOL-78",
+      team: { key: "OOL" },
+      children: { nodes: [
+        child("OOL-96", "completed", "AI-Implement"),
+        child("OOL-97", "started", "AI-Implement"),
+      ]},
+      parent: null,
+    }]);
+    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
+    expect(rollUps).toEqual([]);
+  });
+
+  it("does not surface issues with fewer than 2 AI-Implement children", async () => {
     mockResponse([
-      { identifier: "OOL-50", team: { key: "OOL" },
-        children: { nodes: [{ labels: labels("Improvement") }] }, parent: null },
-      { identifier: "OOL-51", team: { key: "OOL" },
+      { id: "id1", identifier: "OOL-50", team: { key: "OOL" },
+        children: { nodes: [child("OOL-51", "completed", "AI-Implement")] }, parent: null },
+      { id: "id2", identifier: "OOL-60", team: { key: "OOL" },
+        children: { nodes: [child("OOL-61", "completed", "Improvement")] }, parent: null },
+      { id: "id3", identifier: "OOL-70", team: { key: "OOL" },
         children: { nodes: [] }, parent: null },
     ]);
     const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
     expect(rollUps).toEqual([]);
+  });
+
+  it("computes target from parent's AI children when parent is also a grouping container", async () => {
+    mockResponse([{
+      id: "child-id",
+      identifier: "OOL-78",
+      team: { key: "OOL" },
+      children: { nodes: [
+        child("OOL-96", "completed", "AI-Implement"),
+        child("OOL-97", "canceled", "AI-Implement"),
+      ]},
+      parent: {
+        identifier: "OOL-50",
+        labels: lbl("AI-Implement"),
+        children: { nodes: [
+          { identifier: "OOL-78", labels: lbl("AI-Implement") },
+          { identifier: "OOL-79", labels: lbl("AI-Implement") },
+        ]},
+      },
+    }]);
+    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
+    expect(rollUps).toHaveLength(1);
+    expect(rollUps[0]).toMatchObject({
+      issueId: "child-id",
+      identifier: "OOL-78",
+      parentIdentifier: "OOL-50",
+      branch: "ai-implement/multi-issue/ool-96-ool-97",
+      target: "ai-implement/multi-issue/ool-78-ool-79",
+    });
+  });
+
+  it("treats a container under a labeled single-AI-child parent as top-of-tree (parentIdentifier AND target both null)", async () => {
+    // The parent carries the AI-Implement label but is NOT a real grouping container (only 1 AI
+    // child), so this node is the top of the tree. parentIdentifier must be null alongside target
+    // — otherwise merge-up.ts routes it into the internal direct-merge path and silently merges
+    // into the default branch with no human-reviewed PR.
+    mockResponse([{
+      id: "child-id",
+      identifier: "OOL-78",
+      team: { key: "OOL" },
+      children: { nodes: [
+        child("OOL-96", "completed", "AI-Implement"),
+        child("OOL-97", "canceled", "AI-Implement"),
+      ]},
+      parent: {
+        identifier: "OOL-50",
+        labels: lbl("AI-Implement"),
+        children: { nodes: [
+          { identifier: "OOL-78", labels: lbl("AI-Implement") }, // only 1 AI child
+        ]},
+      },
+    }]);
+    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
+    expect(rollUps).toHaveLength(1);
+    expect(rollUps[0].parentIdentifier).toBeNull();
+    expect(rollUps[0].target).toBeNull();
   });
 });
 

--- a/src/feature-branch.ts
+++ b/src/feature-branch.ts
@@ -1,7 +1,6 @@
 import type { RepoMapping } from "./config.js";
 import type { TicketIssue } from "./providers/types.js";
 import { ensureBranchExists } from "./github.js";
-import { buildFeatureBranchName } from "./pipeline/branch-name.js";
 
 /**
  * Feature-branch grouping for parent/child issues.
@@ -20,9 +19,10 @@ import { buildFeatureBranchName } from "./pipeline/branch-name.js";
  * Resolves the branch a dispatched issue's PR should target, creating any feature
  * branches in `issue.featureBranchChain` that don't yet exist.
  *
- * The chain is base-most first: each identifier's branch `ai-implement/feature/<id>` is
- * cut from the previous entry's branch (or mapping.defaultBranch for the first), and the
- * PR targets the LAST entry's branch. An empty/absent chain returns mapping.defaultBranch.
+ * The chain is base-most first and carries resolved branch names (e.g.,
+ * "ai-implement/multi-issue/aii-100-aii-200"). Each branch is cut from the previous
+ * entry's branch (or mapping.defaultBranch for the first), and the PR targets the LAST
+ * entry. An empty/absent chain returns mapping.defaultBranch.
  *
  * `ensureBranchExists` is idempotent (422-tolerant), so an existing ancestor branch is
  * reused and only the missing tip of the chain is cut.
@@ -43,8 +43,7 @@ export async function resolveBaseBranch(opts: {
   try {
     let cutFrom = mapping.defaultBranch;
     let target = mapping.defaultBranch;
-    for (const identifier of chain) {
-      const branch = buildFeatureBranchName(identifier);
+    for (const branch of chain) {
       await ensureBranchExists(ghToken, mapping.owner, mapping.repo, branch, cutFrom);
       cutFrom = branch;
       target = branch;

--- a/src/merge-up.ts
+++ b/src/merge-up.ts
@@ -1,7 +1,6 @@
 import type { RepoMapping } from "./config.js";
 import type { FeatureNodeRollUp } from "./providers/types.js";
 import { getInstallationToken } from "./github-app-auth.js";
-import { buildFeatureBranchName } from "./pipeline/branch-name.js";
 import { compareBranches, createPullRequest, deleteBranch, findPullRequestByBranches, mergeBranch } from "./github.js";
 
 /**
@@ -49,10 +48,8 @@ async function rollUpOne(rollUp: FeatureNodeRollUp, deps: MergeUpDeps): Promise<
   const { owner, repo } = mapping;
   const ghToken = await getInstallationToken(deps.githubAppId, deps.githubAppPrivateKey, owner);
 
-  const branch = buildFeatureBranchName(rollUp.identifier);
-  const target = rollUp.parentIdentifier
-    ? buildFeatureBranchName(rollUp.parentIdentifier)
-    : mapping.defaultBranch;
+  const branch = rollUp.branch;
+  const target = rollUp.target ?? mapping.defaultBranch;
 
   if (rollUp.parentIdentifier !== null) {
     // Internal roll-up → direct merge, no PR (avoids Linear linking the roll-up to the

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -67,6 +67,20 @@ export function buildFeatureBranchName(parentIdentifier: string | undefined): st
   return `ai-implement/feature/${slugify(parentIdentifier, "parent")}`;
 }
 
+const MAX_MULTI_ISSUE_KEYS = 3;
+
+/**
+ * Shared branch for a multi-issue grouping container. Named from sorted, capped child
+ * identifiers so the name is order-independent and stable as long as the child set
+ * doesn't change. Grouping truth lives in the Linear hierarchy; nothing parses this name back.
+ */
+export function buildMultiIssueBranchName(childIdentifiers: string[]): string {
+  const slugs = childIdentifiers.map((id) => slugify(id, "issue")).sort();
+  const shown = slugs.slice(0, MAX_MULTI_ISSUE_KEYS).join("-");
+  const extra = slugs.length - MAX_MULTI_ISSUE_KEYS;
+  return `ai-implement/multi-issue/${shown}${extra > 0 ? `-plus${extra}` : ""}`;
+}
+
 export function branchMatchesIssueIdentifier(branchRef: string | undefined, issueIdentifier: string | undefined): boolean {
   if (!branchRef || !issueIdentifier) return false;
 

--- a/src/providers/linear.ts
+++ b/src/providers/linear.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types.js";
 import { MissingProviderConfigError } from "./types.js";
 import { fetchPlanningContext as fetchLinearPlanningContext } from "../linear-planning-fetch.js";
+import { buildMultiIssueBranchName } from "../pipeline/branch-name.js";
 
 interface GraphQLResponse<T> {
   data?: T;
@@ -252,6 +253,24 @@ export class LinearProvider implements TicketingProvider {
     const needsPlanning: AIImplementSnapshot["needsPlanning"] = [];
     const readyForImplementation: AIImplementSnapshot["readyForImplementation"] = [];
 
+    // Build a map from each non-terminal AI-Implement issue's identifier → its AI-Implement
+    // child identifiers. Used to compute grouping branch names for multi-issue containers.
+    const aiChildIdsByIdentifier = new Map<string, string[]>();
+    for (const issue of allNodes) {
+      const aiKids = (issue.children?.nodes ?? [])
+        .filter((c) => (c.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL));
+      if (aiKids.length > 0) {
+        aiChildIdsByIdentifier.set(issue.identifier, aiKids.map((c) => c.identifier));
+      }
+    }
+    // Returns the shared multi-issue branch name when an ancestor has ≥2 AI-Implement children;
+    // returns null for non-grouping ancestors (lone child, or ancestor not in the live set).
+    const groupingBranchFor = (identifier: string): string | null => {
+      const kids = aiChildIdsByIdentifier.get(identifier);
+      if (!kids || kids.length < 2) return null;
+      return buildMultiIssueBranchName(kids);
+    };
+
     for (const issue of allNodes) {
       const labelNames = new Set(issue.labels?.nodes?.map((l) => l.name) ?? []);
 
@@ -278,34 +297,35 @@ export class LinearProvider implements TicketingProvider {
       }
 
       // Feature-branch grouping (see src/feature-branch.ts). An AI-Implement issue is one of:
-      //   - leaf (no children)            → implement now; PR targets nearest feature-node
-      //                                      ancestor branch (or base).
-      //   - feature-node (>=1 AI child)   → its own work waits until ALL its AI-Implement
-      //                                      children reach a terminal state, then implements
-      //                                      onto its OWN feature branch. While children are in
-      //                                      flight the parent is skipped (its branch is cut
-      //                                      lazily when the first child dispatches).
-      //   - waiting parent (children but  → skipped (race guard: the parent was labeled before
-      //     none AI-Implement yet)          its children were, so let it sit).
+      //   - leaf (no children)       → implement now; PR targets any grouping-ancestor branch
+      //                                (ancestors with ≥2 AI children) in base-most order, or base.
+      //   - grouping container       → ≥2 AI-Implement children: never dispatched; its children
+      //     (≥2 AI children)           implement onto the shared multi-issue branch.
+      //   - single-AI-child parent   → exactly 1 AI child: not a group; parent never dispatches;
+      //                                lone child PRs straight to base.
+      //   - waiting parent (children → skipped (race guard: parent was labeled before its children).
+      //     but none AI-Implement)
       const children = issue.children?.nodes ?? [];
       const aiChildren = children.filter((c) => (c.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL));
-      const ancestorChain = labeledAncestorChain(issue.parent);
 
       let featureBranchChain: string[] | undefined;
       if (children.length === 0) {
-        // Leaf.
-        featureBranchChain = ancestorChain.length > 0 ? ancestorChain : undefined;
-      } else if (aiChildren.length > 0) {
-        const allAIChildrenTerminal = aiChildren.every(
-          (c) => c.state?.type === "completed" || c.state?.type === "canceled",
-        );
-        if (!allAIChildrenTerminal) {
-          console.log(`[linear] Skipping ${issue.identifier}: feature-node parent waiting on in-flight AI-Implement children`);
-          continue;
-        }
-        // All AI-Implement children done — implement the parent's closing work onto its own branch.
-        featureBranchChain = [...ancestorChain, issue.identifier];
+        // Leaf: walk labeled ancestors and include only grouping ancestors (≥2 AI children).
+        const ancestorIds = labeledAncestorChain(issue.parent);
+        const chain = ancestorIds
+          .map((id) => groupingBranchFor(id))
+          .filter((b): b is string => b !== null);
+        featureBranchChain = chain.length > 0 ? chain : undefined;
+      } else if (aiChildren.length >= 2) {
+        // Grouping container: pure grouping, never dispatched — children do the work.
+        console.log(`[linear] Skipping ${issue.identifier}: grouping container (${aiChildren.length} AI-Implement children)`);
+        continue;
+      } else if (aiChildren.length === 1) {
+        // Single AI child: not a group; parent is skipped, lone child PRs to base.
+        console.log(`[linear] Skipping ${issue.identifier}: parent with 1 AI-Implement child is not a grouping container`);
+        continue;
       } else {
+        // No AI children yet: race guard.
         console.log(`[linear] Skipping ${issue.identifier}: parent labeled but no child has AI-Implement set yet`);
         continue;
       }
@@ -332,11 +352,11 @@ export class LinearProvider implements TicketingProvider {
   }
 
   async fetchFeatureNodeRollUps(): Promise<FeatureNodeRollUp[]> {
-    // Recently-completed AI-Implement issues that are feature nodes (>=1 AI-Implement
-    // child) need their feature branch rolled up into the parent. Bound the scan to a
-    // recent window so the set stays small; the merge-up step skips already-merged
-    // branches cheaply via a branch comparison. A completed feature node implies its
-    // own closing work merged and all its children done.
+    // Scan recently-updated active AI-Implement grouping containers (≥2 AI-Implement children)
+    // whose AI children are all in a terminal state. These need their shared multi-issue branch
+    // rolled up into the parent (or opened as a top-of-tree PR for human review). The filter
+    // uses nin:["completed","canceled"] so we find still-active grouping parents before they are
+    // finalized — self-finalization happens here, not via a native GitHub integration.
     const since = new Date(Date.now() - ROLLUP_LOOKBACK_MS).toISOString();
     const data = await this.linearMutation<{
       issues: {
@@ -344,8 +364,16 @@ export class LinearProvider implements TicketingProvider {
           id: string;
           identifier: string;
           team: { key: string };
-          children: { nodes: Array<{ labels: { nodes: Array<{ name: string }> } }> };
-          parent: { identifier: string; labels: { nodes: Array<{ name: string }> } } | null;
+          children: { nodes: Array<{
+            identifier: string;
+            state: { type: string };
+            labels: { nodes: Array<{ name: string }> };
+          }> };
+          parent: {
+            identifier: string;
+            labels: { nodes: Array<{ name: string }> };
+            children: { nodes: Array<{ identifier: string; labels: { nodes: Array<{ name: string }> } }> };
+          } | null;
         }>;
       };
     }>(
@@ -354,7 +382,7 @@ export class LinearProvider implements TicketingProvider {
           first: 100
           filter: {
             labels: { name: { eq: "AI-Implement" } }
-            state: { type: { eq: "completed" } }
+            state: { type: { nin: ["completed", "canceled"] } }
             updatedAt: { gt: $since }
           }
         ) {
@@ -362,8 +390,16 @@ export class LinearProvider implements TicketingProvider {
             id
             identifier
             team { key }
-            children(first: 50) { nodes { labels { nodes { name } } } }
-            parent { identifier labels { nodes { name } } }
+            children(first: 50) { nodes {
+              identifier
+              state { type }
+              labels { nodes { name } }
+            } }
+            parent {
+              identifier
+              labels { nodes { name } }
+              children(first: 50) { nodes { identifier labels { nodes { name } } } }
+            }
           }
         }
       }`,
@@ -372,17 +408,44 @@ export class LinearProvider implements TicketingProvider {
 
     const rollUps: FeatureNodeRollUp[] = [];
     for (const node of data.issues?.nodes ?? []) {
-      const isFeatureNode = (node.children?.nodes ?? []).some((c) =>
+      // Only surface grouping containers: ≥2 AI-Implement children, all terminal.
+      const aiChildren = (node.children?.nodes ?? []).filter((c) =>
         (c.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL),
       );
-      if (!isFeatureNode) continue;
+      if (aiChildren.length < 2) continue;
+      const allTerminal = aiChildren.every(
+        (c) => c.state?.type === "completed" || c.state?.type === "canceled",
+      );
+      if (!allTerminal) continue;
+
+      const childKeys = aiChildren.map((c) => c.identifier);
+      const branch = buildMultiIssueBranchName(childKeys);
+
+      // Only treat the parent as an internal roll-up target when it is a REAL grouping
+      // container (labeled AND >=2 AI-Implement children). Otherwise this node is the top of
+      // the tree: parentIdentifier AND target must both be null so merge-up.ts opens a
+      // human-reviewed feature→base PR rather than direct-merging into the default branch.
       const parentIsFeatureNode =
         !!node.parent && (node.parent.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL);
+      let target: string | null = null;
+      let parentIdentifier: string | null = null;
+      if (parentIsFeatureNode && node.parent) {
+        const parentAiChildren = (node.parent.children?.nodes ?? []).filter((c) =>
+          (c.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL),
+        );
+        if (parentAiChildren.length >= 2) {
+          parentIdentifier = node.parent.identifier;
+          target = buildMultiIssueBranchName(parentAiChildren.map((c) => c.identifier));
+        }
+      }
+
       rollUps.push({
         issueId: node.id,
         identifier: node.identifier,
         scopeKey: node.team.key,
-        parentIdentifier: parentIsFeatureNode ? node.parent!.identifier : null,
+        parentIdentifier,
+        branch,
+        target,
       });
     }
     return rollUps;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -22,14 +22,15 @@ export interface TicketIssue {
   /**
    * Feature-branch grouping chain, set by the Linear provider for dispatchable issues.
    *
-   * An ordered list of issue identifiers (base-most first). Each names a feature branch
-   * `ai-implement/feature/<id>` that must exist before this issue dispatches; each branch
-   * is cut from the previous entry's branch (or mapping.defaultBranch for the first). This
-   * issue's PR targets the LAST entry's branch. Absent/empty → PR targets mapping.defaultBranch.
+   * An ordered list of branch names (base-most first). Each branch must exist before this
+   * issue dispatches; each branch is cut from the previous entry's branch (or
+   * mapping.defaultBranch for the first). This issue's PR targets the LAST entry's branch.
+   * Absent/empty → PR targets mapping.defaultBranch.
    *
-   * For a leaf the chain ends at its nearest feature-node ancestor; for a feature-node parent
-   * whose AI-Implement children are all complete, the chain ends at the parent itself (its
-   * closing work lands on its own feature branch). See src/feature-branch.ts.
+   * For a leaf under a multi-issue grouping parent (≥2 AI-Implement siblings), the chain
+   * contains the parent's `ai-implement/multi-issue/<sorted child keys>` branch name.
+   * Grouping ancestors with only one AI-Implement child are dropped (lone child PRs to base).
+   * See src/feature-branch.ts.
    */
   featureBranchChain?: string[];
 }
@@ -41,24 +42,30 @@ export interface AIImplementSnapshot {
 }
 
 /**
- * A completed feature-node issue whose feature branch should be rolled up into its
- * parent (see src/merge-up.ts). Produced by the provider from recently-completed
- * AI-Implement issues that have at least one AI-Implement child.
+ * An active grouping-container issue whose feature branch should be rolled up into its
+ * parent (see src/merge-up.ts). Produced by the provider when an AI-Implement issue with
+ * ≥2 AI-Implement children has all those children in a terminal state.
  */
 export interface FeatureNodeRollUp {
   /** Provider-internal ID (Linear UUID) — passed to markMerged when the top-of-tree PR is detected as merged. */
   issueId: string;
-  /** The feature node's identifier → branch `ai-implement/feature/<identifier>`. */
+  /** The feature node's human-readable identifier. For logging only. */
   identifier: string;
   /** Capacity/scope bucket (team key) — used to resolve the repo mapping. */
   scopeKey: string;
   /**
-   * Parent identifier when the parent is itself a feature node (the parent has the
-   * AI-Implement label) → roll into `ai-implement/feature/<parent>` and auto-merge.
-   * null when there is no feature-node parent → roll into the mapping's base branch
-   * via a human-reviewed PR (never auto-merged).
+   * Parent identifier when the parent is itself a feature node (has the AI-Implement label).
+   * null when there is no feature-node parent (top of tree). Used for logging and internal-vs-top-of-tree
+   * distinction; branch names are carried by `branch` and `target`.
    */
   parentIdentifier: string | null;
+  /** Pre-computed branch name for this roll-up (e.g., "ai-implement/multi-issue/aii-100-aii-200"). */
+  branch: string;
+  /**
+   * Pre-computed target branch name when the parent is itself a grouping container.
+   * null → roll into mapping.defaultBranch via a human-reviewed PR (top of tree, never auto-merged).
+   */
+  target: string | null;
 }
 
 export type IssueLifecycleState = "active" | "completed" | "cancelled";


### PR DESCRIPTION
Top-of-tree review PR for the **AII-191** multi-issue feature-branch grouping feature. Lands the integrated feature branch `ai-implement/feature/aii-191` onto `testing`.

**Child work merged into this branch:**
- **AII-152** (PR #115) — core: parent-does-no-work classification + children-terminal roll-up discovery (folds AII-190) + `buildMultiIssueBranchName`. Includes the roll-up `parentIdentifier` correctness fix flagged in review.
- **AII-192** (PR #116) — `docs/feature-branch-grouping.md` rewritten for the new model.

**Verification:** `tsc --noEmit` clean; full suite 1534/1534 passing on the branch.

**Human gate:** this is the deliberate feature-level review before landing on `testing`. Deferred follow-ups: AII-134 (auto-merge, both flavors) and AII-193 (multi-level internal-container self-finalize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)