### PR TITLE
fix: probe workflow contract against mapping.defaultBranch, not repo's implicit default

### DIFF
--- a/src/__tests__/workflow-probe.test.ts
+++ b/src/__tests__/workflow-probe.test.ts
@@ -42,6 +42,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     expect(mode).toBe("envelope");
@@ -54,6 +55,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     expect(mode).toBe("legacy");
@@ -66,6 +68,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     expect(mode).toBe("legacy");
@@ -78,6 +81,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     expect(mode).toBe("legacy");
@@ -90,6 +94,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     await resolveWorkflowContract({
@@ -97,6 +102,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     expect(fetchImpl).toHaveBeenCalledOnce();
@@ -112,6 +118,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
       nowMs,
     });
@@ -123,6 +130,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
       nowMs,
     });
@@ -139,6 +147,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl: fetchImplA,
     });
     const modeB = await resolveWorkflowContract({
@@ -146,6 +155,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-plan.yml",
       token: "t",
+      ref: "main",
       fetchImpl: fetchImplB,
     });
 
@@ -162,6 +172,7 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     expect(mode).toBe("legacy");
@@ -176,8 +187,53 @@ describe("resolveWorkflowContract", () => {
       repo: "r",
       workflowFile: "claude-implement.yml",
       token: "t",
+      ref: "main",
       fetchImpl,
     });
     expect(mode).toBe("legacy");
+  });
+
+  it("probes the given ref, not the repo's implicit default branch", async () => {
+    const fetchImpl = mockContents(ENVELOPE_YML);
+    await resolveWorkflowContract({
+      owner: "o",
+      repo: "r",
+      workflowFile: "claude-plan.yml",
+      token: "t",
+      ref: "dev",
+      fetchImpl,
+    });
+
+    const [calledUrl] = fetchImpl.mock.calls[0] as [string];
+    expect(calledUrl).toBe(
+      "https://api.github.com/repos/o/r/contents/.github/workflows/claude-plan.yml?ref=dev",
+    );
+  });
+
+  it("keeps separate cache entries per ref, so a stale-ref dispatch can't reuse a live-ref probe", async () => {
+    const fetchImplMain = mockContents(LEGACY_YML);
+    const fetchImplDev = mockContents(ENVELOPE_YML);
+
+    const modeMain = await resolveWorkflowContract({
+      owner: "o",
+      repo: "r",
+      workflowFile: "claude-plan.yml",
+      token: "t",
+      ref: "main",
+      fetchImpl: fetchImplMain,
+    });
+    const modeDev = await resolveWorkflowContract({
+      owner: "o",
+      repo: "r",
+      workflowFile: "claude-plan.yml",
+      token: "t",
+      ref: "dev",
+      fetchImpl: fetchImplDev,
+    });
+
+    expect(modeMain).toBe("legacy");
+    expect(modeDev).toBe("envelope");
+    expect(fetchImplMain).toHaveBeenCalledOnce();
+    expect(fetchImplDev).toHaveBeenCalledOnce();
   });
 });

--- a/src/comment-gapfill-drain.ts
+++ b/src/comment-gapfill-drain.ts
@@ -18,7 +18,7 @@ export interface DrainCommentGapfillsInput {
   runnerTokenSecret: string | null;
   getInstallationToken(owner: string): Promise<string>;
   resolveRunnerImage(mapping: RepoMapping, ghToken: string): Promise<string | undefined>;
-  checkContract(opts: { owner: string; repo: string; workflowFile: string; token: string }): Promise<"legacy" | "envelope">;
+  checkContract(opts: { owner: string; repo: string; workflowFile: string; token: string; ref: string }): Promise<"legacy" | "envelope">;
   dispatch(token: string, mapping: RepoMapping, inputs: Record<string, string | undefined>): Promise<{ success: boolean; status: number; error?: string }>;
   postComment(token: string, owner: string, repo: string, prNumber: number, body: string): Promise<void>;
   onDispatchFailure(failure: { status: number; error?: string }, notifyType: string, notifyWebhookUrl: string | null, ctx: DispatchFailureContext): Promise<void>;
@@ -244,6 +244,7 @@ export async function drainCommentGapfillQueue(opts: DrainCommentGapfillsInput):
           repo: mapping.repo,
           workflowFile: mapping.workflowFile,
           token: ghToken,
+          ref: mapping.defaultBranch,
         });
 
         const gapFillInputs = contract === "envelope"

--- a/src/index.ts
+++ b/src/index.ts
@@ -552,6 +552,7 @@ async function dispatchGitHubActions(
     repo: mapping.repo,
     workflowFile: mapping.workflowFile,
     token: ghToken,
+    ref: mapping.defaultBranch,
   });
 
   const dispatchInputs = contract === "envelope"
