### PR TITLE
Make image-baked custom/ overrides work in the session runner

### DIFF
--- a/.github/workflows/build-runner.yml
+++ b/.github/workflows/build-runner.yml
@@ -17,6 +17,7 @@ on:
       - "session/**"
       - "src/**"
       - "pipelines/**"
+      - "custom/**"
       - ".github/workflows/build-runner.yml"
   workflow_dispatch:
     inputs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,10 @@ Resolution is handled by two functions in `src/pipeline/resolve-module.ts`:
 | `resolveModule(path)` | YAML and template files | Absolute filesystem path |
 | `resolveModuleImport<T>(path)` | TypeScript/JavaScript modules | `default` export, or `null` if no override |
 
-Both check `custom/<path>` (relative to `process.cwd()`) first, then fall back to the built-in package root. There is no per-type discovery logic — the same two functions cover all extension points.
+Both functions search two custom roots in order, then fall back to the built-in package root. There is no per-type discovery logic — the same two functions cover all extension points.
+
+1. **Workspace root** — `custom/<path>` relative to `process.cwd()`. This is how orchestrator-side loading picks up a fork's `custom/` (the orchestrator runs with cwd = app root).
+2. **Baked root** — `<AI_IMPLEMENT_CUSTOM_ROOT>/custom/<path>`, where the `AI_IMPLEMENT_CUSTOM_ROOT` env var names a directory that *contains* a `custom/` subdirectory. This is how the session runner picks up overrides: its cwd is `/workspace` (the target-repo clone dir, empty at process start), so the workspace root never matches there. `Dockerfile.session` copies the repo's `custom/` to `/app/custom/` and sets `AI_IMPLEMENT_CUSTOM_ROOT=/app`, so a client fork that builds its own runner image gets its `custom/pipelines/` and `custom/steps/` honored inside the runner — including the import-time load of `pipelines/autonomous.yml` and the eager step resolution in `createDefaultRunner()`, both of which happen before the clone step runs. With the env var unset (local dev, tests) resolution behaves exactly as before.
 
 ### Extension points
 

--- a/Dockerfile.session
+++ b/Dockerfile.session
@@ -101,6 +101,15 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 COPY pipelines/ ./pipelines/
 
+# Bake custom/ overrides into the image. The runner's cwd is /workspace (the
+# target-repo clone dir, empty at process start), so cwd-relative custom/
+# resolution never fires runner-side; AI_IMPLEMENT_CUSTOM_ROOT points
+# resolve-module.ts at a secondary root that CONTAINS custom/. Upstream ships
+# only placeholders here — client forks that build their own runner image get
+# their custom/pipelines + custom/steps honored by the runner via this bake.
+COPY custom/ ./custom/
+ENV AI_IMPLEMENT_CUSTOM_ROOT=/app
+
 # Tool manifest for the agent
 RUN mkdir -p /etc/ai-implement
 COPY session/tools.md /etc/ai-implement/tools.md

--- a/custom/README.md
+++ b/custom/README.md
@@ -7,7 +7,12 @@ Resolution is implemented by two functions in `src/pipeline/resolve-module.ts`:
 - `resolveModule(path)` — synchronous, returns a file-system path. Used for YAML, template files, and runtime step discovery by the runner.
 - `resolveModuleImport<T>(path, options?)` — async, dynamically imports the module and returns its `default` export. Used for TypeScript/JavaScript step and provider overrides loaded at runner construction. Returns `null` when no custom override is present so the caller can fall back to the built-in.
 
-Both functions check `custom/<path>` (relative to `process.cwd()`) before the built-in. This is the **single utility** — there is no per-module-type discovery logic.
+Both functions check two roots for `custom/<path>` before the built-in. This is the **single utility** — there is no per-module-type discovery logic.
+
+1. `custom/<path>` relative to `process.cwd()` — matches orchestrator-side loading (cwd = app root).
+2. `<AI_IMPLEMENT_CUSTOM_ROOT>/custom/<path>` — the env var names a directory that *contains* a `custom/` subdirectory. `Dockerfile.session` copies this directory to `/app/custom/` and sets `AI_IMPLEMENT_CUSTOM_ROOT=/app`, which is what makes overrides work **inside the session runner**: the runner's cwd is `/workspace` (the target-repo clone dir, empty when the pipeline definition and step registry load), so root 1 never matches there.
+
+So: to get your fork's `custom/` honored by the runner, build and publish your own runner image (see "Runner image resolution" in `CLAUDE.md`) — the image build bakes `custom/` in. `custom/steps/*.ts` files baked into the image are loaded by plain `node` (no tsx), which type-strips them on Node 24; keep them to erasable TypeScript syntax and `import type` for anything under `src/` (runtime imports of `src/` won't resolve in the image — only compiled `dist/` ships).
 
 ## What's wired up today
 

