### PR TITLE
Improve workflow sync error when base branch is missing

### DIFF
--- a/src/__tests__/workflow-sync.test.ts
+++ b/src/__tests__/workflow-sync.test.ts
@@ -397,6 +397,47 @@ describe("syncWorkflowTemplates", () => {
     })).rejects.toThrow("Missing workflow template: workflows/claude-plan.yml");
   });
 
+  it("throws a descriptive error when the base branch does not exist", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    // The fake repo only has "main"; a mapping pointing at "develop" hits a 404 on the ref lookup.
+    const fake = makeGithubFetch();
+
+    await expect(syncWorkflowTemplates({
+      mapping: { ...mapping, defaultBranch: "develop" },
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    })).rejects.toThrow(
+      'Base branch "develop" does not exist in acme/app. ' +
+        "The repository may be empty (no commits yet) or the configured branch name is wrong. " +
+        "Push an initial commit or correct the branch name in the project settings.",
+    );
+  });
+
+  it("surfaces the missing-base-branch message verbatim through classifySyncError (the sync-status path)", async () => {
+    const templatesRoot = makeTemplatesRoot();
+    const fake = makeGithubFetch();
+
+    // Mirrors runWorkflowSync in workflow-sync-queue.ts, which stores
+    // classifySyncError(err) on the failed job; the admin UI renders its .message.
+    const err = await syncWorkflowTemplates({
+      mapping: { ...mapping, defaultBranch: "develop" },
+      githubAppId: "app-id",
+      githubAppPrivateKey: "private-key",
+      templatesRoot,
+      fetchImpl: fake.fetchImpl,
+      getInstallationTokenImpl: async () => "token",
+    }).then(() => null, (e: unknown) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    const classified = classifySyncError(err);
+    expect(classified.category).toBe("unknown");
+    expect(classified.message).toBe((err as Error).message);
+    expect(classified.message).toContain('Base branch "develop" does not exist in acme/app');
+  });
+
   it("prefixes the sync branch when the mapping sets a branchPrefix", async () => {
     const templatesRoot = makeTemplatesRoot();
     const fake = makeGithubFetch();

--- a/src/workflow-sync.ts
+++ b/src/workflow-sync.ts
@@ -314,9 +314,19 @@ async function ensureSyncBranch(params: {
   syncBranch: string;
 }): Promise<void> {
   const { gh, repo, baseBranch, syncBranch } = params;
-  const base = await gh.request<{ object: { sha: string } }>(
+  const base = await gh.maybeRequest<{ object: { sha: string } }>(
     `/repos/${repo}/git/ref/heads/${encodeRefPath(baseBranch)}`,
   );
+  if (!base) {
+    // Deliberately a plain Error, not a GitHubApiError: classifySyncError passes an
+    // unknown error's raw message through verbatim, so this descriptive text is exactly
+    // what the admin UI shows instead of an opaque "GitHub 404 /repos/.../git/ref/..." dump.
+    throw new Error(
+      `Base branch "${baseBranch}" does not exist in ${repo}. ` +
+        `The repository may be empty (no commits yet) or the configured branch name is wrong. ` +
+        `Push an initial commit or correct the branch name in the project settings.`,
+    );
+  }
   const syncRef = await gh.maybeRequest<{ object: { sha: string } }>(
     `/repos/${repo}/git/ref/heads/${encodeRefPath(syncBranch)}`,
   );


### PR DESCRIPTION
## Summary
When a project's configured base branch doesn't exist in the target repo (empty repo, or a wrong branch name in the mapping), the Sync workflows action failed with an opaque `GitHub 404 /repos/<owner>/<repo>/git/ref/heads/...` dump. This swaps the base-branch ref lookup in `ensureSyncBranch` from `gh.request` to `gh.maybeRequest` and throws a descriptive error instead: the branch name tried, the likely causes (empty repo / wrong configured name), and the fix.

Verified on current `testing`: `classifySyncError` still passes an unknown error's raw message through verbatim (`classify("unknown", raw)` returns the raw message untouched), so this descriptive text is exactly what the admin UI shows on the failed sync job — no classifier change needed.

A dedicated `base-branch-missing` `SyncErrorCategory` was considered and deliberately not added: the admin UI renders only `error.message` (category is stored but never keyed on), and non-unknown categories get static `SYNC_ERROR_MESSAGES` strings, which would drop the dynamic branch/repo names that make this error actionable.

## Tests
- `syncWorkflowTemplates` against a repo missing the configured base branch → asserts the full descriptive message.
- The same error run through the real `classifySyncError` (mirroring the queue's failed-job path) → `category: "unknown"`, message surfaces verbatim.

Ported from the Cloudshare fork (cloudshare/ai-implement commit `a9a04fb`, authored by Paz).

🤖 Generated with [Claude Code](https://claude.com/claude-code)