@@ -892,6 +893,7 @@ async function dispatchPlanning(
     repo: mapping.repo,
     workflowFile: mapping.planningWorkflowFile,
     token: ghToken,
+    ref: mapping.defaultBranch,
   });
 
   const planningDispatchInputs = planningContract === "envelope"
@@ -2169,6 +2171,7 @@ async function processReviewFixQueue(config: AppConfig): Promise<void> {
         repo: mapping.repo,
         workflowFile: mapping.workflowFile,
         token: ghToken,
+        ref: mapping.defaultBranch,
       });
 
       const fixIssue = {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -483,6 +483,7 @@ async function handleIssueCommentWebhook(
       repo,
       workflowFile: mapping.workflowFile,
       token,
+      ref: mapping.defaultBranch,
     }).catch(() => "legacy" as const);
 
     if (contract !== "envelope") {

--- a/src/workflow-probe.ts
+++ b/src/workflow-probe.ts
@@ -16,6 +16,8 @@ export interface ResolveWorkflowContractInput {
   repo: string;
   workflowFile: string;
   token: string;
+  /** Branch the actual workflow_dispatch will target (mapping.defaultBranch). Probes this ref so the contract check agrees with the dispatch. */
+  ref: string;
   /** Injected for tests. Defaults to the global `fetch`. */
   fetchImpl?: typeof fetch;
   /** Injected for tests. Defaults to `Date.now`. */
@@ -25,17 +27,17 @@ export interface ResolveWorkflowContractInput {
 export async function resolveWorkflowContract(
   input: ResolveWorkflowContractInput,
 ): Promise<WorkflowContract> {
-  const { owner, repo, workflowFile, token } = input;
+  const { owner, repo, workflowFile, token, ref } = input;
   const fetchImpl = input.fetchImpl ?? fetch;
   const now = (input.nowMs ?? Date.now)();
 
-  const cacheKey = `${owner}/${repo}/${workflowFile}`;
+  const cacheKey = `${owner}/${repo}/${workflowFile}/${ref}`;
   const cached = cache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
     return cached.contract;
   }
 
-  const contract = await probeContract(owner, repo, workflowFile, token, fetchImpl);
+  const contract = await probeContract(owner, repo, workflowFile, ref, token, fetchImpl);
   cache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, contract });
   return contract;
 }
@@ -44,10 +46,11 @@ async function probeContract(
   owner: string,
   repo: string,
   workflowFile: string,
+  ref: string,
   token: string,
   fetchImpl: typeof fetch,
 ): Promise<WorkflowContract> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/.github/workflows/${workflowFile}`;
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/.github/workflows/${workflowFile}?ref=${encodeURIComponent(ref)}`;
   let res: Response;
   try {
     res = await fetchImpl(url, {


### PR DESCRIPTION
## Summary
- `resolveWorkflowContract` fetched `.github/workflows/<file>` via the GitHub Contents API with no `ref`, so it always read whatever GitHub considers the repo's actual default branch. The real `workflow_dispatch` call fires with `ref: mapping.defaultBranch` — a value configured independently in the AI-Implement admin UI. When those two differ, the probe's legacy/envelope classification can disagree with the branch actually being dispatched to, producing a 422 `"Unexpected inputs provided"` error.
- Surfaced in production on a client fork whose AI-Implement mapping's Default Branch was `dev` (re-synced to the envelope `claude-plan.yml`) while GitHub's repo-level default branch was still `main` (still on the legacy per-field `claude-plan.yml`). The probe read `main`, classified "legacy," and the orchestrator sent legacy-style inputs to a dispatch targeting `dev`'s envelope-only workflow. This can happen to any target repo whose GitHub default branch differs from the branch configured in its AI-Implement mapping.
- Fix: `resolveWorkflowContract` now requires a `ref` and probes that exact branch; the per-workflow cache key is scoped by ref too, so a probe result for one branch can never be reused for a dispatch targeting a different branch. All five call sites (implementation, planning, review-fix, `/ai-implement` webhook, comment gap-fill drain) now pass `mapping.defaultBranch`.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/__tests__/workflow-probe.test.ts` — 11/11 pass (asserts the probe URL includes the given `ref`, and that cache entries are isolated per-ref)

## Note
This is the clean, single-commit extraction of the intended fix from #185. That branch also carried a fork's private AWS Terraform stack and CI rewiring (30+ unrelated files) that should not land upstream, so #185 is being closed in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
