### PR TITLE
feat: time-range filter for /api/log and the Pipelines page, plus local dev DX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ clients/*.toml
 .conductor/
 .wrangler/
 .worktrees/
+
+/.idea/**
+
+/data/dedup.**

--- a/README.md
+++ b/README.md
@@ -75,6 +75,67 @@ npm run dev:local          # rebuilds the runner image, then starts RUNNER_MODE=
 
 Docker must be running. Local mode still opens real GitHub PRs; it just avoids deploying the orchestrator or publishing a runner image while you test changes.
 
+### Getting an admin token
+
+Once the service is running, open `http://localhost:8080/admin` in your browser, log in with `ADMIN_ACCESS_CODE`, then run this in the browser console:
+
+```js
+localStorage.getItem('admin_token')
+```
+
+Copy the returned token for use in API calls below.
+
+### Testing the admin API with curl
+
+**Linux / macOS**
+
+```bash
+TOKEN="<paste token here>"
+
+# All jobs (up to 100)
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/log
+
+# Jobs from the last hour
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/log?since=$(($(date +%s%3N) - 3600000))"
+
+# Jobs in a fixed time range (Unix ms)
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/log?since=1750000000000&until=1750999999999"
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$TOKEN = "<paste token here>"
+
+# All jobs (up to 100)
+Invoke-WebRequest -Uri "http://localhost:8080/api/log" `
+  -Headers @{ Authorization = "Bearer $TOKEN" } | Select-Object -ExpandProperty Content
+
+# Jobs from the last hour
+$since = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds() - 3600000
+Invoke-WebRequest -Uri "http://localhost:8080/api/log?since=$since" `
+  -Headers @{ Authorization = "Bearer $TOKEN" } | Select-Object -ExpandProperty Content
+
+# Jobs in a fixed time range (Unix ms)
+Invoke-WebRequest -Uri "http://localhost:8080/api/log?since=1750000000000&until=1750999999999" `
+  -Headers @{ Authorization = "Bearer $TOKEN" } | Select-Object -ExpandProperty Content
+```
+
+> **Note:** PowerShell's `curl` is an alias for `Invoke-WebRequest` — the `-H` flag syntax used by real curl doesn't work. Use `Invoke-WebRequest` as above, or install real curl via `winget install curl.curl` and call it as `curl.exe`.
+
+### Seeding test data locally
+
+To pre-populate the DB with jobs spread across different time windows (useful for testing time filters):
+
+```powershell
+New-Item -ItemType Directory -Force data
+.\scripts\seed-test-jobs.ps1
+```
+
+Requires `sqlite3` on PATH (`winget install SQLite.SQLite`). Run after the service has started at least once so the DB schema is initialized.
+
 AI-Implement uses `better-sqlite3`, which ships a native Node addon. Always run
 `npm install`, `npm ci`, and `npm rebuild` with the Node major pinned in
 `.tool-versions` / `.nvmrc`; otherwise `node_modules` can be compiled for one

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "check:node": "node scripts/check-node-version.mjs",
-    "dev": "npm run check:node && tsx src/index.ts",
+    "dev": "npm run check:node && tsx --env-file-if-exists=.env src/index.ts",
     "build:runner:local": "DOCKER_BUILDKIT=1 docker build -f Dockerfile.session -t ai-implement-runner:local .",
-    "dev:local": "npm run check:node && npm run build:runner:local && RUNNER_MODE=local LOCAL_RUNNER_IMAGE=ai-implement-runner:local tsx src/index.ts",
+    "dev:local": "npm run check:node && npm run build:runner:local && RUNNER_MODE=local LOCAL_RUNNER_IMAGE=ai-implement-runner:local tsx --env-file-if-exists=.env src/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/scripts/seed-test-jobs.ps1
+++ b/scripts/seed-test-jobs.ps1
@@ -1,0 +1,39 @@
+# scripts/seed-test-jobs.ps1
+# Pre-seeds dispatch_log with jobs spread across time for local filter testing.
+# Usage: .\scripts\seed-test-jobs.ps1 [-DbPath .\data\dedup.sqlite]
+
+param(
+    [string]$DbPath = ".\data\dedup.sqlite"
+)
+
+$now = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()
+$h   = 3600000
+$d   = 86400000
+
+$jobs = @(
+    # Last hour
+    @{ offset = 10*60*1000;  id = "LIN-101"; title = "Fix login bug";           status = "completed"; mode = "github-actions"; phase = "implementation" }
+    @{ offset = 30*60*1000;  id = "LIN-102"; title = "Add dark mode";           status = "running";   mode = "github-actions"; phase = "implementation" }
+    # Last day (1-24 h ago)
+    @{ offset = 3*$h;        id = "LIN-103"; title = "Refactor auth module";    status = "completed"; mode = "fly-machines";   phase = "implementation" }
+    @{ offset = 8*$h;        id = "LIN-104"; title = "Update deps";             status = "failed";    mode = "github-actions"; phase = "implementation" }
+    @{ offset = 20*$h;       id = "LIN-105"; title = "Add rate limiting";       status = "completed"; mode = "github-actions"; phase = "planning"        }
+    # Last week (1-7 d ago)
+    @{ offset = 2*$d;        id = "LIN-106"; title = "DB migration v3";         status = "completed"; mode = "fly-machines";   phase = "implementation" }
+    @{ offset = 4*$d;        id = "LIN-107"; title = "CI pipeline fix";         status = "timed_out"; mode = "github-actions"; phase = "implementation" }
+    @{ offset = 6*$d;        id = "LIN-108"; title = "Resize images on upload"; status = "completed"; mode = "github-actions"; phase = "implementation" }
+    # Older (> 7 d)
+    @{ offset = 10*$d;       id = "LIN-109"; title = "Initial scaffold";        status = "completed"; mode = "github-actions"; phase = "implementation" }
+    @{ offset = 30*$d;       id = "LIN-110"; title = "Prototype spike";         status = "completed"; mode = "fly-machines";   phase = "implementation" }
+)
+
+$inserts = $jobs | ForEach-Object {
+    $at  = $now - $_.offset
+    "INSERT INTO dispatch_log (issue_id, issue_identifier, issue_title, team_key, repo, dispatched_at, status, execution_mode, phase, dispatch_number) VALUES ('$($_.id)', '$($_.id)', '$($_.title)', 'ENG', 'acme/backend', $at, '$($_.status)', '$($_.mode)', '$($_.phase)', 1);"
+}
+
+$sql = ($inserts -join "`n")
+
+Write-Host "Seeding $($jobs.Count) jobs into $DbPath ..."
+$sql | sqlite3 $DbPath
+Write-Host "Done. Jobs span: last hour (2), last day (3), last week (3), older (2)."

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1554,6 +1554,55 @@ describe("admin log", () => {
     const data = JSON.parse(res.body);
     expect(data[0].phase).toBe("planning");
   });
+
+  /** Appends a job and pins its dispatched_at to the given timestamp. */
+  function seedJobAt(issueId: string, dispatchedAt: number): void {
+    const jobId = log.appendLog({ issueId, issueIdentifier: issueId, repo: "org/repo" });
+    dedup.getDb()
+      .prepare("UPDATE dispatch_log SET dispatched_at = ? WHERE id = ?")
+      .run(dispatchedAt, jobId);
+  }
+
+  it("GET /api/log?since= filters out jobs dispatched before the bound", async () => {
+    seedJobAt("LNR-OLD", 1_000);
+    seedJobAt("LNR-NEW", 3_000);
+    const token = await login("secret");
+    const res = await request("/api/log?since=2000", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.map((j: { issueId: string }) => j.issueId)).toEqual(["LNR-NEW"]);
+  });
+
+  it("GET /api/log?until= filters out jobs dispatched after the bound", async () => {
+    seedJobAt("LNR-OLD", 1_000);
+    seedJobAt("LNR-NEW", 3_000);
+    const token = await login("secret");
+    const res = await request("/api/log?until=2000", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.map((j: { issueId: string }) => j.issueId)).toEqual(["LNR-OLD"]);
+  });
+
+  it("GET /api/log?since=&until= returns only the inclusive window", async () => {
+    seedJobAt("LNR-A", 1_000);
+    seedJobAt("LNR-B", 2_000);
+    seedJobAt("LNR-C", 3_000);
+    const token = await login("secret");
+    const res = await request("/api/log?since=2000&until=2000", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.map((j: { issueId: string }) => j.issueId)).toEqual(["LNR-B"]);
+  });
+
+  it("GET /api/log ignores non-numeric since/until instead of erroring", async () => {
+    seedJobAt("LNR-A", 1_000);
+    seedJobAt("LNR-B", 3_000);
+    const token = await login("secret");
+    const res = await request("/api/log?since=banana&until=", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data).toHaveLength(2);
+  });
 });
 
 describe("classifyTemplate", () => {

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -218,8 +218,65 @@ describe("jobs table", () => {
       log.appendLog({ issueId: `issue-${i}` });
     }
 
-    const all = log.listLog(600);
+    const all = log.listLog({ limit: 600 });
     expect(all.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("listLog time filtering", () => {
+  /** Appends a job and pins its dispatched_at to the given timestamp. */
+  function seedJobAt(issueId: string, dispatchedAt: number): number {
+    const jobId = log.appendLog({ issueId });
+    dedup.getDb()
+      .prepare("UPDATE dispatch_log SET dispatched_at = ? WHERE id = ?")
+      .run(dispatchedAt, jobId);
+    return jobId;
+  }
+
+  it("since returns only jobs dispatched at or after the bound (inclusive)", () => {
+    seedJobAt("old", 1_000);
+    seedJobAt("boundary", 2_000);
+    seedJobAt("new", 3_000);
+
+    const jobs = log.listLog({ since: 2_000 });
+    expect(jobs.map((j) => j.issueId)).toEqual(["new", "boundary"]);
+  });
+
+  it("until returns only jobs dispatched at or before the bound (inclusive)", () => {
+    seedJobAt("old", 1_000);
+    seedJobAt("boundary", 2_000);
+    seedJobAt("new", 3_000);
+
+    const jobs = log.listLog({ until: 2_000 });
+    expect(jobs.map((j) => j.issueId)).toEqual(["boundary", "old"]);
+  });
+
+  it("since + until returns the inclusive window, newest first", () => {
+    seedJobAt("too-old", 1_000);
+    seedJobAt("in-window-1", 2_000);
+    seedJobAt("in-window-2", 2_500);
+    seedJobAt("too-new", 3_000);
+
+    const jobs = log.listLog({ since: 2_000, until: 2_500 });
+    expect(jobs.map((j) => j.issueId)).toEqual(["in-window-2", "in-window-1"]);
+  });
+
+  it("limit option applies together with a time filter", () => {
+    seedJobAt("a", 1_000);
+    seedJobAt("b", 2_000);
+    seedJobAt("c", 3_000);
+
+    const jobs = log.listLog({ since: 1_000, limit: 2 });
+    expect(jobs.map((j) => j.issueId)).toEqual(["c", "b"]);
+  });
+
+  it("defaults to 100 rows without a filter but the full retained window with one", () => {
+    for (let i = 0; i < 150; i++) {
+      log.appendLog({ issueId: `issue-${i}` });
+    }
+
+    expect(log.listLog()).toHaveLength(100);
+    expect(log.listLog({ since: 0 })).toHaveLength(150);
   });
 });
 

--- a/src/admin-ui/__tests__/pipelines.test.ts
+++ b/src/admin-ui/__tests__/pipelines.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { pipelinesHtml, pipelinesScript } from "../pages/pipelines.js";
+
+describe("pipelines page time filter", () => {
+  it("renders the Time Filter controls (relative + absolute range)", () => {
+    expect(pipelinesHtml).toContain("Time Filter");
+    expect(pipelinesHtml).toContain('id="log-time-type"');
+    expect(pipelinesHtml).toContain('id="log-rel-n"');
+    expect(pipelinesHtml).toContain('id="log-rel-unit"');
+    expect(pipelinesHtml).toContain('id="log-range-start"');
+    expect(pipelinesHtml).toContain('id="log-range-end"');
+  });
+
+  it("defaults the relative filter to last 7 days", () => {
+    expect(pipelinesHtml).toContain('value="7"');
+    expect(pipelinesHtml).toContain('<option value="d" selected>');
+  });
+
+  it("appends the time filter to the /api/log request", () => {
+    expect(pipelinesScript).toContain("'/api/log' + getTimeFilter()");
+    expect(pipelinesScript).toMatch(/'\?since=' \+ \(Date\.now\(\)/);
+  });
+
+  it("appends the filter label to the job count and range-aware empty state", () => {
+    expect(pipelinesScript).toContain("' · ' + getFilterLabel()");
+    expect(pipelinesScript).toContain("No jobs in the selected time range");
+  });
+
+  it("pauses auto-refresh while an absolute range is selected", () => {
+    expect(pipelinesScript).toContain("function startLogAutoRefresh");
+    expect(pipelinesScript).toContain("function stopLogAutoRefresh");
+    expect(pipelinesScript).toContain(
+      "if (isRange) { stopLogAutoRefresh(); } else { startLogAutoRefresh(); }",
+    );
+    // registerPage uses the managed auto-refresh, not a bare setInterval
+    expect(pipelinesScript).toMatch(/registerPage\('jobs',[\s\S]*startLogAutoRefresh\(\);/);
+  });
+});

--- a/src/admin-ui/pages/pipelines.ts
+++ b/src/admin-ui/pages/pipelines.ts
@@ -5,8 +5,28 @@ export const pipelinesHtml = `
       <h1 class="page-title">Pipelines</h1>
       <div class="page-subtitle">Recent dispatches — running pipelines appear at the top</div>
     </div>
-    <div class="page-header-actions">
-      <button class="btn btn-sm" onclick="loadLog()">&#8635; Refresh</button>
+    <div class="page-header-actions" style="display:flex;align-items:stretch;gap:8px;flex-wrap:wrap">
+      <fieldset style="border:1px solid var(--border);border-radius:6px;padding:2px 10px 6px;margin:0;display:flex;align-items:center;gap:6px">
+        <legend style="font-size:0.7em;color:var(--fg-tertiary);padding:0 4px;margin-left:2px">Time Filter</legend>
+        <select id="log-time-type" class="select" style="width:auto;height:30px" onchange="onTimeTypeChange()">
+          <option value="relative">Relative</option>
+          <option value="range">Time range</option>
+        </select>
+        <div id="log-rel-controls" style="display:flex;align-items:center;gap:4px">
+          <input id="log-rel-n" type="number" class="input" style="width:58px;height:30px;padding:0 7px" min="1" max="999" value="7" onchange="loadLog()">
+          <select id="log-rel-unit" class="select" style="width:auto;height:30px" onchange="loadLog()">
+            <option value="h">h</option>
+            <option value="d" selected>d</option>
+            <option value="w">w</option>
+          </select>
+        </div>
+        <div id="log-range-controls" style="display:none;align-items:center;gap:4px">
+          <input id="log-range-start" type="datetime-local" class="input" style="width:175px;height:30px;padding:0 7px" onchange="loadLog()">
+          <span style="color:var(--fg-tertiary)">&#8594;</span>
+          <input id="log-range-end" type="datetime-local" class="input" style="width:175px;height:30px;padding:0 7px" onchange="loadLog()">
+        </div>
+      </fieldset>
+      <button class="btn btn-sm" onclick="loadLog()" style="height:30px;align-self:flex-end;padding:0 12px;margin-bottom:6px">&#8635; Refresh</button>
     </div>
   </header>
   <div class="page-body">
@@ -34,17 +54,71 @@ export const pipelinesScript = `
     if (el) el.textContent = 'updated ' + new Date().toLocaleTimeString();
   }
 
+  function getTimeFilter() {
+    const type = document.getElementById('log-time-type').value;
+    if (type === 'relative') {
+      const n = parseInt(document.getElementById('log-rel-n').value, 10) || 7;
+      const unit = document.getElementById('log-rel-unit').value;
+      const ms = { h: 3600000, d: 86400000, w: 604800000 };
+      return '?since=' + (Date.now() - n * (ms[unit] || ms.d));
+    }
+    const start = document.getElementById('log-range-start').value;
+    const end   = document.getElementById('log-range-end').value;
+    const parts = [];
+    if (start) parts.push('since=' + new Date(start).getTime());
+    if (end)   parts.push('until=' + new Date(end).getTime());
+    return parts.length ? '?' + parts.join('&') : '';
+  }
+
+  function getFilterLabel() {
+    const type = document.getElementById('log-time-type').value;
+    if (type === 'relative') {
+      const n = parseInt(document.getElementById('log-rel-n').value, 10) || 7;
+      const unit = document.getElementById('log-rel-unit').value;
+      return 'last ' + n + unit;
+    }
+    const start = document.getElementById('log-range-start').value;
+    const end   = document.getElementById('log-range-end').value;
+    if (start && end) return new Date(start).toLocaleDateString() + ' → ' + new Date(end).toLocaleDateString();
+    if (start)        return 'from ' + new Date(start).toLocaleDateString();
+    if (end)          return 'until ' + new Date(end).toLocaleDateString();
+    return 'all time';
+  }
+
+  let _logRefreshInterval = null;
+
+  function startLogAutoRefresh() {
+    if (_logRefreshInterval) return;
+    _logRefreshInterval = setInterval(function () { loadLog(); }, 15000);
+  }
+
+  function stopLogAutoRefresh() {
+    if (_logRefreshInterval) { clearInterval(_logRefreshInterval); _logRefreshInterval = null; }
+  }
+
+  function onTimeTypeChange() {
+    const rel   = document.getElementById('log-rel-controls');
+    const range = document.getElementById('log-range-controls');
+    const isRange = document.getElementById('log-time-type').value === 'range';
+    rel.style.display   = isRange ? 'none' : 'flex';
+    range.style.display = isRange ? 'flex' : 'none';
+    if (isRange) { stopLogAutoRefresh(); } else { startLogAutoRefresh(); }
+    loadLog();
+  }
+  window.onTimeTypeChange = onTimeTypeChange;
+
   async function loadLog() {
     try {
-      const res = await window.api('/api/log');
+      const res = await window.api('/api/log' + getTimeFilter());
       const data = await res.json();
       const tbody = document.getElementById('log-body');
       const empty = document.getElementById('log-empty');
       const countEl = document.getElementById('log-count');
       tbody.innerHTML = '';
       if (data.length === 0) {
+        empty.textContent = 'No jobs in the selected time range';
         empty.classList.remove('hidden');
-        if (countEl) countEl.textContent = '0 jobs';
+        if (countEl) countEl.textContent = '0 jobs · ' + getFilterLabel();
         setLastUpdated('lu-log');
         return;
       }
@@ -104,7 +178,7 @@ export const pipelinesScript = `
         consumed.add(i);
       }
 
-      if (countEl) countEl.textContent = grouped.length + ' job' + (grouped.length === 1 ? '' : 's');
+      if (countEl) countEl.textContent = grouped.length + ' job' + (grouped.length === 1 ? '' : 's') + ' · ' + getFilterLabel();
 
       for (const item of grouped) {
         const tr = document.createElement('tr');
@@ -187,7 +261,7 @@ export const pipelinesScript = `
   window.registerPage('jobs', function () {
     loadLog();
     wireRowClicks();
-    setInterval(function () { loadLog(); }, 15000);
+    startLogAutoRefresh();
   });
 })();
 `;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -256,8 +256,15 @@ export function handleAdminRequest(
       return true;
     }
 
-    if (url === "/api/log" && method === "GET") {
-      json(res, 200, listLog());
+    if ((url === "/api/log" || url.startsWith("/api/log?")) && method === "GET") {
+      const qs = url.includes("?") ? url.slice(url.indexOf("?") + 1) : "";
+      const p = new URLSearchParams(qs);
+      const sinceRaw = p.get("since");
+      const untilRaw = p.get("until");
+      // Invalid (non-numeric) values are ignored rather than rejected.
+      const since = sinceRaw && Number.isFinite(Number(sinceRaw)) ? Number(sinceRaw) : undefined;
+      const until = untilRaw && Number.isFinite(Number(untilRaw)) ? Number(untilRaw) : undefined;
+      json(res, 200, listLog({ since, until }));
       return true;
     }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -273,13 +273,21 @@ export function getUnnotifiedTerminalJobs(): Job[] {
   );
 }
 
-export function listLog(limit = 100): Job[] {
+export function listLog(opts: { since?: number; until?: number; limit?: number } = {}): Job[] {
+  const { since, until } = opts;
+  // When a time filter is present, default to the full retained window so a
+  // range query isn't silently truncated to the newest 100 rows.
+  const limit = opts.limit ?? (since !== undefined || until !== undefined ? MAX_LOG_ENTRIES : 100);
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  if (since !== undefined) { conditions.push("dispatched_at >= ?"); params.push(since); }
+  if (until !== undefined) { conditions.push("dispatched_at <= ?"); params.push(until); }
+  const where = conditions.length ? " WHERE " + conditions.join(" AND ") : "";
+  params.push(limit);
   return mapRows(
     getDb()
-      .prepare(
-        "SELECT * FROM dispatch_log ORDER BY dispatched_at DESC LIMIT ?",
-      )
-      .all(limit) as RawRow[],
+      .prepare("SELECT * FROM dispatch_log" + where + " ORDER BY dispatched_at DESC LIMIT ?")
+      .all(...params) as RawRow[],
   );
 }
 
@@ -365,7 +373,7 @@ export interface PullSummary {
 }
 
 export function getPulls(): PullSummary[] {
-  const rows = listLog(500).filter((j) => j.prUrl);
+  const rows = listLog({ limit: 500 }).filter((j) => j.prUrl);
   const byUrl = new Map<string, PullSummary>();
   for (const j of rows) {
     const ts = j.dispatchedAt;

--- a/src/poll-merged-prs.ts
+++ b/src/poll-merged-prs.ts
@@ -33,7 +33,7 @@ export function prNumberFromUrl(url: string): number | null {
  * re-checked next tick.
  */
 export async function detectMergedPrs(deps: DetectDeps): Promise<void> {
-  for (const job of listLog(500)) {
+  for (const job of listLog({ limit: 500 })) {
     if (!job.repo || !job.prUrl) continue;
     if (!CANDIDATE_STATUSES.has(job.status)) continue;
     const prNumber = prNumberFromUrl(job.prUrl);

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -117,7 +117,7 @@ const TRUSTED_REVIEW_COMMENT_AUTHORS = new Set([
  *    `ai-implement/{issueIdentifier}-...`.
  */
 function findMatchingDispatch(repo: string, branch?: string, prUrl?: string, prNumber?: number) {
-  const jobs = listLog(500);
+  const jobs = listLog({ limit: 500 });
 
   for (const job of jobs) {
     if (job.repo !== repo) continue;


### PR DESCRIPTION
Ports a feature originally built on the Cloudshare fork of AI-Implement (fork commits f807066, d34011a, be3cef7, 8d7a315) — credit to the Cloudshare team.

## What
- **`listLog()` takes options**: `listLog({ since?, until?, limit? })` builds a dynamic `WHERE` on `dispatched_at` (Unix ms, inclusive). With a time filter and no explicit limit, the default rises from 100 to the full retained window (500) so range queries aren't silently truncated.
- **`GET /api/log?since=&until=`**: Unix-ms query params, validated with `Number.isFinite` + null/empty guard. Invalid values are ignored (unfiltered 200), not rejected — useful for curl-driven ops queries (see new README dev section).
- **Pipelines page Time Filter**: relative last-N hours/days/weeks (default 7d) or an absolute datetime-local range; the job count now shows the active filter; empty state is range-aware; the 15s auto-refresh is now start/stoppable and **pauses while an absolute range is selected** so a historical view doesn't refresh out from under you.
- **Dev DX riders**: `tsx --env-file-if-exists=.env` in `dev`/`dev:local`; `.gitignore` entries for `/.idea/**` and `/data/dedup.**`; README section on getting an admin token and querying `/api/log`; `scripts/seed-test-jobs.ps1` to seed `dispatch_log` across time windows. The seeder is PowerShell-only and optional — happy to drop it or swap for a cross-platform Node seeder if preferred.

## Caller migration (the important interaction)
Upstream has grown `listLog` callers the fork didn't have. All numeric callers are migrated to the options form: `getPulls`, `findMatchingDispatch` (webhook), `detectMergedPrs` (poll-merged-prs), and the `listLog(600)` in jobs.test.ts. Without migration, **`detectMergedPrs` would have silently scanned only the newest 100 rows instead of 500** — missing done-on-merge reconciliation for older open PRs; the test would have kept passing while querying a sixth of the intended window.

## Tests (the fork shipped none for this feature; this PR adds 14)
- `jobs.test.ts`: 5 unit tests — since/until inclusive bounds, combined window, limit + filter, default-limit behavior (100 unfiltered vs 500 filtered).
- `admin.test.ts`: 4 endpoint tests — `?since`, `?until`, combined window, non-numeric/empty params ignored.
- `src/admin-ui/__tests__/pipelines.test.ts`: 5 string smoke tests for the filter UI and auto-refresh pause, in the existing admin-ui string-test style.

`npm run typecheck` and `npm test` (103 files / 1579 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)