### PR TITLE
fix(reconcile): bounded retries + unique (repo, pr_number) invariant on the reconciliation queue

### DIFF
--- a/src/__tests__/poll-merged-prs.test.ts
+++ b/src/__tests__/poll-merged-prs.test.ts
@@ -81,6 +81,22 @@ describe("detectMergedPrs", () => {
     });
     expect(recon.hasReconciliationForPr("o/r", 5)).toBe(false);
   });
+  it("does not create a duplicate row when a webhook enqueues during the poller's await gap", async () => {
+    seedCompletedJob(5);
+    // Simulate a merged-PR webhook delivery landing while the poller is parked
+    // on the GitHub API call — i.e. after the poller's hasReconciliationForPr
+    // check but before its enqueueReconciliation.
+    const getPullRequestState = vi.fn(async () => {
+      recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "webhook-sha" });
+      return { merged: true, state: "closed" as const };
+    });
+    await mod.detectMergedPrs({
+      getPullRequestState,
+      tokenForOwner: async () => "tok",
+      mappingForRepo: () => ({ owner: "o", repo: "r" } as never),
+    });
+    expect(recon.getPendingReconciliations()).toHaveLength(1);
+  });
   it("skips rows whose PR already has a queue row", async () => {
     seedCompletedJob(5);
     recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "" });

--- a/src/__tests__/process-reconciliations.test.ts
+++ b/src/__tests__/process-reconciliations.test.ts
@@ -43,6 +43,26 @@ describe("runReconciliations", () => {
       resolveProvider: async () => ({ markMerged } as never),
       mappingForRepo: () => ({ owner: "o", repo: "r", paused: false } as never),
     });
-    expect(recon.getPendingReconciliations()).toHaveLength(1);
+    const pending = recon.getPendingReconciliations();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]!.attempts).toBe(1);
+  });
+  it("marks the row failed after MAX_RECONCILIATION_ATTEMPTS failures and stops processing it", async () => {
+    recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha" });
+    const markMerged = vi.fn(async () => { throw new Error("issue deleted"); });
+    const deps = {
+      resolveProvider: async () => ({ markMerged } as never),
+      mappingForRepo: () => ({ owner: "o", repo: "r", paused: false } as never),
+    };
+    for (let tick = 0; tick < recon.MAX_RECONCILIATION_ATTEMPTS; tick++) {
+      await mod.runReconciliations(deps);
+    }
+    expect(markMerged).toHaveBeenCalledTimes(recon.MAX_RECONCILIATION_ATTEMPTS);
+    expect(recon.getPendingReconciliations()).toHaveLength(0);
+    // Terminal: further ticks never touch the row again.
+    await mod.runReconciliations(deps);
+    expect(markMerged).toHaveBeenCalledTimes(recon.MAX_RECONCILIATION_ATTEMPTS);
+    // The failed row still counts for PR dedup.
+    expect(recon.hasReconciliationForPr("o/r", 5)).toBe(true);
   });
 });

--- a/src/__tests__/reconciliation.test.ts
+++ b/src/__tests__/reconciliation.test.ts
@@ -29,4 +29,43 @@ describe("reconciliation pr-dedup", () => {
     expect(recon.hasReconciliationForPr("o/r", 9)).toBe(true);
     expect(recon.getPendingReconciliations()).toHaveLength(0);
   });
