### PR TITLE
fix(github): prefer merged > open > most-recently-updated PR in findPullRequestByBranches

### DIFF
--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -442,6 +442,56 @@ describe("findPullRequestByBranches", () => {
     expect(result).toMatchObject({ number: 8, merged: true });
   });
 
+  it("prefers an open PR over a newer closed-unmerged one (reopened PRs keep their created date)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { number: 12, html_url: "https://gh/pr/12", state: "closed", merged_at: null, updated_at: "2026-07-02T09:00:00Z" },
+        { number: 7, html_url: "https://gh/pr/7", state: "open", merged_at: null, updated_at: "2026-07-01T08:00:00Z" },
+      ],
+    })));
+    expect(await findPullRequestByBranches("tok", "owner", "repo", "h", "b")).toEqual({
+      number: 7, url: "https://gh/pr/7", state: "open", merged: false,
+    });
+  });
+
+  it("prefers a merged PR over an open one", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { number: 12, html_url: "https://gh/pr/12", state: "open", merged_at: null, updated_at: "2026-07-02T09:00:00Z" },
+        { number: 7, html_url: "https://gh/pr/7", state: "closed", merged_at: "2026-06-30T12:00:00Z", updated_at: "2026-06-30T12:00:00Z" },
+      ],
+    })));
+    expect(await findPullRequestByBranches("tok", "owner", "repo", "h", "b")).toEqual({
+      number: 7, url: "https://gh/pr/7", state: "closed", merged: true,
+    });
+  });
+
+  it("picks the most recently updated PR when all are closed-unmerged, regardless of list order", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        { number: 4, html_url: "https://gh/pr/4", state: "closed", merged_at: null, updated_at: "2026-06-20T10:00:00Z" },
+        { number: 2, html_url: "https://gh/pr/2", state: "closed", merged_at: null, updated_at: "2026-07-05T10:00:00Z" },
+        { number: 3, html_url: "https://gh/pr/3", state: "closed", merged_at: null, updated_at: "2026-06-28T10:00:00Z" },
+      ],
+    })));
+    expect(await findPullRequestByBranches("tok", "owner", "repo", "h", "b")).toEqual({
+      number: 2, url: "https://gh/pr/2", state: "closed", merged: false,
+    });
+  });
+
+  it("requests the list sorted by updated desc so the per_page window holds recently active PRs", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => [] }));
+    vi.stubGlobal("fetch", fetchMock);
+    await findPullRequestByBranches("tok", "owner", "repo", "h", "b");
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("state=all&sort=updated&direction=desc&per_page=10"),
+      expect.anything(),
+    );
+  });
+
   it("returns null on non-OK response", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 404 })));
     expect(await findPullRequestByBranches("tok", "owner", "repo", "h", "b")).toBeNull();

--- a/src/github.ts
+++ b/src/github.ts
@@ -422,8 +422,16 @@ export async function findOpenPullRequest(
 }
 
 /**
- * Finds any PR (open, closed, or merged) for the given head→base pair.
- * Prefers a merged PR when multiple results exist (e.g. after a re-open / force-push).
+ * Finds the most relevant PR (open, closed, or merged) for the given head→base pair.
+ * Selection is intent-ordered rather than list-ordered: a merged PR wins (terminal state),
+ * else an open PR, else the most recently updated closed PR. This matters when several
+ * PRs have existed for the same branch pair over time — GitHub's default list order is
+ * `created` desc, so a newer closed PR would otherwise shadow an older PR that was later
+ * reopened (reopened PRs keep their created date). The query sorts by `updated` desc so
+ * the per_page=10 window holds the most recently *active* PRs (a window cut by created
+ * date could drop that reopened-but-old PR entirely — something client-side sorting
+ * cannot recover); the explicit selection below then makes the choice deterministic
+ * without trusting response ordering.
  * Returns null on empty list or non-OK response (soft failure).
  */
 export async function findPullRequestByBranches(
@@ -435,7 +443,8 @@ export async function findPullRequestByBranches(
 ): Promise<{ number: number; url: string; state: "open" | "closed"; merged: boolean } | null> {
   const url =
     `https://api.github.com/repos/${owner}/${repo}/pulls` +
-    `?head=${encodeURIComponent(`${owner}:${head}`)}&base=${encodeURIComponent(base)}&state=all&per_page=10`;
+    `?head=${encodeURIComponent(`${owner}:${head}`)}&base=${encodeURIComponent(base)}` +
+    `&state=all&sort=updated&direction=desc&per_page=10`;
   const res = await fetch(url, { headers: ghHeaders(token) });
   if (!res.ok) return null;
   const prs = (await res.json()) as Array<{
@@ -443,10 +452,13 @@ export async function findPullRequestByBranches(
     html_url: string;
     state: string;
     merged_at: string | null;
+    updated_at: string;
   }>;
   if (prs.length === 0) return null;
-  const mergedPr = prs.find((p) => p.merged_at !== null);
-  const pr = mergedPr ?? prs[0];
+  const pr =
+    prs.find((p) => p.merged_at !== null) ??
+    prs.find((p) => p.state === "open") ??
+    prs.reduce((best, p) => (p.updated_at > best.updated_at ? p : best));
   return {
     number: pr.number,
     url: pr.html_url,


### PR DESCRIPTION
## Problem

`findPullRequestByBranches` returned `mergedPr ?? prs[0]` from `GET /pulls?state=all&per_page=10`. GitHub's default list sort is `created` desc, so `prs[0]` is the most recently **created** PR — not the most relevant. When multiple PRs have existed for the same head→base pair, a newer closed-unmerged PR shadows an older PR that was later **reopened** (reopened PRs keep their created date). The merge-up top-of-tree logic then sees "closed" while an open PR actually exists, wedging the feature-branch roll-up. *(Flagged by Copilot review on the Cloudshare fork's sync PR cloudshare/ai-implement#70.)*

## Fix

Selection is now deterministic and intent-ordered: **merged** (terminal state, highest priority) → **open** → **most recently updated closed**. Two complementary pieces:
- `sort=updated&direction=desc` on the query, so the `per_page=10` window holds the most recently *active* PRs — a created-date window could drop a reopened-but-old PR entirely, which client-side sorting cannot recover;
- explicit client-side selection, so the choice doesn't depend on response ordering and the priority is unit-testable.

Return shape is unchanged; no merge-up semantics touched.

## Tests

New cases: open beats a newer closed-unmerged PR; merged beats open; multiple closed → most recently updated wins regardless of list order; query carries the sort params. `npm run typecheck` + full `npm test` green (102 files / 1536 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)