### PR TITLE
fix(runner): plumb the envelope's runnerCallbackUrl into postRunnerResult

### DIFF
--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { runAutonomous, resolveLogLevel } from "../run-autonomous.js";
 import { PipelineRunner } from "../pipeline/runner.js";
 import { NoopStepReporter } from "../pipeline/reporter.js";
+import { encodeRunConfig } from "../run-config.js";
 import type { LLMExecutor, PipelineDefinition, StepModule } from "../pipeline/types.js";
 
 const REQUIRED_ENV: Record<string, string> = {
@@ -588,6 +589,44 @@ describe("runAutonomous", () => {
       prUrl: "https://github.com/acme/app/pull/1",
     });
     expect(body.comments).toEqual([{ body: "first" }, { body: "second" }]);
+  });
+
+  it("posts the implementation callback using the AI_IMPLEMENT_RUN_CONFIG envelope's runnerCallbackUrl (GHA mode, RUNNER_CALLBACK_URL unset)", async () => {
+    // GHA workflows never set RUNNER_CALLBACK_URL directly — only RUN_TOKEN — and carry the
+    // callback URL inside the envelope. Regression test for the bug where postRunnerResult
+    // silently no-op'd because it only ever read the legacy env var. The envelope takes
+    // precedence over the flat ISSUE_ID/etc env vars stubbed by stubRequiredEnv() above.
+    vi.stubEnv(
+      "AI_IMPLEMENT_RUN_CONFIG",
+      encodeRunConfig({
+        v: 1,
+        issue: { id: "issue-abc", identifier: "AII-1", title: "Test issue", description: "Issue description" },
+        runnerCallbackUrl: "https://orchestrator.example",
+      }),
+    );
+    vi.stubEnv("RUN_TOKEN", "run-token");
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+    const mod: StepModule = { run: vi.fn().mockResolvedValue({ prUrl: "https://github.com/acme/app/pull/1" }) };
+    const { pipeline, runner } = makeSingleStepPipeline("push", mod);
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://orchestrator.example/runner/result",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer run-token" }),
+      }),
+    );
   });
 
   it("uses token-backed progress reporting when a progress token is present", async () => {

--- a/src/__tests__/run-planning.test.ts
+++ b/src/__tests__/run-planning.test.ts
@@ -131,6 +131,30 @@ describe("runPlanning", () => {
     expect(capturedPrompt).toContain("**Dependencies:** AII-3");
   });
 
+  it("posts the runner-callback result using the envelope's runnerCallbackUrl when RUNNER_CALLBACK_URL is unset (GHA envelope mode)", async () => {
+    delete process.env.RUNNER_CALLBACK_URL;
+    process.env.RUN_TOKEN = "tok";
+    process.env.AI_IMPLEMENT_RUN_CONFIG = encodeRunConfig({
+      v: 1,
+      issue: { id: "e-1", identifier: "AII-9", title: "Envelope issue", description: "From envelope." },
+      runnerCallbackUrl: "https://orch.example/callback",
+    });
+    const posted: Array<{ url: string; body: unknown }> = [];
+    const fakeFetch = async (u: string, init: RequestInit = {}) => {
+      posted.push({ url: u, body: JSON.parse(String(init.body)) });
+      return { ok: true, text: async () => "" } as Response;
+    };
+    const result = await runPlanning({
+      workspaceDir: ws,
+      executor: () => ({ status: 0, stdout: "", stderr: "" }),
+      fetchImpl: fakeFetch,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(posted).toHaveLength(1);
+    expect(posted[0].url).toBe("https://orch.example/callback/runner/result");
+    expect(posted[0].body).toMatchObject({ phase: "planning", outcome: "success" });
+  });
+
   it("CLAUDE_MODEL env overrides PLANNING.md model", async () => {
     writeFileSync(join(ws, "PLANNING.md"), "---\nmodel: claude-x\n---\nbody");
     process.env.CLAUDE_MODEL = "claude-override";

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -401,6 +401,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       phase: runnerPhase,
       outcome: "success",
       prUrl: typeof pushOutputs.prUrl === "string" ? pushOutputs.prUrl : undefined,
+      callbackUrl,
       fetchImpl: opts.fetchImpl,
     });
     return { exitCode: 0 };
@@ -412,6 +413,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       outcome: "failure",
       failureReason: err instanceof Error ? err.message : String(err),
       failureCode: err instanceof SensitiveFilesError ? err.code : undefined,
+      callbackUrl,
       fetchImpl: opts.fetchImpl,
     });
     return { exitCode: 1 };

--- a/src/run-planning.ts
+++ b/src/run-planning.ts
@@ -59,19 +59,25 @@ export interface RunPlanningOptions {
 export async function runPlanning(opts: RunPlanningOptions = {}): Promise<{ exitCode: number }> {
   const workspaceDir = opts.workspaceDir ?? process.env.WORKSPACE_DIR ?? "/workspace";
 
-  // Resolve issue fields + planning context: prefer the envelope, fall back to legacy env vars.
+  // Resolve issue fields + planning context + callback URL: prefer the envelope,
+  // fall back to legacy env vars. The callback URL matters most here — GHA never
+  // sets RUNNER_CALLBACK_URL as a plain env var, so without this the orchestrator
+  // never learns the run finished and the issue gets stuck mid-planning.
   let envelopeIssue: { id: string; identifier: string; title: string; description: string } | undefined;
   let envelopePlanningContext: { parent?: string; siblings?: string; dependencies?: string } | undefined;
+  let envelopeCallbackUrl: string | undefined;
   const rawConfig = process.env.AI_IMPLEMENT_RUN_CONFIG;
   if (rawConfig) {
     try {
       const cfg = decodeRunConfig(rawConfig);
       envelopeIssue = cfg.issue;
       if (cfg.planningContext) envelopePlanningContext = cfg.planningContext;
+      envelopeCallbackUrl = cfg.runnerCallbackUrl;
     } catch {
       // Malformed envelope: fall back to env vars without failing.
     }
   }
+  const callbackUrl = envelopeCallbackUrl ?? process.env.RUNNER_CALLBACK_URL?.trim() ?? null;
 
   const subs: Record<string, string> = {
     ISSUE_ID: envelopeIssue?.id ?? requireEnv("ISSUE_ID"),
@@ -111,6 +117,7 @@ export async function runPlanning(opts: RunPlanningOptions = {}): Promise<{ exit
       workspaceDir,
       outcome: "failure",
       failureReason: (result.stderr || "planning run failed").slice(-4000),
+      callbackUrl,
       fetchImpl: opts.fetchImpl,
     });
     return { exitCode: 1 };
@@ -119,6 +126,7 @@ export async function runPlanning(opts: RunPlanningOptions = {}): Promise<{ exit
     phase: "planning",
     workspaceDir,
     outcome: "success",
+    callbackUrl,
     fetchImpl: opts.fetchImpl,
   });
   return { exitCode: 0 };

--- a/src/runner-result.ts
+++ b/src/runner-result.ts
@@ -46,9 +46,15 @@ export async function postRunnerResult(params: {
   failureReason?: string;
   /** Machine-readable code set when a known guardrail trips (e.g. "SENSITIVE_FILES_BLOCKED"). */
   failureCode?: string;
+  /**
+   * Resolved callback URL, e.g. from resolveRunnerInputs()/the envelope's runnerCallbackUrl.
+   * Falls back to the legacy RUNNER_CALLBACK_URL env var (never set in GHA envelope mode,
+   * where the URL travels inside AI_IMPLEMENT_RUN_CONFIG instead).
+   */
+  callbackUrl?: string | null;
   fetchImpl?: typeof fetch;
 }): Promise<void> {
-  const callbackUrl = process.env.RUNNER_CALLBACK_URL;
+  const callbackUrl = params.callbackUrl ?? process.env.RUNNER_CALLBACK_URL;
   const runToken = process.env.RUN_TOKEN;
   if (!callbackUrl || !runToken) return;
   if (params.phase === "implementation" && params.outcome === "success" && !params.prUrl) {


### PR DESCRIPTION
## Summary
Follow-up to #182. That PR fixed the runner reading issue fields from the `AI_IMPLEMENT_RUN_CONFIG` envelope, but a second envelope-awareness gap remained in the result-callback path.

`src/runner-result.ts`'s `postRunnerResult()` reads `process.env.RUNNER_CALLBACK_URL` directly and has no envelope awareness. GHA workflows only ever set `RUN_TOKEN` as a plain env var — the callback URL travels **inside** `AI_IMPLEMENT_RUN_CONFIG` (`run_config.runnerCallbackUrl`) — so `postRunnerResult()` silently no-op's on every GHA envelope-mode run (planning and implementation alike). The GHA job reports success, but the orchestrator never receives the result callback: the issue's `AI-Planning`/`AI-Working` state never advances and the ticket gets stuck forever with no planning comments posted.

Observed live: a Jira issue dispatched for planning ran a clean ~2-minute GHA job with zero errors, yet never advanced past `AI-Planning` and got no planning comments — the classic signature of a silently-dropped callback.

## Fix
- `postRunnerResult()` now accepts an explicit `callbackUrl` param, falling back to the legacy `RUNNER_CALLBACK_URL` env var when absent (Fly/local modes still set it directly).
- `run-autonomous.ts` already decoded `runnerCallbackUrl` from the envelope via `resolveRunnerInputs()` — it just never passed it to `postRunnerResult`. Now it does (both success and failure call sites).
- `run-planning.ts` now decodes `runnerCallbackUrl` from the envelope (falling back to the env var) and passes it through.

## Test plan
- [x] Regression test in `run-planning.test.ts`: runner-callback POST fires using the envelope's `runnerCallbackUrl` with `RUNNER_CALLBACK_URL` unset (GHA envelope mode)
- [x] Regression test in `run-autonomous.test.ts`: implementation callback POST fires using the envelope's `runnerCallbackUrl` with `RUNNER_CALLBACK_URL` unset
- [x] Full suite passes (1887/1887), `tsc --noEmit` clean