### PR TITLE
AII-132: rename SESSION_IMAGE → AI_IMPLEMENT_RUNNER_IMAGE in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,8 +53,9 @@ FLY_SESSIONS_REGION=iad
 # Fly API token scoped to the sessions app (use `fly tokens create deploy`).
 FLY_SESSIONS_TOKEN=
 
-# Runner image pulled by Fly Machines. Override per-repo via .ai-implement/image.yml.
-SESSION_IMAGE=ghcr.io/builddownai/ai-implement-runner:latest
+# Orchestrator default runner image (both execution modes; formerly SESSION_IMAGE).
+# Override per-repo via .ai-implement/image.yml.
+AI_IMPLEMENT_RUNNER_IMAGE=ghcr.io/builddownai/ai-implement-runner:latest
 
 # Runner authentication for Claude inside the session — set one of:
 ANTHROPIC_API_KEY=


### PR DESCRIPTION
## Summary

Completes **AII-132** (unify + document the runner-image configuration). PR #87 already landed
the substance — `AI_IMPLEMENT_RUNNER_IMAGE` as the primary orchestrator env var with `SESSION_IMAGE`
kept as a deprecated alias, the authoritative "Runner image resolution" section in CLAUDE.md/README,
and tests. The one acceptance criterion left open was the example config: `.env.example` still shipped
the deprecated `SESSION_IMAGE` name, so a new operator copying it would adopt the old knob.

No behavior change — `SESSION_IMAGE` remains a working alias (with a startup deprecation warning). This
just makes the example model the current preferred name.

## What changed

- **`.env.example`** — `SESSION_IMAGE` → `AI_IMPLEMENT_RUNNER_IMAGE` (same value). Also corrected the
  adjacent comment: this image is the orchestrator default for **both** execution modes, not just Fly
  Machines.

## Scope

`clients/example-client.toml` never referenced the image var, so nothing to change there. Two prose
channel-pinning examples still use the alias (the feature-branch-grouping operational note in CLAUDE.md
and `docs/feature-branch-grouping.md`) — accurate since the alias works, and outside AII-132's acceptance
criteria; left as-is.

Closes AII-132.
