### PR TITLE
Jira poll fixes: text-typed repo field + blocked-issue skip

### DIFF
--- a/src/__tests__/providers/jira.test.ts
+++ b/src/__tests__/providers/jira.test.ts
@@ -293,6 +293,31 @@ describe("JiraProvider lifecycle status setters", () => {
     expectStatusBody(lastCall, "Plan Approved");
   });
 
+  it("multi-mapping scopeKey lookup handles a plain-text (bare-string) repo field", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE) // listFields
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "10001",
+          key: "PROJ-1",
+          fields: { customfield_10101: "acme/y" }, // text field: bare string
+        }),
+      } as Response) // getIssue
+      .mockResolvedValueOnce(okEmpty()); // setField
+    const p = makeProvider({
+      cacheScope: "c8-text",
+      mappings: {
+        "acme/x": jiraMapping({ repoFieldValue: "acme/x" }),
+        "acme/y": jiraMapping({ repoFieldValue: "acme/y" }),
+      },
+    });
+    await p.markPlanComplete("10001");
+    const lastCall = vi.mocked(fetch).mock.calls.at(-1)!;
+    expect(String(lastCall[0])).toMatch(/\/issue\/10001/);
+    expectStatusBody(lastCall, "Plan Approved");
+  });
+
   it("scopeKeyForIssue throws when no mapping matches the issue's repo field", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(FIELDS_RESPONSE) // listFields
@@ -453,6 +478,35 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
     expect(snap.needsPlanning.map((i) => i.identifier)).toEqual(["P-20"]);
     expect(onRepoFieldMismatch).toHaveBeenCalledTimes(1);
     expect(onRepoFieldMismatch).toHaveBeenCalledWith("acme/x", "P-21", "acme/wrong");
+  });
+
+  it("matches a plain-text repo field that serializes as a bare string (not an option object)", async () => {
+    // Text custom fields come back as a bare string, unlike single-select
+    // option fields which come back as { value: string }.
+    const textIssue = (id: string, key: string, status: string, repo: string) => ({
+      id, key,
+      fields: {
+        summary: `summary-${key}`, description: null,
+        customfield_10100: { value: status },
+        customfield_10101: repo,
+      },
+    });
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(searchOk([textIssue("50001", "P-40", "Ready", "acme/x")]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const onRepoFieldMismatch = vi.fn();
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-text" }),
+      cacheScope: "c-text", siteUrl: "https://x",
+      getMappings: () => ({ "acme/x": jiraMapping() }),
+      onRepoFieldMismatch,
+    });
+    const snap = await p.fetchAIImplementSnapshot();
+
+    expect(snap.needsPlanning.map((i) => i.identifier)).toEqual(["P-40"]);
+    expect(onRepoFieldMismatch).not.toHaveBeenCalled();
   });
 
   it("does not double-fire onRepoFieldMismatch on second snapshot for the same issue", async () => {

--- a/src/__tests__/providers/jira.test.ts
+++ b/src/__tests__/providers/jira.test.ts
@@ -530,6 +530,135 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
 
     expect(onRepoFieldMismatch).toHaveBeenCalledTimes(1);
   });
