### PR TITLE
AII-238 hotfix: escape newline in sensitive-glob client scripts

### DIFF
--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -304,8 +304,8 @@ export const projectsScript = `
     document.getElementById('md-max-job-min').value = m.maxJobMinutes == null ? '' : String(m.maxJobMinutes);
     document.getElementById('md-branch-prefix').value = m.branchPrefix || '';
     document.getElementById('md-skills-repo').value = m.skillsRepo || '';
-    document.getElementById('md-sensitive-add').value = (m.sensitiveAddPatterns || []).join('\n');
-    document.getElementById('md-sensitive-allow').value = (m.sensitiveAllowPatterns || []).join('\n');
+    document.getElementById('md-sensitive-add').value = (m.sensitiveAddPatterns || []).join('\\n');
+    document.getElementById('md-sensitive-allow').value = (m.sensitiveAllowPatterns || []).join('\\n');
 
     // Ticketing provider + Jira config
     const tp = m.ticketingProvider || 'linear';

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -747,8 +747,8 @@ export const stepperScript = `
     set('repo', window.esc(data.owner) + '/' + window.esc(data.repo));
     set('defaultBranch', window.esc(data.defaultBranch) || '&mdash;');
     set('skillsRepo', data.skillsRepo ? window.esc(data.skillsRepo) : '&mdash;');
-    set('sensitiveAddPatterns', data.sensitiveAddPatterns ? (data.sensitiveAddPatterns.split('\n').filter(function(l){return l.trim();}).length + ' pattern(s)') : '&mdash;');
-    set('sensitiveAllowPatterns', data.sensitiveAllowPatterns ? (data.sensitiveAllowPatterns.split('\n').filter(function(l){return l.trim();}).length + ' exception(s)') : '&mdash;');
+    set('sensitiveAddPatterns', data.sensitiveAddPatterns ? (data.sensitiveAddPatterns.split('\\n').filter(function(l){return l.trim();}).length + ' pattern(s)') : '&mdash;');
+    set('sensitiveAllowPatterns', data.sensitiveAllowPatterns ? (data.sensitiveAllowPatterns.split('\\n').filter(function(l){return l.trim();}).length + ' exception(s)') : '&mdash;');
 
     let runnerText = window.esc(data.executionMode);
     if (data.executionMode === 'fly-machines') {


### PR DESCRIPTION
Hotfix for AII-238 (#168). #168 merged with single-backslash `\n` inside the projectsScript/stepperScript template literals, injecting a raw newline into the served client JS — a SyntaxError that broke the entire admin SPA (all page scripts concatenate into one inline `<script>`). This changes those 4 lines to `\\n` (matching the pre-existing correct lines projects.ts:922,934).

Verified: the assembled admin `<script>` now parses (vm.Script) and typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)