### PR TITLE
Hygiene: scratch-exclude helper extraction + doc accuracy fixes (README onboarding, runner-image channels, stubs list)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Page conventions: each `<name>.ts` exports two strings. The HTML uses `data-page
 
 When adding a new page: create the page module, append both strings to the lists in `src/admin-ui/index.ts`, and add the route to `sidebar.ts`. When adding a new design token: extend `tokens.ts` and the `tokens.test.ts` spot-check. When adding a new icon: drop the SVG inner markup into `iconRegistry`.
 
-The 14 not-yet-implemented routes (`overview`, `issues`, `pulls`, `blockers`, `pipelines`, `models`, `channels`, `policies`, `runners`, `secrets`, `mcp`, `webhooks`, `customizations`, `updates`) are stubbed in `src/admin-ui/pages/stubs.ts` with `RoadmapNote`-style placeholders pointing to the plan that ships them.
+Six routes (`channels`, `policies`, `secrets`, `mcp`, `webhooks`, `updates`) are still stubbed in `src/admin-ui/pages/stubs.ts` with "Coming soon" placeholders (badged "Not implemented yet" or "Partially implemented") that explain what exists today and link to the related built pages.
 
 ## Notification adapter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,8 +330,9 @@ The default runner image itself must also be public on GHCR — Fly pulls anonym
 
 Runner image channels:
 
-- `ghcr.io/builddownai/ai-implement-runner:latest` is published from `main` and is the stable default for production orchestrators and synced target-repo workflows.
-- `ghcr.io/builddownai/ai-implement-runner:next` is published from `testing` and is intended for staging/testing orchestrators. Set `SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:next` in that orchestrator environment to keep it paired with the testing runner.
+- `.github/workflows/build-runner.yml` publishes the runner image to `ghcr.io/<owner>/ai-implement-runner` (the lowercased owner of the repo it runs in), so a fork's builds land in its own namespace automatically — a namespace the `github-actions` allowlist already trusts. The built-in fallback in the code and synced workflows stays `ghcr.io/builddownai/ai-implement-runner` regardless; a fork that wants its own image used must pin it via `AI_IMPLEMENT_RUNNER_IMAGE` or `.ai-implement/image.yml` rather than editing the fallback.
+- The `:latest` channel is published from `main` and is the stable default for production orchestrators and synced target-repo workflows.
+- The `:next` channel is published from `testing` and is intended for staging/testing orchestrators. Set the orchestrator's runner-image env var to your namespace's `:next` tag (e.g. `AI_IMPLEMENT_RUNNER_IMAGE=ghcr.io/builddownai/ai-implement-runner:next`) to keep that environment paired with the testing runner.
 - Commit SHA tags are pushed first, then the build digest is smoke-tested before any mutable channel is promoted. Use the immutable digest for the strongest rollback pin; the SHA tag is a convenient lookup tag for the same build.
 - Channel-scoped date/debug tags are promoted only after the digest image passes smoke testing. They use `base-<channel>-vYYYYMMDD-<12-char-sha>` (for example, `base-next-v20260526-abc123def456`) so `latest` and `next` builds do not collide and same-day builds do not overwrite each other.
 - Cancelled or failed runs can leave SHA-only images with no channel pointer. That is intentional fail-closed behavior; clean old SHA-only images through GHCR retention/cleanup rather than relying on mutable channel tags for retention.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-**Turn your Linear backlog into pull requests.** Label an issue `AI-Implement`, and a PR appears in the right repo a few minutes later.
+**Turn your backlog into pull requests.** Label a Linear issue `AI-Implement` — or set a Jira issue's `AI-Implement Status` to `Ready` — and a PR appears in the right repo a few minutes later.
 
-The goal is a team workflow, not a developer tool. Your ticketing system is the source of truth (Linear today, others pluggable) — not just for individual tickets, but for cross-issue context when planning. The PR is the work product. The team sees both in the tools they already use.
+The goal is a team workflow, not a developer tool. Your ticketing system is the source of truth (Linear and Jira today, others pluggable) — not just for individual tickets, but for cross-issue context when planning. The PR is the work product. The team sees both in the tools they already use.
 
 ---
 
 ## What it does
 
-You point this service at your Linear workspace and one or more GitHub repos. It then:
+You point this service at your Linear workspace or Jira project and one or more GitHub repos. It then:
 
-1. Polls Linear every 60 seconds for unblocked issues with the `AI-Implement` label, respecting per-team concurrency limits.
+1. Polls the tracker every 60 seconds for ready work — unblocked Linear issues with the `AI-Implement` label, or Jira issues with `AI-Implement Status = Ready` in the mapping's scope — respecting per-team concurrency limits.
 2. For each one, dispatches a GitHub Actions workflow in the target repo — **or** boots a Fly Machine — that runs Claude Code against the issue.
 3. The runner checks out the repo, follows your repo-local `WORKFLOW.md` prompt, opens a PR, and runs a second Claude pass that posts a gap analysis comparing the diff to the original ticket.
-4. The Linear issue is updated to In Progress, then Ready for Review, with a link back to the PR.
+4. The ticket is updated to In Progress, then Ready for Review, with a link back to the PR.
 5. Comment `/ai-implement` on the resulting PR to re-run Claude in gap-fill mode against the same branch.
 
 The orchestrator is a small Node.js service backed by SQLite. It runs comfortably on a single Fly.io shared-cpu-1x machine.
@@ -24,7 +24,7 @@ The orchestrator is a small Node.js service backed by SQLite. It runs comfortabl
 
 Most AI coding tools assume one developer, one task, one session. AI-Implement assumes a team, a backlog, and a ticketing workflow. A few consequences of that design:
 
-- **The ticket is the prompt, and the backlog is the context.** Writing well-specified tickets is something teams already know how to do. We use that skill — and the cross-issue structure that already exists in Linear — instead of asking product people to learn prompt engineering.
+- **The ticket is the prompt, and the backlog is the context.** Writing well-specified tickets is something teams already know how to do. We use that skill — and the cross-issue structure that already exists in your tracker — instead of asking product people to learn prompt engineering.
 - **The work is legible.** Every run produces a PR, a gap analysis comment, and a ticket state change. Reviewers see exactly what was attempted and where it fell short of the spec.
 - **It runs in your CI, with your secrets, against your provider.** Anthropic API, OAuth, or AWS Bedrock — pick per target repo. Nothing about your code or your tickets leaves your infrastructure.
 - **One orchestrator, many repos, many GitHub orgs.** Designed from day one for teams running multiple codebases, not a single-repo prototype.
@@ -35,7 +35,7 @@ This is opinionated tooling for teams that have decided AI-assisted development 
 
 You'll get value from this if:
 
-- You already run tickets through Linear and want to skip the "open a PR yourself" step on small, well-specified issues.
+- You already run tickets through Linear or Jira and want to skip the "open a PR yourself" step on small, well-specified issues.
 - You want AI output to land in your existing review process, not in a parallel tool.
 - You're comfortable operating a small Node service on Fly.io (or similar).
 - You have at least some tickets that are focused enough for an LLM to land in one shot.
@@ -45,26 +45,21 @@ You should look elsewhere if:
 - You want a hosted "press a button, get a PR" experience without operating any infrastructure.
 - Your tickets tend to be sprawling or vague. Claude does well with focused, well-specified issues and poorly with everything else.
 
-## Quick start (single target repo)
+## Quick start (local dev)
 
-You'll need a Linear workspace, a GitHub App you control, a Fly.io account, and an Anthropic API key (or AWS Bedrock access).
+You'll need a Linear workspace or Jira project, a GitHub App you control, and an Anthropic API key (or AWS Bedrock access).
 
 ```bash
 git clone https://github.com/BuildDownAI/AI-Implement.git
 cd AI-Implement
 asdf install                 # installs the Node version pinned in .tool-versions
