### PR TITLE
fix: widen GitHub App JWT clock-skew headroom (AII-199)

### DIFF
--- a/src/__tests__/github-app-auth.test.ts
+++ b/src/__tests__/github-app-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { getInstallationToken, getInstallation, getAppSlug, installationIncludesRepo, clearTokenCache } from "../github-app-auth.js";
+import { getInstallationToken, getInstallation, getAppSlug, installationIncludesRepo, clearTokenCache, createAppJwt } from "../github-app-auth.js";
 
 // Generate a real RSA key pair for tests so JWT signing works correctly
 const { privateKey } = generateKeyPairSync("rsa", {
@@ -29,6 +29,12 @@ function mockFetch(responses: Array<{ ok: boolean; status?: number; json?: unkno
       text: async () => r.text ?? "",
     };
   });
+}
+
+// Decodes a JWT's payload segment (header.PAYLOAD.signature) so tests can assert its claims.
+function decodePayload(jwt: string): { iat: number; exp: number; iss: string } {
+  const [, payload] = jwt.split(".");
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
 }
 
 beforeEach(() => {
@@ -290,5 +296,57 @@ describe("installationIncludesRepo", () => {
 
     await expect(installationIncludesRepo("ghs_x", "backend"))
       .rejects.toThrow("Failed to list installation repositories");
+  });
+});
+
+describe("createAppJwt clock-skew tolerance", () => {
+  // A fixed reference second (~2027) to reason about relative to GitHub's clock.
+  const REF = 1_800_000_000;
+
+  it("backdates iat and pulls exp below GitHub's cap by the tolerance; iss is the app id", () => {
+    vi.spyOn(Date, "now").mockReturnValue(REF * 1000);
+
+    const payload = decodePayload(createAppJwt(APP_ID, privateKey));
+    expect(payload.iat).toBe(REF - 300); // backdated by the tolerance
+    expect(payload.exp).toBe(REF + 300); // 300s below GitHub's 600s cap
+    expect(payload.iss).toBe(APP_ID);
+  });
+
+  // GitHub validates against ITS clock. Simulate a host running `skew` seconds ahead of GitHub
+  // (REF = GitHub's now): iat must not be in GitHub's future, exp must be <= GitHub's now + 600.
+  it.each([0, 60, 120, 300])(
+    "stays within GitHub's bounds when the host clock is %i s ahead",
+    (skew) => {
+      vi.spyOn(Date, "now").mockReturnValue((REF + skew) * 1000);
+
+      const payload = decodePayload(createAppJwt(APP_ID, privateKey));
+      expect(payload.iat).toBeLessThanOrEqual(REF);       // not in GitHub's future
+      expect(payload.exp).toBeLessThanOrEqual(REF + 600); // within GitHub's 10-min exp cap
+    },
+  );
+
+  it("exceeds GitHub's exp cap one second past the tolerance (pins the margin)", () => {
+    vi.spyOn(Date, "now").mockReturnValue((REF + 301) * 1000); // 1s past CLOCK_SKEW_TOLERANCE_S
+
+    const payload = decodePayload(createAppJwt(APP_ID, privateKey));
+    // exp = (REF + 301) + 300 = REF + 601 → 1s over GitHub's cap: the failure the margin defends
+    // against. Widening or removing CLOCK_SKEW_TOLERANCE_S makes this assertion fail — the guard.
+    expect(payload.exp).toBeGreaterThan(REF + 600);
+  });
+
+  it("emits the widened claims on the real mint path (through getInstallation)", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(REF * 1000);
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 7, repository_selection: "all" } },
+      { ok: true, json: { token: "ghs_x", expires_at: "" } },
+    ]));
+
+    await getInstallation(APP_ID, privateKey, "my-org");
+
+    const [, opts] = vi.mocked(fetch).mock.calls[0];
+    const auth = (opts as RequestInit & { headers: Record<string, string> }).headers["Authorization"];
+    const payload = decodePayload(auth.replace(/^Bearer /, ""));
+    expect(payload.iat).toBe(REF - 300);
+    expect(payload.exp).toBe(REF + 300);
   });
 });

--- a/src/github-app-auth.ts
+++ b/src/github-app-auth.ts
@@ -62,16 +62,21 @@ function parsePrivateKey(pem: string): crypto.KeyObject {
   return crypto.createPrivateKey(normalized);
 }
 
+// exp is minted this many seconds below GitHub's 600s cap (and iat backdated the same)
+// so a host clock running ahead of GitHub still validates. Larger drift needs a clock resync (NTP).
+const CLOCK_SKEW_TOLERANCE_S = 300;
+
 /**
  * Creates a signed JWT for authenticating as a GitHub App.
- * Valid for 10 minutes (GitHub's max is 10 min).
+ * Minted below GitHub's 10-min exp cap by CLOCK_SKEW_TOLERANCE_S so a host clock running ahead of GitHub still passes validation.
+ * Exported for unit tests that assert the iat/exp skew bounds.
  */