--- a/docs/adr/001-custom-path-precedence.md
+++ b/docs/adr/001-custom-path-precedence.md
@@ -64,3 +64,13 @@ A YAML config file would map step/provider IDs to implementation modules. Reject
 
 ### Monorepo with packages
 Split the orchestrator into a core package and per-client packages in a monorepo. Rejected: significantly more infrastructure (Turborepo/Nx, changesets, per-client CI); overkill for the number of extension points currently needed.
+
+---
+
+## Amendment (2026-07-13): baked runner-image root
+
+The original cwd-relative resolution only worked orchestrator-side (cwd = app root). In the session runner, cwd is `/workspace` — the target-repo clone dir, empty when the pipeline definition and step registry load — so `custom/` was dead code runner-side.
+
+Resolution now searches a second root between the workspace and the built-in: `<AI_IMPLEMENT_CUSTOM_ROOT>/custom/<path>`, where the env var names a directory containing `custom/`. `Dockerfile.session` bakes the repo's `custom/` into the image at `/app/custom/` and sets `AI_IMPLEMENT_CUSTOM_ROOT=/app`, so forks that build their own runner image get their overrides honored inside the runner. Precedence: workspace `custom/` > baked `custom/` > built-in. With the env var unset, behavior is unchanged. Both `resolveModule` and `resolveModuleImport` accept an injectable `bakedRoot` option for tests.
+
+Per-target-repo overrides (a `custom/` inside the cloned repo at `/workspace`) remain out of scope: the pipeline definition and step registry load before the clone step runs, so post-clone semantics need a separate design.

--- a/src/__tests__/default-pipeline.test.ts
+++ b/src/__tests__/default-pipeline.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createDefaultRunner } from "../pipeline/default-pipeline.js";
 import type { PipelineRunner } from "../pipeline/runner.js";
 import type { StepModule } from "../pipeline/types.js";
@@ -29,6 +32,45 @@ describe("createDefaultRunner", () => {
 
     for (const id of ["clone", "install-skills", "install", "feedback-loop", "preflight", "push", "post-push-review"]) {
       expect(registeredModule(runner, id)).toBeDefined();
+    }
+  });
+
+  it("substitutes a baked custom step when bakedRoot custom/steps/<id>.ts exists", async () => {
+    const bakedClone: StepModule = { run: async () => ({ baked: true }) };
+
+    const runner = await createDefaultRunner({
+      customRoot: "/workspace",
+      bakedRoot: "/app",
+      existsSyncImpl: (p) => p === "/app/custom/steps/clone.ts",
+      importFn: async () => ({ default: bakedClone }),
+    });
+
+    expect(registeredModule(runner, "clone")).toBe(bakedClone);
+  });
+});
+
+describe("DEFAULT_PIPELINE baked custom root", () => {
+  // DEFAULT_PIPELINE is loaded at module-import time, before any workspace
+  // clone exists. Re-import the module with AI_IMPLEMENT_CUSTOM_ROOT pointing
+  // at a real on-disk baked root (no injected fs) to prove an image-baked
+  // custom/pipelines/autonomous.yml takes effect at import time.
+  it("honors AI_IMPLEMENT_CUSTOM_ROOT at module-import time", async () => {
+    const bakedRoot = mkdtempSync(join(tmpdir(), "ai-implement-baked-"));
+    try {
+      mkdirSync(join(bakedRoot, "custom", "pipelines"), { recursive: true });
+      writeFileSync(
+        join(bakedRoot, "custom", "pipelines", "autonomous.yml"),
+        "id: baked-loop\nsteps:\n  - id: clone\n    type: clone\n",
+      );
+      vi.stubEnv("AI_IMPLEMENT_CUSTOM_ROOT", bakedRoot);
+      vi.resetModules();
+      const { DEFAULT_PIPELINE } = await import("../pipeline/default-pipeline.js");
+      expect(DEFAULT_PIPELINE.id).toBe("baked-loop");
+      expect(DEFAULT_PIPELINE.steps.map((s) => s.id)).toEqual(["clone"]);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+      rmSync(bakedRoot, { recursive: true, force: true });
     }
   });
 });

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -119,6 +119,30 @@ describe("loadPipelineDefinition", () => {
     expect(resolvedPath).toContain("custom/pipelines/autonomous.yml");
   });
 
