### PR TITLE
merge-up: respect a human closing the top-of-tree PR without merging

### DIFF
--- a/src/__tests__/merge-up.test.ts
+++ b/src/__tests__/merge-up.test.ts
@@ -144,6 +144,18 @@ describe("runMergeUps", () => {
     expect(finalizeMerged).toHaveBeenCalledWith("uuid-p", "OOL");
   });
 
+  it("does not re-open the top-level PR after a human closed it without merging (veto)", async () => {
+    vi.mocked(compareBranches).mockResolvedValue(3);
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({
+      number: 55, url: "https://gh/pr/55", state: "closed", merged: false,
+    });
+    const finalizeMerged = vi.fn();
+    await runMergeUps([rollUp({ identifier: "OOL-106", parentIdentifier: null })], deps(() => mapping(), finalizeMerged));
+    expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+    expect(vi.mocked(deleteBranch)).not.toHaveBeenCalled();
+    expect(finalizeMerged).not.toHaveBeenCalled();
+  });
+
   it("warns (does not crash) when the internal merge conflicts", async () => {
     vi.mocked(compareBranches).mockResolvedValue(1);
     vi.mocked(mergeBranch).mockResolvedValue("conflict");

--- a/src/merge-up.ts
+++ b/src/merge-up.ts
@@ -89,6 +89,14 @@ async function rollUpOne(rollUp: FeatureNodeRollUp, deps: MergeUpDeps): Promise<
     return;
   }
   if (pr?.state === "open") return; // awaiting human merge
+  // A human may have closed the PR without merging (a deliberate veto). Respect that
+  // decision — do not re-open on every poll cycle while the branch stays ahead.
+  if (pr && pr.state === "closed" && !pr.merged) {
+    console.log(
+      `[merge-up] Skipping feature→base PR for ${rollUp.identifier}: PR #${pr.number} was closed without merging`,
+    );
+    return;
+  }
 
   // No PR yet — open one if the branch has commits not yet in the base.
   const ahead = await compareBranches(ghToken, owner, repo, target, branch);


### PR DESCRIPTION
**Stacked on #135** (`cameron/scoped-lifecycle-verbs`; independent of the Jira feature-branch PR).

In the top-of-tree roll-up flow, a feature→base PR found **closed and unmerged** is now treated as a deliberate human veto: log and return, instead of falling through to the `compareBranches` fallback — which would re-open a fresh PR on every poll cycle for as long as the feature branch stays ahead of base.

This composes correctly with #133's intent-ordered selection in `findPullRequestByBranches` (merged > open > most-recently-updated closed): a closed-unmerged PR is only ever returned when **no** merged and **no** open PR exists for the branch pair — an open PR now beats a stale closed one — so the veto fires exactly when the branch pair's latest disposition truly is closed-without-merge.

Test: `{state:"closed", merged:false}` from `findPullRequestByBranches` with the branch 3 commits ahead → no `createPullRequest`, no `deleteBranch`, no `finalizeMerged`.

Credit: ported from the Cloudshare fork (July 2026 sync reconciliation of its merge-up changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)