### PR TITLE
[ai-implement] Feature branch ready for review — AII-191 co-existing grouping modes

### DIFF
--- a/docs/feature-branch-grouping.md
+++ b/docs/feature-branch-grouping.md
@@ -11,22 +11,16 @@ This is the operator/developer reference. The decision history lives in
 
 ## 1. Mental model
 
-A Linear issue tree maps onto a tree of git branches:
+Two grouping modes are available, selected by whether the parent issue also carries
+the `Multi-Issue` label.
 
-- A **parent issue** that carries the `AI-Implement` label *and* has at least one
-  `AI-Implement` child becomes a **feature node**. It owns a long-running feature branch
-  `ai-implement/feature/<issue-key>`.
-- Its **labelled children** are worked on and open PRs **into that feature branch**, not
-  into the repo's base branch.
-- Unlabelled children are ignored until they too get the `AI-Implement` label — so you can
-  roll a tree out incrementally.
-- The tree is **recursive**: a child that is itself a feature node gets its own branch cut
-  from its parent's branch, and so on.
-- When a feature node's children are all done, the node's **own work** runs (a parent
-  can carry work that isn't done in any child — e.g. a final cleanup), committed onto its
-  own feature branch.
-- Completed feature branches **roll up** into their parent's branch automatically; the
-  single top-of-tree `feature → base` merge is left as a human-reviewed PR.
+### Feature-node mode (default)
+
+A **parent issue** that carries `AI-Implement` *and* has at least one `AI-Implement` child
+(without the `Multi-Issue` label) becomes a **feature node**. It owns a long-running branch
+`ai-implement/feature/<issue-key>`. Its labelled children open PRs **into that branch**.
+When all children finish, the parent runs its own closing work on that branch, then the
+branch rolls up.
 
 ```
 testing                                  (repo base branch)
@@ -37,6 +31,29 @@ testing                                  (repo base branch)
    └─ PR: PROJ-102 (leaf) ─────────────► feature/PROJ-100
 ```
 
+The tree is **recursive**: a child that is itself a feature node gets its own branch cut
+from its parent's branch. Unlabelled children are ignored until they get `AI-Implement`,
+so trees can be rolled out incrementally.
+
+### Multi-issue mode
+
+A parent that carries **both** `AI-Implement` and `Multi-Issue` (and has ≥2 `AI-Implement`
+children) becomes a **multi-issue grouping node**. It is a pure container — it never
+dispatches its own work. All children PRs target the shared grouping branch
+`ai-implement/multi-issue/<sorted-child-slugs>`. When all children are terminal, the
+grouping branch self-finalizes.
+
+```
+testing                                  (repo base branch)
+└─ ai-implement/multi-issue/aii-10-aii-5 shared grouping branch
+   ├─ PR: AII-5 (leaf) ─────────────────► multi-issue/aii-10-aii-5
+   └─ PR: AII-10 (leaf) ────────────────► multi-issue/aii-10-aii-5
+```
+
+**Degenerate case:** `Multi-Issue` label on a parent with fewer than 2 `AI-Implement`
+children is not recognised as a group. The parent is skipped with a log line:
+`Skipping <key>: Multi-Issue parent needs >=2 AI-Implement children (has N) — not a group`.
+
 ---
 
 ## 2. The labels
@@ -44,6 +61,7 @@ testing                                  (repo base branch)
 | Label | Meaning | Who sets it |
 |-------|---------|-------------|
 | `AI-Implement` | **Trigger.** The orchestrator only sees issues with this label (and a non-terminal state). | Human |
+| `Multi-Issue` | **Mode selector.** Applied to a parent alongside `AI-Implement` to opt it into multi-issue grouping mode (pure container, ≥2 children required). Without this label a parent with AI-Implement children is a feature node. | Human |
 | `AI-Planning` | Planning in flight. Counts against the team's in-progress capacity; the issue is skipped while present. | Orchestrator on planning dispatch |
 | `Plan-Complete` | Planning finished and approved → the issue is ready for implementation. | Orchestrator via the **runner callback** (`runner-callback.ts` → `markPlanComplete`) |
 | `AI-Working` | Implementation in flight. Counts against capacity; the issue is skipped while present. | Orchestrator on implementation dispatch |
@@ -67,9 +85,12 @@ classifies each one (`src/providers/linear.ts`, `fetchAIImplementSnapshot`):
 | `AI-Working` or `AI-Planning` present | in-progress | counted for capacity, skipped |
 | `Ready for Review` present | in review | skipped |
 | blocked by an open "blocks" relation | blocked | skipped |
-| **no children** | **leaf** | dispatched; PR targets the nearest feature-node ancestor branch (or base) |
-| **≥1 `AI-Implement` child, not all terminal** | **feature node (waiting)** | skipped — its branch is cut lazily when the first child dispatches |
-| **≥1 `AI-Implement` child, all terminal** | **feature node (ready)** | dispatched; its own closing work lands on its own feature branch |
+| **no children** | **leaf** | dispatched; PR targets the nearest grouping-ancestor branch (or base) |
+| **`Multi-Issue` label + ≥2 `AI-Implement` children, not all terminal** | **multi-issue grouping (in flight)** | skipped — grouping branch cut lazily when the first child dispatches |
+| **`Multi-Issue` label + ≥2 `AI-Implement` children, all terminal** | **multi-issue grouping (ready)** | not dispatched (no work); roll-up fires via `fetchFeatureNodeRollUps` |
+| **`Multi-Issue` label + <2 `AI-Implement` children** | **degenerate multi-issue** | skipped — not a group |
+| **≥1 `AI-Implement` child (no `Multi-Issue`), not all terminal** | **feature node (waiting)** | skipped — its branch is cut lazily when the first child dispatches |
+| **≥1 `AI-Implement` child (no `Multi-Issue`), all terminal** | **feature node (ready)** | dispatched; its own closing work lands on its own feature branch |
 | **has children but none `AI-Implement` yet** | **waiting parent** | skipped — race guard (see below) |
 
 ### The race guard
@@ -80,7 +101,7 @@ a child gets labelled. This is what lets you label a whole tree at once (or top-
 without the parent being worked prematurely. Log line:
 `Skipping <key>: parent labeled but no child has AI-Implement set yet`.
 
-### Parent closing work is deferred
+### Parent closing work is deferred (feature-node mode only)
 
 A feature node is **not** implemented while any of its `AI-Implement` children are still
 in flight (`Skipping <key>: feature-node parent waiting on in-flight AI-Implement
@@ -88,21 +109,41 @@ children`). Only once **all** its labelled children reach a terminal state does 
 work dispatch — onto its own feature branch. "Terminal" means completed *or* cancelled, so
 a cancelled child doesn't block the parent forever.
 
+A multi-issue grouping node **never** dispatches closing work; it is a pure container.
+
 ---
 
 ## 4. Feature branches: naming and the cascade
 
-- Branch name: `ai-implement/feature/<issue-key-slug>` (`buildFeatureBranchName` in
-  `src/pipeline/branch-name.ts`).
-- The provider attaches an ordered `featureBranchChain` (base-most first) to each
-  dispatchable issue (`TicketIssue.featureBranchChain` in `src/providers/types.ts`). For a
-  leaf it ends at the nearest feature-node ancestor; for a ready feature node it ends at
-  the node itself.
-- At dispatch time, `resolveBaseBranch` (`src/feature-branch.ts`) walks the chain and
-  **creates each branch that doesn't exist, cut from the previous one** (or from the repo
-  base for the first), returning the branch the PR should target. Branch creation is
-  idempotent and **fails open**: any GitHub error falls back to the base branch, so a
-  grouping failure never blocks the work.
+Two branch-naming functions live in `src/pipeline/branch-name.ts`:
+
+- **`buildFeatureBranchName(parentIdentifier)`** → `ai-implement/feature/<slug>`  
+  Used for feature-node parents (no `Multi-Issue` label). The branch is derived from the
+  parent identifier only (stable across child dispatches; no title drift).
+
+- **`buildMultiIssueBranchName(childIdentifiers[])`** → `ai-implement/multi-issue/<sorted-slugs>`  
+  Used for multi-issue grouping nodes. Slugs are sorted lexicographically and capped at 3,
+  with a `-plus<N>` suffix for any extras:
+  - `["AII-10", "AII-5"]` → `ai-implement/multi-issue/aii-10-aii-5`
+  - `["AII-5", "AII-10", "AII-1"]` → `ai-implement/multi-issue/aii-1-aii-10-aii-5`
+  - `["AII-1", "AII-2", "AII-3", "AII-4", "AII-5"]` → `ai-implement/multi-issue/aii-1-aii-2-aii-3-plus2`
+  
+  The parent key is **excluded** from the multi-issue branch name — the name is derived
+  from child identifiers (the grouping truth is the hierarchy, not the parent's identity).
+  The sort is order-independent, so any permutation of the same child set yields the same
+  branch name.
+
+The provider attaches an ordered `featureBranchChain` (base-most first) to each
+dispatchable issue (`TicketIssue.featureBranchChain` in `src/providers/types.ts`). Branch
+names are **pre-computed** by the provider (either `ai-implement/feature/<key>` or
+`ai-implement/multi-issue/<slugs>`) — consumers never need to derive them. For a leaf it
+ends at the nearest grouping ancestor; for a ready feature node it ends at the node itself.
+
+At dispatch time, `resolveBaseBranch` (`src/feature-branch.ts`) walks the chain and
+**creates each branch that doesn't exist, cut from the previous one** (or from the repo
+base for the first), returning the branch the PR should target. Branch creation is
+idempotent and **fails open**: any GitHub error falls back to the base branch, so a
+grouping failure never blocks the work.
 
 This resolution is the same in all execution modes — the resolved branch is passed to the
 runner as the `base_branch` workflow input (GitHub Actions) or as the runner's default
@@ -114,35 +155,67 @@ grouping**.
 
 ## 5. Roll-up (the merge-up)
 
-When a feature-node issue completes, its branch is merged into its parent's branch
-(`src/merge-up.ts`, fed by `LinearProvider.fetchFeatureNodeRollUps`, run each poll **before**
-dispatch so a parent's own work clones a branch that already contains its children's work):
+`src/merge-up.ts` (fed by `LinearProvider.fetchFeatureNodeRollUps`, run each poll **before**
+dispatch) handles both modes:
 
-- **Internal level** (the parent is itself a feature node) → a **direct git merge**
+### Feature-node roll-up
+
+Fires when a feature-node issue's `state.type` is `"completed"` and it has ≥1
+`AI-Implement` child. The branch `ai-implement/feature/<key>` is merged into its parent's
+branch (or offered as a top-of-tree PR).
+
+### Multi-issue roll-up
+
+Fires when a multi-issue grouping node has ≥2 `AI-Implement` children **and** all of those
+children are terminal (completed or cancelled). The grouping branch
+`ai-implement/multi-issue/<sorted-slugs>` is then merged up via the same paths below.
+The multi-issue grouping node itself is never dispatched (no closing work), so its
+`markMerged` is driven purely by the top-of-tree PR merged-state detection.
+
+> ⚠️ **Internal multi-issue self-finalize is deferred (AII-193).** When a multi-issue
+> grouping node is itself a child of a larger feature tree (i.e., it has a
+> `parentIdentifier` in the roll-up record), the direct-merge path runs as expected, but
+> the inner container does **not** currently self-finalize (call `markMerged`) — that is
+> scheduled for AII-193. Only the top-of-tree multi-issue PR path self-finalizes today.
+
+### Merge paths (shared by both modes)
+
+- **Internal level** (the node's parent is itself a grouping node) → a **direct git merge**
   (`POST /merges`, `mergeBranch` in `src/github.ts`), **not** a pull request, with a commit
   message that carries no issue identifier. *Why no PR:* a roll-up PR's base branch name and
   title encode the parent's key, so Linear's GitHub integration would auto-link the PR to the
   parent issue and mark it **Done on merge — before the parent's own work runs**. A plain
   merge commit gives Linear nothing to link, so the parent's lifecycle stays correct.
-- **Top of the tree** (no feature-node parent) → an open `feature → base` **PR for human
+- **Top of the tree** (no grouping parent) → an open `grouping → base` **PR for human
   review**, never auto-merged.
 
-The step is **idempotent** and **fails soft** per roll-up — one failure never aborts the others or the poll loop. It scans only feature nodes completed in a recent window to stay cheap.
+The step is **idempotent** and **fails soft** per roll-up — one failure never aborts the
+others or the poll loop. It scans only issues updated in a recent window to stay cheap.
 
 Idempotency is handled differently per path:
-- **Internal level:** `compareBranches` returning 0 (branch already merged into parent) or `null` (branch missing) causes an early return.
-- **Top of the tree:** `findPullRequestByBranches` is checked first. If the `feature → base` PR is **merged** — by any method (merge-commit, squash, or rebase) — the orchestrator deletes the feature branch (`deleteBranch`) and calls `markMerged` to idempotently finalize the parent node in the tracker. If the PR is still open, the step returns and awaits the human. Only when no PR exists is a new one opened (guarded by an ahead-check so a missing branch exits early). This replaces the old git-ancestry heuristic (`compareBranches` alone at the top-of-tree path), which misread squash/rebase merges as "still ahead" and re-opened the PR on each poll tick ([AII-188](https://linear.app/eudoxus/issue/AII-188)).
+- **Internal level:** `compareBranches` returning 0 (branch already merged into parent) or
+  `null` (branch missing) causes an early return.
+- **Top of the tree:** `findPullRequestByBranches` is checked first. If the PR is **merged**
+  — by any method (merge-commit, squash, or rebase) — the orchestrator deletes the grouping
+  branch (`deleteBranch`) and calls `markMerged` to idempotently finalize the node in the
+  tracker. If the PR is still open, the step returns and awaits the human. Only when no PR
+  exists is a new one opened (guarded by an ahead-check so a missing branch exits early).
+  This replaces the old git-ancestry heuristic, which misread squash/rebase merges as
+  "still ahead" and re-opened the PR on each poll tick ([AII-188](https://linear.app/eudoxus/issue/AII-188)).
 
 > ⚠️ **Auto-roll-up needs the runner callback.** A feature node only completes when its
-> closing-work PR merges and Linear marks it Done; the roll-up keys off that completed
-> state. Planning's `Plan-Complete` transition is delivered by the runner callback
+> closing-work PR merges and Linear marks it Done; the feature-node roll-up keys off that
+> completed state. Planning's `Plan-Complete` transition is delivered by the runner callback
 > (`RUNNER_CALLBACK_BASE_URL` + `RUNNER_TOKEN_SECRET`, which must be **publicly reachable**).
 > With the callback disabled, planning stalls at `AI-Planning` and the cascade can't advance
-> on its own.
+> on its own. Multi-issue roll-up is not affected since it keys off children being terminal,
+> not the parent's own state.
 
 ---
 
 ## 6. End-to-end lifecycle of one tree
+
+### Feature-node tree
 
 1. Label the tree `AI-Implement` (whole tree at once is fine — the gates sequence it).
 2. Leaves with no blockers dispatch: **plan → (auto-approve) → implement → PR** into their
@@ -153,7 +226,20 @@ Idempotency is handled differently per path:
    into its own feature branch → human merges → orchestrator marks node Done.
 5. The **merge-up** rolls each completed feature node's branch up into its parent's branch
    (direct merge). The top node's branch is offered as a `feature → base` PR.
-6. A human reviews and merges that final PR **by any merge method** (merge-commit, squash, or rebase). On the next poll tick the orchestrator detects the merged PR state, deletes the feature branch, and calls `markMerged` to finalize the top node Done — the tree lands on the base branch and the PR is never re-opened.
+6. A human reviews and merges that final PR **by any merge method** (merge-commit, squash, or rebase). On the next poll tick the orchestrator detects the merged PR state, deletes the feature branch, and calls `markMerged` to finalize the top node Done.
+
+### Multi-issue group
+
+1. Label the parent `AI-Implement` + `Multi-Issue`; label children `AI-Implement`.
+2. Children dispatch as leaves: **plan → implement → PR** into the shared multi-issue branch.
+   The grouping branch is created on the first child dispatch.
+3. A human merges each child PR → the orchestrator marks the child **Done**.
+4. When **all** children are terminal (Done or cancelled), `fetchFeatureNodeRollUps`
+   emits a roll-up record for the grouping node.
+5. The merge-up offers the grouping branch as a `multi-issue → base` PR (if at the top of
+   the tree) or direct-merges it into the parent (if it's nested).
+6. A human reviews and merges the top-of-tree PR. The orchestrator detects the merged PR
+   state, deletes the grouping branch, and calls `markMerged` to finalize the grouping node.
 
 ---
 
@@ -161,12 +247,14 @@ Idempotency is handled differently per path:
 
 | Concern | File |
 |---------|------|
-| Label query, classification, roll-up discovery | `src/providers/linear.ts` (`fetchAIImplementSnapshot`, `fetchFeatureNodeRollUps`) |
+| `AI_IMPLEMENT_LABEL`, `MULTI_ISSUE_LABEL` constants | `src/providers/linear.ts` |
+| Label query, classification, roll-up discovery (mode-aware) | `src/providers/linear.ts` (`fetchAIImplementSnapshot`, `fetchFeatureNodeRollUps`) |
 | Shared types (`featureBranchChain`, `FeatureNodeRollUp`) | `src/providers/types.ts` |
-| Branch names | `src/pipeline/branch-name.ts` (`buildFeatureBranchName`) |
+| Feature-node branch names (`buildFeatureBranchName`) | `src/pipeline/branch-name.ts` |
+| Multi-issue branch names (`buildMultiIssueBranchName`) | `src/pipeline/branch-name.ts` |
 | Cascade branch creation + PR-base resolution | `src/feature-branch.ts` (`resolveBaseBranch`) |
-| Roll-up (direct merge / human PR) | `src/merge-up.ts` (`runMergeUps`) |
-| GitHub helpers (branch/compare/merge/PR/merged-state) | `src/github.ts` (`ensureBranchExists`, `compareBranches`, `mergeBranch`, `createPullRequest`, `findOpenPullRequest`, `findPullRequestByBranches`, `deleteBranch`) — `findPullRequestByBranches` detects the top-of-tree PR's merged state (robust to any merge method); `deleteBranch` removes the feature branch after merge |
+| Roll-up (direct merge / human PR, both modes) | `src/merge-up.ts` (`runMergeUps`) |
+| GitHub helpers (branch/compare/merge/PR/merged-state) | `src/github.ts` (`ensureBranchExists`, `compareBranches`, `mergeBranch`, `createPullRequest`, `findOpenPullRequest`, `findPullRequestByBranches`, `deleteBranch`) — `findPullRequestByBranches` detects the top-of-tree PR's merged state (robust to any merge method); `deleteBranch` removes the grouping branch after merge |
 | Plan-Complete transition | `src/runner-callback.ts` → `markPlanComplete` |
 | Poll-loop wiring (roll-up before dispatch; base resolved per issue) | `src/index.ts` |
 
@@ -181,14 +269,38 @@ and no `featureBranchChain`, so its issues always PR to the base branch.
   `base_branch` input; otherwise GitHub 422s the grouped dispatch (the orchestrator only
   sends `base_branch` when grouping moved it off the default, so un-synced repos keep
   working for the non-grouped path).
-- **Runner callback must be public** for planning to auto-advance and thus for the cascade
-  to self-drive. On a local (`localhost`) orchestrator the callback can't be reached, so
-  `Plan-Complete` must be set by hand to test the implementation/grouping path.
+- **Runner callback must be public** for planning to auto-advance and thus for the
+  feature-node cascade to self-drive. On a local (`localhost`) orchestrator the callback
+  can't be reached, so `Plan-Complete` must be set by hand to test the
+  implementation/grouping path. Multi-issue roll-up does not require the callback — it
+  triggers on children being terminal, not on the parent's own planning/implementation state.
 - **Pair the runner image with the orchestrator.** A testing orchestrator should set
   `SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:next`; otherwise a GitHub Actions
   run falls back to the `:latest` runner, which may be incompatible with the current
   workflow/entrypoint.
-- **Top-of-tree PR merge method:** any method (merge-commit, squash, rebase) works correctly — the orchestrator detects completion via the PR's merged state, not git ancestry. On orchestrator versions before AII-188 shipped, squash/rebase merges left the feature branch appearing "ahead" of base, causing the PR to be re-opened each poll tick. If running a pre-fix orchestrator, use merge-commit with **Delete branch** checked as a temporary workaround.
+- **Top-of-tree PR merge method:** any method (merge-commit, squash, rebase) works
+  correctly — the orchestrator detects completion via the PR's merged state, not git
+  ancestry. On orchestrator versions before AII-188 shipped, squash/rebase merges left the
+  grouping branch appearing "ahead" of base, causing the PR to be re-opened each poll tick.
+  If running a pre-fix orchestrator, use merge-commit with **Delete branch** checked as a
+  temporary workaround.
+- **Opt a parent into multi-issue mode** by adding both `AI-Implement` and `Multi-Issue`
+  labels. Without `Multi-Issue`, a parent with AI-Implement children is always treated as a
+  feature node (deferred closing work). With `Multi-Issue`, it becomes a pure container
+  (no closing work, children share a grouping branch).
+- **The ≥2 child gate:** a `Multi-Issue` parent with 0 or 1 AI-Implement children is
+  treated as degenerate and skipped each poll tick with a log line. Add a second labelled
+  child (or remove `Multi-Issue` to fall back to feature-node mode) to resolve.
+- **Child-set mutation hazard:** the multi-issue branch name is derived from the child
+  identifiers at the time the first child dispatches. Adding or removing AI-Implement
+  children after the grouping branch is cut will cause the computed name to drift from
+  the existing branch. The safest recovery is to rename the existing branch manually to
+  match the new name, or to re-derive the name by looking at the current child set via
+  `buildMultiIssueBranchName`.
+- **Internal multi-issue self-finalize is deferred (AII-193).** When a multi-issue grouping
+  node is nested inside a larger feature tree (it has a parent grouping node), the
+  orchestrator direct-merges its branch but does not call `markMerged` on it. Only the
+  top-of-tree multi-issue PR path calls `markMerged` today. AII-193 will close this gap.
 - **Don't restart the orchestrator mid-run.** A restart drops in-flight job tracking,
   leaving dispatched issues stuck with `AI-Working` plus a dedup row. Recover by removing
   `AI-Working` in Linear and deleting the dedup entry (`DELETE /api/dedup/<issue-uuid>`).

--- a/src/__tests__/branch-name.test.ts
+++ b/src/__tests__/branch-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { branchMatchesIssueIdentifier, buildIssueBranchName, buildFeatureBranchName, normalizeBranchPrefix } from "../pipeline/branch-name.js";
+import { branchMatchesIssueIdentifier, buildIssueBranchName, buildFeatureBranchName, buildMultiIssueBranchName, normalizeBranchPrefix } from "../pipeline/branch-name.js";
 
 describe("buildIssueBranchName", () => {
   it("builds issue-scoped branch names from issue metadata", () => {
@@ -33,6 +33,34 @@ describe("buildFeatureBranchName", () => {
 
   it("falls back defensively for empty identifiers", () => {
     expect(buildFeatureBranchName(undefined)).toBe("ai-implement/feature/parent");
+  });
+});
+
+describe("buildMultiIssueBranchName", () => {
+  it("sorts child identifiers and joins with dashes", () => {
+    expect(buildMultiIssueBranchName(["AII-10", "AII-5"])).toBe("ai-implement/multi-issue/aii-10-aii-5");
+  });
+
+  it("is order-independent — same result regardless of input order", () => {
+    const a = buildMultiIssueBranchName(["AII-10", "AII-5"]);
+    const b = buildMultiIssueBranchName(["AII-5", "AII-10"]);
+    expect(a).toBe(b);
+  });
+
+  it("sorts three identifiers ascending", () => {
+    expect(buildMultiIssueBranchName(["Z-3", "A-1", "M-2"])).toBe("ai-implement/multi-issue/a-1-m-2-z-3");
+  });
+
+  it("caps at 3 slugs and appends -plusN suffix for extras (lexicographic sort)", () => {
+    // aii-1, aii-10, aii-2, aii-3, aii-5 in lexicographic order
+    const result = buildMultiIssueBranchName(["AII-5", "AII-10", "AII-1", "AII-2", "AII-3"]);
+    expect(result).toBe("ai-implement/multi-issue/aii-1-aii-10-aii-2-plus2");
+  });
+
+  it("produces no suffix for exactly 3 children", () => {
+    // aii-1, aii-10, aii-5 in lexicographic order
+    const result = buildMultiIssueBranchName(["AII-5", "AII-10", "AII-1"]);
+    expect(result).toBe("ai-implement/multi-issue/aii-1-aii-10-aii-5");
   });
 });
 

--- a/src/__tests__/feature-branch.test.ts
+++ b/src/__tests__/feature-branch.test.ts
@@ -49,7 +49,7 @@ describe("resolveBaseBranch", () => {
       .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "base-sha" } }) } as Response) // base head
       .mockResolvedValueOnce({ ok: true, status: 201 } as Response);                                // create ref
 
-    const base = await resolveBaseBranch({ ghToken: "t", issue: makeIssue(["OOL-78"]), mapping: makeMapping() });
+    const base = await resolveBaseBranch({ ghToken: "t", issue: makeIssue(["ai-implement/feature/ool-78"]), mapping: makeMapping() });
 
     expect(base).toBe("ai-implement/feature/ool-78");
     const createBody = JSON.parse((vi.mocked(fetch).mock.calls[2][1] as RequestInit).body as string);
@@ -58,28 +58,44 @@ describe("resolveBaseBranch", () => {
 
   it("cascades a multi-entry chain: each branch cut from the previous one", async () => {
     vi.mocked(fetch)
-      // ensure OOL-78 (missing → cut from testing)
+      // ensure ai-implement/feature/ool-78 (missing → cut from testing)
       .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
       .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "testing-sha" } }) } as Response)
       .mockResolvedValueOnce({ ok: true, status: 201 } as Response)
-      // ensure OOL-96 (missing → cut from OOL-78 branch)
+      // ensure ai-implement/feature/ool-96 (missing → cut from ool-78 branch)
       .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
       .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "f78-sha" } }) } as Response)
       .mockResolvedValueOnce({ ok: true, status: 201 } as Response);
 
     const base = await resolveBaseBranch({
       ghToken: "t",
-      issue: makeIssue(["OOL-78", "OOL-96"]),
+      issue: makeIssue(["ai-implement/feature/ool-78", "ai-implement/feature/ool-96"]),
       mapping: makeMapping(),
     });
 
     expect(base).toBe("ai-implement/feature/ool-96");
-    // The OOL-78 branch is read from refs/heads/testing; the OOL-96 branch is cut from the OOL-78 branch head.
     const f78Sha = JSON.parse((vi.mocked(fetch).mock.calls[2][1] as RequestInit).body as string).sha;
     expect(f78Sha).toBe("testing-sha");
     const f96Sha = JSON.parse((vi.mocked(fetch).mock.calls[5][1] as RequestInit).body as string).sha;
     expect(f96Sha).toBe("f78-sha");
     expect(vi.mocked(fetch).mock.calls[4][0]).toContain("ai-implement/feature/ool-78");
+  });
+
+  it("handles a multi-issue branch name in the chain", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ object: { sha: "base-sha" } }) } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 201 } as Response);
+
+    const base = await resolveBaseBranch({
+      ghToken: "t",
+      issue: makeIssue(["ai-implement/multi-issue/aii-10-aii-5"]),
+      mapping: makeMapping(),
+    });
+
+    expect(base).toBe("ai-implement/multi-issue/aii-10-aii-5");
+    const createBody = JSON.parse((vi.mocked(fetch).mock.calls[2][1] as RequestInit).body as string);
+    expect(createBody.ref).toBe("refs/heads/ai-implement/multi-issue/aii-10-aii-5");
   });
 
   it("returns defaultBranch and creates nothing when there is no chain", async () => {
@@ -92,7 +108,7 @@ describe("resolveBaseBranch", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500, text: async () => "boom" } as Response);
 
-    const base = await resolveBaseBranch({ ghToken: "t", issue: makeIssue(["OOL-78"]), mapping: makeMapping() });
+    const base = await resolveBaseBranch({ ghToken: "t", issue: makeIssue(["ai-implement/feature/ool-78"]), mapping: makeMapping() });
 
     expect(base).toBe("testing");
     expect(warn).toHaveBeenCalled();

--- a/src/__tests__/merge-up-multilevel.test.ts
+++ b/src/__tests__/merge-up-multilevel.test.ts
@@ -39,7 +39,9 @@ const deps = (resolve: (k: string) => RepoMapping | null, finalizeMerged = vi.fn
 });
 
 const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
