### PR TITLE
security: restrict skills-repo clone token to github.com hosts

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -86,7 +86,7 @@ on:
         type: string
         default: ""
       skills_repo:
-        description: "Optional skills repo (owner/repo or git URL) cloned + installed into ~/.claude/skills (empty = none)"
+        description: "Optional skills repo (owner/repo or https://github.com URL; token auth is github.com-only) cloned + installed into ~/.claude/skills (empty = none)"
         required: false
         type: string
         default: ""

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -736,13 +736,40 @@ describe("admin mappings", () => {
     expect(JSON.parse(res.body).error).toContain("skillsRepo");
   });
 
-  it("persists a non-github HTTPS skillsRepo URL (host-agnostic)", async () => {
+  it("rejects a non-github HTTPS skillsRepo URL (the runner's token must never leave github.com)", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", {
       teamKey: "SR5", owner: "org", repo: "app", skillsRepo: "https://gitlab.com/acme/skills",
     }, token);
+    expect(create.statusCode).toBe(400);
+    expect(JSON.parse(create.body).error).toContain("skillsRepo");
+  });
+
+  it("rejects a lookalike-host skillsRepo URL (github.com prefix on another domain)", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "SR6", owner: "org", repo: "app", skillsRepo: "https://github.com.evil.example/acme/skills",
+    }, token);
+    expect(create.statusCode).toBe(400);
+    expect(JSON.parse(create.body).error).toContain("skillsRepo");
+  });
+
+  it("rejects a www.github.com skillsRepo URL (git remotes live on the apex host)", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "SR7", owner: "org", repo: "app", skillsRepo: "https://www.github.com/acme/skills",
+    }, token);
+    expect(create.statusCode).toBe(400);
+    expect(JSON.parse(create.body).error).toContain("skillsRepo");
+  });
+
+  it("accepts a github.com skillsRepo URL regardless of host case", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "SR8", owner: "org", repo: "app", skillsRepo: "https://GitHub.com/acme/skills.git",
+    }, token);
     expect(create.statusCode).toBe(202);
