### PR TITLE
Harden sensitive-files push guard: anchor patterns, fail closed, allow secret deletions

### DIFF
--- a/src/__tests__/sensitive-files.test.ts
+++ b/src/__tests__/sensitive-files.test.ts
@@ -22,6 +22,13 @@ describe("findSensitiveFiles – env files", () => {
     expect(findSensitiveFiles(["prod.env"])).toHaveLength(1);
     expect(findSensitiveFiles(["secrets.env"])).toHaveLength(1);
   });
+
+  it("allows intentionally-committed env templates", () => {
+    expect(findSensitiveFiles([".env.example"])).toHaveLength(0);
+    expect(findSensitiveFiles([".env.sample"])).toHaveLength(0);
+    expect(findSensitiveFiles([".env.template"])).toHaveLength(0);
+    expect(findSensitiveFiles([".env.production.example"])).toHaveLength(0);
+  });
 });
 
 describe("findSensitiveFiles – private keys and certificates", () => {
@@ -62,6 +69,20 @@ describe("findSensitiveFiles – cloud credentials", () => {
   it("blocks GCP service account key files", () => {
     expect(findSensitiveFiles(["serviceAccountKey.json"])).toHaveLength(1);
     expect(findSensitiveFiles(["my-service-account.json"])).toHaveLength(1);
+    expect(findSensitiveFiles(["my-service-account-key.json"])).toHaveLength(1);
+    expect(findSensitiveFiles(["svc-service_account-credentials.json"])).toHaveLength(1);
+  });
+
+  it("does not block source files that merely mention service accounts", () => {
+    expect(
+      findSensitiveFiles([
+        "serviceAccount.ts",
+        "service_account.py",
+        "ServiceAccountController.java",
+        "service-account.go",
+        "service-account.md",
+      ]),
+    ).toHaveLength(0);
   });
 
   it("blocks Terraform variable and state files", () => {

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -394,6 +394,68 @@ describe("pushStep", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("blocks the push when a sensitive file is staged", async () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
+      if (gitArgs[0] === "diff") return spawnResult(0, "src/app.ts\n.env\n");
+      return spawnResult(0);
+    });
+
+    await expect(
+      pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
+    ).rejects.toThrow(/Push blocked/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not block a staged deletion of a sensitive file", async () => {
+    // git itself omits deletions when --diff-filter=d is passed; simulate that:
+    // the deleted .env only shows up if the filter flag is missing.
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, " D .env\n M src/app.ts\n");
+      if (gitArgs[0] === "diff") {
+        return gitArgs.includes("--diff-filter=d")
+          ? spawnResult(0, "src/app.ts\n")
+          : spawnResult(0, "src/app.ts\n.env\n");
+      }
+      if (gitArgs[0] === "rev-parse") return spawnResult(0, "abc123\n");
+      if (gitArgs[0] === "show") return spawnResult(0, "M\tsrc/app.ts\nD\t.env\n");
+      if (gitArgs[0] === "ls-remote") {
+        return spawnResult(0, "beadfeed\trefs/heads/ai-implement/eng-42-feature\n");
+      }
+      return spawnResult(0);
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: "https://github.com/acme/app/pull/9", number: 9 }),
+    } as Response);
+
+    const outputs = await pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter());
+
+    expect(outputs.prUrl).toBe("https://github.com/acme/app/pull/9");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["diff", "--cached", "--name-only", "--diff-filter=d"],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+  });
+
+  it("throws when listing staged files fails instead of skipping the sensitive-file guard", async () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, " M src/app.ts\n");
+      if (gitArgs[0] === "diff") return spawnResult(128, "", "fatal: bad revision");
+      return spawnResult(0);
+    });
+
+    await expect(
+      pushStep.run(makeContext(), BASE_INPUTS, new NoopStepReporter()),
+    ).rejects.toThrow(/git diff --cached failed/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("refuses to push over the base branch", async () => {
     await expect(
       pushStep.run(

--- a/src/pipeline/sensitive-files.ts
+++ b/src/pipeline/sensitive-files.ts
@@ -24,7 +24,11 @@ const SENSITIVE_PATTERNS: SensitivePattern[] = [
   { description: ".env file",
     match: (_, b) => b === ".env" },
   { description: ".env.* variant",
-    match: (_, b) => b.startsWith(".env.") },
+    // .env.example / .env.sample / .env.template (and e.g. .env.production.example)
+    // are intentionally-committed templates with no real values — allow them.
+    match: (_, b) =>
+      b.startsWith(".env.") &&
+      ![".example", ".sample", ".template"].some((t) => b.endsWith(t)) },
   { description: "*.env file",
     match: (_, b) => b !== ".env" && b.endsWith(".env") },
   { description: "Rails master.key",
@@ -57,8 +61,11 @@ const SENSITIVE_PATTERNS: SensitivePattern[] = [
   // ── Cloud provider credentials ───────────────────────────────────────────
   { description: "AWS credentials file",
     match: (f) => f.includes("/.aws/credentials") || f === ".aws/credentials" },
-  { description: "GCP service account key (*-service-account*.json or serviceAccountKey.json)",
-    match: (_, b) => b === "serviceAccountKey.json" || /service.?account/i.test(b) },
+  { description: "GCP service account key (*service-account*.json or serviceAccountKey.json)",
+    // Anchored to .json so ordinary source files that mention service accounts
+    // (serviceAccount.ts, service_account.py, ServiceAccountController.java, …)
+    // are not blocked — GCP keys are always JSON documents.
+    match: (_, b) => b === "serviceAccountKey.json" || /service.?account.*\.json$/i.test(b) },
   { description: "Terraform variable file (*.tfvars)",
     match: (_, b) => b.endsWith(".tfvars") },
   { description: "Terraform state file (*.tfstate)",

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -56,10 +56,17 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
       "git config user.email",
     );
     runGit(workspaceDir, ["add", "-A"], githubToken, "git add");
-    const stagedResult = spawnSync("git", ["diff", "--cached", "--name-only"], {
+    // --diff-filter=d excludes staged deletions: removing an accidentally-committed
+    // secret (e.g. deleting a .env) is exactly what the guard wants to allow.
+    const stagedResult = spawnSync("git", ["diff", "--cached", "--name-only", "--diff-filter=d"], {
       cwd: workspaceDir,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    if (stagedResult.status !== 0) {
+      // Fail closed: an empty list on git failure would silently skip the guard.
+      const stderr = (stagedResult.stderr?.toString() ?? "").replaceAll(githubToken, "***");
+      throw new Error(`git diff --cached failed (exit ${stagedResult.status ?? "null"}): ${stderr}`);
+    }
     const stagedFiles = stagedResult.stdout.toString().split("\n").map((f) => f.trim()).filter(Boolean);
     const sensitiveHits = findSensitiveFiles(stagedFiles);
     if (sensitiveHits.length > 0) {


### PR DESCRIPTION
## Summary

Two review findings on the push step's sensitive-file hard block (`src/pipeline/sensitive-files.ts` + `src/pipeline/steps/push.ts`), which has no override knob and therefore must not false-positive. *(Surfaced by Claude + Copilot review on the Cloudshare fork's sync PR cloudshare/ai-implement#70.)*

- **False positives on ordinary source files.** The GCP service-account pattern was an unanchored basename substring (`/service.?account/i`), so files like `serviceAccount.ts`, `service_account.py`, `ServiceAccountController.java`, or `service-account.go` — common in backend repos — aborted legitimate pushes. The pattern is now anchored to `.json` (GCP keys are always JSON): `serviceAccountKey.json`, `my-service-account-key.json`, `svc-service_account-credentials.json` etc. are still blocked. Same class of fix for `.env.*`: intentionally-committed templates (`.env.example` / `.env.sample` / `.env.template`) are now allowed, since implement runs routinely edit them to document new env vars.
- **Staged-files guard robustness.** `git diff --cached --name-only` was used without checking exit status (a git failure fail-opened the guard with an empty list) and without filtering deletions (staging the *removal* of an accidentally-committed `.env` was blocked — the opposite of the guard's intent). Now uses `--diff-filter=d` and throws a clear, token-redacted error on git failure.

## Test plan

- [x] New boundary tests: service-account catch/must-not-catch lists, env-template allowance
- [x] New push-step tests: sensitive addition blocked; sensitive deletion not blocked (asserts `--diff-filter=d` argv); git diff failure throws instead of skipping the guard
- [x] `npm run typecheck` + full `npm test` (102 files / 1537 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)