-function createAppJwt(appId: string, privateKey: string): string {
+export function createAppJwt(appId: string, privateKey: string): string {
   const now = Math.floor(Date.now() / 1000);
   const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
   const payload = Buffer.from(JSON.stringify({
-    iat: now - 60, // 60s clock skew buffer
-    exp: now + 600,
+    iat: now - CLOCK_SKEW_TOLERANCE_S, // 300s clock skew buffer (for hosts ahead of GitHub's time)
+    exp: now + 600 - CLOCK_SKEW_TOLERANCE_S,
     iss: appId,
   })).toString("base64url");
 

--- a/src/workflow-sync.ts
+++ b/src/workflow-sync.ts
@@ -120,8 +120,9 @@ const SYNC_ERROR_MESSAGES: Record<Exclude<SyncErrorCategory, "unknown">, string>
 
 export function classifySyncError(err: unknown): ClassifiedSyncError {
   if (err instanceof GitHubApiError) {
-    // 401 first: a bad/expired App JWT (often host clock skew — the JWT currently has no forward-skew margin) 401s regardless of which endpoint was hit.
-    // Never let a 401 fall through to the 404 "not installed" check below.
+    // 401 first: a bad/expired App JWT is rejected at GitHub's auth layer regardless of endpoint,
+    // so catch every 401 here before the 404 "not installed" check.
+    // Host clock skew is the usual cause — the JWT tolerates ±300s of drift (AII-199), so a 401 implies drift beyond that or bad credentials.
     if (err.status === 401) return classify("clock-skew-suspected", err.message);
     if (err.status === 403) return classify("permission-denied", err.message); // incl. missing `workflows` perm on .github/workflows PUT
     


### PR DESCRIPTION
## Summary
The GitHub App JWT was minted with `exp: now + 600` — GitHub's exact 10-minute ceiling — leaving **zero forward clock-skew headroom**. A host clock running ahead of GitHub therefore 401s on *every* App token mint (workflow sync, dispatch, install probes). This bites local orchestrators on drift-prone hosts (e.g. WSL after sleep), a documented onboarding path; NTP-synced Fly deploys are unaffected. AII-94 already fixed the *mislabeling* (401 → `clock-skew-suspected`); this is the underlying resilience fix.

## What changed
`src/github-app-auth.ts` — `createAppJwt` now derives both time claims from a single `CLOCK_SKEW_TOLERANCE_S = 300`:
- `iat: now - 300` (backdated) and `exp: now + 600 - 300 = now + 300` (300s below GitHub's cap).
- Tolerates a host clock up to **300s ahead** of GitHub (and 300s behind) while keeping `exp` within GitHub's 10-minute limit.
- `createAppJwt` is exported so unit tests assert the `iat`/`exp` bounds directly (mirrors the file's existing `clearTokenCache` test-export).
- `src/workflow-sync.ts` — updated the `classifySyncError` 401 comment, which stated the JWT "has no forward-skew margin" (now false); it explains why 401s are caught first and path-agnostically, and ties the reasoning to the new ±300s tolerance. No behavior change (comment only) — the 401 → `clock-skew-suspected` mapping still holds.


## Why 300s
GitHub caps `exp` at ≤600s ahead of *its* clock and rejects a future `iat`; there is **no `exp − iat` span limit** (verified against GitHub's docs — the "keep span ≤600" framing was stricter than GitHub enforces). Forward tolerance = `min(iat_backdate, 600 − exp_offset)` = `min(300, 300)` = 300s. The JWT is consumed within seconds (mint → immediate install-token call), so the shorter 5-minute lifetime is immaterial. Gross drift (minutes–hours) still needs an NTP / `hwclock -s` resync — this covers the common small-drift case.

## Tests
`src/__tests__/github-app-auth.test.ts` — new `createAppJwt clock-skew tolerance` block (`Date.now` spied, not fake timers):
- aligned-clock exactness (`iat`/`exp`/`iss`);
- skew table `{0, 60, 120, 300}`s ahead — asserts claims stay within GitHub's bounds;
- boundary guard at 301s ahead — asserts `exp` breaches the cap, pinning the margin against silent regression;
- through-`getInstallation` decode — confirms the real mint path emits the widened claims.

## Verification
- `npm run typecheck` + `npm test` green.
- Live (drift-set host, real mint path): 126s ahead → mints OK (old code would 401), 368s ahead → 401 (bounded tolerance confirmed), `hwclock -s` restore → OK. Also confirmed via the `dev:local` admin install-check stepper at +2 min.

## Scope
Deliberately AII-199 only. The sibling `exp`-derived cache-TTL cleanup (AII-200, same file) is left for its own PR to keep this atomic.
