### PR TITLE
fix(pipelines): PR links + orphaned planning-job status on the pipelines page

### DIFF
--- a/src/__tests__/log-job-updates.test.ts
+++ b/src/__tests__/log-job-updates.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import type * as DedupModule from "../dedup.js";
+import type * as LogModule from "../log.js";
+
+let dbPath: string;
+let dedup: typeof DedupModule;
+let log: typeof LogModule;
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(
+    os.tmpdir(),
+    `log-job-updates-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  log = await import("../log.js");
+  log.initLogTable();
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
+});
+
+describe("updateJobStatus pr_url handling", () => {
+  it("preserves an existing pr_url when the caller passes none", () => {
+    const id = log.appendLog({ issueId: "i1", executionMode: "github-actions" });
+    log.updateJobPrUrl(id, "https://github.com/o/r/pull/5");
+    log.updateJobStatus(id, "completed", "success", null);
+    expect(log.getJobById(id)?.prUrl).toBe("https://github.com/o/r/pull/5");
+  });
+
+  it("records a fresh pr_url when provided", () => {
+    const id = log.appendLog({ issueId: "i2", executionMode: "github-actions" });
+    log.updateJobStatus(id, "completed", "success", "https://github.com/o/r/pull/9");
+    expect(log.getJobById(id)?.prUrl).toBe("https://github.com/o/r/pull/9");
+  });
+
+  it("overwrites an older pr_url when a new one is provided", () => {
+    const id = log.appendLog({ issueId: "i3", executionMode: "github-actions" });
+    log.updateJobPrUrl(id, "https://github.com/o/r/pull/5");
+    log.updateJobStatus(id, "completed", "success", "https://github.com/o/r/pull/6");
+    expect(log.getJobById(id)?.prUrl).toBe("https://github.com/o/r/pull/6");
+  });
+});
+
+describe("completeOrphanedPlanningJobs", () => {
+  it("marks an 'unknown' planning job completed for the issue", () => {
+    const id = log.appendLog({ issueId: "i1", executionMode: "github-actions", phase: "planning" });
+    // Simulate the boot-time orphan reset for untracked GHA jobs.
+    log.updateJobStatus(id, "unknown");
+    expect(log.completeOrphanedPlanningJobs("i1")).toBe(1);
+    const job = log.getJobById(id);
+    expect(job?.status).toBe("completed");
+    expect(job?.completedAt).not.toBeNull();
+  });
+
+  it("leaves running planning jobs alone (monitor still owns them)", () => {
+    const id = log.appendLog({ issueId: "i2", executionMode: "github-actions", phase: "planning" });
+    log.updateJobStatus(id, "running");
+    expect(log.completeOrphanedPlanningJobs("i2")).toBe(0);
+    expect(log.getJobById(id)?.status).toBe("running");
+  });
+
+  it("never touches implementation jobs or other issues", () => {
+    const impl = log.appendLog({ issueId: "i3", executionMode: "github-actions" });
+    log.updateJobStatus(impl, "unknown");
+    const otherIssue = log.appendLog({ issueId: "i4", executionMode: "github-actions", phase: "planning" });
+    log.updateJobStatus(otherIssue, "unknown");
+    expect(log.completeOrphanedPlanningJobs("i3")).toBe(0);
+    expect(log.getJobById(impl)?.status).toBe("unknown");
+    expect(log.getJobById(otherIssue)?.status).toBe("unknown");
+  });
+
+  it("returns 0 when the issue has no planning rows", () => {
+    expect(log.completeOrphanedPlanningJobs("nope")).toBe(0);
+  });
+});

--- a/src/admin-ui/pages/pipelines.ts
+++ b/src/admin-ui/pages/pipelines.ts
@@ -198,7 +198,12 @@ export const pipelinesScript = `
           const imageCell = impl.sessionImage
             ? '<td class="mono" title="' + window.esc(impl.sessionImage) + '">' + window.esc(impl.sessionImage.split('/').pop()) + '</td>'
             : '<td style="color:#aaa">—</td>';
-          const combinedStatus = statusBadge(plan.status) + ' <span style="color:#aaa;font-size:0.8em">→</span> ' + statusBadge(impl.status);
+          // A grouped row exists only when an implement dispatch followed this plan,
+          // which requires plan approval — so a plan row stranded in a non-terminal
+          // status (e.g. 'unknown' after an orchestrator restart) is known-completed.
+          const planStatus = (plan.status === 'unknown' || plan.status === 'dispatched' || plan.status === 'running')
+            ? 'completed' : plan.status;
+          const combinedStatus = statusBadge(planStatus) + ' <span style="color:#aaa;font-size:0.8em">→</span> ' + statusBadge(impl.status);
           const prLink = impl.prUrl ? '<a href="' + window.esc(impl.prUrl) + '" target="_blank">View</a>' : '—';
           tr.innerHTML = '<td style="white-space:nowrap">' + dt + '</td>'
             + '<td style="text-align:center">' + dnBadge + '</td>'

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { notify, notifyCompletion } from "./notify.js";
 import { remediateStuckJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
 import { handleAdminRequest } from "./admin.js";
-import { initLogTable, appendLog, countPriorDispatches, updateJobRunId, updateJobStatus, updateJobPrUrl, markJobNotified, getInFlightJobs, getInFlightIssueIds, getUnnotifiedTerminalJobs, getClaimedRunIds, suppressStaleNotifications, invalidateNonce, getJobByMachineId, resetStuckAttempts } from "./log.js";
+import { initLogTable, appendLog, countPriorDispatches, completeOrphanedPlanningJobs, updateJobRunId, updateJobStatus, updateJobPrUrl, markJobNotified, getInFlightJobs, getInFlightIssueIds, getUnnotifiedTerminalJobs, getClaimedRunIds, suppressStaleNotifications, invalidateNonce, getJobByMachineId, resetStuckAttempts } from "./log.js";
 import type { Job, JobStatus } from "./log.js";
 import { getInstallationToken } from "./github-app-auth.js";
 import { handleTokenRequest } from "./token-vending.js";
@@ -306,6 +306,17 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
           await dispatchPlanning(config, issueProvider, issue, mapping);
         } else {
           const prior = countPriorDispatches(issue.id);
+
+          // Implementation only dispatches after plan approval, so any planning row
+          // still stuck in 'unknown' (orphaned by an orchestrator restart before its
+          // run was attached) demonstrably finished — finalize it so the pipelines
+          // UI doesn't show 'unknown' forever.
+          const finalizedPlans = completeOrphanedPlanningJobs(issue.id);
+          if (finalizedPlans > 0) {
+            console.log(
+              `[poll] Finalized ${finalizedPlans} orphaned planning job(s) for ${issue.identifier} (implementation dispatching)`,
+            );
+          }
 
           if (prior.count > 0) {
             const ago = prior.lastDispatchedAt
@@ -1381,6 +1392,14 @@ async function monitorGitHubActionsJob(
         prUrl = await findPrForRun(ghToken, owner, repo, job.runId);
       } catch {
         // Non-critical
+      }
+      // workflow_dispatch runs report the ref they were dispatched on (the default
+      // branch) as head_branch, so findPrForRun misses the PR the runner created
+      // during the run. Fall back to matching an open PR by the issue's branch
+      // naming. Planning runs never open PRs — skip them so an implementation PR
+      // from an earlier dispatch is not misattributed to a planning row.
+      if (!prUrl && job.phase !== "planning") {
+        prUrl = await findPrForIssue(config, job.repo, job.issueIdentifier);
       }
     }
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -208,9 +208,12 @@ export function updateJobStatus(
   prUrl?: string | null,
 ): void {
   const isTerminal = status === "completed" || status === "review_failed" || status === "failed" || status === "timed_out";
+  // COALESCE keeps a pr_url recorded earlier (e.g. by the runner callback) when the
+  // caller has none — the GHA monitor often can't resolve a PR for dispatch runs and
+  // must not wipe the link on completion.
   getDb()
     .prepare(
-      "UPDATE dispatch_log SET status = ?, conclusion = ?, pr_url = ?, completed_at = ? WHERE id = ?",
+      "UPDATE dispatch_log SET status = ?, conclusion = ?, pr_url = COALESCE(?, pr_url), completed_at = ? WHERE id = ?",
     )
     .run(
       status,
@@ -219,6 +222,23 @@ export function updateJobStatus(
       isTerminal ? Date.now() : null,
       jobId,
     );
+}
+
+/**
+ * Finalizes planning jobs left in 'unknown' (the boot-time reset for GHA jobs whose
+ * run was never attached — e.g. the orchestrator restarted mid-run). Called when the
+ * same issue's IMPLEMENTATION phase dispatches: implementation only follows plan
+ * approval, so any still-'unknown' planning row demonstrably finished. Jobs the
+ * monitor still tracks ('dispatched'/'running') are left alone — the monitor will
+ * record their real outcome. Returns the number of rows finalized.
+ */
+export function completeOrphanedPlanningJobs(issueId: string): number {
+  const result = getDb()
+    .prepare(
+      "UPDATE dispatch_log SET status = 'completed', conclusion = COALESCE(conclusion, 'inferred_from_plan_approval'), completed_at = COALESCE(completed_at, ?) WHERE issue_id = ? AND phase = 'planning' AND status = 'unknown'",
+    )
+    .run(Date.now(), issueId);
+  return result.changes;
 }
 
 export function markJobNotified(jobId: number): void {


### PR DESCRIPTION
## Symptoms (admin UI Pipelines page)

1. Grouped planning→implement rows show **"unknown → completed"** even though planning demonstrably succeeded (implementation only dispatches after plan approval).
2. The **PR column never shows a link** for orchestrator-dispatched GHA runs.

## Root causes & fixes

**PR links (two compounding bugs):**
- `findPrForRun` resolves the run's `head_branch`, but a `workflow_dispatch` run reports the ref it was dispatched **on** (the default branch) — not the `ai-implement/...` branch the runner creates mid-run. The run→PR lookup therefore never matches. → The GHA monitor now falls back to the existing `findPrForIssue` (branch-shape matching) when `findPrForRun` returns nothing; planning jobs are excluded so an earlier implementation PR is never misattributed to a planning row.
- `updateJobStatus` unconditionally wrote `pr_url = ?`, so a monitor completion with no PR **clobbered a link the runner callback had already recorded**. → `COALESCE(?, pr_url)`.

**Stranded "unknown" planning rows:**
- On boot, GHA jobs with no attached `run_id` are reset to `unknown` (existing behavior, correct for live monitoring). But a planning job orphaned this way — orchestrator redeployed between dispatch and run-attach — stays `unknown` forever, even after the plan is approved and implementation dispatches. → New `completeOrphanedPlanningJobs(issueId)` finalizes `unknown` planning rows when the same issue's implementation phase dispatches (plan approval is a precondition of that dispatch, so the plan finished). Jobs still tracked as `dispatched`/`running` are left to the monitor. The pipelines page applies the same inference display-side for grouped rows, covering pre-existing data without a migration.

## Validation

TDD: 7 new tests in `src/__tests__/log-job-updates.test.ts` (pr_url preservation ×3, orphan finalization ×4) — red before, green after. Full suite **1669/1669**, typecheck clean.

Note: the `findPrForIssue` fallback wiring in `monitorGitHubActionsJob` follows the existing untested wiring pattern in that function; the building blocks on both sides of it are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)