+  it("enqueueReconciliation is idempotent per (repo, pr_number)", () => {
+    const first = recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha" });
+    const second = recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha2" });
+    expect(second).toBe(first);
+    expect(recon.getPendingReconciliations()).toHaveLength(1);
+  });
+  it("enqueueReconciliation after a tombstone does not resurrect the PR", () => {
+    const tombstoneId = recon.recordReconciliationTombstone({ issueId: "i3", issueIdentifier: "ENG-3", prNumber: 7, repo: "o/r" });
+    const enqueueId = recon.enqueueReconciliation({ issueId: "i3", issueIdentifier: "ENG-3", prNumber: 7, repo: "o/r", mergeCommitSha: "sha" });
+    expect(enqueueId).toBe(tombstoneId);
+    expect(recon.getPendingReconciliations()).toHaveLength(0);
+  });
+  it("initReconciliationTable dedupes pre-index duplicate rows before creating the unique index", () => {
+    const db = dedup.getDb();
+    db.exec("DROP INDEX IF EXISTS reconciliation_queue_repo_pr");
+    const insert = db.prepare(
+      "INSERT INTO reconciliation_queue (issue_id, issue_identifier, pr_number, repo, merge_commit_sha, status, created_at) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+    );
+    insert.run("i1", "ENG-1", 5, "o/r", "sha", 1);
+    insert.run("i1", "ENG-1", 5, "o/r", "sha", 2);
+    expect(() => recon.initReconciliationTable()).not.toThrow();
+    expect(recon.getPendingReconciliations()).toHaveLength(1);
+  });
+});
+describe("bounded retries", () => {
+  it("recordReconciliationFailure counts attempts and flips to failed at the cap", () => {
+    const id = recon.enqueueReconciliation({ issueId: "i1", issueIdentifier: "ENG-1", prNumber: 5, repo: "o/r", mergeCommitSha: "sha" });
+    for (let attempt = 1; attempt < recon.MAX_RECONCILIATION_ATTEMPTS; attempt++) {
+      expect(recon.recordReconciliationFailure(id)).toEqual({ attempts: attempt, failed: false });
+      expect(recon.getPendingReconciliations()).toHaveLength(1);
+    }
+    expect(recon.recordReconciliationFailure(id)).toEqual({
+      attempts: recon.MAX_RECONCILIATION_ATTEMPTS,
+      failed: true,
+    });
+    expect(recon.getPendingReconciliations()).toHaveLength(0);
+    // A failed row still counts for PR dedup so the PR is never re-enqueued.
+    expect(recon.hasReconciliationForPr("o/r", 5)).toBe(true);
+  });
 });

--- a/src/reconcile-merged.ts
+++ b/src/reconcile-merged.ts
@@ -1,6 +1,11 @@
 import type { RepoMapping } from "./config.js";
 import type { TicketingProvider } from "./providers/types.js";