-  issueId: "issue-uuid-1", identifier: "AII-101", scopeKey: "AII", parentIdentifier: "AII-102", ...o,
+  issueId: "issue-uuid-1", identifier: "AII-101", scopeKey: "AII", parentIdentifier: "AII-102",
+  branch: "ai-implement/feature/aii-101", target: "ai-implement/feature/aii-102",
+  ...o,
 });
 
 beforeEach(() => {
@@ -90,8 +92,8 @@ describe("runMergeUps — multi-level feature trees", () => {
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
       [
-        rollUp({ issueId: "uuid-101", identifier: "AII-101", parentIdentifier: "AII-102" }),
-        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null }),
+        rollUp({ issueId: "uuid-101", identifier: "AII-101", parentIdentifier: "AII-102", branch: "ai-implement/feature/aii-101", target: "ai-implement/feature/aii-102" }),
+        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null, branch: "ai-implement/feature/aii-102", target: null }),
       ],
       deps(() => mapping(), finalizeMerged),
     );
@@ -108,8 +110,8 @@ describe("runMergeUps — multi-level feature trees", () => {
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
       [
-        rollUp({ issueId: "uuid-101", identifier: "AII-101", parentIdentifier: "AII-102" }),
-        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null }),
+        rollUp({ issueId: "uuid-101", identifier: "AII-101", parentIdentifier: "AII-102", branch: "ai-implement/feature/aii-101", target: "ai-implement/feature/aii-102" }),
+        rollUp({ issueId: "uuid-102", identifier: "AII-102", parentIdentifier: null, branch: "ai-implement/feature/aii-102", target: null }),
       ],
       deps(() => mapping(), finalizeMerged),
     );
