### PR TITLE
fix(github): deleteBranch idempotency — missing ref is 422, not 404

### DIFF
--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -410,6 +410,25 @@ describe("deleteBranch", () => {
     expect(await deleteBranch("tok", "owner", "repo", "ai-implement/feature/foo-1")).toBe(true);
   });
 
+  it('returns true on 422 "Reference does not exist" (the git-refs API reports a missing ref as 422, not 404)', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 422,
+      ok: false,
+      text: async () =>
+        '{"message":"Reference does not exist","documentation_url":"https://docs.github.com/rest/git/refs#delete-a-reference","status":"422"}',
+    } as unknown as Response);
+    expect(await deleteBranch("tok", "owner", "repo", "ai-implement/feature/foo-1")).toBe(true);
+  });
+
+  it("throws on a 422 that is not a missing ref (e.g. protected branch)", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      status: 422,
+      ok: false,
+      text: async () => '{"message":"Refusing to delete the default branch"}',
+    } as unknown as Response);
+    await expect(deleteBranch("tok", "owner", "repo", "ai-implement/feature/foo-1")).rejects.toThrow();
+  });
+
   it("throws on other non-success statuses", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       status: 403,

--- a/src/github.ts
+++ b/src/github.ts
@@ -495,8 +495,11 @@ export async function findPullRequestByBranches(
 }
 
 /**
- * Deletes a branch ref. Treats 404 as success (idempotent — branch may have been
- * manually deleted or removed by GitHub's "delete on merge" setting).
+ * Deletes a branch ref. Treats an already-missing ref as success (idempotent —
+ * branch may have been manually deleted or removed by GitHub's "delete on merge"
+ * setting). The git-refs DELETE endpoint reports a missing ref as
+ * 422 "Reference does not exist" (404 only covers a missing repo), so both are
+ * accepted; other 422s (e.g. refusing to delete a protected branch) still throw.
  */
 export async function deleteBranch(
   token: string,
@@ -509,6 +512,7 @@ export async function deleteBranch(
   const res = await fetch(url, { method: "DELETE", headers: ghHeaders(token) });
   if (res.status === 204 || res.status === 404) return true;
   const body = await res.text().catch(() => "");
+  if (res.status === 422 && body.includes("Reference does not exist")) return true;
   throw new GitHubApiError({
     status: res.status,
     path: `/repos/${owner}/${repo}/git/refs/heads/${enc}`,


### PR DESCRIPTION
## Bug

`deleteBranch` was written to be idempotent — 404 treated as success, with a comment citing GitHub's "delete on merge" setting. But the git-refs DELETE endpoint reports an already-deleted ref as **HTTP 422 `{"message":"Reference does not exist"}`**, not 404 (404 only covers a missing repo). So the idempotency never fired.

## Observed failure (production, feature-branch roll-up)

A top-of-tree `feature → base` PR was human-merged in a target repo with **"Automatically delete head branches"** enabled. On the next poll tick, `rollUpOne` saw `pr.merged`, called `deleteBranch` on the already-vanished branch, got the 422, and threw — so **`finalizeMerged` never ran**: the issue was never moved to Merged/Done, the roll-up stayed in the query, and the same failure repeated every poll tick forever:

```
[merge-up] Failed for TSAI-54: GitHubApiError: deleteBranch(ai-implement/feature/tsai-54) failed: HTTP 422: {"message":"Reference does not exist",...}
```

## Fix

Treat 422 with a `Reference does not exist` body as success, matching the existing 404 handling. Other 422s (e.g. "Refusing to delete the default branch" / protected-branch refusals) still throw.

TDD: new test reproducing the production 422 body (red before the fix), plus a guard test that a non-missing-ref 422 still throws. Full suite 1662/1662 green.

Self-healing on deploy: the stuck roll-up completes on the next poll tick (delete now succeeds idempotently → `finalizeMerged` runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)