-cp .env.example .env       # fill in LINEAR_API_KEY + GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY
+cp .env.example .env         # fill in GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY, plus
+                             # LINEAR_API_KEY (Linear) or JIRA_TOKEN + JIRA_CLOUD_ID + JIRA_SITE_URL (Jira)
 npm install
-npm run dev                # starts polling + HTTP server on :8080
+npm run dev                  # starts polling + HTTP server on :8080
 ```
 
-Then in your Linear workspace, create an `AI-Implement` label. Install the GitHub App on the target repo, then in the orchestrator's admin UI at http://localhost:8080/admin (gated by `ADMIN_ACCESS_CODE`), add a team → repo mapping. From the Projects page, click **Sync workflows** for that project; the orchestrator opens or updates a PR in the target repo with the workflow templates.
-
-The synced workflows allow the GitHub App bot that minted the workflow token by
-default. To allow a different bot or a comma-separated allow-list, set the
-`AI_IMPLEMENT_ALLOWED_BOTS` Actions variable on the target repo or org.
-
-Merge the resulting PR in the target repo, enable "Allow GitHub Actions to create and approve pull requests" in its settings, then label any Linear issue `AI-Implement` and watch.
+The admin UI is at http://localhost:8080/admin (gated by `ADMIN_ACCESS_CODE`). To connect your first repo, see [Adding a new target repo](#adding-a-new-target-repo) below.
 
 For local runner development, keep the orchestrator on your host and run implementation jobs in Docker:
 
@@ -97,6 +92,59 @@ The first one set wins. A fork that publishes its own image typically sets `AI_I
 `SESSION_IMAGE` is the deprecated former name of the orchestrator's `AI_IMPLEMENT_RUNNER_IMAGE` env var; it still works but logs a warning at startup.
 
 The full architecture, env-var reference, SQLite schema, multi-client deploy model, and Bedrock setup live in [`CLAUDE.md`](CLAUDE.md).