+  it("uses a baked-root custom/pipelines/autonomous.yml when the workspace has none", () => {
+    let resolvedPath = "";
+    const pipeline = loadPipelineDefinition("pipelines/autonomous.yml", {
+      customRoot: "/workspace",
+      bakedRoot: "/baked",
+      existsSyncImpl: (p) => p.startsWith("/baked/"),
+      readFileSyncImpl: (path, _enc) => {
+        resolvedPath = path;
+        return CUSTOM_PIPELINE_YAML;
+      },
+    });
+
+    expect(resolvedPath).toBe("/baked/custom/pipelines/autonomous.yml");
+    expect(pipeline.id).toBe("custom-loop");
+    expect(pipeline.steps.map((s) => s.id)).toEqual([
+      "clone",
+      "install",
+      "feedback-loop",
+      "preflight",
+      "push",
+      "notify",
+    ]);
+  });
+
   it("resolves to the builtin path when no custom override exists", () => {
     let resolvedPath = "";
     loadPipelineDefinition("pipelines/autonomous.yml", {

--- a/src/__tests__/resolve-module.test.ts
+++ b/src/__tests__/resolve-module.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { resolveModule, resolveModuleImport } from "../pipeline/resolve-module.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("resolveModule", () => {
   it("returns custom path when custom override exists", () => {
@@ -18,6 +22,75 @@ describe("resolveModule", () => {
       existsSyncImpl: () => false,
     });
     expect(result).toBe("/app/pipelines/autonomous.yml");
+  });
+
+  it("falls back to bakedRoot custom/ when workspace has no override", () => {
+    const result = resolveModule("pipelines/autonomous.yml", {
+      customRoot: "/workspace",
+      bakedRoot: "/baked",
+      builtinRoot: "/app",
+      existsSyncImpl: (p) => p.startsWith("/baked/"),
+    });
+    expect(result).toBe("/baked/custom/pipelines/autonomous.yml");
+  });
+
+  it("prefers workspace custom/ over bakedRoot custom/ when both exist", () => {
+    const result = resolveModule("pipelines/autonomous.yml", {
+      customRoot: "/workspace",
+      bakedRoot: "/baked",
+      builtinRoot: "/app",
+      existsSyncImpl: () => true,
+    });
+    expect(result).toBe("/workspace/custom/pipelines/autonomous.yml");
+  });
+
+  it("returns builtin path when neither workspace nor bakedRoot has an override", () => {
+    const result = resolveModule("pipelines/autonomous.yml", {
+      customRoot: "/workspace",
+      bakedRoot: "/baked",
+      builtinRoot: "/app",
+      existsSyncImpl: () => false,
+    });
+    expect(result).toBe("/app/pipelines/autonomous.yml");
+  });
+
+  it("reads the baked root from AI_IMPLEMENT_CUSTOM_ROOT when the option is not passed", () => {
+    vi.stubEnv("AI_IMPLEMENT_CUSTOM_ROOT", "/image");
+    const result = resolveModule("pipelines/autonomous.yml", {
+      customRoot: "/workspace",
+      builtinRoot: "/app",
+      existsSyncImpl: (p) => p.startsWith("/image/"),
+    });
+    expect(result).toBe("/image/custom/pipelines/autonomous.yml");
+  });
+
+  it("checks only the workspace custom path when no baked root is configured", () => {
+    vi.stubEnv("AI_IMPLEMENT_CUSTOM_ROOT", "");
+    const checkedPaths: string[] = [];
+    const result = resolveModule("pipelines/autonomous.yml", {
+      customRoot: "/workspace",
+      builtinRoot: "/app",
+      existsSyncImpl: (p) => {
+        checkedPaths.push(p);
+        return false;
+      },
+    });
+    expect(checkedPaths).toEqual(["/workspace/custom/pipelines/autonomous.yml"]);
+    expect(result).toBe("/app/pipelines/autonomous.yml");
+  });
+
+  it("does not check the baked root twice when it equals customRoot", () => {
+    const checkedPaths: string[] = [];
+    resolveModule("pipelines/autonomous.yml", {
+      customRoot: "/workspace",
+      bakedRoot: "/workspace",
+      builtinRoot: "/app",
+      existsSyncImpl: (p) => {
+        checkedPaths.push(p);
+        return false;
+      },
+    });
+    expect(checkedPaths).toEqual(["/workspace/custom/pipelines/autonomous.yml"]);
   });
 });
 
@@ -124,5 +197,77 @@ describe("resolveModuleImport", () => {
       importFn: async () => ({ default: fakeProvider }),
     });
     expect(result).toBe(fakeProvider);
+  });
+
+  it("falls back to bakedRoot custom/ when workspace has no override", async () => {
+    const bakedModule = { run: async () => ({}) };
+    const result = await resolveModuleImport("steps/implement", {
+      customRoot: "/workspace",
+      bakedRoot: "/baked",
+      existsSyncImpl: (p) => p === "/baked/custom/steps/implement.ts",
+      importFn: async () => ({ default: bakedModule }),
+    });
+    expect(result).toBe(bakedModule);
+  });
+
+  it("prefers a workspace override over a bakedRoot override", async () => {
+    const workspaceModule = { run: async () => ({ source: "workspace" }) };
+    const bakedModule = { run: async () => ({ source: "baked" }) };
+    const result = await resolveModuleImport("steps/implement", {
+      customRoot: "/workspace",
+      bakedRoot: "/baked",
+      existsSyncImpl: (p) => p.endsWith("implement.ts"),
+      importFn: async (url) => ({
+        default: url.includes("/workspace/") ? workspaceModule : bakedModule,
+      }),
+    });
+    expect(result).toBe(workspaceModule);
+  });
+
+  it("reads the baked root from AI_IMPLEMENT_CUSTOM_ROOT when the option is not passed", async () => {
+    vi.stubEnv("AI_IMPLEMENT_CUSTOM_ROOT", "/image");
+    const bakedModule = { run: async () => ({}) };
+    const result = await resolveModuleImport("steps/implement", {
+      customRoot: "/workspace",
+      existsSyncImpl: (p) => p === "/image/custom/steps/implement.ts",
+      importFn: async () => ({ default: bakedModule }),
+    });
+    expect(result).toBe(bakedModule);
+  });
+
+  it("checks only workspace custom paths when no baked root is configured", async () => {
+    vi.stubEnv("AI_IMPLEMENT_CUSTOM_ROOT", "");
+    const checkedPaths: string[] = [];
+    const result = await resolveModuleImport("steps/push", {
+      customRoot: "/workspace",
+      existsSyncImpl: (p) => {
+        checkedPaths.push(p);
+        return false;
+      },
+    });
+    expect(checkedPaths).toEqual([
+      "/workspace/custom/steps/push.ts",
+      "/workspace/custom/steps/push.js",
+      "/workspace/custom/steps/push.mjs",
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it("falls through to the baked root when the workspace override has no default export", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const bakedModule = { run: async () => ({}) };
+      const result = await resolveModuleImport("steps/implement", {
+        customRoot: "/workspace",
+        bakedRoot: "/baked",
+        existsSyncImpl: (p) => p.endsWith("implement.ts"),
+        importFn: async (url) =>
+          url.includes("/workspace/") ? { namedExport: {} } : { default: bakedModule },
+      });
+      expect(result).toBe(bakedModule);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("has no default export"));
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/src/pipeline/resolve-module.ts
+++ b/src/pipeline/resolve-module.ts
@@ -8,6 +8,13 @@ const BUILTIN_ROOT = join(fileURLToPath(new URL(".", import.meta.url)), "..", ".
 export interface ResolveModuleOptions {
   /** Root directory to look for custom/ overrides. Defaults to process.cwd(). */
   customRoot?: string;
+  /**
+   * Secondary root for custom/ overrides baked into the runner image — a
+   * directory that CONTAINS a custom/ subdirectory (same shape as customRoot).
+   * Defaults to the AI_IMPLEMENT_CUSTOM_ROOT env var. Checked after customRoot,
+   * before the built-in.
+   */
+  bakedRoot?: string;
   /** Root directory for built-in files. Defaults to the package root. */
   builtinRoot?: string;
   /** Injectable fs.existsSync for testing. */
@@ -15,27 +22,53 @@ export interface ResolveModuleOptions {
 }
 
 /**
+ * Roots to search for custom/ overrides, in precedence order:
+ *   1. customRoot (defaults to process.cwd()) — the workspace always wins.
+ *   2. bakedRoot (defaults to env AI_IMPLEMENT_CUSTOM_ROOT) — overrides baked
+ *      into the runner image at build time. In Dockerfile.session this is /app,
+ *      i.e. the image's custom/ lives at /app/custom/. Skipped when unset or
+ *      identical to customRoot.
+ */
+function customSearchRoots(options?: { customRoot?: string; bakedRoot?: string }): string[] {
+  const customRoot = options?.customRoot ?? process.cwd();
+  const bakedRoot = options?.bakedRoot ?? process.env.AI_IMPLEMENT_CUSTOM_ROOT;
+  const roots = [customRoot];
+  if (bakedRoot && bakedRoot !== customRoot) roots.push(bakedRoot);
+  return roots;
+}
+
+/**
  * Resolves a module path by checking custom/<path> before falling back to the
  * built-in package root. Enables per-workspace overrides without patching the
- * runner image.
+ * runner image, and image-baked overrides (AI_IMPLEMENT_CUSTOM_ROOT) for forks
+ * that build their own runner image.
  *
  * resolveModule('pipelines/autonomous.yml')
- *   → custom/pipelines/autonomous.yml   (if present in customRoot)
- *   → <package-root>/pipelines/autonomous.yml  (fallback)
+ *   → <customRoot>/custom/pipelines/autonomous.yml   (if present; customRoot defaults to cwd)
+ *   → <bakedRoot>/custom/pipelines/autonomous.yml    (if present; bakedRoot defaults to env AI_IMPLEMENT_CUSTOM_ROOT)
+ *   → <package-root>/pipelines/autonomous.yml        (fallback)
  */
 export function resolveModule(modulePath: string, options?: ResolveModuleOptions): string {
   const existsSyncFn = options?.existsSyncImpl ?? existsSync;
-  const customRoot = options?.customRoot ?? process.cwd();
   const builtinRoot = options?.builtinRoot ?? BUILTIN_ROOT;
 
-  const customPath = join(customRoot, "custom", modulePath);
-  if (existsSyncFn(customPath)) return customPath;
+  for (const root of customSearchRoots(options)) {
+    const customPath = join(root, "custom", modulePath);
+    if (existsSyncFn(customPath)) return customPath;
+  }
   return join(builtinRoot, modulePath);
 }
 
 export interface ImportModuleOptions {
   /** Root directory to look for custom/ overrides. Defaults to process.cwd(). */
   customRoot?: string;
+  /**
+   * Secondary root for custom/ overrides baked into the runner image — a
+   * directory that CONTAINS a custom/ subdirectory (same shape as customRoot).
+   * Defaults to the AI_IMPLEMENT_CUSTOM_ROOT env var. Checked after customRoot,
+   * before the built-in.
+   */
+  bakedRoot?: string;
   /** Injectable fs.existsSync for testing. */
   existsSyncImpl?: (path: string) => boolean;
   /** Injectable import function for testing. Receives a file:// URL string. */
@@ -78,6 +111,7 @@ async function tryImportDefault<T>(
  *
  * resolveModuleImport("steps/implement")
  *   → imports custom/steps/implement.ts (or .js) and returns its default export
+ *     (workspace customRoot first, then the baked AI_IMPLEMENT_CUSTOM_ROOT)
  *   → null if no custom override exists (caller uses built-in)
  */
 export async function resolveModuleImport<T>(
@@ -85,19 +119,20 @@ export async function resolveModuleImport<T>(
   options?: ImportModuleOptions,
 ): Promise<T | null> {
   const existsSyncFn = options?.existsSyncImpl ?? existsSync;
-  const customRoot = options?.customRoot ?? process.cwd();
 
-  for (const ext of [".ts", ".js", ".mjs"]) {
-    const customPath = join(customRoot, "custom", `${modulePath}${ext}`);
-    if (!existsSyncFn(customPath)) continue;
-    const mod = await tryImportDefault<T>(customPath, options?.importFn);
-    if (mod !== null) return mod;
-    // File existed but produced no default export. A named-only export is
-    // almost certainly a mistake — warn loudly rather than silently using the
-    // built-in.
-    console.warn(
-      `resolveModuleImport: ${customPath} exists but has no default export; ignoring`,
-    );
+  for (const root of customSearchRoots(options)) {
+    for (const ext of [".ts", ".js", ".mjs"]) {
+      const customPath = join(root, "custom", `${modulePath}${ext}`);
+      if (!existsSyncFn(customPath)) continue;
+      const mod = await tryImportDefault<T>(customPath, options?.importFn);
+      if (mod !== null) return mod;
+      // File existed but produced no default export. A named-only export is
+      // almost certainly a mistake — warn loudly rather than silently using the
+      // built-in (or the next root).
+      console.warn(
+        `resolveModuleImport: ${customPath} exists but has no default export; ignoring`,
+      );
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Problem

The `custom/` extension mechanism (`src/pipeline/resolve-module.ts`, ADR 001) resolves overrides relative to `process.cwd()`. That works orchestrator-side (cwd = app root), but runner-side it is dead code:

- `Dockerfile.session` never copied `custom/` into the image, and the final `WORKDIR` is `/workspace`.
- `session/entrypoint.sh` does `cd /workspace` before `node /app/dist/run-autonomous.js`, so cwd is the target-repo clone dir — **empty at process start** (the clone step populates it later).
- `DEFAULT_PIPELINE` loads `pipelines/autonomous.yml` at module-import time and `createDefaultRunner()` eagerly resolves custom step overrides — both pre-clone.

So a client fork's `custom/pipelines/autonomous.yml` and `custom/steps/*` never took effect in the runner, even though the docs describe fork-owned runner-image channels.

## Fix

Add a second, "baked" custom root between the workspace and the built-in:

1. `<cwd>/custom/<path>` — workspace root, always wins (unchanged)
2. `<AI_IMPLEMENT_CUSTOM_ROOT>/custom/<path>` — the env var names a directory that **contains** `custom/`
3. built-in package root

`Dockerfile.session` now bakes the repo's `custom/` into the runtime stage at `/app/custom/` and sets `ENV AI_IMPLEMENT_CUSTOM_ROOT=/app` (the entrypoint launches node via `su -p`, which preserves env). Forks that build their own runner image get their `custom/pipelines/` + `custom/steps/` honored inside the runner, including the import-time pipeline load and eager step registration. With the env var unset, resolution is byte-identical to the old behavior (test-asserted). `runner.ts` step discovery and provider resolution inherit the baked root automatically via the shared resolver.

Also: `build-runner.yml` now triggers on `custom/**` (a custom/-only change must rebuild the image); docs updated (`CLAUDE.md`, `custom/README.md`, amendment to ADR 001).

**Out of scope:** per-target-repo overrides (a `custom/` inside the cloned repo at `/workspace`) — the pipeline definition and step registry load pre-clone, so that needs a separate design.

## Testing

- `npm run typecheck` clean; `npm test` green (1546 tests, +14 new: baked/workspace precedence for both resolvers, env pathway, env-unset identical behavior, baked pipeline via loader, baked step via `createDefaultRunner`, and a real-FS re-import test proving `DEFAULT_PIPELINE` honors `AI_IMPLEMENT_CUSTOM_ROOT` at module-import time).
- Compiled-dist smoke from an empty cwd (runner boot condition): baked pipeline id resolves with the env var set; built-in `autonomous-loop` without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)