@@ -147,7 +149,7 @@ describe("runMergeUps — multi-level feature trees", () => {
     vi.mocked(compareBranches).mockResolvedValue(0);
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
-      [rollUp({ identifier: "AII-102", parentIdentifier: null })],
+      [rollUp({ identifier: "AII-102", parentIdentifier: null, branch: "ai-implement/feature/aii-102", target: null })],
       deps(() => mapping(), finalizeMerged),
     );
 

--- a/src/__tests__/merge-up.test.ts
+++ b/src/__tests__/merge-up.test.ts
@@ -33,7 +33,9 @@ const deps = (resolve: (k: string) => RepoMapping | null, finalizeMerged = vi.fn
 });
 
 const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
-  issueId: "issue-uuid-1", identifier: "OOL-107", scopeKey: "OOL", parentIdentifier: "OOL-106", ...o,
+  issueId: "issue-uuid-1", identifier: "OOL-107", scopeKey: "OOL", parentIdentifier: "OOL-106",
+  branch: "ai-implement/feature/ool-107", target: "ai-implement/feature/ool-106",
+  ...o,
 });
 
 beforeEach(() => {
@@ -81,7 +83,7 @@ describe("runMergeUps", () => {
   it("opens a human PR (no direct merge) for the top-level feature→base roll-up", async () => {
     vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
     vi.mocked(compareBranches).mockResolvedValue(3);
-    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping()));
+    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })], deps(() => mapping()));
 
     expect(vi.mocked(createPullRequest)).toHaveBeenCalledWith("tok", "jodwyer", "alpacaWheel", expect.objectContaining({
       head: "ai-implement/feature/ool-106",
@@ -98,7 +100,7 @@ describe("runMergeUps", () => {
       number: 42, url: "https://gh/pr/42", state: "open", merged: false,
     });
     const finalizeMerged = vi.fn();
-    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping(), finalizeMerged));
+    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })], deps(() => mapping(), finalizeMerged));
     expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
     expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
     expect(finalizeMerged).not.toHaveBeenCalled();
