### PR TITLE
feat: label Slack/Teams dispatch notifications by phase (AII-168)

### DIFF
--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { notify, notifyCompletion } from "../notify.js";
+import type { Notification } from "../notify.js";
 
-const notification = {
+const notification: Notification = {
   issueIdentifier: "TEST-5",
   issueTitle: "Fix the thing",
   issueUrl: "https://linear.app/issue/TEST-5",
   repoFullName: "org/repo",
+  phase: "implementation",
 };
 
 describe("notify (dispatch)", () => {
@@ -70,6 +72,32 @@ describe("notify (dispatch)", () => {
     it("throws on non-ok response", async () => {
       vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500, text: async () => "Server Error" } as Response);
       await expect(notify("teams", "https://webhook.example.com/teams", notification)).rejects.toThrow("500");
+    });
+  });
+
+  // AII-168: planning and implementation dispatch separately; each must be labelled
+  // so one issue's two dispatches don't read as a duplicate run.
+  describe("phase label", () => {
+    // Returns the dispatch title for a given provider + phase: the slack mrkdwn line
+    // (title embedded in a larger string) or the teams TextBlock text (the title alone).
+    async function dispatchTitle(type: "slack" | "teams", phase: Notification["phase"]): Promise<string> {
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+      await notify(type, "https://webhook.example.com/hook", { ...notification, phase });
+      const body = JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+      return type === "slack" ? body.blocks[0].text.text : body.attachments[0].content.body[0].text;
+    }
+
+    it("slack labels a planning dispatch", async () => {
+      expect(await dispatchTitle("slack", "planning")).toContain("AI Planning Dispatched");
+    });
+    it("slack labels an implementation dispatch", async () => {
+      expect(await dispatchTitle("slack", "implementation")).toContain("AI Implementation Dispatched");
+    });
+    it("teams labels a planning dispatch", async () => {
+      expect(await dispatchTitle("teams", "planning")).toBe("AI Planning Dispatched");
+    });
+    it("teams labels an implementation dispatch", async () => {
+      expect(await dispatchTitle("teams", "implementation")).toBe("AI Implementation Dispatched");
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -702,6 +702,7 @@ async function dispatchPlanning(
             issueTitle: issue.title,
             issueUrl: provider.issueUrl(issue),
             repoFullName: `${mapping.owner}/${mapping.repo}`,
+            phase: "planning",
           }).catch((err) => console.error(`[poll] Planning notification failed:`, err));
         }
         // Intentionally do NOT call markDispatched() — dedup table stays clear
@@ -785,6 +786,7 @@ async function dispatchPlanning(
       issueTitle: issue.title,
       issueUrl: provider.issueUrl(issue),
       repoFullName: `${mapping.owner}/${mapping.repo}`,
+      phase: "planning",
     }).catch((err) => console.error(`[poll] Planning notification failed:`, err));
   }
 
@@ -1116,6 +1118,7 @@ async function postDispatch(
       issueTitle: issue.title,
       issueUrl: provider.issueUrl(issue),
       repoFullName: `${mapping.owner}/${mapping.repo}`,
+      phase: "implementation",
     }).catch((err) => console.error(`[poll] Notification failed:`, err));
   }
 

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -13,11 +13,15 @@ export interface StuckGiveUpNotification {
   lastRunStatus: string; // "queued" | "in_progress" | "run_not_found"
 }
 
+// The run phases that produce a user-facing notification
+export type NotificationPhase = "planning" | "implementation";
+
 export interface Notification {
   issueIdentifier: string;
   issueTitle: string;
   issueUrl: string;
   repoFullName: string;
+  phase: NotificationPhase;
 }
 
 export interface CompletionNotification {
@@ -31,6 +35,13 @@ export interface CompletionNotification {
   runUrl: string | null;
   durationMs?: number | null;
 }
+
+// Human label for a run phase, reused across notification kinds (dispatch, completion, …).
+// Keyed on NotificationPhase, so widening that union is a compile error here until the new phase gets a label — no silent fallthrough.
+const PHASE_LABELS: Record<NotificationPhase, string> = {
+  planning: "AI Planning",
+  implementation: "AI Implementation",
+};
 
 export async function notifyStuckGiveUp(
   type: string,
@@ -96,7 +107,7 @@ async function notifySlack(webhookUrl: string, n: Notification): Promise<void> {
           type: "section",
           text: {
             type: "mrkdwn",
-            text: `*AI Implementation Dispatched*\n<${n.issueUrl}|${n.issueIdentifier}: ${n.issueTitle}>\nRepo: \`${n.repoFullName}\``,
+            text: `*${PHASE_LABELS[n.phase]} Dispatched*\n<${n.issueUrl}|${n.issueIdentifier}: ${n.issueTitle}>\nRepo: \`${n.repoFullName}\``,
           },
         },
       ],
@@ -122,7 +133,7 @@ async function notifyTeams(webhookUrl: string, n: Notification): Promise<void> {
           body: [
             {
               type: "TextBlock",
-              text: "AI Implementation Dispatched",
+              text: `${PHASE_LABELS[n.phase]} Dispatched`,
               weight: "Bolder",
               size: "Medium",
             },


### PR DESCRIPTION
## Summary
An AI-Implement issue dispatches **planning** then **implementation**, but both dispatch
notifications read "AI Implementation Dispatched" — so on Slack/Teams a single issue looked like
it ran twice. This labels each dispatch by its phase. Implements **AII-168**, the dispatch half of
**AII-208** (run-lifecycle phase legibility); the completion half follows in **AII-144**.

## What changed
- **`src/notify.ts`** — adds a `NotificationPhase` type + `phase` field on `Notification`, and a
  `PHASE_LABELS` record keyed on that union (a new phase is a compile error until it gets a label —
  no silent fallthrough). `notifySlack`/`notifyTeams` compose `${PHASE_LABELS[phase]} Dispatched`,
  replacing the hardcoded "AI Implementation Dispatched" constant. The label is verb-less so the
  completion path (AII-144) can reuse it.
- **`src/index.ts`** — passes `phase` at the three dispatch sites (planning ×2, implementation ×1);
  each already had the phase in scope.

## Tests
`src/__tests__/notify.test.ts` — the shared fixture carries the new required `phase`; added
assertions that both slack and teams render "AI Planning Dispatched" vs "AI Implementation
Dispatched" per phase (the existing dispatch tests never checked the title). `npm run typecheck` +
`npm test` (1532) green.

## Verification
Live (local-docker, real Slack webhook): one issue produced **"AI Planning Dispatched"** then
**"AI Implementation Dispatched"** as two distinct messages.

<img width="419" height="404" alt="slack-dispatch-labels" src="https://github.com/user-attachments/assets/0f6caa20-ae4d-4984-86b8-add2eab7ad0a" />


## Scope
Dispatch notifications only. The completion side — phase-labeled completion messages **and** the
"successful planning run reported as failed" classification fix — is **AII-144** (reuses
`PHASE_LABELS`). Branches off `testing`; AII-144 follows once this merges.
