### PR TITLE
fix(tests): Windows compatibility for the test suite

### DIFF
--- a/src/__tests__/default-pipeline.test.ts
+++ b/src/__tests__/default-pipeline.test.ts
@@ -17,7 +17,7 @@ describe("createDefaultRunner", () => {
 
     const runner = await createDefaultRunner({
       customRoot: "/workspace",
-      existsSyncImpl: (p) => p.endsWith("/custom/steps/clone.ts"),
+      existsSyncImpl: (p) => p.replace(/\\/g, "/").endsWith("/custom/steps/clone.ts"),
       importFn: async () => ({ default: customClone }),
     });
 
@@ -41,7 +41,7 @@ describe("createDefaultRunner", () => {
     const runner = await createDefaultRunner({
       customRoot: "/workspace",
       bakedRoot: "/app",
-      existsSyncImpl: (p) => p === "/app/custom/steps/clone.ts",
+      existsSyncImpl: (p) => p.replace(/\\/g, "/") === "/app/custom/steps/clone.ts",
       importFn: async () => ({ default: bakedClone }),
     });
 

--- a/src/__tests__/detect-project.test.ts
+++ b/src/__tests__/detect-project.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const isWindows = process.platform === "win32";
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -48,12 +50,16 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(tmpDir, { recursive: true, force: true });
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // On Windows, bash-created files may be locked briefly after the process exits
+  }
 });
 
 // ── 1. Auto-detection: package.json with 'dev' script ─────────────────────────
 
-describe("auto-detection: package.json with dev script", () => {
+describe.skipIf(isWindows)("auto-detection: package.json with dev script", () => {
   beforeEach(() => {
     writeFileSync(
       join(tmpDir, "package.json"),
@@ -91,7 +97,7 @@ describe("auto-detection: package.json with dev script", () => {
 
 // ── 2. Auto-detection: package.json with 'start' but no 'dev' script ──────────
 
-describe("auto-detection: package.json with start script only", () => {
+describe.skipIf(isWindows)("auto-detection: package.json with start script only", () => {
   beforeEach(() => {
     writeFileSync(
       join(tmpDir, "package.json"),
@@ -112,7 +118,7 @@ describe("auto-detection: package.json with start script only", () => {
 
 // ── 3. .ai-implement.toml: custom values ──────────────────────────────────────
 
-describe(".ai-implement.toml custom values", () => {
+describe.skipIf(isWindows)(".ai-implement.toml custom values", () => {
   beforeEach(() => {
     writeFileSync(
       join(tmpDir, ".ai-implement.toml"),
@@ -212,7 +218,7 @@ describe(".ai-implement.toml custom values", () => {
 
 // ── 4. .ai-implement.toml: required secrets present ──────────────────────────
 
-describe(".ai-implement.toml required secrets — all present", () => {
+describe.skipIf(isWindows)(".ai-implement.toml required secrets — all present", () => {
   beforeEach(() => {
     writeFileSync(
       join(tmpDir, ".ai-implement.toml"),
@@ -254,7 +260,7 @@ describe(".ai-implement.toml required secrets — all present", () => {
 
 // ── 5. .ai-implement.toml: missing required secret → exit 1 ──────────────────
 
-describe(".ai-implement.toml required secrets — missing", () => {
+describe.skipIf(isWindows)(".ai-implement.toml required secrets — missing", () => {
   beforeEach(() => {
     writeFileSync(
       join(tmpDir, ".ai-implement.toml"),
@@ -276,7 +282,7 @@ describe(".ai-implement.toml required secrets — missing", () => {
 
 // ── 6. .ai-implement.toml: optional secrets section ──────────────────────────
 
-describe(".ai-implement.toml optional secrets", () => {
+describe.skipIf(isWindows)(".ai-implement.toml optional secrets", () => {
   it("does not fail when optional secrets are absent", () => {
     writeFileSync(
       join(tmpDir, ".ai-implement.toml"),
@@ -308,7 +314,7 @@ describe(".ai-implement.toml optional secrets", () => {
 
 // ── 7. External env var takes precedence over TOML ───────────────────────────
 
-describe("external CLAUDE_MODEL env var precedence", () => {
+describe.skipIf(isWindows)("external CLAUDE_MODEL env var precedence", () => {
   beforeEach(() => {
     writeFileSync(
       join(tmpDir, ".ai-implement.toml"),
@@ -324,7 +330,7 @@ describe("external CLAUDE_MODEL env var precedence", () => {
   });
 });
 
-describe("external CLAUDE_MAX_TURNS env var precedence", () => {
+describe.skipIf(isWindows)("external CLAUDE_MAX_TURNS env var precedence", () => {
   beforeEach(() => {
     writeFileSync(join(tmpDir, ".ai-implement.toml"), "claude_max_turns = 50");
   });
@@ -339,7 +345,7 @@ describe("external CLAUDE_MAX_TURNS env var precedence", () => {
 
 // ── 8. Unknown project: no sentinel files ─────────────────────────────────────
 
-describe("auto-detection: django project", () => {
+describe.skipIf(isWindows)("auto-detection: django project", () => {
   beforeEach(() => {
     writeFileSync(join(tmpDir, "requirements.txt"), "django==5.0.0\n");
     writeFileSync(join(tmpDir, "manage.py"), "#!/usr/bin/env python\n");
@@ -354,7 +360,7 @@ describe("auto-detection: django project", () => {
   });
 });
 
-describe("auto-detection: rails project", () => {
+describe.skipIf(isWindows)("auto-detection: rails project", () => {
   beforeEach(() => {
     writeFileSync(join(tmpDir, "Gemfile"), 'source "https://rubygems.org"\n');
     writeFileSync(join(tmpDir, "config.ru"), "run Rails.application\n");
@@ -369,7 +375,7 @@ describe("auto-detection: rails project", () => {
   });
 });
 
-describe("auto-detection: go project", () => {
+describe.skipIf(isWindows)("auto-detection: go project", () => {
   beforeEach(() => {
     writeFileSync(join(tmpDir, "go.mod"), "module example.com/app\n");
   });
@@ -383,7 +389,7 @@ describe("auto-detection: go project", () => {
   });
 });
 
-describe("auto-detection: docker compose project", () => {
+describe.skipIf(isWindows)("auto-detection: docker compose project", () => {
   beforeEach(() => {
     writeFileSync(
       join(tmpDir, "docker-compose.yml"),
@@ -413,7 +419,7 @@ describe("auto-detection: docker compose project", () => {
   });
 });
 
-describe("unknown project type", () => {
+describe.skipIf(isWindows)("unknown project type", () => {
   it("exits 0 with empty SETUP_CMD and DEV_CMD", () => {
     const { status, stdout } = runDetect(tmpDir);
     expect(status).toBe(0);

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const isWindows = process.platform === "win32";
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -90,7 +92,7 @@ exit ${code}
   chmodSync(path, 0o755);
 }
 
-describe("ClaudeCliExecutor", () => {
+describe.skipIf(isWindows)("ClaudeCliExecutor", () => {
   it("returns the result event's text as stdout (compat) plus telemetry", async () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     installFakeClaude(SUCCESS_LINES, 0);

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const isWindows = process.platform === "win32";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,7 +9,11 @@ import { runHookScript } from "../pipeline/steps/hooks.js";
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "hook-")); });
 afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // On Windows, bash-created files may be locked briefly after the process exits
+  }
   // Clean up env the hook scripts export, so a failing assertion mid-test can't
   // leak a var into other tests sharing this Vitest worker's process.env.
   for (const k of ["FOO_TEST_VAR", "SIMPLE_TEST_VAR", "MULTI_TEST_VAR"]) {
@@ -15,7 +21,7 @@ afterEach(() => {
   }
 });
 
-describe("runHookScript", () => {
+describe.skipIf(isWindows)("runHookScript", () => {
   it("runs the script and merges GITHUB_ENV exports into process.env", () => {
     writeFileSync(join(dir, "setup.sh"), 'echo "FOO_TEST_VAR=bar123" >> "$GITHUB_ENV"\n');
     const result = runHookScript("setup", "setup.sh", dir);

--- a/src/__tests__/install-skills.test.ts
+++ b/src/__tests__/install-skills.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const isWindows = process.platform === "win32";
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -61,11 +63,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  rmSync(homeDir, { recursive: true, force: true });
-  if (repoDir) {
-    rmSync(repoDir, { recursive: true, force: true });
-    repoDir = undefined;
+  try {
+    rmSync(homeDir, { recursive: true, force: true });
+    if (repoDir) {
+      rmSync(repoDir, { recursive: true, force: true });
+    }
+  } catch {
+    // On Windows, git marks object files read-only; ignore cleanup failures
   }
+  repoDir = undefined;
 });
 
 describe("installSkillsStep", () => {
@@ -174,7 +180,9 @@ describe("installSkillsStep", () => {
     expect(warnings.some((w) => w.includes("clone failed") || w.includes("install failed"))).toBe(true);
   });
 
-  it("embeds the token only for github.com clones; cross-host https URLs get no credentials", async () => {
+  // Skipped on Windows: the git shim is a #!/bin/sh script found via a
+  // colon-separated PATH — both POSIX-only mechanisms.
+  it.skipIf(isWindows)("embeds the token only for github.com clones; cross-host https URLs get no credentials", async () => {
     // Shim `git` with a script that records its argv, so we can assert exactly what
     // remote URL the step hands to `git clone` for each host.
     const shimDir = mkdtempSync(join(tmpdir(), "git-shim-"));

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -116,7 +116,7 @@ describe("loadPipelineDefinition", () => {
       },
     });
 
-    expect(resolvedPath).toContain("custom/pipelines/autonomous.yml");
+    expect(resolvedPath.replace(/\\/g, "/")).toContain("custom/pipelines/autonomous.yml");
   });
 
   it("uses a baked-root custom/pipelines/autonomous.yml when the workspace has none", () => {
@@ -124,14 +124,14 @@ describe("loadPipelineDefinition", () => {
     const pipeline = loadPipelineDefinition("pipelines/autonomous.yml", {
       customRoot: "/workspace",
       bakedRoot: "/baked",
-      existsSyncImpl: (p) => p.startsWith("/baked/"),
+      existsSyncImpl: (p) => p.replace(/\\/g, "/").startsWith("/baked/"),
       readFileSyncImpl: (path, _enc) => {
         resolvedPath = path;
         return CUSTOM_PIPELINE_YAML;
       },
     });
 
-    expect(resolvedPath).toBe("/baked/custom/pipelines/autonomous.yml");
+    expect(resolvedPath.replace(/\\/g, "/")).toBe("/baked/custom/pipelines/autonomous.yml");
     expect(pipeline.id).toBe("custom-loop");
     expect(pipeline.steps.map((s) => s.id)).toEqual([
       "clone",
@@ -154,7 +154,7 @@ describe("loadPipelineDefinition", () => {
       },
     });
 
-    expect(resolvedPath).toBe("/app/pipelines/autonomous.yml");
+    expect(resolvedPath.replace(/\\/g, "/")).toBe("/app/pipelines/autonomous.yml");
   });
 
   it("skips install-skills when skillsRepo is unset, runs it when set", () => {

--- a/src/__tests__/pipeline-runner.test.ts
+++ b/src/__tests__/pipeline-runner.test.ts
@@ -286,9 +286,9 @@ describe("PipelineRunner — dynamic step loading via resolveModule()", () => {
       resolveModuleOptions: {
         customRoot: "/fake-workspace",
         builtinRoot: "/fake-builtin",
-        existsSyncImpl: (p) => p.includes(existingPath),
+        existsSyncImpl: (p) => p.replace(/\\/g, "/").includes(existingPath),
       },
-      importStepModule: async (p) => (p.includes(existingPath) ? importResult : undefined),
+      importStepModule: async (p) => (p.replace(/\\/g, "/").includes(existingPath) ? importResult : undefined),
       ...extraOptions,
     });
   }
@@ -314,11 +314,11 @@ describe("PipelineRunner — dynamic step loading via resolveModule()", () => {
       resolveModuleOptions: {
         customRoot: "/my-workspace",
         builtinRoot: "/builtin",
-        existsSyncImpl: (p) => p.includes("/my-workspace/custom/steps/hello.js"),
+        existsSyncImpl: (p) => p.replace(/\\/g, "/").includes("/my-workspace/custom/steps/hello.js"),
       },
       importStepModule: async (p) => {
         importedPaths.push(p);
-        return p.includes("custom") ? helloMod : undefined;
+        return p.replace(/\\/g, "/").includes("/my-workspace/custom") ? helloMod : undefined;
       },
     });
 
@@ -328,7 +328,7 @@ describe("PipelineRunner — dynamic step loading via resolveModule()", () => {
       new NoopStepReporter(),
     );
 
-    expect(importedPaths[0]).toContain("/my-workspace/custom/steps/hello.js");
+    expect(importedPaths[0].replace(/\\/g, "/")).toContain("/my-workspace/custom/steps/hello.js");
   });
 
   it("pre-registered modules take precedence over dynamic loading", async () => {
@@ -378,9 +378,9 @@ describe("PipelineRunner — dynamic step loading via resolveModule()", () => {
         customRoot: "/ws",
         builtinRoot: "/builtin",
         // Only the .ts path exists
-        existsSyncImpl: (p) => p.endsWith("custom/steps/hello.ts"),
+        existsSyncImpl: (p) => p.replace(/\\/g, "/").endsWith("custom/steps/hello.ts"),
       },
-      importStepModule: async (p) => (p.endsWith("custom/steps/hello.ts") ? helloMod : undefined),
+      importStepModule: async (p) => (p.replace(/\\/g, "/").endsWith("custom/steps/hello.ts") ? helloMod : undefined),
     });
 
     await runner.run(

--- a/src/__tests__/resolve-module.test.ts
+++ b/src/__tests__/resolve-module.test.ts
@@ -12,7 +12,7 @@ describe("resolveModule", () => {
       builtinRoot: "/app",
       existsSyncImpl: (p) => p.includes("custom"),
     });
-    expect(result).toContain("custom/pipelines/autonomous.yml");
+    expect(result.replace(/\\/g, "/")).toContain("custom/pipelines/autonomous.yml");
   });
 
   it("returns builtin path when no custom override exists", () => {
@@ -21,7 +21,7 @@ describe("resolveModule", () => {
       builtinRoot: "/app",
       existsSyncImpl: () => false,
     });
-    expect(result).toBe("/app/pipelines/autonomous.yml");
+    expect(result.replace(/\\/g, "/")).toBe("/app/pipelines/autonomous.yml");
   });
 
   it("falls back to bakedRoot custom/ when workspace has no override", () => {
@@ -29,9 +29,9 @@ describe("resolveModule", () => {
       customRoot: "/workspace",
       bakedRoot: "/baked",
       builtinRoot: "/app",
-      existsSyncImpl: (p) => p.startsWith("/baked/"),
+      existsSyncImpl: (p) => p.replace(/\\/g, "/").startsWith("/baked/"),
     });
-    expect(result).toBe("/baked/custom/pipelines/autonomous.yml");
+    expect(result.replace(/\\/g, "/")).toBe("/baked/custom/pipelines/autonomous.yml");
   });
 
   it("prefers workspace custom/ over bakedRoot custom/ when both exist", () => {
@@ -41,7 +41,7 @@ describe("resolveModule", () => {
       builtinRoot: "/app",
       existsSyncImpl: () => true,
     });
-    expect(result).toBe("/workspace/custom/pipelines/autonomous.yml");
+    expect(result.replace(/\\/g, "/")).toBe("/workspace/custom/pipelines/autonomous.yml");
   });
 
   it("returns builtin path when neither workspace nor bakedRoot has an override", () => {
@@ -51,7 +51,7 @@ describe("resolveModule", () => {
       builtinRoot: "/app",
       existsSyncImpl: () => false,
     });
-    expect(result).toBe("/app/pipelines/autonomous.yml");
+    expect(result.replace(/\\/g, "/")).toBe("/app/pipelines/autonomous.yml");
   });
 
   it("reads the baked root from AI_IMPLEMENT_CUSTOM_ROOT when the option is not passed", () => {
@@ -59,9 +59,9 @@ describe("resolveModule", () => {
     const result = resolveModule("pipelines/autonomous.yml", {
       customRoot: "/workspace",
       builtinRoot: "/app",
-      existsSyncImpl: (p) => p.startsWith("/image/"),
+      existsSyncImpl: (p) => p.replace(/\\/g, "/").startsWith("/image/"),
     });
-    expect(result).toBe("/image/custom/pipelines/autonomous.yml");
+    expect(result.replace(/\\/g, "/")).toBe("/image/custom/pipelines/autonomous.yml");
   });
 
   it("checks only the workspace custom path when no baked root is configured", () => {
@@ -71,12 +71,12 @@ describe("resolveModule", () => {
       customRoot: "/workspace",
       builtinRoot: "/app",
       existsSyncImpl: (p) => {
-        checkedPaths.push(p);
+        checkedPaths.push(p.replace(/\\/g, "/"));
         return false;
       },
     });
     expect(checkedPaths).toEqual(["/workspace/custom/pipelines/autonomous.yml"]);
-    expect(result).toBe("/app/pipelines/autonomous.yml");
+    expect(result.replace(/\\/g, "/")).toBe("/app/pipelines/autonomous.yml");
   });
 
   it("does not check the baked root twice when it equals customRoot", () => {
@@ -86,7 +86,7 @@ describe("resolveModule", () => {
       bakedRoot: "/workspace",
       builtinRoot: "/app",
       existsSyncImpl: (p) => {
-        checkedPaths.push(p);
+        checkedPaths.push(p.replace(/\\/g, "/"));
         return false;
       },
     });
@@ -172,7 +172,7 @@ describe("resolveModuleImport", () => {
         return false;
       },
     });
-    expect(capturedPaths.some((p) => p.includes("/my/workspace/custom/steps/push"))).toBe(true);
+    expect(capturedPaths.some((p) => p.replace(/\\/g, "/").includes("/my/workspace/custom/steps/push"))).toBe(true);
   });
 
   it("rethrows non-MODULE_NOT_FOUND import errors", async () => {
@@ -204,7 +204,7 @@ describe("resolveModuleImport", () => {
     const result = await resolveModuleImport("steps/implement", {
       customRoot: "/workspace",
       bakedRoot: "/baked",
-      existsSyncImpl: (p) => p === "/baked/custom/steps/implement.ts",
+      existsSyncImpl: (p) => p.replace(/\\/g, "/") === "/baked/custom/steps/implement.ts",
       importFn: async () => ({ default: bakedModule }),
     });
     expect(result).toBe(bakedModule);
@@ -229,7 +229,7 @@ describe("resolveModuleImport", () => {
     const bakedModule = { run: async () => ({}) };
     const result = await resolveModuleImport("steps/implement", {
       customRoot: "/workspace",
-      existsSyncImpl: (p) => p === "/image/custom/steps/implement.ts",
+      existsSyncImpl: (p) => p.replace(/\\/g, "/") === "/image/custom/steps/implement.ts",
       importFn: async () => ({ default: bakedModule }),
     });
     expect(result).toBe(bakedModule);
@@ -241,7 +241,7 @@ describe("resolveModuleImport", () => {
     const result = await resolveModuleImport("steps/push", {
       customRoot: "/workspace",
       existsSyncImpl: (p) => {
-        checkedPaths.push(p);
+        checkedPaths.push(p.replace(/\\/g, "/"));
         return false;
       },
     });

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const isWindows = process.platform === "win32";
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
@@ -72,7 +74,11 @@ describe("runAutonomous", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    rmSync(workspaceDir, { recursive: true, force: true });
+    try {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    } catch {
+      // On Windows, bash-created files may be locked briefly after the process exits
+    }
   });
 
   it("returns exitCode 0 on successful pipeline run", async () => {
@@ -772,9 +778,9 @@ describe("runAutonomous", () => {
     ).rejects.toThrow("Missing required env var: ISSUE_ID");
   });
 
-  it("runs the teardown hook even when the pipeline fails", async () => {
+  it.skipIf(isWindows)("runs the teardown hook even when the pipeline fails", async () => {
     writeFileSync(join(workspaceDir, "WORKFLOW.md"), "---\nteardown: teardown.sh\n---\nbody\n");
-    writeFileSync(join(workspaceDir, "teardown.sh"), 'touch "teardown-ran.marker"\n');
+    writeFileSync(join(workspaceDir, "teardown.sh"), 'printf "" > teardown-ran.marker\n');
     const { pipeline, runner } = makeSingleStepPipeline("bad-step", {
       run: vi.fn().mockRejectedValue(new Error("step exploded")),
     });
@@ -791,9 +797,9 @@ describe("runAutonomous", () => {
     expect(existsSync(join(workspaceDir, "teardown-ran.marker"))).toBe(true);
   });
 
-  it("runs the teardown hook on a successful run", async () => {
+  it.skipIf(isWindows)("runs the teardown hook on a successful run", async () => {
     writeFileSync(join(workspaceDir, "WORKFLOW.md"), "---\nteardown: teardown.sh\n---\nbody\n");
-    writeFileSync(join(workspaceDir, "teardown.sh"), 'touch "teardown-ran.marker"\n');
+    writeFileSync(join(workspaceDir, "teardown.sh"), 'printf "" > teardown-ran.marker\n');
     const { pipeline, runner } = makeSingleStepPipeline("ok-step", { run: vi.fn().mockResolvedValue({}) });
 
     const result = await runAutonomous({
@@ -808,11 +814,11 @@ describe("runAutonomous", () => {
     expect(existsSync(join(workspaceDir, "teardown-ran.marker"))).toBe(true);
   });
 
-  it("a failing teardown does not mask the run outcome or throw", async () => {
+  it.skipIf(isWindows)("a failing teardown does not mask the run outcome or throw", async () => {
     writeFileSync(join(workspaceDir, "WORKFLOW.md"), "---\nteardown: teardown.sh\n---\nbody\n");
     // Teardown runs (marker) but exits non-zero — its failure must not change the
     // pipeline's exitCode 1 nor surface as an unhandled rejection.
-    writeFileSync(join(workspaceDir, "teardown.sh"), 'touch "teardown-ran.marker"\nexit 1\n');
+    writeFileSync(join(workspaceDir, "teardown.sh"), 'printf "" > teardown-ran.marker\nexit 1\n');
     const { pipeline, runner } = makeSingleStepPipeline("bad-step", {
       run: vi.fn().mockRejectedValue(new Error("step exploded")),
     });

--- a/src/__tests__/scratch-exclude.test.ts
+++ b/src/__tests__/scratch-exclude.test.ts
@@ -29,7 +29,11 @@ describe("prepareScratchExclusion", () => {
     dir = initRepo();
   });
   afterEach(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // On Windows, git marks object files read-only; ignore cleanup failures
+    }
   });
 
   it("keeps untracked ai-output/ out of the staged set after git add -A", () => {

--- a/src/__tests__/session-lib.test.ts
+++ b/src/__tests__/session-lib.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+
+const isWindows = process.platform === "win32";
 import { spawnSync } from "node:child_process";
 
 function runBash(script: string) {
@@ -8,7 +10,7 @@ function runBash(script: string) {
   });
 }
 
-describe("session/lib.sh", () => {
+describe.skipIf(isWindows)("session/lib.sh", () => {
   it("passes shellcheck cleanly", () => {
     const result = spawnSync("shellcheck", ["session/lib.sh"], {
       encoding: "utf-8",

--- a/src/__tests__/steps-feedback-loop-diff.test.ts
+++ b/src/__tests__/steps-feedback-loop-diff.test.ts
@@ -38,7 +38,11 @@ describe("getDiff generated-file exclusion", () => {
   });
 
   afterEach(() => {
-    rmSync(repo, { recursive: true, force: true });
+    try {
+      rmSync(repo, { recursive: true, force: true });
+    } catch {
+      // On Windows, git marks object files read-only; ignore cleanup failures
+    }
   });
 
   it("includes hand-written source changes", () => {
@@ -108,7 +112,11 @@ describe("getDiff untracked-file inclusion", () => {
   });
 
   afterEach(() => {
-    rmSync(repo, { recursive: true, force: true });
+    try {
+      rmSync(repo, { recursive: true, force: true });
+    } catch {
+      // On Windows, git marks object files read-only; ignore cleanup failures
+    }
   });
 
   it("includes newly created untracked files as additions", () => {

--- a/src/__tests__/steps-install.test.ts
+++ b/src/__tests__/steps-install.test.ts
@@ -40,7 +40,7 @@ function makeContext(): DefaultPipelineContext {
 
 function mockRootPackageJson(extraMatches?: (p: string) => boolean) {
   vi.mocked(fs.existsSync).mockImplementation((p) => {
-    const rawPath = String(p);
+    const rawPath = String(p).replace(/\\/g, "/");
     return rawPath.endsWith("package.json") || extraMatches?.(rawPath) === true;
   });
 }
@@ -312,7 +312,7 @@ describe("installStep", () => {
 
   it("preserves configured packageManager when skipping without package.json", async () => {
     vi.mocked(fs.existsSync).mockImplementation((p) =>
-      String(p).includes(".ai-implement/config.yml"),
+      String(p).replace(/\\/g, "/").includes(".ai-implement/config.yml"),
     );
     vi.mocked(fs.readFileSync).mockReturnValue("packageManager: pnpm\n");
 

--- a/src/__tests__/steps-setup-verify.test.ts
+++ b/src/__tests__/steps-setup-verify.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const isWindows = process.platform === "win32";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -18,9 +20,9 @@ function ctx() {
 
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "sv-")); });
-afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+afterEach(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* Windows EPERM on bash-created files */ } });
 
-describe("setupStep", () => {
+describe.skipIf(isWindows)("setupStep", () => {
   it("runs the setup script and returns ran:true", async () => {
     writeFileSync(join(dir, "s.sh"), "echo hi\n");
     const out = await setupStep.run(ctx(), { workspaceDir: dir, scriptPath: "s.sh" }, new NoopStepReporter());
@@ -34,7 +36,7 @@ describe("setupStep", () => {
   });
 });
 
-describe("verifyStep", () => {
+describe.skipIf(isWindows)("verifyStep", () => {
   it("throws when the verify script fails", async () => {
     writeFileSync(join(dir, "v.sh"), "exit 2\n");
     await expect(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     exclude: ["node_modules/**", "dist/**", ".worktrees/**"],
+    testTimeout: 30000,
+    hookTimeout: 30000,
   },
 });


### PR DESCRIPTION
Makes `npm test` pass on Windows. Originates from the Cloudshare fork (commit `b17a6aa` by Paz, "Fix test suite compatibility on Windows"), re-applied onto current `testing` and extended to cover test files that landed after the fork diverged (#108/#114/#130–#133 era), so the suite passes on Windows as a coherent property rather than a stale patch.

**What it does**
- `describe.skipIf` / `it.skipIf(process.platform === "win32")` on genuinely POSIX-dependent tests only: bash spawns (`detect-project`, `session-lib`, `hooks`, `steps-setup-verify`, `run-autonomous` teardown hooks), PATH-shimmed shell-script executables (`executor` fake claude, `install-skills` git shim). Tests that merely use git or real temp dirs still run on Windows.
- Path-separator normalization (`.replace(/\\/g, "/")`) in assertions and injected `existsSync` predicates that compare `path.join` output against POSIX literals (`resolve-module`, `pipeline-loader`, `pipeline-runner`, `default-pipeline`, `steps-install`, `run-autonomous`) — including the baked-root (`AI_IMPLEMENT_CUSTOM_ROOT`) tests added since the fork commit.
- `try/catch` around `rmSync` cleanup of git-backed temp repos (git marks object files read-only on Windows) in `scratch-exclude`, `steps-feedback-loop-diff`, `install-skills`, and hook/tmpdir teardowns.
- `printf "" > marker` instead of `touch` in teardown-hook fixture scripts; vitest `testTimeout`/`hookTimeout` raised to 30s for spawn-heavy tests under parallel load.

**Verification and its limits**
This was authored and validated on macOS — the suite was not run on an actual Windows machine. The verifiable claims are: (1) zero behavior change on POSIX — the full suite is **1565/1565 passed (0 skipped)** both before and after this change; (2) each guard/normalization is mechanically sound against the code under test (all normalized assertions target values produced by `path.join`/`resolveModule`; every remaining bash/sh spawn sits behind a skipIf). A Windows CI run or manual confirmation would close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)