@@ -110,7 +112,7 @@ describe("runMergeUps", () => {
     });
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
-      [rollUp({ issueId: "uuid-parent", identifier: "OOL-106", parentIdentifier: null })],
+      [rollUp({ issueId: "uuid-parent", identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })],
       deps(() => mapping(), finalizeMerged),
     );
 
@@ -121,11 +123,10 @@ describe("runMergeUps", () => {
   });
 
   it("is idempotent after branch is deleted — no PR re-opened on subsequent polls", async () => {
-    // After deletion: findPullRequestByBranches returns null (branch gone), compareBranches returns null
     vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
     vi.mocked(compareBranches).mockResolvedValue(null);
     const finalizeMerged = vi.fn();
-    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping(), finalizeMerged));
+    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })], deps(() => mapping(), finalizeMerged));
     expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
     expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
     expect(finalizeMerged).not.toHaveBeenCalled();
@@ -138,7 +139,7 @@ describe("runMergeUps", () => {
     vi.mocked(deleteBranch).mockResolvedValue(true); // 404 treated as success → true
     const finalizeMerged = vi.fn(async () => {});
     await runMergeUps(
-      [rollUp({ issueId: "uuid-p", identifier: "OOL-106", parentIdentifier: null })],
+      [rollUp({ issueId: "uuid-p", identifier: "OOL-106", parentIdentifier: null, branch: "ai-implement/feature/ool-106", target: null })],
       deps(() => mapping(), finalizeMerged),
     );
     expect(finalizeMerged).toHaveBeenCalledWith("uuid-p");

--- a/src/__tests__/providers/linear.test.ts
+++ b/src/__tests__/providers/linear.test.ts
@@ -153,15 +153,22 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
   beforeEach(() => { vi.stubGlobal("fetch", vi.fn()); });
   afterEach(() => { vi.restoreAllMocks(); });
 
-  type Ancestor = { identifier: string; labels?: string[]; parent?: Ancestor | null };
-  type Child = { labels?: string[]; stateType?: string };
+  type Ancestor = { identifier: string; labels?: string[]; aiChildIdentifiers?: string[]; parent?: Ancestor | null };
+  type Child = { identifier?: string; labels?: string[]; stateType?: string };
 
   function labelNodes(names: string[] | undefined) {
     return { nodes: (names ?? []).map((name) => ({ name })) };
   }
   function ancestorNode(a: Ancestor | null | undefined): unknown {
     if (!a) return null;
-    return { identifier: a.identifier, labels: labelNodes(a.labels), parent: ancestorNode(a.parent) };
+    return {
+      identifier: a.identifier,
+      labels: labelNodes(a.labels),
+      children: {
+        nodes: (a.aiChildIdentifiers ?? []).map((id) => ({ identifier: id, labels: labelNodes(["AI-Implement"]) })),
+      },
+      parent: ancestorNode(a.parent),
+    };
   }
 
   function makeIssue(overrides: {
@@ -177,9 +184,10 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
     parent?: Ancestor | null;
     children?: Child[];
   } = {}) {
+    const issueIdentifier = overrides.identifier ?? "ENG-1";
     return {
       id: overrides.id ?? "uuid-1",
-      identifier: overrides.identifier ?? "ENG-1",
+      identifier: issueIdentifier,
       title: overrides.title ?? "Title",
       description: overrides.description ?? null,
       team: { id: "team-id", key: overrides.teamKey ?? "ENG" },
@@ -192,7 +200,7 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
       inverseRelations: { nodes: overrides.inverseRelations ?? [] },
       children: {
         nodes: (overrides.children ?? []).map((c, i) => ({
-          identifier: `${overrides.identifier ?? "ENG-1"}-c${i}`,
+          identifier: c.identifier ?? `${issueIdentifier}-c${i}`,
           state: { type: c.stateType ?? "unstarted" },
           labels: labelNodes(c.labels),
         })),
@@ -258,12 +266,12 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
           id: "leaf",
           identifier: "OOL-96",
           labels: ["AI-Implement", "Plan-Complete"],
-          parent: { identifier: "OOL-78", labels: ["AI-Implement"] },
+          parent: { identifier: "OOL-78", labels: ["AI-Implement"], aiChildIdentifiers: ["OOL-96"] },
         }),
       ]);
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
       const leaf = snap.readyForImplementation.find((i) => i.id === "leaf")!;
-      expect(leaf.featureBranchChain).toEqual(["OOL-78"]);
+      expect(leaf.featureBranchChain).toEqual(["ai-implement/feature/ool-78"]);
     });
 
     it("a leaf under an UNlabeled parent gets no chain (PRs to base)", async () => {
@@ -289,14 +297,15 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
           parent: {
             identifier: "OOL-96",
             labels: ["AI-Implement"],
-            parent: { identifier: "OOL-78", labels: ["AI-Implement"] },
+            aiChildIdentifiers: ["OOL-99"],
+            parent: { identifier: "OOL-78", labels: ["AI-Implement"], aiChildIdentifiers: ["OOL-96"] },
           },
         }),
       ]);
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
       const leaf = snap.needsPlanning.find((i) => i.id === "leaf")!;
