### PR TITLE
test: cwd-independent baked-root DEFAULT_PIPELINE test; fix Dockerfile custom/ comment

### DIFF
--- a/Dockerfile.session
+++ b/Dockerfile.session
@@ -101,12 +101,15 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 COPY pipelines/ ./pipelines/
 
-# Bake custom/ overrides into the image. The runner's cwd is /workspace (the
-# target-repo clone dir, empty at process start), so cwd-relative custom/
-# resolution never fires runner-side; AI_IMPLEMENT_CUSTOM_ROOT points
-# resolve-module.ts at a secondary root that CONTAINS custom/. Upstream ships
+# Bake custom/ overrides into the image. AI_IMPLEMENT_CUSTOM_ROOT points
+# resolve-module.ts at a secondary root that CONTAINS custom/; upstream ships
 # only placeholders here — client forks that build their own runner image get
 # their custom/pipelines + custom/steps honored by the runner via this bake.
+# NOTE: the workspace (cwd) root still outranks this baked root, and the
+# entrypoint clones the target repo into /workspace BEFORE node starts — so a
+# target repo (or a checked-out PR head, on gap-fill runs) that ships its own
+# custom/ files shadows the baked ones. That is the documented per-workspace
+# override behavior, not a bake failure.
 COPY custom/ ./custom/
 ENV AI_IMPLEMENT_CUSTOM_ROOT=/app
 

--- a/src/__tests__/default-pipeline.test.ts
+++ b/src/__tests__/default-pipeline.test.ts
@@ -56,6 +56,12 @@ describe("DEFAULT_PIPELINE baked custom root", () => {
   // custom/pipelines/autonomous.yml takes effect at import time.
   it("honors AI_IMPLEMENT_CUSTOM_ROOT at module-import time", async () => {
     const bakedRoot = mkdtempSync(join(tmpdir(), "ai-implement-baked-"));
+    // The workspace (cwd) root outranks the baked root, so run the import from
+    // an empty temp cwd — otherwise a repo that actually ships a
+    // custom/pipelines/autonomous.yml (any real fork) would win and break this
+    // test's baked-root assertion.
+    const emptyCwd = mkdtempSync(join(tmpdir(), "ai-implement-cwd-"));
+    const prevCwd = process.cwd();
     try {
       mkdirSync(join(bakedRoot, "custom", "pipelines"), { recursive: true });
       writeFileSync(
@@ -63,14 +69,17 @@ describe("DEFAULT_PIPELINE baked custom root", () => {
         "id: baked-loop\nsteps:\n  - id: clone\n    type: clone\n",
       );
       vi.stubEnv("AI_IMPLEMENT_CUSTOM_ROOT", bakedRoot);
+      process.chdir(emptyCwd);
       vi.resetModules();
       const { DEFAULT_PIPELINE } = await import("../pipeline/default-pipeline.js");
       expect(DEFAULT_PIPELINE.id).toBe("baked-loop");
       expect(DEFAULT_PIPELINE.steps.map((s) => s.id)).toEqual(["clone"]);
     } finally {
+      process.chdir(prevCwd);
       vi.unstubAllEnvs();
       vi.resetModules();
       rmSync(bakedRoot, { recursive: true, force: true });
+      rmSync(emptyCwd, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
Two small fixes found while building the first real consumer of the baked custom root (a fork-owned pipeline step on the Cloudshare fork, cloudshare/ai-implement#73):

- **The baked-root `DEFAULT_PIPELINE` test breaks in any fork that actually uses the feature.** It imported `default-pipeline` with the suite's real cwd, but the workspace (cwd) root outranks `AI_IMPLEMENT_CUSTOM_ROOT` — so a repo shipping a real `custom/pipelines/autonomous.yml` (the exact audience of #129) wins the resolution and the `baked-loop` assertion fails. The test now imports from an empty temp cwd, with a comment explaining why.
- **`Dockerfile.session`'s comment claimed `/workspace` is "empty at process start" so cwd-relative `custom/` "never fires runner-side" — that's false.** `session/entrypoint.sh` clones the target repo (and on gap-fill runs checks out the PR head) into `/workspace` and `cd`s there *before* exec'ing node, so target-repo `custom/` files shadow the baked ones. That's the documented per-workspace precedence working as designed, but the comment would mislead anyone debugging a shadowed step. Rewritten to state the actual behavior.

`npm run typecheck` clean; targeted test file green (4/4); no behavior changes — one test import made hermetic, one comment corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)