+
+  // --- Blocking relations (mirrors the Linear "blocks" inverse-relation skip) ---
+
+  // A Jira "Blocks" issue link, as it appears in the blocked issue's `issuelinks`:
+  // `inwardIssue` present ⇒ this issue "is blocked by" that issue.
+  const blockedByLink = (statusCategoryKey: string) => ({
+    type: { name: "Blocks", inward: "is blocked by", outward: "blocks" },
+    inwardIssue: { key: "BLK-1", fields: { status: { statusCategory: { key: statusCategoryKey } } } },
+  });
+
+  // The other direction: this issue blocks something else (it is not itself blocked).
+  const blocksOtherLink = () => ({
+    type: { name: "Blocks", inward: "is blocked by", outward: "blocks" },
+    outwardIssue: { key: "OTH-1", fields: { status: { statusCategory: { key: "new" } } } },
+  });
+
+  const withLinks = (
+    iss: ReturnType<typeof issue>,
+    links: unknown[],
+  ) => ({ ...iss, fields: { ...iss.fields, issuelinks: links } });
+
+  it("requests the issuelinks field in the bucket search", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(searchOk([]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-links-field" }),
+      cacheScope: "c-links-field", siteUrl: "https://x",
+      getMappings: () => ({ "acme/x": jiraMapping() }),
+    });
+    await p.fetchAIImplementSnapshot();
+
+    const bucketBody = JSON.parse(vi.mocked(fetch).mock.calls[1][1]?.body as string);
+    expect(bucketBody.fields).toContain("issuelinks");
+  });
+
+  it("skips an issue blocked by an incomplete issue", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(searchOk([
+        withLinks(issue("50001", "P-40", "Ready", "acme/x"), [blockedByLink("indeterminate")]),
+        issue("50002", "P-41", "Ready", "acme/x"),
+      ]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-blocked" }),
+      cacheScope: "c-blocked", siteUrl: "https://x",
+      getMappings: () => ({ "acme/x": jiraMapping() }),
+    });
+    const snap = await p.fetchAIImplementSnapshot();
+
+    expect(snap.needsPlanning.map((i) => i.identifier)).toEqual(["P-41"]);
+  });
+
+  it("includes an issue whose blocker is already done", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(searchOk([
+        withLinks(issue("50003", "P-42", "Ready", "acme/x"), [blockedByLink("done")]),
+      ]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-blk-done" }),
+      cacheScope: "c-blk-done", siteUrl: "https://x",
+      getMappings: () => ({ "acme/x": jiraMapping() }),
+    });
+    const snap = await p.fetchAIImplementSnapshot();
+
+    expect(snap.needsPlanning.map((i) => i.identifier)).toEqual(["P-42"]);
+  });
+
+  it("includes an issue that blocks others but is not itself blocked", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(searchOk([
+        withLinks(issue("50004", "P-43", "Ready", "acme/x"), [blocksOtherLink()]),
+      ]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-blocks-other" }),
+      cacheScope: "c-blocks-other", siteUrl: "https://x",
+      getMappings: () => ({ "acme/x": jiraMapping() }),
+    });
+    const snap = await p.fetchAIImplementSnapshot();
+
+    expect(snap.needsPlanning.map((i) => i.identifier)).toEqual(["P-43"]);
+  });
+
+  it("includes an issue with no issuelinks field", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(searchOk([issue("50005", "P-44", "Ready", "acme/x")]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-no-links" }),
+      cacheScope: "c-no-links", siteUrl: "https://x",
+      getMappings: () => ({ "acme/x": jiraMapping() }),
+    });
+    const snap = await p.fetchAIImplementSnapshot();
+
+    expect(snap.needsPlanning.map((i) => i.identifier)).toEqual(["P-44"]);
+  });
+
+  it("skips an issue with a mix of done and incomplete blockers", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(FIELDS_RESPONSE)
+      .mockResolvedValueOnce(searchOk([
+        withLinks(issue("50006", "P-45", "Ready", "acme/x"), [
+          blockedByLink("done"),
+          blockedByLink("indeterminate"),
+        ]),
+      ]))
+      .mockResolvedValueOnce(searchOk([]));
+
+    const p = new JiraProvider({
+      client: new JiraClient({ token: "t", cloudId: "c-blk-mix" }),
+      cacheScope: "c-blk-mix", siteUrl: "https://x",
+      getMappings: () => ({ "acme/x": jiraMapping() }),
+    });
+    const snap = await p.fetchAIImplementSnapshot();
+
+    expect(snap.needsPlanning).toEqual([]);
+  });
 });
 
 describe("JiraProvider.fetchLifecycleStates", () => {

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -42,6 +42,22 @@ function jqlFieldRef(fieldId: string): string {
   return match ? `cf[${match[1]}]` : fieldId;
 }
 
+/**
+ * Read the repo-field value regardless of how the custom field is typed in
+ * Jira. Single-select option fields serialize as { value: string }; plain
+ * text (short-text) fields serialize as a bare string. Both are legitimate
+ * ways to hold the repo identifier, so support either rather than assuming
+ * an option field (which silently reads "" for text fields and drops the
+ * issue as a mismatch).
+ */
+function readRepoFieldValue(raw: unknown): string {
+  if (typeof raw === "string") return raw.trim();
+  if (raw && typeof raw === "object" && typeof (raw as { value?: unknown }).value === "string") {
+    return (raw as { value: string }).value;
+  }
+  return "";
+}
+
 export interface JiraProviderConstructor {
   client: JiraClient;
   /** Per-instance cache scope label; typically the cloud ID. */
@@ -117,7 +133,7 @@ export class JiraProvider implements TicketingProvider {
     if (jiraEntries.length === 1) return jiraEntries[0][0];
     const repoFieldId = (await this.fields(jiraEntries[0][0])).repoFieldId;
     const issue = await this.client.getIssue(issueId, [repoFieldId]);
-    const repoValue = (issue.fields[repoFieldId] as { value?: string } | null)?.value ?? "";
+    const repoValue = readRepoFieldValue(issue.fields[repoFieldId]);
     const match = jiraEntries.find(
       ([, m]) => m.ticketingConfig.kind === "jira" && m.ticketingConfig.repoFieldValue === repoValue,
     );
@@ -159,8 +175,7 @@ export class JiraProvider implements TicketingProvider {
       const bucketIssues = await this.client.searchJql(bucketJql, fieldsToFetch);
 
       for (const raw of bucketIssues) {
-        const repoOption = raw.fields[fieldIds.repoFieldId] as { value?: string } | null;
-        const actualRepo = repoOption?.value ?? "";
+        const actualRepo = readRepoFieldValue(raw.fields[fieldIds.repoFieldId]);
         if (actualRepo !== cfg.repoFieldValue) {
           const mismatchKey = `${scopeKey}::${raw.key}`;
           if (!this.notifiedMismatches.has(mismatchKey)) {

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -58,6 +58,33 @@ function readRepoFieldValue(raw: unknown): string {
   return "";
 }
 
+/** Shape of a single entry in an issue's `issuelinks` field. A `Blocks` link with
+ *  an `inwardIssue` means "this issue is blocked by inwardIssue". */
+interface JiraIssueLink {
+  type?: { name?: string };
+  inwardIssue?: { key?: string; fields?: { status?: { statusCategory?: { key?: string } } } };
+  outwardIssue?: { key?: string; fields?: { status?: { statusCategory?: { key?: string } } } };
+}
+
+/**
+ * True when the issue has an open "Blocks" link pointing inward (it is blocked by an
+ * issue whose status category is not terminal). Mirrors the Linear provider's
+ * inverse-relation "blocks" skip. A blocker in the `done` category never blocks.
+ *
+ * NOTE: the link type is matched on the default name "Blocks". A Jira instance that
+ * renames this link type will fail open here (the issue dispatches as if unblocked).
+ * Making the name per-mapping configurable is the follow-up if that becomes a need.
+ */
+function isBlockedByIncomplete(issuelinks: unknown): boolean {
+  if (!Array.isArray(issuelinks)) return false;
+  return (issuelinks as JiraIssueLink[]).some(
+    (l) =>
+      l.type?.name === "Blocks" &&
+      l.inwardIssue != null &&
+      l.inwardIssue.fields?.status?.statusCategory?.key !== "done",
+  );
+}
+
 export interface JiraProviderConstructor {
   client: JiraClient;
   /** Per-instance cache scope label; typically the cloud ID. */
@@ -160,6 +187,7 @@ export class JiraProvider implements TicketingProvider {
       const fieldsToFetch = [
         "summary",
         "description",
+        "issuelinks",
         fieldIds.statusFieldId,
         fieldIds.repoFieldId,
       ];
@@ -182,6 +210,10 @@ export class JiraProvider implements TicketingProvider {
             this.notifiedMismatches.add(mismatchKey);
             this.onRepoFieldMismatch(scopeKey, raw.key, actualRepo);
           }
+          continue;
+        }
+        if (isBlockedByIncomplete(raw.fields.issuelinks)) {
+          console.log(`[jira] Skipping ${raw.key}: blocked by an incomplete issue`);
           continue;
         }
         const statusOption = raw.fields[fieldIds.statusFieldId] as { value?: string } | null;


### PR DESCRIPTION
Two orchestrator-side Jira poll fixes, ported from the Cloudshare fork (cloudshare/ai-implement #55 and #58).

**1. Read the repo field as text or option (`readRepoFieldValue`).** The Jira repo-field read assumed a single-select option field (`{ value: string }`), so plain-text (short-text) repo fields — which serialize as a bare string — read as `""`. Every issue then looked like a repo mismatch and was silently dropped from the poll. Both read sites are fixed: `fetchAIImplementSnapshot` (poll filter) and `scopeKeyForIssue` (multi-mapping callback lookup, same latent bug).

**2. Skip blocked Jira issues at poll time (`isBlockedByIncomplete`).** Mirrors the Linear provider's "blocks" inverse-relation skip: `fetchAIImplementSnapshot` now requests `issuelinks` and keeps any issue with an open inward "Blocks" link (blocker statusCategory ≠ done) out of `needsPlanning`/`readyForImplementation` until its blockers resolve. Fails open if the instance renamed the "Blocks" link type (documented in a comment). Poll logic only — no interface, schema, admin-UI, or target-repo workflow changes.

Tests: repo-field shape coverage in both read sites; six blocked-relation cases (incomplete blocker, done blocker, outward-only link, no links, mixed blockers, issuelinks field requested).

Credit: originally implemented on the Cloudshare fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)