### PR TITLE
fix(monitor): planning→implementation handoff no longer waits out the 11m stuck timeout

### DIFF
--- a/src/__tests__/integration-callback.test.ts
+++ b/src/__tests__/integration-callback.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
 import type * as DedupModule from "../dedup.js";
+import type * as LogModule from "../log.js";
 import type * as RunnerTokensModule from "../runner-tokens.js";
 import type * as RunnerCallbackModule from "../runner-callback.js";
 import { FakeProvider } from "./providers/fake.js";
@@ -11,6 +12,7 @@ const SECRET = "integration-test-secret";
 
 let dbPath: string;
 let dedup: typeof DedupModule;
+let log: typeof LogModule;
 let runnerTokens: typeof RunnerTokensModule;
 let runnerCallback: typeof RunnerCallbackModule;
 
@@ -22,9 +24,13 @@ beforeEach(async () => {
   );
   process.env.DEDUP_DB_PATH = dbPath;
   dedup = await import("../dedup.js");
+  log = await import("../log.js");
   runnerTokens = await import("../runner-tokens.js");
   runnerCallback = await import("../runner-callback.js");
   dedup.getDb();
+  // The callback handler now reads dispatch_log (planning job finalization);
+  // production always creates it at startup via initLogTable().
+  log.initLogTable();
 });
 
 afterEach(() => {

--- a/src/__tests__/runner-callback.test.ts
+++ b/src/__tests__/runner-callback.test.ts
@@ -191,6 +191,38 @@ describe("handleRunnerResult — planning", () => {
     expect(fake.getPhase("i")).toBe("plan_complete");
   });
 
+  it("finalizes the dispatch-log job as completed on planning success", async () => {
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "planning",
+      ttlSeconds: runnerTokens.PLANNING_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const jobId = log.appendLog({
+      issueId: "i",
+      issueIdentifier: "ENG-1",
+      issueTitle: "Plan it",
+      teamKey: "ENG",
+      repo: "o/r",
+      dispatchId,
+      executionMode: "github-actions",
+      phase: "planning",
+    });
+
+    const res = await runnerCallback.handleRunnerResult({
+      authorization: `Bearer ${token}`,
+      body: { phase: "planning", outcome: "success", comments: [] },
+      secret: SECRET,
+      resolveProvider: makeResolve(new FakeProvider({ recordCalls: true })),
+    });
+
+    expect(res.status).toBe(200);
+    const job = log.getJobById(jobId);
+    expect(job?.status).toBe("completed");
+    expect(job?.completedAt).not.toBeNull();
+  });
+
   it("calls markPlanningFailed on failure", async () => {
     const { token } = runnerTokens.mintRunToken({
       issueId: "i",

--- a/src/__tests__/workflow-file-for-job.test.ts
+++ b/src/__tests__/workflow-file-for-job.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { workflowFileForJob } from "../monitor-status.js";
+
+const mapping = { workflowFile: "claude-implement.yml", planningWorkflowFile: "claude-plan.yml" };
+
+describe("workflowFileForJob", () => {
+  it("returns the planning workflow for planning-phase jobs", () => {
+    expect(workflowFileForJob({ phase: "planning" }, mapping)).toBe("claude-plan.yml");
+  });
+
+  it("returns the implementation workflow for implementation-phase jobs", () => {
+    expect(workflowFileForJob({ phase: "implementation" }, mapping)).toBe("claude-implement.yml");
+  });
+
+  it("returns the implementation workflow for legacy rows with no phase", () => {
+    expect(workflowFileForJob({ phase: null }, mapping)).toBe("claude-implement.yml");
+  });
+
+  it("falls back to the implementation workflow when planningWorkflowFile is unset", () => {
+    expect(
+      workflowFileForJob({ phase: "planning" }, { workflowFile: "claude-implement.yml", planningWorkflowFile: null }),
+    ).toBe("claude-implement.yml");
+  });
+});

--- a/src/admin-ui/drawer.ts
+++ b/src/admin-ui/drawer.ts
@@ -284,7 +284,7 @@ export const drawerScript = `
     const logsLink = document.getElementById('drawer-logs-link');
     const mapping = mappings && job.teamKey ? mappings[job.teamKey] : null;
     const repoParts = repoPartsForJob(job, mapping);
-    const hasWorkflowLogs = job.runId && (job.executionMode === 'github-actions' || job.executionMode === 'planning');
+    const hasWorkflowLogs = job.runId && job.executionMode === 'github-actions';
     if (hasWorkflowLogs && repoParts) {
       logsLink.href = 'https://github.com/' + repoParts.owner + '/' + repoParts.repo + '/actions/runs/' + job.runId;
       logsLink.textContent = 'View workflow logs ↗';

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ import {
   removeLocalContainer,
   startLocalRunnerContainer,
 } from "./local-docker.js";
-import { resolveTerminalStatus } from "./monitor-status.js";
+import { resolveTerminalStatus, workflowFileForJob } from "./monitor-status.js";
 import { branchMatchesIssueIdentifier } from "./pipeline/branch-name.js";
 import { resolveBaseBranch } from "./feature-branch.js";
 import { runMergeUps } from "./merge-up.js";
@@ -1331,9 +1331,7 @@ async function monitorGitHubActionsJob(
     );
     if (!mapping) return;
 
-    const workflowFile = job.executionMode === "planning"
-      ? mapping.planningWorkflowFile
-      : mapping.workflowFile;
+    const workflowFile = workflowFileForJob(job, mapping);
 
     const runId = await findWorkflowRunId(
       ghToken,

--- a/src/monitor-status.ts
+++ b/src/monitor-status.ts
@@ -6,6 +6,22 @@ import type { JobStatus } from "./log.js";
  * destroyed before we polled, or a clean exit 0 that Fly reports without an exit_code); a
  * definite non-zero exit is always a failure.
  */
+/**
+ * The workflow whose run list a GHA job's run ID must be searched in. Planning
+ * dispatches go to the planning workflow (claude-plan.yml), so searching the
+ * implementation workflow's runs for them never matches — the job then sits
+ * "waiting for run ID" until the stuck watchdog force-requeues it, delaying the
+ * planning→implementation handoff by the full stuck timeout.
+ */
+export function workflowFileForJob(
+  job: { phase: string | null },
+  mapping: { workflowFile: string; planningWorkflowFile: string | null },
+): string {
+  return job.phase === "planning" && mapping.planningWorkflowFile
+    ? mapping.planningWorkflowFile
+    : mapping.workflowFile;
+}
+
 export function resolveTerminalStatus(
   exitCode: number | null,
   prUrl: string | null,

--- a/src/monitor-status.ts
+++ b/src/monitor-status.ts
@@ -1,12 +1,6 @@
 import type { JobStatus } from "./log.js";
 
 /**
- * Shared terminal-status resolver for the fly-machines and local-docker monitors — one rule
- * across execution paths. `exitCode` is null only when it can't be read (a fly machine already
- * destroyed before we polled, or a clean exit 0 that Fly reports without an exit_code); a
- * definite non-zero exit is always a failure.
- */
-/**
  * The workflow whose run list a GHA job's run ID must be searched in. Planning
  * dispatches go to the planning workflow (claude-plan.yml), so searching the
  * implementation workflow's runs for them never matches — the job then sits
@@ -22,6 +16,12 @@ export function workflowFileForJob(
     : mapping.workflowFile;
 }
 
+/**
+ * Shared terminal-status resolver for the fly-machines and local-docker monitors — one rule
+ * across execution paths. `exitCode` is null only when it can't be read (a fly machine already
+ * destroyed before we polled, or a clean exit 0 that Fly reports without an exit_code); a
+ * definite non-zero exit is always a failure.
+ */
 export function resolveTerminalStatus(
   exitCode: number | null,
   prUrl: string | null,

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -1,4 +1,4 @@
-import { getJobByDispatchId, updateJobPrUrl } from "./log.js";
+import { getJobByDispatchId, updateJobPrUrl, updateJobStatus } from "./log.js";
 import type { Step } from "./pipeline/types.js";
 import type { TicketingProvider } from "./providers/types.js";
 import { verifyAndConsumeRunToken, verifyRunToken } from "./runner-tokens.js";
@@ -209,6 +209,14 @@ export async function handleRunnerResult(
       await provider.markPlanComplete(claims.issueId, mappingTeamKey);
     } catch (err) {
       warn("markPlanComplete", err);
+    }
+    // Finalize the job row immediately: the issue stays excluded from dispatch
+    // while its planning job is in flight, so waiting for the GHA monitor to
+    // notice the run finished delays the planning→implementation handoff — and
+    // if run tracking failed entirely, blocks it until the stuck watchdog fires.
+    const job = getJobByDispatchId(claims.dispatchId);
+    if (job) {
+      updateJobStatus(job.id, "completed", "planning_callback");
     }
   } else if (input.body.phase === "implementation") {
     try {


### PR DESCRIPTION
## Symptom

After a planning run finishes (and the callback sets Plan Approved), nothing happens for ~11 minutes, then:

```
[monitor] Job 208 (TSAI-92) timed out waiting for run ID
[monitor] Job 208 (TSAI-92) stuck after 11m (attempt 1/3) — requeueing
[monitor] Reset ticket TSAI-92 for requeue
[poll] RE-DISPATCH #2 for TSAI-92 ...
```

The job drawer shows the planning job as **timed_out — "Workflow exceeded timeout"** even though the planning workflow succeeded.

## Root cause

The GHA monitor's run-ID lookup chose the workflow to search with:

```ts
const workflowFile = job.executionMode === "planning" ? mapping.planningWorkflowFile : mapping.workflowFile;
```

`executionMode` is `github-actions`/`fly-machines`/`local-docker` — the planning marker lives in **`job.phase`** (a vestige from before the phase column existed). The condition is always false, so planning dispatches were searched for in `claude-implement.yml`'s run list and never found. Since an issue is excluded from dispatch while it has an in-flight job, the implementation dispatch stayed blocked until the stuck watchdog force-requeued the ticket at the 11-minute mark — the entire planning→implementation gap the deadlock produced. It also explains planning rows stranding in `unknown` across restarts (they never attach run IDs at all).

## Fix (two independent layers)

1. **`workflowFileForJob(job, mapping)`** (new, tested, in `monitor-status.ts`) keyed on `job.phase`, used by the monitor's run-ID lookup — planning runs are now found in `claude-plan.yml`'s run list and tracked normally.
2. **Callback finalization**: the planning result callback now marks the dispatch-log job `completed` (conclusion `planning_callback`) — the issue leaves the in-flight set immediately, so implementation dispatches on the **next poll tick** even if run tracking hiccups for any other reason. The handoff no longer depends on the monitor winning a race with the watchdog.

## Validation

TDD: 5 new tests red-then-green (`workflow-file-for-job.test.ts` ×4, callback finalization ×1). `integration-callback.test.ts` setup gained `initLogTable()` (the handler now touches `dispatch_log`, which production always creates at startup). Full suite **1674/1674**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)