### PR TITLE
fix(runner): resolve issue fields from AI_IMPLEMENT_RUN_CONFIG envelope

### DIFF
--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -27,7 +27,15 @@ case "$PROVIDER" in
   *) fail "Unsupported provider: $PROVIDER" ;;
 esac
 export PROVIDER
-require_env ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION
+# AI_IMPLEMENT_RUN_CONFIG (the envelope) carries the issue fields when set; the
+# TS runner decodes them itself. Only the legacy per-field contract needs them
+# validated and exported here.
+if [ -n "${AI_IMPLEMENT_RUN_CONFIG:-}" ]; then
+  log "Issue fields will be resolved from the AI_IMPLEMENT_RUN_CONFIG envelope"
+else
+  require_env ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION
+  export ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION
+fi
 
 if [ "$AI_IMPLEMENT_MODE" = "gha" ]; then
   require_env GITHUB_TOKEN GITHUB_REPOSITORY
@@ -36,7 +44,6 @@ if [ "$AI_IMPLEMENT_MODE" = "gha" ]; then
 else
   require_env GITHUB_TOKEN GITHUB_OWNER GITHUB_REPO
 fi
-export ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION
 export GITHUB_OWNER GITHUB_REPO
 export PR_NUMBER="${PR_NUMBER:-}"
 

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -57,4 +57,11 @@ describe("session/entrypoint.sh", () => {
     expect(content).toContain("su -p coder");
     expect(content).not.toContain("su -m -p coder");
   });
+
+  it("skips the legacy ISSUE_ID require/export when AI_IMPLEMENT_RUN_CONFIG is set", () => {
+    const content = readFileSync("session/entrypoint.sh", "utf-8");
+    expect(content).toMatch(/if \[ -n "\$\{AI_IMPLEMENT_RUN_CONFIG:-\}" \]; then/);
+    expect(content).toContain('require_env ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION');
+    expect(content).toContain("export ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION");
+  });
 });

