### PR TITLE
fix: skip push for all gap-fill runs; approved gap-fill posts gap-analysis success

### DIFF
--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -500,7 +500,10 @@ describe("loadPipelineDefinition", () => {
       expect(push.skip?.(ctx)).toBe(true);
     });
 
-    it("does not skip push when prNumber is set (gap-fill) and feedback-loop approved", () => {
+    it("skips push when prNumber is set (gap-fill) even when feedback-loop approved", () => {
+      // Gap-fill runs never own git: Claude commits and pushes to the existing PR
+      // branch itself, so the tree is clean by the time push would run — running it
+      // would throw "Nothing to commit" and turn an approved gap-fill into a failure.
       const pipeline = loadPipelineDefinition("pipelines/autonomous.yml", {
         existsSyncImpl: () => false,
         readFileSyncImpl: (_path, _enc) => BUILTIN_PIPELINE_YAML,
@@ -509,7 +512,7 @@ describe("loadPipelineDefinition", () => {
       const push = pipeline.steps.find((s) => s.id === "push")!;
       const ctx = makeContext({ prNumber: "42" });
       ctx.setOutputs("feedback-loop", { approved: true });
-      expect(push.skip?.(ctx)).toBe(false);
+      expect(push.skip?.(ctx)).toBe(true);
     });
 
     it("does not skip push on an initial run (no prNumber) even when feedback-loop was not approved", () => {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -879,9 +879,9 @@ describe("runAutonomous", () => {
 
   it("gap-fill run (prNumber set, unapproved) skips push — outcome derivation still reports a coded failure with no prUrl", async () => {
     // Mirrors pipeline-loader.ts's push skip condition for gap-fill runs: Claude owns git on
-    // the existing PR branch there, so an unapproved gap-fill must not run push against an
+    // the existing PR branch there, so a gap-fill run must not run push against an
     // already-clean tree (it would throw "Nothing to commit"). This verifies the skip and the
-    // existing outcome-derivation fallback compose correctly — no change to run-autonomous.ts.
+    // outcome-derivation fallback compose correctly for the unapproved case.
     vi.stubEnv("PR_NUMBER", "42");
     vi.stubEnv("RUNNER_CALLBACK_URL", "https://orchestrator.example");
     vi.stubEnv("RUN_TOKEN", "run-token");
@@ -896,7 +896,7 @@ describe("runAutonomous", () => {
           id: "push",
           type: "custom",
           moduleId: "push",
-          skip: (ctx) => Boolean(ctx.data.prNumber) && ctx.getOutputs("feedback-loop").approved !== true,
+          skip: (ctx) => Boolean(ctx.data.prNumber),
         },
       ],
     };
@@ -930,6 +930,57 @@ describe("runAutonomous", () => {
     };
     expect(body.outcome).toBe("failure");
     expect(body.failureCode).toBe("REVIEW_UNAPPROVED");
+    expect(body.prUrl).toBeUndefined();
+  });
+
+  it("gap-fill run (prNumber set, approved) with push skipped posts a gap-analysis success callback and exits 0", async () => {
+    // Approved gap-fill: Claude already committed and pushed to the existing PR branch
+    // itself, so push is skipped and there are no push outputs (no prUrl). That is a
+    // successful gap-analysis run — it must NOT fall down the REVIEW_UNAPPROVED path.
+    vi.stubEnv("PR_NUMBER", "42");
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orchestrator.example");
+    vi.stubEnv("RUN_TOKEN", "run-token");
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+    const pushRun = vi.fn().mockResolvedValue({ prUrl: "https://github.com/o/r/pull/1", prNumber: 1, branchPushed: true });
+    const pipeline: PipelineDefinition = {
+      id: "test",
+      steps: [
+        { id: "feedback-loop", type: "custom", moduleId: "feedback-loop" },
+        {
+          id: "push",
+          type: "custom",
+          moduleId: "push",
+          skip: (ctx) => Boolean(ctx.data.prNumber),
+        },
+      ],
+    };
+    const runner = new PipelineRunner()
+      .register("feedback-loop", {
+        run: vi.fn().mockResolvedValue({ approved: true, iterations: 2, terminationReason: "approved", passes: [] }),
+      })
+      .register("push", { run: pushRun });
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(pushRun).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
+      phase: string;
+      outcome: string;
+      failureCode?: string;
+      prUrl?: string;
+    };
+    expect(body.phase).toBe("gap-analysis");
+    expect(body.outcome).toBe("success");
+    expect(body.failureCode).toBeUndefined();
     expect(body.prUrl).toBeUndefined();
   });
 

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -153,15 +153,14 @@ function applyWiring(step: YamlStep): StepDefinition {
       // as a draft PR (with the reviewer feedback in the body) instead of being silently
       // discarded. Gap-fill runs are different: Claude commits and pushes to the *existing*
       // PR branch itself (the pipeline never owns git there — see run-autonomous.ts's
-      // gap-fill prompt). If the feedback loop doesn't approve a gap-fill, the tree Claude
-      // left behind is already clean/unchanged, so running push here would just throw
-      // "Nothing to commit" and turn a handled outcome into a generic red failure. Skip push
-      // in that one case; run-autonomous.ts's outcome derivation already produces a proper
-      // failure callback (code, no prUrl, autopsy) when push never ran.
+      // gap-fill prompt), so the tree is clean by the time push would run and it would just
+      // throw "Nothing to commit" — turning an approved gap-fill into a red failure. Skip
+      // push for every gap-fill run; run-autonomous.ts's outcome derivation handles both
+      // gap-fill outcomes without push outputs (approved → gap-analysis success, unapproved
+      // → coded failure callback with no prUrl plus autopsy).
       return {
         ...step,
-        skip: (ctx: PipelineContext) =>
-          Boolean(ctx.data.prNumber) && ctx.getOutputs("feedback-loop").approved !== true,
+        skip: (ctx: PipelineContext) => Boolean(ctx.data.prNumber),
         inputs: (ctx: PipelineContext) => {
           const fb = ctx.getOutputs("feedback-loop");
           const approved = fb.approved === true;

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -411,8 +411,14 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     const prUrl = typeof pushOutputs.prUrl === "string" ? pushOutputs.prUrl : undefined;
     const approved = fbOutputs.approved === true;
 
-    if (approved && prUrl) {
-      disposition = `PR ${prUrl} (approved after ${typeof fbOutputs.iterations === "number" ? fbOutputs.iterations : "?"} iteration(s))`;
+    // A gap-fill run (prNumber set) never produces push outputs: the pipeline skips
+    // push because Claude commits and pushes to the existing PR branch itself. An
+    // approved gap-fill without a prUrl is therefore a success, not REVIEW_UNAPPROVED.
+    if (approved && (prUrl || prNumber)) {
+      const iterations = typeof fbOutputs.iterations === "number" ? fbOutputs.iterations : "?";
+      disposition = prUrl
+        ? `PR ${prUrl} (approved after ${iterations} iteration(s))`
+        : `gap-fill on PR #${prNumber} (approved after ${iterations} iteration(s))`;
       await postRunnerResult({
         workspaceDir,
         phase: runnerPhase,


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug confirmed twice during review of #187: an **approved** gap-fill run (`run_config.prNumber` set) still executed the pipeline's push step. But in gap-fill mode the pipeline never owns git — the gap-fill prompt in `run-autonomous.ts` has Claude commit and push to the existing PR branch itself — so push always saw a clean working tree and threw `Nothing to commit: Claude left no file changes in the working tree`, turning a successful gap-fill into an exit-1 generic failure callback.

## Changes

- **`src/pipeline/pipeline-loader.ts`** — the push step's skip is now `Boolean(ctx.data.prNumber)`: push is skipped for *every* gap-fill run, approved or not (previously only unapproved gap-fill was skipped).
- **`src/run-autonomous.ts`** — outcome derivation now treats an approved gap-fill without push outputs as success: the success condition is `approved && (prUrl || prNumber)`, posting a `gap-analysis`/`success` callback with no `prUrl` and exiting 0 instead of falling into the `REVIEW_UNAPPROVED` coded-failure path. Safe on the orchestrator side: `runner-callback.ts` only requires `prUrl` for implementation-phase successes, and its gap-analysis success handler resolves the PR from the job row.
- Unapproved gap-fill behavior is unchanged (coded failure + autopsy, no prUrl).

## Tests (TDD — both written and confirmed failing first)

- pipeline-loader: flipped the test that enshrined the buggy behavior — approved gap-fill now expects push skipped; unapproved and initial-run cases unchanged.
- run-autonomous: new test — approved gap-fill with push skipped → push never runs, `gap-analysis`/`success` callback, exit 0.

## Verification

- `npm test`: 1961 tests / 119 files pass
- `npm run typecheck`: clean

Related: gap-fill dispatch tracking in AII-242 / AII-243 ([Linear team AII](https://linear.app/eudoxus/team/AII/overview)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)