+
+## Adding a new target repo
+
+### Step 1 — Ticketing setup (one-time per workspace/project)
+
+**Linear**: create an `AI-Implement` label in your workspace. That label is the trigger.
+
+**Jira**: add two custom fields to your Jira project. The orchestrator auto-discovers them by name, so use these exact names — or pick the field explicitly in the mapping (stored as a `customfield_XXXXX` override) if yours are named differently.
+
+| Field name | Type | Purpose |
+|---|---|---|
+| `AI-Implement Status` | Select | Orchestrator-managed state transitions (Ready → In Progress → Ready for Review) |
+| `AI-Implement Repo` | Select | Identifies which GitHub repo the issue belongs to — each option should be `owner/repo` |
+
+### Step 2 — GitHub App
+
+Install your GitHub App on the target repo. It needs **Contents** and **Workflows** permissions. Also enable **"Allow GitHub Actions to create and approve pull requests"** in the target repo's Settings → Actions → General.
+
+The synced workflows allow the GitHub App bot that minted the workflow token by default. To allow a different bot or a comma-separated allow-list, set the `AI_IMPLEMENT_ALLOWED_BOTS` Actions variable on the target repo or org.
+
+### Step 3 — Add the project in the admin UI
+
+Go to the orchestrator's admin UI → **Projects** → **+ New project**. The stepper walks through:
+
+- **Ticketing System** — `linear` or `jira`.
+- **Ticketing Config** — Linear: the team key (e.g. `ENG`). Jira: a scope JQL (e.g. `project = MYPROJECT` — no status clauses; the orchestrator adds those), the status/repo fields (leave at auto-discover if you used the exact names above), and the Repo Field Value option matching this repo (e.g. `your-org/your-repo`).
+- **Source** — GitHub owner, repo, and default branch. Click **Check installation**: the stepper probes whether the GitHub App is installed and can see the repo, and links straight to the fix when it can't (install the App, or add this repo to the installation). The check is advisory — you can still save without it.
+- **Runner** — `github-actions` (zero infrastructure) or `fly-machines`.
+- **Provider** — `anthropic` or `bedrock` (see [CLAUDE.md](CLAUDE.md) for Bedrock setup), plus planning toggles.
+- **Capacity** — max parallel AI issues (default 3, keep low while evaluating).
+- **Secrets** — optionally seed per-project secrets now (write-only; you can add more later from the Projects page).
+
+**Save.** The mapping persists immediately and the workflow sync runs in the background: the project row shows **"Syncing…"**, then **"Workflows synced — PR opened ↗"** — or reverts with an alert naming the failure. Per-run caps (Max Turns, Max Iterations, Job Timeout) are editable later via **Edit** on the project row.
+
+### Step 4 — Merge the sync PR
+
+The sync opens a PR in the target repo containing:
+
+- `.github/workflows/claude-implement.yml`
+- `.github/workflows/comment-trigger.yml`
+- `.github/workflows/claude-plan.yml`
+- `WORKFLOW.md` — your Claude implementation prompt template (seeded once, never overwritten)
+- `PLANNING.md` — your Claude planning prompt template (seeded once, never overwritten)
+
+**Merge that PR** in the target repo. The **Sync workflows** button on the project row re-runs the sync any time workflow templates change upstream.
+
+### Step 5 — Trigger a run
+
+**Linear**: label any issue in the mapped team `AI-Implement`.
+
+**Jira**: on any issue in scope of your JQL, set `AI-Implement Repo` to the matching option and `AI-Implement Status` to `Ready`.
+
+The orchestrator picks it up within 60 seconds and dispatches a run. The resulting PR is linked back to the ticket, and commenting `/ai-implement` on that PR re-runs Claude in gap-fill mode.
 
 ## Layout
 