-      // base-most first
-      expect(leaf.featureBranchChain).toEqual(["OOL-78", "OOL-96"]);
+      // base-most first; each entry is a branch name
+      expect(leaf.featureBranchChain).toEqual(["ai-implement/feature/ool-78", "ai-implement/feature/ool-96"]);
     });
 
     it("skips a feature-node parent while any AI-Implement child is in flight", async () => {
@@ -323,15 +332,15 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
           identifier: "OOL-78",
           labels: ["AI-Implement"],
           children: [
-            { labels: ["AI-Implement"], stateType: "completed" },
-            { labels: ["AI-Implement"], stateType: "canceled" },
-            { labels: ["Improvement"], stateType: "started" }, // non-AI child does not gate
+            { identifier: "OOL-78-c0", labels: ["AI-Implement"], stateType: "completed" },
+            { identifier: "OOL-78-c1", labels: ["AI-Implement"], stateType: "canceled" },
+            { identifier: "OOL-78-c2", labels: ["Improvement"], stateType: "started" }, // non-AI child does not gate
           ],
         }),
       ]);
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
       const parent = snap.needsPlanning.find((i) => i.id === "parent")!;
-      expect(parent.featureBranchChain).toEqual(["OOL-78"]);
+      expect(parent.featureBranchChain).toEqual(["ai-implement/feature/ool-78"]);
     });
 
     it("skips a labeled parent whose children are not yet AI-Implement (race guard)", async () => {
@@ -346,6 +355,111 @@ describe("LinearProvider.fetchAIImplementSnapshot", () => {
       const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
       expect(snap.needsPlanning).toEqual([]);
       expect(snap.readyForImplementation).toEqual([]);
+    });
+
+    describe("Multi-Issue grouping", () => {
+      it("Multi-Issue parent with >=2 terminal AI children is never dispatched", async () => {
+        mockSinglePage([
+          makeIssue({
+            id: "mi-parent",
+            identifier: "AII-10",
+            labels: ["AI-Implement", "Multi-Issue"],
+            children: [
+              { identifier: "AII-11", labels: ["AI-Implement"], stateType: "completed" },
+              { identifier: "AII-12", labels: ["AI-Implement"], stateType: "completed" },
+            ],
+          }),
+        ]);
+        const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+        expect(snap.needsPlanning).toEqual([]);
+        expect(snap.readyForImplementation).toEqual([]);
+      });
+
+      it("Multi-Issue parent with children in flight is skipped", async () => {
+        mockSinglePage([
+          makeIssue({
+            id: "mi-parent",
+            identifier: "AII-10",
+            labels: ["AI-Implement", "Multi-Issue"],
+            children: [
+              { identifier: "AII-11", labels: ["AI-Implement"], stateType: "started" },
+              { identifier: "AII-12", labels: ["AI-Implement"], stateType: "completed" },
+            ],
+          }),
+        ]);
+        const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+        expect(snap.needsPlanning).toEqual([]);
+        expect(snap.readyForImplementation).toEqual([]);
+      });
+
+      it("Multi-Issue parent with <2 AI children is skipped (degenerate)", async () => {
+        mockSinglePage([
+          makeIssue({
+            id: "mi-parent",
+            identifier: "AII-10",
+            labels: ["AI-Implement", "Multi-Issue"],
+            children: [
+              { identifier: "AII-11", labels: ["AI-Implement"], stateType: "completed" },
+            ],
+          }),
+        ]);
+        const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+        expect(snap.needsPlanning).toEqual([]);
+        expect(snap.readyForImplementation).toEqual([]);
+      });
+
+      it("leaf under a Multi-Issue parent gets multi-issue branch in chain", async () => {
+        mockSinglePage([
+          makeIssue({
+            id: "leaf",
+            identifier: "AII-11",
+            labels: ["AI-Implement"],
+            parent: {
+              identifier: "AII-10",
+              labels: ["AI-Implement", "Multi-Issue"],
+              aiChildIdentifiers: ["AII-11", "AII-12"],
+            },
+          }),
+        ]);
+        const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+        const leaf = snap.needsPlanning.find((i) => i.id === "leaf")!;
+        expect(leaf.featureBranchChain).toEqual(["ai-implement/multi-issue/aii-11-aii-12"]);
+      });
+
+      it("leaf under degenerate Multi-Issue parent (<2 AI children) gets no chain", async () => {
+        mockSinglePage([
+          makeIssue({
+            id: "leaf",
+            identifier: "AII-11",
+            labels: ["AI-Implement"],
+            parent: {
+              identifier: "AII-10",
+              labels: ["AI-Implement", "Multi-Issue"],
+              aiChildIdentifiers: ["AII-11"], // only 1 AI child — degenerate
+            },
+          }),
+        ]);
+        const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+        const leaf = snap.needsPlanning.find((i) => i.id === "leaf")!;
+        expect(leaf.featureBranchChain).toBeUndefined();
+      });
+
+      it("feature-node parent without Multi-Issue label still dispatches normally (regression guard)", async () => {
+        mockSinglePage([
+          makeIssue({
+            id: "fn-parent",
+            identifier: "OOL-78",
+            labels: ["AI-Implement"],
+            children: [
+              { identifier: "OOL-78-c0", labels: ["AI-Implement"], stateType: "completed" },
+              { identifier: "OOL-78-c1", labels: ["AI-Implement"], stateType: "canceled" },
+            ],
+          }),
+        ]);
+        const snap = await new LinearProvider({ linearApiKey: "k" }).fetchAIImplementSnapshot();
+        const parent = snap.needsPlanning.find((i) => i.id === "fn-parent")!;
+        expect(parent.featureBranchChain).toEqual(["ai-implement/feature/ool-78"]);
+      });
     });
   });
 