--- a/src/__tests__/run-planning.test.ts
+++ b/src/__tests__/run-planning.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runPlanning } from "../run-planning.js";
+import { encodeRunConfig } from "../run-config.js";
 
 type RunnerResultPayload = {
   phase: "planning";
@@ -34,6 +35,7 @@ describe("runPlanning", () => {
     delete process.env.RUNNER_CALLBACK_URL;
     delete process.env.RUN_TOKEN;
     delete process.env.CLAUDE_MODEL;
+    delete process.env.AI_IMPLEMENT_RUN_CONFIG;
   });
 
   it("renders PLANNING.md, runs the executor, collects comments, posts a planning callback", async () => {
@@ -102,6 +104,31 @@ describe("runPlanning", () => {
     expect(result.exitCode).toBe(0);
     expect(capturedPrompt).toContain("ENG-42");
     expect(capturedPrompt).toContain("Add widget");
+  });
+
+  it("resolves issue fields and planning context from the AI_IMPLEMENT_RUN_CONFIG envelope, ignoring legacy env", async () => {
+    delete process.env.ISSUE_ID;
+    delete process.env.ISSUE_IDENTIFIER;
+    delete process.env.ISSUE_TITLE;
+    delete process.env.ISSUE_DESCRIPTION;
+    process.env.AI_IMPLEMENT_RUN_CONFIG = encodeRunConfig({
+      v: 1,
+      issue: { id: "e-1", identifier: "AII-9", title: "Envelope issue", description: "From envelope." },
+      planningContext: { parent: "AII-1", siblings: "AII-2", dependencies: "AII-3" },
+    });
+    let capturedPrompt = "";
+    const fakeExecutor = (prompt: string) => {
+      capturedPrompt = prompt;
+      return { status: 0, stdout: "", stderr: "" };
+    };
+    const result = await runPlanning({ workspaceDir: ws, executor: fakeExecutor });
+    expect(result.exitCode).toBe(0);
+    expect(capturedPrompt).toContain("AII-9");
+    expect(capturedPrompt).toContain("Envelope issue");
+    expect(capturedPrompt).toContain("From envelope.");
+    expect(capturedPrompt).toContain("**Parent:** AII-1");
+    expect(capturedPrompt).toContain("**Siblings:** AII-2");
+    expect(capturedPrompt).toContain("**Dependencies:** AII-3");
   });
 
   it("CLAUDE_MODEL env overrides PLANNING.md model", async () => {

--- a/src/run-planning.ts
+++ b/src/run-planning.ts
@@ -59,12 +59,14 @@ export interface RunPlanningOptions {
 export async function runPlanning(opts: RunPlanningOptions = {}): Promise<{ exitCode: number }> {
   const workspaceDir = opts.workspaceDir ?? process.env.WORKSPACE_DIR ?? "/workspace";
 
-  // Resolve planning context: prefer envelope cfg.planningContext, fall back to legacy env vars.
+  // Resolve issue fields + planning context: prefer the envelope, fall back to legacy env vars.
+  let envelopeIssue: { id: string; identifier: string; title: string; description: string } | undefined;
   let envelopePlanningContext: { parent?: string; siblings?: string; dependencies?: string } | undefined;
   const rawConfig = process.env.AI_IMPLEMENT_RUN_CONFIG;
   if (rawConfig) {
     try {
       const cfg = decodeRunConfig(rawConfig);
+      envelopeIssue = cfg.issue;
       if (cfg.planningContext) envelopePlanningContext = cfg.planningContext;
     } catch {
       // Malformed envelope: fall back to env vars without failing.
@@ -72,10 +74,10 @@ export async function runPlanning(opts: RunPlanningOptions = {}): Promise<{ exit
   }
 
   const subs: Record<string, string> = {
-    ISSUE_ID: requireEnv("ISSUE_ID"),
-    ISSUE_IDENTIFIER: requireEnv("ISSUE_IDENTIFIER"),
-    ISSUE_TITLE: requireEnv("ISSUE_TITLE"),
-    ISSUE_DESCRIPTION: requireEnv("ISSUE_DESCRIPTION"),
+    ISSUE_ID: envelopeIssue?.id ?? requireEnv("ISSUE_ID"),
+    ISSUE_IDENTIFIER: envelopeIssue?.identifier ?? requireEnv("ISSUE_IDENTIFIER"),
+    ISSUE_TITLE: envelopeIssue?.title ?? requireEnv("ISSUE_TITLE"),
+    ISSUE_DESCRIPTION: envelopeIssue?.description ?? requireEnv("ISSUE_DESCRIPTION"),
     PARENT: envelopePlanningContext?.parent ?? process.env.PARENT?.trim() ?? "None",
     SIBLINGS: envelopePlanningContext?.siblings ?? process.env.SIBLINGS?.trim() ?? "None",
     DEPENDENCIES: envelopePlanningContext?.dependencies ?? process.env.DEPENDENCIES?.trim() ?? "None",


### PR DESCRIPTION
## Summary
Two related bugs from the Workflow Envelope migration (#178), both causing GHA-mode runs to silently fail to report back to the orchestrator:

1. **`session/entrypoint.sh`** unconditionally required the legacy `ISSUE_ID`/`ISSUE_IDENTIFIER`/`ISSUE_TITLE`/`ISSUE_DESCRIPTION` env vars before invoking the TS runner. Since `claude-plan.yml`/`claude-implement.yml` now send only `AI_IMPLEMENT_RUN_CONFIG`, every GHA-mode run failed immediately with `FATAL: Required environment variable ISSUE_ID is not set` — before the TS runner ever got a chance to decode the envelope. `src/run-planning.ts` had a matching gap (it decoded `planningContext` from the envelope but not the issue fields themselves, unlike `run-autonomous.ts`).

2. **`src/runner-result.ts`'s `postRunnerResult()`** read `process.env.RUNNER_CALLBACK_URL` directly and had no envelope awareness. GHA workflows only ever set `RUN_TOKEN` as a plain env var — the callback URL travels inside `AI_IMPLEMENT_RUN_CONFIG` — so the function silently no-op'd on every GHA envelope-mode run. The job would report success to GitHub Actions, but the orchestrator never learned the run finished, leaving the issue stuck mid-planning/implementation forever (discovered via a real stuck-in-`AI-Planning` issue after deploying fix #1).

## Fix
- `entrypoint.sh` skips the legacy require/export when `AI_IMPLEMENT_RUN_CONFIG` is set.
- `run-planning.ts` decodes `cfg.issue` from the envelope, matching `run-autonomous.ts`.
- `postRunnerResult()` now accepts an explicit `callbackUrl` param; both `run-autonomous.ts` and `run-planning.ts` resolve it from the envelope first (falling back to the legacy env var) and pass it through explicitly.

## Test plan
- [x] Regression test in `run-planning.test.ts`: issue fields + planning context resolve from the envelope, ignoring legacy env
- [x] Regression test in `run-planning.test.ts`: runner-callback POST fires using the envelope's `runnerCallbackUrl` with `RUNNER_CALLBACK_URL` unset
- [x] Regression test in `run-autonomous.test.ts`: implementation callback POST fires using the envelope's `runnerCallbackUrl` with `RUNNER_CALLBACK_URL` unset
- [x] Assertion in `entrypoint-shellcheck.test.ts` documenting the conditional skip
- [x] Full suite passes (1861/1861), `tsc --noEmit` clean
- [x] Verified end-to-end against a live GHA planning run after deploying fix #1, which surfaced bug #2