-import { getPendingReconciliations, updateReconciliationStatus } from "./reconciliation.js";
+import {
+  MAX_RECONCILIATION_ATTEMPTS,
+  getPendingReconciliations,
+  recordReconciliationFailure,
+  updateReconciliationStatus,
+} from "./reconciliation.js";
 
 export interface ReconcileDeps {
   mappingForRepo: (repo: string) => RepoMapping | undefined;
@@ -10,7 +15,9 @@ export interface ReconcileDeps {
 /**
  * Drains the reconciliation queue by moving each merged PR's issue to Done.
  * Runs even for paused projects (bookkeeping only). On provider error the row
- * is left pending so the next tick retries it.
+ * is left pending so the next tick retries it — up to
+ * MAX_RECONCILIATION_ATTEMPTS failures, after which it is marked terminally
+ * 'failed' (dead-lettered) so a permanent error cannot retry forever.
  */
 export async function runReconciliations(deps: ReconcileDeps): Promise<void> {
   const pending = getPendingReconciliations();
@@ -29,7 +36,18 @@ export async function runReconciliations(deps: ReconcileDeps): Promise<void> {
       updateReconciliationStatus(job.id, "dispatched");
       console.log(`[reconcile] Marked ${job.issueIdentifier ?? job.issueId} Done (PR #${job.prNumber} in ${job.repo})`);
     } catch (err) {
-      console.error(`[reconcile] Error processing reconciliation #${job.id} (left pending):`, err);
+      const { attempts, failed } = recordReconciliationFailure(job.id);
+      if (failed) {
+        console.error(
+          `[reconcile] Reconciliation #${job.id} (${job.issueIdentifier ?? job.issueId}, PR #${job.prNumber} in ${job.repo}) failed permanently after ${attempts} attempt(s); marking failed and giving up:`,
+          err,
+        );
+      } else {
+        console.error(
+          `[reconcile] Error processing reconciliation #${job.id} (attempt ${attempts}/${MAX_RECONCILIATION_ATTEMPTS}, left pending):`,
+          err,
+        );
+      }
     }
   }
 }

--- a/src/reconciliation.ts
+++ b/src/reconciliation.ts
@@ -1,6 +1,14 @@
 import { getDb } from "./dedup.js";
 
-export type ReconciliationStatus = "pending" | "dispatched" | "skipped";
+export type ReconciliationStatus = "pending" | "dispatched" | "skipped" | "failed";
+
+/**
+ * Number of markMerged failures a job may accumulate before it is marked
+ * terminally 'failed' and dropped from the retry loop. Keeps transient errors
+ * retryable while preventing permanent failures (deleted issue, removed
+ * mapping, tracker 4xx) from retrying and log-spamming every poll forever.
+ */
+export const MAX_RECONCILIATION_ATTEMPTS = 5;
 
 export interface ReconciliationJob {
   id: number;
@@ -10,11 +18,13 @@ export interface ReconciliationJob {
   repo: string;
   mergeCommitSha: string;
   status: ReconciliationStatus;
+  attempts: number;
   createdAt: number;
 }
 
 export function initReconciliationTable(): void {
-  getDb().exec(`
+  const db = getDb();
+  db.exec(`
     CREATE TABLE IF NOT EXISTS reconciliation_queue (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       issue_id TEXT NOT NULL,
@@ -23,11 +33,36 @@ export function initReconciliationTable(): void {
       repo TEXT NOT NULL,
       merge_commit_sha TEXT NOT NULL,
       status TEXT NOT NULL DEFAULT 'pending',
+      attempts INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL
     )
   `);
+  const info = db.prepare("PRAGMA table_info(reconciliation_queue)").all() as Array<{ name: string }>;
+  const names = new Set(info.map((c) => c.name));
+  if (!names.has("attempts")) {
+    db.exec("ALTER TABLE reconciliation_queue ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0");
+  }
+  // One queue row per (repo, pr_number) is the table's dedup invariant. Before
+  // the unique index existed, the poller's check→enqueue pair spanned awaits and
+  // could interleave with a webhook enqueue, leaving duplicate rows — remove
+  // those (keeping the earliest; markMerged is idempotent, so which duplicate
+  // had already been processed does not matter) so index creation cannot fail.
+  db.exec(`
+    DELETE FROM reconciliation_queue
+    WHERE id NOT IN (SELECT MIN(id) FROM reconciliation_queue GROUP BY repo, pr_number)
+  `);
+  db.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS reconciliation_queue_repo_pr ON reconciliation_queue (repo, pr_number)",
+  );
 }
 
+/**
+ * Enqueues a pending reconciliation for a merged PR. Idempotent per
+ * (repo, pr_number): if a row already exists (any status), no new row is
+ * inserted and the existing row's id is returned. This closes the race between
+ * the two producers (webhook handler and merge poller) whose check→enqueue
+ * pairs can interleave across the poller's awaits.
+ */
 export function enqueueReconciliation(entry: {
   issueId: string;
   issueIdentifier: string | null;
@@ -37,7 +72,7 @@ export function enqueueReconciliation(entry: {
 }): number {
   const result = getDb()
     .prepare(
-      "INSERT INTO reconciliation_queue (issue_id, issue_identifier, pr_number, repo, merge_commit_sha, status, created_at) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+      "INSERT OR IGNORE INTO reconciliation_queue (issue_id, issue_identifier, pr_number, repo, merge_commit_sha, status, created_at) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
     )
     .run(
       entry.issueId,
@@ -47,6 +82,7 @@ export function enqueueReconciliation(entry: {
       entry.mergeCommitSha,
       Date.now(),
     );
+  if (result.changes === 0) return existingRowId(entry.repo, entry.prNumber);
   return Number(result.lastInsertRowid);
 }
 
@@ -57,6 +93,10 @@ export function hasReconciliationForPr(repo: string, prNumber: number): boolean 
   return row !== undefined;
 }
 
+/**
+ * Records a 'skipped' tombstone for a closed-unmerged PR. Idempotent per
+ * (repo, pr_number) like enqueueReconciliation.
+ */
 export function recordReconciliationTombstone(entry: {
   issueId: string;
   issueIdentifier: string | null;
@@ -65,9 +105,10 @@ export function recordReconciliationTombstone(entry: {
 }): number {
   const result = getDb()
     .prepare(
-      "INSERT INTO reconciliation_queue (issue_id, issue_identifier, pr_number, repo, merge_commit_sha, status, created_at) VALUES (?, ?, ?, ?, '', 'skipped', ?)",
+      "INSERT OR IGNORE INTO reconciliation_queue (issue_id, issue_identifier, pr_number, repo, merge_commit_sha, status, created_at) VALUES (?, ?, ?, ?, '', 'skipped', ?)",
     )
     .run(entry.issueId, entry.issueIdentifier ?? null, entry.prNumber, entry.repo, Date.now());
+  if (result.changes === 0) return existingRowId(entry.repo, entry.prNumber);
   return Number(result.lastInsertRowid);
 }
 
@@ -85,6 +126,33 @@ export function updateReconciliationStatus(id: number, status: ReconciliationSta
     .run(status, id);
 }
 
+/**
+ * Records one failed markMerged attempt. When the attempt count reaches
+ * MAX_RECONCILIATION_ATTEMPTS the row is marked terminally 'failed' so it is
+ * never retried (getPendingReconciliations only returns 'pending' rows) while
+ * still counting for PR dedup (hasReconciliationForPr matches any status).
+ */
+export function recordReconciliationFailure(id: number): { attempts: number; failed: boolean } {
+  const db = getDb();
+  db.prepare("UPDATE reconciliation_queue SET attempts = attempts + 1 WHERE id = ?").run(id);
+  const row = db
+    .prepare("SELECT attempts FROM reconciliation_queue WHERE id = ?")
+    .get(id) as { attempts: number } | undefined;
+  const attempts = row?.attempts ?? 0;
+  const failed = attempts >= MAX_RECONCILIATION_ATTEMPTS;
+  if (failed) {
+    db.prepare("UPDATE reconciliation_queue SET status = 'failed' WHERE id = ?").run(id);
+  }
+  return { attempts, failed };
+}
+
+function existingRowId(repo: string, prNumber: number): number {
+  const row = getDb()
+    .prepare("SELECT id FROM reconciliation_queue WHERE repo = ? AND pr_number = ? LIMIT 1")
+    .get(repo, prNumber) as { id: number };
+  return row.id;
+}
+
 interface RawRow {
   id: number;
   issue_id: string;
@@ -93,6 +161,7 @@ interface RawRow {
   repo: string;
   merge_commit_sha: string;
   status: string;
+  attempts: number;
   created_at: number;
 }
 
@@ -105,6 +174,7 @@ function mapRow(row: RawRow): ReconciliationJob {
     repo: row.repo,
     mergeCommitSha: row.merge_commit_sha,
     status: row.status as ReconciliationStatus,
+    attempts: row.attempts,
     createdAt: row.created_at,
   };
 }


### PR DESCRIPTION
Hardens the AII-166 done-on-merge reconciliation queue against two review findings. *(Surfaced by Claude + Copilot review on the Cloudshare fork's sync PR cloudshare/ai-implement#70.)*

**1. Bounded retries with dead-letter (real bug).** `runReconciliations` left a row `pending` on *any* `markMerged` failure. Right for transient errors, but a permanent failure (issue deleted, mapping removed mid-flight, tracker 4xx) retried and log-spammed every poll forever. Each failure now increments an `attempts` column (added via the existing `PRAGMA table_info` + `ALTER TABLE` migration idiom); after `MAX_RECONCILIATION_ATTEMPTS` (5) the row transitions to a terminal `failed` status with a single loud log line. Failed rows still count for PR dedup, so the PR is never re-enqueued.

**2. UNIQUE(repo, pr_number) + idempotent enqueue (real race, different from the one claimed).** The claimed webhook-vs-webhook race is impossible: the webhook handler's check→insert pair is consecutive synchronous better-sqlite3 calls with no await between them. But `detectMergedPrs` awaits `tokenForOwner`/`getPullRequestState` between its `hasReconciliationForPr` check and its `enqueueReconciliation` — a merged-PR webhook landing in that gap enqueued a duplicate row and `markMerged` ran twice. Enqueue and tombstone now use `INSERT OR IGNORE` against a `UNIQUE(repo, pr_number)` index, returning the existing row id on conflict. `initReconciliationTable` dedupes any pre-index duplicate rows (keeping the earliest; `markMerged` is idempotent) before creating the index, so existing databases migrate cleanly.

**Non-goal (documented, no code):** `detectMergedPrs` still re-queries the PR state of every unreconciled open AI PR each tick (bounded at `listLog(500)`). A cheap follow-up would be per-PR `last_checked_at` bookkeeping with age-scaled backoff so long-open PRs are polled less often; the webhook path already provides instant detection where configured.

**Tests:** +6 (idempotent/duplicate enqueue, tombstone non-resurrection, pre-index dedupe migration, attempts→failed cap, terminal no-reprocess through `runReconciliations`, poller-await-gap race regression). `npm run typecheck` + full `npm test` green (1538 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)