@@ -412,29 +526,80 @@ describe("LinearProvider.fetchFeatureNodeRollUps", () => {
     } as Response);
   }
   const labels = (...names: string[]) => ({ nodes: names.map((name) => ({ name })) });
+  const stateOf = (type: string) => ({ type });
 
-  it("returns feature nodes with parent target; non-feature parent → null (base)", async () => {
+  it("feature-node: returns branch/target; non-feature parent → target null", async () => {
     mockResponse([
-      { identifier: "OOL-107", team: { key: "OOL" },
-        children: { nodes: [{ labels: labels("AI-Implement") }] },
-        parent: { identifier: "OOL-106", labels: labels("AI-Implement") } },
-      { identifier: "OOL-106", team: { key: "OOL" },
-        children: { nodes: [{ labels: labels("AI-Implement") }] },
+      { id: "id-107", identifier: "OOL-107", state: stateOf("completed"), team: { key: "OOL" },
+        labels: labels("AI-Implement"),
+        children: { nodes: [{ identifier: "OOL-107-c", state: stateOf("completed"), labels: labels("AI-Implement") }] },
+        parent: { identifier: "OOL-106", labels: labels("AI-Implement"),
+          children: { nodes: [{ identifier: "OOL-107", labels: labels("AI-Implement") }] } } },
+      { id: "id-106", identifier: "OOL-106", state: stateOf("completed"), team: { key: "OOL" },
+        labels: labels("AI-Implement"),
+        children: { nodes: [{ identifier: "OOL-107", state: stateOf("completed"), labels: labels("AI-Implement") }] },
         parent: null },
     ]);
     const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
     expect(rollUps).toEqual([
-      { identifier: "OOL-107", scopeKey: "OOL", parentIdentifier: "OOL-106" },
-      { identifier: "OOL-106", scopeKey: "OOL", parentIdentifier: null },
+      { issueId: "id-107", identifier: "OOL-107", scopeKey: "OOL", parentIdentifier: "OOL-106",
+        branch: "ai-implement/feature/ool-107", target: "ai-implement/feature/ool-106" },
+      { issueId: "id-106", identifier: "OOL-106", scopeKey: "OOL", parentIdentifier: null,
+        branch: "ai-implement/feature/ool-106", target: null },
     ]);
   });
 
   it("excludes completed issues that are not feature nodes (no AI-Implement child)", async () => {
     mockResponse([
-      { identifier: "OOL-50", team: { key: "OOL" },
-        children: { nodes: [{ labels: labels("Improvement") }] }, parent: null },
-      { identifier: "OOL-51", team: { key: "OOL" },
+      { id: "id-50", identifier: "OOL-50", state: stateOf("completed"), team: { key: "OOL" },
+        labels: labels("AI-Implement"),
+        children: { nodes: [{ identifier: "OOL-50-c", state: stateOf("completed"), labels: labels("Improvement") }] },
+        parent: null },
+      { id: "id-51", identifier: "OOL-51", state: stateOf("completed"), team: { key: "OOL" },
+        labels: labels("AI-Implement"),
         children: { nodes: [] }, parent: null },
+    ]);
+    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
+    expect(rollUps).toEqual([]);
+  });
+
+  it("feature-node with non-completed state is excluded", async () => {
+    mockResponse([
+      { id: "id-99", identifier: "OOL-99", state: stateOf("started"), team: { key: "OOL" },
+        labels: labels("AI-Implement"),
+        children: { nodes: [{ identifier: "OOL-99-c", state: stateOf("completed"), labels: labels("AI-Implement") }] },
+        parent: null },
+    ]);
+    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
+    expect(rollUps).toEqual([]);
+  });
+
+  it("Multi-Issue: surfaces when all AI children terminal, with multi-issue branch and null target", async () => {
+    mockResponse([
+      { id: "id-mi", identifier: "AII-10", state: stateOf("started"), team: { key: "AII" },
+        labels: labels("AI-Implement", "Multi-Issue"),
+        children: { nodes: [
+          { identifier: "AII-11", state: stateOf("completed"), labels: labels("AI-Implement") },
+          { identifier: "AII-12", state: stateOf("completed"), labels: labels("AI-Implement") },
+        ] },
+        parent: null },
+    ]);
+    const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
+    expect(rollUps).toEqual([
+      { issueId: "id-mi", identifier: "AII-10", scopeKey: "AII", parentIdentifier: null,
+        branch: "ai-implement/multi-issue/aii-11-aii-12", target: null },
+    ]);
+  });
+
+  it("Multi-Issue: excluded when a child is still in flight", async () => {
+    mockResponse([
+      { id: "id-mi", identifier: "AII-10", state: stateOf("started"), team: { key: "AII" },
+        labels: labels("AI-Implement", "Multi-Issue"),
+        children: { nodes: [
+          { identifier: "AII-11", state: stateOf("started"), labels: labels("AI-Implement") },
+          { identifier: "AII-12", state: stateOf("completed"), labels: labels("AI-Implement") },
+        ] },
+        parent: null },
     ]);
     const rollUps = await new LinearProvider({ linearApiKey: "k" }).fetchFeatureNodeRollUps();
     expect(rollUps).toEqual([]);

--- a/src/feature-branch.ts
+++ b/src/feature-branch.ts
@@ -1,7 +1,6 @@
 import type { RepoMapping } from "./config.js";
 import type { TicketIssue } from "./providers/types.js";
 import { ensureBranchExists } from "./github.js";
-import { buildFeatureBranchName } from "./pipeline/branch-name.js";
 
 /**
  * Feature-branch grouping for parent/child issues.
@@ -20,9 +19,9 @@ import { buildFeatureBranchName } from "./pipeline/branch-name.js";
  * Resolves the branch a dispatched issue's PR should target, creating any feature
  * branches in `issue.featureBranchChain` that don't yet exist.
  *
- * The chain is base-most first: each identifier's branch `ai-implement/feature/<id>` is
- * cut from the previous entry's branch (or mapping.defaultBranch for the first), and the
- * PR targets the LAST entry's branch. An empty/absent chain returns mapping.defaultBranch.
+ * The chain is base-most first: each branch name is cut from the previous entry's branch
+ * (or mapping.defaultBranch for the first), and the PR targets the LAST entry.
+ * An empty/absent chain returns mapping.defaultBranch.
  *
  * `ensureBranchExists` is idempotent (422-tolerant), so an existing ancestor branch is
  * reused and only the missing tip of the chain is cut.
@@ -43,8 +42,7 @@ export async function resolveBaseBranch(opts: {
   try {
     let cutFrom = mapping.defaultBranch;
     let target = mapping.defaultBranch;
-    for (const identifier of chain) {
-      const branch = buildFeatureBranchName(identifier);
+    for (const branch of chain) {
       await ensureBranchExists(ghToken, mapping.owner, mapping.repo, branch, cutFrom);
       cutFrom = branch;
       target = branch;

--- a/src/merge-up.ts
+++ b/src/merge-up.ts
@@ -1,7 +1,6 @@
 import type { RepoMapping } from "./config.js";
 import type { FeatureNodeRollUp } from "./providers/types.js";
 import { getInstallationToken } from "./github-app-auth.js";
-import { buildFeatureBranchName } from "./pipeline/branch-name.js";
 import { compareBranches, createPullRequest, deleteBranch, findPullRequestByBranches, mergeBranch } from "./github.js";
 
 /**
@@ -49,10 +48,8 @@ async function rollUpOne(rollUp: FeatureNodeRollUp, deps: MergeUpDeps): Promise<
   const { owner, repo } = mapping;
   const ghToken = await getInstallationToken(deps.githubAppId, deps.githubAppPrivateKey, owner);
 
-  const branch = buildFeatureBranchName(rollUp.identifier);
-  const target = rollUp.parentIdentifier
-    ? buildFeatureBranchName(rollUp.parentIdentifier)
-    : mapping.defaultBranch;
+  const branch = rollUp.branch;
+  const target = rollUp.target ?? mapping.defaultBranch;
 
   if (rollUp.parentIdentifier !== null) {
     // Internal roll-up → direct merge, no PR (avoids Linear linking the roll-up to the

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -67,6 +67,20 @@ export function buildFeatureBranchName(parentIdentifier: string | undefined): st
   return `ai-implement/feature/${slugify(parentIdentifier, "parent")}`;
 }
 
+const MAX_MULTI_ISSUE_KEYS = 3;
+
+/**
+ * Shared branch for a Multi-Issue grouping parent's children. Derived from the
+ * sorted, slugified child identifiers (capped at 3) so the name is stable regardless
+ * of child-array ordering and distinguishable from feature-node branches.
+ */
+export function buildMultiIssueBranchName(childIdentifiers: string[]): string {
+  const slugs = childIdentifiers.map((id) => slugify(id, "issue")).sort();
+  const shown = slugs.slice(0, MAX_MULTI_ISSUE_KEYS).join("-");
+  const extra = slugs.length - MAX_MULTI_ISSUE_KEYS;
+  return `ai-implement/multi-issue/${shown}${extra > 0 ? `-plus${extra}` : ""}`;
+}
+
 export function branchMatchesIssueIdentifier(branchRef: string | undefined, issueIdentifier: string | undefined): boolean {
   if (!branchRef || !issueIdentifier) return false;
 

--- a/src/providers/linear.ts
+++ b/src/providers/linear.ts
@@ -8,6 +8,7 @@ import type {
 } from "./types.js";
 import { MissingProviderConfigError } from "./types.js";
 import { fetchPlanningContext as fetchLinearPlanningContext } from "../linear-planning-fetch.js";
+import { buildFeatureBranchName, buildMultiIssueBranchName } from "../pipeline/branch-name.js";
 
 interface GraphQLResponse<T> {
   data?: T;
@@ -15,14 +16,23 @@ interface GraphQLResponse<T> {
 }
 
 const AI_IMPLEMENT_LABEL = "AI-Implement";
+const MULTI_ISSUE_LABEL = "Multi-Issue";
+
+const isAIImplement = (n: { labels?: { nodes: Array<{ name: string }> } }): boolean =>
+  (n.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL);
+const hasMultiIssue = (n: { labels?: { nodes: Array<{ name: string }> } }): boolean =>
+  (n.labels?.nodes ?? []).some((l) => l.name === MULTI_ISSUE_LABEL);
+const isTerminal = (n: { state?: { type: string } }): boolean =>
+  n.state?.type === "completed" || n.state?.type === "canceled";
 
 /** How far back to scan completed feature nodes for roll-up (bounds the query). */
 const ROLLUP_LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000;
 
-/** A node in the ancestor chain: identifier + labels, with a nullable parent. */
+/** A node in the ancestor chain: identifier + labels + children, with a nullable parent. */
 type AncestorNode = {
   identifier: string;
   labels?: { nodes: Array<{ name: string }> };
+  children?: { nodes: Array<{ identifier: string; labels?: { nodes: Array<{ name: string }> } }> };
   parent?: AncestorNode | null;
 } | null;
 
@@ -170,23 +180,28 @@ export class LinearProvider implements TicketingProvider {
                 labels { nodes { name } }
               }
             }
-            # Ancestor chain (labels only) — used to build the cascading feature-branch
-            # chain. Nested to a fixed depth; deeper ancestries cut from the base branch.
+            # Ancestor chain — used to build the cascading feature-branch chain.
+            # Each level carries labels + children so groupingBranchFor can determine mode.
             parent {
               identifier
               labels { nodes { name } }
+              children(first: 50) { nodes { identifier labels { nodes { name } } } }
               parent {
                 identifier
                 labels { nodes { name } }
+                children(first: 50) { nodes { identifier labels { nodes { name } } } }
                 parent {
                   identifier
                   labels { nodes { name } }
+                  children(first: 50) { nodes { identifier labels { nodes { name } } } }
                   parent {
                     identifier
                     labels { nodes { name } }
+                    children(first: 50) { nodes { identifier labels { nodes { name } } } }
                     parent {
                       identifier
                       labels { nodes { name } }
+                      children(first: 50) { nodes { identifier labels { nodes { name } } } }
                     }
                   }
                 }
@@ -205,6 +220,7 @@ export class LinearProvider implements TicketingProvider {
     type LinearAncestor = {
       identifier: string;
       labels: LinearLabelNodes;
+      children: { nodes: Array<{ identifier: string; labels: LinearLabelNodes }> };
       parent: LinearAncestor | null;
     };
 
@@ -252,6 +268,42 @@ export class LinearProvider implements TicketingProvider {
     const needsPlanning: AIImplementSnapshot["needsPlanning"] = [];
     const readyForImplementation: AIImplementSnapshot["readyForImplementation"] = [];
 
+    // Build a mode-info map so groupingBranchFor can determine feature-node vs. multi-issue
+    // for any ancestor. Primary source: allNodes (active issues in this query). Secondary
+    // source: ancestor chains embedded in the query results, which cover terminal parents
+    // not returned by the state filter.
+    const nodeInfo = new Map<string, { multi: boolean; aiChildKeys: string[] }>();
+    for (const node of allNodes) {
+      nodeInfo.set(node.identifier, {
+        multi: hasMultiIssue(node),
+        aiChildKeys: (node.children?.nodes ?? []).filter(isAIImplement).map((c) => c.identifier),
+      });
+    }
+    const populateFromAncestorChain = (node: AncestorNode): void => {
+      while (node) {
+        if (!nodeInfo.has(node.identifier)) {
+          nodeInfo.set(node.identifier, {
+            multi: hasMultiIssue(node),
+            aiChildKeys: (node.children?.nodes ?? []).filter(isAIImplement).map((c) => c.identifier),
+          });
+        }
+        node = node.parent ?? null;
+      }
+    };
+    for (const issue of allNodes) {
+      populateFromAncestorChain(issue.parent);
+    }
+
+    const groupingBranchFor = (identifier: string): string | null => {
+      const info = nodeInfo.get(identifier);
+      if (!info) return null;
+      if (info.multi) return info.aiChildKeys.length >= 2 ? buildMultiIssueBranchName(info.aiChildKeys) : null;
+      return info.aiChildKeys.length >= 1 ? buildFeatureBranchName(identifier) : null;
+    };
+
+    const ancestorBranchesFor = (parent: AncestorNode): string[] =>
+      labeledAncestorChain(parent).map((id) => groupingBranchFor(id)).filter((b): b is string => b !== null);
+
     for (const issue of allNodes) {
       const labelNames = new Set(issue.labels?.nodes?.map((l) => l.name) ?? []);
 
@@ -277,34 +329,28 @@ export class LinearProvider implements TicketingProvider {
         continue;
       }
 
-      // Feature-branch grouping (see src/feature-branch.ts). An AI-Implement issue is one of:
-      //   - leaf (no children)            → implement now; PR targets nearest feature-node
-      //                                      ancestor branch (or base).
-      //   - feature-node (>=1 AI child)   → its own work waits until ALL its AI-Implement
-      //                                      children reach a terminal state, then implements
-      //                                      onto its OWN feature branch. While children are in
-      //                                      flight the parent is skipped (its branch is cut
-      //                                      lazily when the first child dispatches).
-      //   - waiting parent (children but  → skipped (race guard: the parent was labeled before
-      //     none AI-Implement yet)          its children were, so let it sit).
       const children = issue.children?.nodes ?? [];
-      const aiChildren = children.filter((c) => (c.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL));
-      const ancestorChain = labeledAncestorChain(issue.parent);
+      const aiChildren = children.filter(isAIImplement);
 
       let featureBranchChain: string[] | undefined;
       if (children.length === 0) {
-        // Leaf.
-        featureBranchChain = ancestorChain.length > 0 ? ancestorChain : undefined;
+        const anc = ancestorBranchesFor(issue.parent);
+        featureBranchChain = anc.length > 0 ? anc : undefined;
+      } else if (hasMultiIssue(issue)) {
+        if (aiChildren.length < 2) {
+          console.log(`[linear] Skipping ${issue.identifier}: Multi-Issue parent needs >=2 AI-Implement children (has ${aiChildren.length}) — not a group`);
+          continue;
+        }
+        const allTerminal = aiChildren.every(isTerminal);
+        console.log(`[linear] Skipping ${issue.identifier}: multi-issue grouping parent (no work; ${allTerminal ? "children terminal — awaiting roll-up" : "children in flight"})`);
+        continue;
       } else if (aiChildren.length > 0) {
-        const allAIChildrenTerminal = aiChildren.every(
-          (c) => c.state?.type === "completed" || c.state?.type === "canceled",
-        );
-        if (!allAIChildrenTerminal) {
+        const allTerminal = aiChildren.every(isTerminal);
+        if (!allTerminal) {
           console.log(`[linear] Skipping ${issue.identifier}: feature-node parent waiting on in-flight AI-Implement children`);
           continue;
         }
-        // All AI-Implement children done — implement the parent's closing work onto its own branch.
-        featureBranchChain = [...ancestorChain, issue.identifier];
+        featureBranchChain = [...ancestorBranchesFor(issue.parent), buildFeatureBranchName(issue.identifier)];
       } else {
         console.log(`[linear] Skipping ${issue.identifier}: parent labeled but no child has AI-Implement set yet`);
         continue;
@@ -332,20 +378,24 @@ export class LinearProvider implements TicketingProvider {
   }
 
   async fetchFeatureNodeRollUps(): Promise<FeatureNodeRollUp[]> {
-    // Recently-completed AI-Implement issues that are feature nodes (>=1 AI-Implement
-    // child) need their feature branch rolled up into the parent. Bound the scan to a
-    // recent window so the set stays small; the merge-up step skips already-merged
-    // branches cheaply via a branch comparison. A completed feature node implies its
-    // own closing work merged and all its children done.
+    // Scan recently-updated AI-Implement issues (excluding canceled) for roll-up triggers:
+    //   - Feature-node: state.type === "completed" AND >=1 AI-Implement child
+    //   - Multi-Issue:  Multi-Issue label AND >=2 AI-Implement children AND all terminal
     const since = new Date(Date.now() - ROLLUP_LOOKBACK_MS).toISOString();
     const data = await this.linearMutation<{
       issues: {
         nodes: Array<{
           id: string;
           identifier: string;
+          state: { type: string };
           team: { key: string };
-          children: { nodes: Array<{ labels: { nodes: Array<{ name: string }> } }> };
-          parent: { identifier: string; labels: { nodes: Array<{ name: string }> } } | null;
+          labels: { nodes: Array<{ name: string }> };
+          children: { nodes: Array<{ identifier: string; state: { type: string }; labels: { nodes: Array<{ name: string }> } }> };
+          parent: {
+            identifier: string;
+            labels: { nodes: Array<{ name: string }> };
+            children: { nodes: Array<{ identifier: string; labels: { nodes: Array<{ name: string }> } }> };
+          } | null;
         }>;
       };
     }>(
@@ -354,16 +404,22 @@ export class LinearProvider implements TicketingProvider {
           first: 100
           filter: {
             labels: { name: { eq: "AI-Implement" } }
-            state: { type: { eq: "completed" } }
+            state: { type: { nin: ["canceled"] } }
             updatedAt: { gt: $since }
           }
         ) {
           nodes {
             id
             identifier
+            state { type }
             team { key }
-            children(first: 50) { nodes { labels { nodes { name } } } }
-            parent { identifier labels { nodes { name } } }
+            labels { nodes { name } }
+            children(first: 50) { nodes { identifier state { type } labels { nodes { name } } } }
+            parent {
+              identifier
+              labels { nodes { name } }
+              children(first: 50) { nodes { identifier labels { nodes { name } } } }
+            }
           }
         }
       }`,
@@ -372,17 +428,39 @@ export class LinearProvider implements TicketingProvider {
 
     const rollUps: FeatureNodeRollUp[] = [];
     for (const node of data.issues?.nodes ?? []) {
-      const isFeatureNode = (node.children?.nodes ?? []).some((c) =>
-        (c.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL),
-      );
-      if (!isFeatureNode) continue;
-      const parentIsFeatureNode =
-        !!node.parent && (node.parent.labels?.nodes ?? []).some((l) => l.name === AI_IMPLEMENT_LABEL);
+      const aiChildren = (node.children?.nodes ?? []).filter(isAIImplement);
+      let branch: string;
+      if (hasMultiIssue(node)) {
+        if (aiChildren.length < 2) continue;
+        if (!aiChildren.every(isTerminal)) continue;
+        branch = buildMultiIssueBranchName(aiChildren.map((c) => c.identifier));
+      } else {
+        if (aiChildren.length < 1) continue;
+        if (node.state?.type !== "completed") continue;
+        branch = buildFeatureBranchName(node.identifier);
+      }
+
+      let parentIdentifier: string | null = null;
+      let target: string | null = null;
+      const parent = node.parent;
+      if (parent && isAIImplement(parent)) {
+        const pKeys = (parent.children?.nodes ?? []).filter(isAIImplement).map((c) => c.identifier);
+        if (hasMultiIssue(parent) && pKeys.length >= 2) {
+          parentIdentifier = parent.identifier;
+          target = buildMultiIssueBranchName(pKeys);
+        } else if (!hasMultiIssue(parent) && pKeys.length >= 1) {
+          parentIdentifier = parent.identifier;
+          target = buildFeatureBranchName(parent.identifier);
+        }
+      }
+
       rollUps.push({
         issueId: node.id,
         identifier: node.identifier,
         scopeKey: node.team.key,
-        parentIdentifier: parentIsFeatureNode ? node.parent!.identifier : null,
+        parentIdentifier,
+        branch,
+        target,
       });
     }
     return rollUps;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -22,14 +22,13 @@ export interface TicketIssue {
   /**
    * Feature-branch grouping chain, set by the Linear provider for dispatchable issues.
    *
-   * An ordered list of issue identifiers (base-most first). Each names a feature branch
-   * `ai-implement/feature/<id>` that must exist before this issue dispatches; each branch
-   * is cut from the previous entry's branch (or mapping.defaultBranch for the first). This
-   * issue's PR targets the LAST entry's branch. Absent/empty → PR targets mapping.defaultBranch.
+   * An ordered list of branch names (base-most first). Each branch must exist before this
+   * issue dispatches; each is cut from the previous entry's branch (or mapping.defaultBranch
+   * for the first). This issue's PR targets the LAST entry. Absent/empty → PR targets
+   * mapping.defaultBranch.
    *
-   * For a leaf the chain ends at its nearest feature-node ancestor; for a feature-node parent
-   * whose AI-Implement children are all complete, the chain ends at the parent itself (its
-   * closing work lands on its own feature branch). See src/feature-branch.ts.
+   * Branch names are pre-computed by the provider (feature/<key> or multi-issue/<slugs>)
+   * so consumers never need to derive them. See src/feature-branch.ts.
    */
   featureBranchChain?: string[];
 }
@@ -41,24 +40,25 @@ export interface AIImplementSnapshot {
 }
 
 /**
- * A completed feature-node issue whose feature branch should be rolled up into its
- * parent (see src/merge-up.ts). Produced by the provider from recently-completed
- * AI-Implement issues that have at least one AI-Implement child.
+ * A feature-node or multi-issue-grouping issue whose branch should be rolled up
+ * (see src/merge-up.ts). Produced by the provider.
  */
 export interface FeatureNodeRollUp {
   /** Provider-internal ID (Linear UUID) — passed to markMerged when the top-of-tree PR is detected as merged. */
   issueId: string;
-  /** The feature node's identifier → branch `ai-implement/feature/<identifier>`. */
+  /** The issue's human-readable identifier (for logging). */
   identifier: string;
   /** Capacity/scope bucket (team key) — used to resolve the repo mapping. */
   scopeKey: string;
   /**
-   * Parent identifier when the parent is itself a feature node (the parent has the
-   * AI-Implement label) → roll into `ai-implement/feature/<parent>` and auto-merge.
-   * null when there is no feature-node parent → roll into the mapping's base branch
-   * via a human-reviewed PR (never auto-merged).
+   * Parent identifier when the parent is itself a grouping node → auto-merge.
+   * null when there is no grouping parent → open human-reviewed PR into the base branch.
    */
   parentIdentifier: string | null;
+  /** The branch to roll up (e.g. `ai-implement/feature/<key>` or `ai-implement/multi-issue/<slugs>`). */
+  branch: string;
+  /** The target branch to merge/PR into, or null → mapping.defaultBranch. */
+  target: string | null;
 }
 
 export type IssueLifecycleState = "active" | "completed" | "cancelled";


### PR DESCRIPTION
Top-of-tree review PR for **AII-191**: feature-node and multi-issue grouping now **co-exist**, selected per parent by the `Multi-Issue` label. Lands `ai-implement/feature/aii-191` onto `testing`.

**Child work merged into this branch:**
- **AII-152** (PR #118) — core: adds multi-issue mode (`ai-implement/multi-issue/<sorted slugs>`, parent no work, ≥2 children, children-terminal roll-up) **alongside** the unchanged feature-node mode. Per-node mode resolver; `buildMultiIssueBranchName`; mode-aware roll-up with the `parentIdentifier` gating fix.
- **AII-192** (PR #119) — `docs/feature-branch-grouping.md` documents both modes + the selector.

**Verification:** `tsc` clean; 1536/1536 tests pass on the branch. Feature-node behavior unchanged (existing trees unaffected); multi-issue is opt-in via the new `Multi-Issue` workspace label.

**Human gate.** Deferred: AII-134 (auto-merge, both flavors), AII-193 (internal multi-issue self-finalize / full nesting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)