-    expect(JSON.parse(create.body).skillsRepo).toBe("https://gitlab.com/acme/skills");
+    expect(JSON.parse(create.body).skillsRepo).toBe("https://GitHub.com/acme/skills.git");
   });
 
   it("clears skillsRepo when an existing mapping is updated to null", async () => {

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -172,6 +172,49 @@ describe("installSkillsStep", () => {
     // Shorthand was converted to HTTPS — clone was attempted (and failed), not silently skipped
     expect(warnings.every((w) => !w.includes("non-https"))).toBe(true);
     expect(warnings.some((w) => w.includes("clone failed") || w.includes("install failed"))).toBe(true);
+  });
+
+  it("embeds the token only for github.com clones; cross-host https URLs get no credentials", async () => {
+    // Shim `git` with a script that records its argv, so we can assert exactly what
+    // remote URL the step hands to `git clone` for each host.
+    const shimDir = mkdtempSync(join(tmpdir(), "git-shim-"));
+    const argsFile = join(shimDir, "git-args.txt");
+    writeFileSync(
+      join(shimDir, "git"),
+      `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsFile}"\nexit 1\n`,
+      { mode: 0o755 },
+    );
+    const origPath = process.env.PATH;
+    process.env.PATH = `${shimDir}:${origPath}`;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const cloneArgsFor = async (skillsRepoUrl: string): Promise<string> => {
+      await installSkillsStep.run(
+        ctx(),
+        { skillsRepoUrl, githubToken: "sekret-token", homeDir },
+        new NoopStepReporter(),
+      );
+      return readFileSync(argsFile, "utf8");
+    };
+    try {
+      // Cross-host: the remote is passed through verbatim — no token, no basic auth.
+      const crossHost = await cloneArgsFor("https://evil.example.com/acme/skills.git");
+      expect(crossHost).toContain("https://evil.example.com/acme/skills.git");
+      expect(crossHost).not.toContain("sekret-token");
+      expect(crossHost).not.toContain("x-access-token");
+
+      // github.com (any case): the token is embedded as basic auth.
+      const github = await cloneArgsFor("https://GitHub.com/acme/skills.git");
+      expect(github).toContain("https://x-access-token:sekret-token@GitHub.com/acme/skills.git");
+
+      // www.github.com is deliberately not credentialed — apex host only.
+      const www = await cloneArgsFor("https://www.github.com/acme/skills.git");
+      expect(www).toContain("https://www.github.com/acme/skills.git");
+      expect(www).not.toContain("sekret-token");
+    } finally {
+      process.env.PATH = origPath;
+      warnSpy.mockRestore();
+      rmSync(shimDir, { recursive: true, force: true });
+    }
   });
 
   it("does not install dirs where SKILL.md is arbitrarily nested (not under a recognized root)", async () => {

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -44,7 +44,7 @@ import { enqueueWorkflowSync, runWorkflowSync, getWorkflowSyncById } from "./wor
 import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
 
 const SKILLS_REPO_SHORTHAND = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
-// NOTE: skillsRepo is *syntax*-validated only — it is NOT sanitised. Any code that
+// NOTE: skillsRepo is syntax- and host-validated only — it is NOT sanitised. Any code that
 // later feeds this value to a subprocess (e.g. the `git clone` in the runner) MUST
 // pass it as a separate argv element, never interpolated into a shell string, to
 // avoid command injection.
@@ -54,13 +54,23 @@ function normalizeSkillsRepo(raw: unknown): string | null {
   const v = raw.trim();
   if (v === "") return null;
   if (SKILLS_REPO_SHORTHAND.test(v)) return `https://github.com/${v}`;
-  // Only https:// remotes (and the owner/repo shorthand handled above) are usable on
-  // the runner: clone auth is the orchestrator-minted token embedded in the URL. An
-  // SSH (git@…) URL would need keys the runner doesn't have, so the install step just
-  // warns and installs nothing — a silent no-op. Reject it here rather than storing a
-  // value that looks accepted but does nothing at dispatch.
-  const ok = /^https:\/\/[^\s]+$/.test(v); // any https:// git URL, host-agnostic, with or without a trailing .git
-  if (!ok) throw new Error("skillsRepo must be 'owner/repo' shorthand or an https:// URL (SSH git@ URLs are not supported — the runner clones via an https token)");
+  // Only https://github.com remotes (and the owner/repo shorthand handled above, which
+  // implies github.com) are usable on the runner: clone auth is the orchestrator-minted
+  // GitHub App installation token embedded in the URL, and that credential must never
+  // be sent to any other host. An SSH (git@…) URL would need keys the runner doesn't
+  // have, so the install step just warns and installs nothing — a silent no-op. Reject
+  // both here rather than storing a value that looks accepted but does nothing (or
+  // worse) at dispatch. Exact host match, case-insensitive; www.github.com excluded —
+  // git remotes live on the apex host.
+  let host: string | null = null;
+  if (/^https:\/\/[^\s]+$/.test(v)) {
+    try {
+      host = new URL(v).hostname.toLowerCase();
+    } catch {
+      host = null;
+    }
+  }
+  if (host !== "github.com") throw new Error("skillsRepo must be 'owner/repo' shorthand or an https://github.com/... URL (the runner clones with a GitHub token, so other hosts and SSH git@ URLs are not supported)");
   return v;
 }
 

--- a/src/pipeline/steps/install-skills.ts
+++ b/src/pipeline/steps/install-skills.ts
@@ -43,7 +43,7 @@ export const installSkillsStep: StepModule<InstallSkillsInputs, InstallSkillsOut
     try {
       tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ai-implement-skills-"));
 
-      // Local paths (used in tests) pass through unchanged; remote URLs get the token embedded.
+      // Local paths (used in tests) pass through unchanged; github.com remotes get the token embedded.
       const isLocalPath = skillsRepoUrl.startsWith("/") || skillsRepoUrl.startsWith("file://");
       // Only https:// remotes are cloneable on the runner — auth is the orchestrator-minted
       // token embedded in the URL. SSH (git@…) or http:// would need keys the runner lacks, so
@@ -54,9 +54,25 @@ export const installSkillsStep: StepModule<InstallSkillsInputs, InstallSkillsOut
         );
         return { skillsInstalled: 0, skillsRepoRef: null };
       }
-      const remote = isLocalPath
-        ? skillsRepoUrl
-        : skillsRepoUrl.replace("https://", `https://x-access-token:${githubToken}@`);
+      // The GitHub App installation token is only valid for github.com — embedding it
+      // in the clone URL for any other host would hand an org-scoped credential to a
+      // third party as HTTP basic auth. Exact host match only ("github.com",
+      // case-insensitive; "www.github.com" is deliberately excluded — GitHub serves
+      // git remotes on the apex host, and a redirect must never carry credentials).
+      // Cross-host https remotes are cloned WITHOUT credentials: public repos still
+      // work, private ones fail fast under GIT_TERMINAL_PROMPT=0 instead of leaking.
+      let isGitHubHost = false;
+      if (!isLocalPath) {
+        try {
+          isGitHubHost = new URL(skillsRepoUrl).hostname.toLowerCase() === "github.com";
+        } catch {
+          // unparseable URL — treat as non-GitHub; the clone below fails on its own
+        }
+      }
+      const remote =
+        isLocalPath || !isGitHubHost
+          ? skillsRepoUrl
+          : skillsRepoUrl.replace("https://", `https://x-access-token:${githubToken}@`);
 
       const cloneResult = spawnSync(
         "git",

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -86,7 +86,7 @@ on:
         type: string
         default: ""
       skills_repo:
-        description: "Optional skills repo (owner/repo or git URL) cloned + installed into ~/.claude/skills (empty = none)"
+        description: "Optional skills repo (owner/repo or https://github.com URL; token auth is github.com-only) cloned + installed into ~/.claude/skills (empty = none)"
         required: false
         type: string
         default: ""


### PR DESCRIPTION
## Problem

`install-skills.ts` embedded the GitHub App installation token into the clone remote for ANY https host: a mapping whose `skillsRepo` pointed at `https://evil.example.com/x.git` would send the org-scoped token there as HTTP basic auth. `normalizeSkillsRepo()` in `src/admin.ts` only syntax-validated (host-agnostic https). Admin-gated, so defense-in-depth — but credentials must never go cross-host.

*(Surfaced by Claude review on the Cloudshare fork's sync PR cloudshare/ai-implement#70.)*

## Fix (both layers)

- **Runner step** (`src/pipeline/steps/install-skills.ts`): parse the URL host and embed the token only when the hostname is exactly `github.com` (case-insensitive; `www.github.com` deliberately excluded — git remotes live on the apex host and a redirect must never carry credentials). Any other https host clones WITHOUT credentials: public repos still work, private ones fail fast under the existing `GIT_TERMINAL_PROMPT=0`. Token redaction behavior unchanged.
- **Admin API** (`src/admin.ts`): `normalizeSkillsRepo()` rejects full https URLs on non-`github.com` hosts with the existing 400 `skillsRepo invalid: …` convention, instead of storing a value that would now clone credential-less. The `owner/repo` shorthand already implies github.com and is unchanged.
- **Docs**: `skills_repo` dispatch-input description updated in `workflows/claude-implement.yml` and its byte-identical `.github/workflows/` shim.

## Tests

- `install-skills.test.ts`: a PATH `git` shim captures clone argv — cross-host URLs carry no token, `github.com` (any case) carries it, `www.github.com` does not.
- `admin.test.ts`: accepts github.com URL (any host case) + shorthand; rejects gitlab.com, lookalike-suffix (`github.com.evil.example`), and `www.github.com` hosts.

`npm run typecheck` and `npm test` (102 files / 1536 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)