--- a/src/__tests__/scratch-exclude.test.ts
+++ b/src/__tests__/scratch-exclude.test.ts
@@ -29,7 +29,11 @@ describe("prepareScratchExclusion", () => {
     dir = initRepo();
   });
   afterEach(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // On Windows, git marks object files read-only; ignore cleanup failures
+    }
   });
 
   it("keeps untracked ai-output/ out of the staged set after git add -A", () => {

--- a/src/pipeline/scratch-exclude.ts
+++ b/src/pipeline/scratch-exclude.ts
@@ -11,6 +11,28 @@ import path from "node:path";
 export const SCRATCH_PATHS = ["ai-output/"] as const;
 
 /**
+ * Append gitignore-style patterns to `.git/info/exclude` if not already present.
+ * Idempotent: patterns already in the file are never duplicated.
+ */
+export function appendExcludePaths(workspaceDir: string, paths: string[]): void {
+  const excludePath = path.join(workspaceDir, ".git", "info", "exclude");
+  fs.mkdirSync(path.dirname(excludePath), { recursive: true });
+
+  let existing = "";
+  try {
+    existing = fs.readFileSync(excludePath, "utf-8");
+  } catch {
+    existing = "";
+  }
+  const present = new Set(existing.split("\n").map((line) => line.trim()));
+  const missing = paths.filter((p) => !present.has(p));
+  if (missing.length > 0) {
+    const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+    fs.appendFileSync(excludePath, `${separator}${missing.join("\n")}\n`);
+  }
+}
+
+/**
  * Make orchestrator scratch paths uncommittable in a freshly-prepared workspace.
  *
  * Two deterministic guards, applied once after the working tree exists so every
@@ -27,21 +49,7 @@ export const SCRATCH_PATHS = ["ai-output/"] as const;
  * workspace.
  */
 export function prepareScratchExclusion(workspaceDir: string): void {
-  const excludePath = path.join(workspaceDir, ".git", "info", "exclude");
-  fs.mkdirSync(path.dirname(excludePath), { recursive: true });
-
-  let existing = "";
-  try {
-    existing = fs.readFileSync(excludePath, "utf-8");
-  } catch {
-    existing = "";
-  }
-  const present = new Set(existing.split("\n").map((line) => line.trim()));
-  const missing = SCRATCH_PATHS.filter((p) => !present.has(p));
-  if (missing.length > 0) {
-    const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
-    fs.appendFileSync(excludePath, `${separator}${missing.join("\n")}\n`);
-  }
+  appendExcludePaths(workspaceDir, [...SCRATCH_PATHS]);
 
   // Untrack scratch paths a prior run committed; `--ignore-unmatch` makes this a
   // no-op when nothing matches, so it's safe to run unconditionally. A non-zero


### PR DESCRIPTION
Four small independent hygiene items ported from the Cloudshare AI-Implement fork, one commit each:

1. **`appendExcludePaths` extraction** (`src/pipeline/scratch-exclude.ts`) — lift the `.git/info/exclude` append logic out of `prepareScratchExclusion` into a generic exported helper. Behavior-preserving; makes the mechanics reusable for other never-commit paths and brings the file in line with the fork so future syncs stop conflicting here. Includes a Windows-safe temp-repo cleanup in the test.
2. **Fork-neutral runner-image channels doc** (`CLAUDE.md`) — the section hardcoded `ghcr.io/builddownai/...` in lines every fork had to edit (recurring sync conflicts). Now worded the way the code works: `build-runner.yml` publishes to `ghcr.io/<owner>/ai-implement-runner` (auto-trusted namespace), the built-in fallback remains `ghcr.io/builddownai`, and forks pin via `AI_IMPLEMENT_RUNNER_IMAGE` / `.ai-implement/image.yml`. Also swaps the deprecated `SESSION_IMAGE` example for its current name. No factual change to the builddownai default.
3. **Stale admin-ui stubs list** (`CLAUDE.md`) — 8 of the "14 not-yet-implemented routes" have shipped; only six remain stubbed, and the placeholders are "Coming soon" alerts, not `RoadmapNote` plan pointers. Sentence updated to match `src/admin-ui/pages/stubs.ts`.
4. **README onboarding** — dual-provider framing (Linear label / Jira `AI-Implement Status = Ready`) and a step-by-step "Adding a new target repo" section: Jira custom fields with auto-discovery-by-name, GitHub App install + `AI_IMPLEMENT_ALLOWED_BOTS`, an admin-UI walkthrough matching the current New-project stepper (install-state probe, save-then-background-sync), sync-PR contents, and first-run trigger. Quick start slims to local dev. Existing sections (runner image choice, Layout, PR reviews, Fly operation) untouched.

Validation: `npm run typecheck` clean; `npm test` green — 102 files / 1565 tests.

Credit: items originate in the Cloudshare AI-Implement fork (scratch-exclude refactor from its PR-review iteration `4084aa2`; README onboarding from `794d0fe`), genericized for upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)