### PR TITLE
Fix run-telemetry token accounting and self-review 422s

### DIFF
--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -73,6 +73,8 @@ describe("extractTelemetry", () => {
       costUsd: 0.83,
       tokensIn: 182000,
       tokensOut: 4100,
+      cacheReadTokens: null,
+      cacheCreationTokens: null,
       toolTrace: ["Bash pnpm check"],
     });
   });
@@ -89,6 +91,8 @@ describe("extractTelemetry", () => {
       costUsd: null,
       tokensIn: null,
       tokensOut: null,
+      cacheReadTokens: null,
+      cacheCreationTokens: null,
       toolTrace: [],
     });
   });
@@ -96,6 +100,29 @@ describe("extractTelemetry", () => {
     const t = extractTelemetry([{ type: "result", subtype: "success", num_turns: 3, usage: { input_tokens: 10, output_tokens: 2 } }]);
     expect(t.costUsd).toBeNull();
     expect(t.outcome).toBe("success");
+  });
+  it("counts cache-creation and cache-read tokens as input", () => {
+    const t = extractTelemetry([{
+      type: "result",
+      subtype: "success",
+      num_turns: 104,
+      usage: {
+        input_tokens: 90,
+        cache_creation_input_tokens: 400000,
+        cache_read_input_tokens: 12000000,
+        output_tokens: 89900,
+      },
+    }]);
+    expect(t.tokensIn).toBe(90 + 400000 + 12000000);
+    expect(t.cacheReadTokens).toBe(12000000);
+    expect(t.cacheCreationTokens).toBe(400000);
+    expect(t.tokensOut).toBe(89900);
+  });
+  it("leaves cache fields null when usage has no cache counters", () => {
+    const t = extractTelemetry([{ type: "result", subtype: "success", usage: { input_tokens: 10, output_tokens: 2 } }]);
+    expect(t.tokensIn).toBe(10);
+    expect(t.cacheReadTokens).toBeNull();
+    expect(t.cacheCreationTokens).toBeNull();
   });
 });
 
@@ -162,6 +189,20 @@ describe("summaryLine", () => {
   it("shows max_turns outcome at summary level", () => {
     expect(summaryLine({ outcome: "max_turns", numTurns: 50, durationMs: null, costUsd: null, tokensIn: null, tokensOut: null }))
       .toBe("[claude] result=max_turns turns=50");
+  });
+  it("formats million-scale input and shows the cached share", () => {
+    expect(
+      summaryLine({
+        outcome: "success",
+        numTurns: 104,
+        durationMs: 1544000,
+        costUsd: 5.08,
+        tokensIn: 12400090,
+        tokensOut: 89900,
+        cacheReadTokens: 12000000,
+        cacheCreationTokens: 400000,
+      }),
+    ).toBe("[claude] result=success turns=104 duration=25m44s cost=$5.08 tokens=12.4M/89.9k (in/out, 97% cache reads)");
   });
 });
 

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -40,7 +40,7 @@ describe("postPushReviewStep", () => {
     expect(ghComments.some((c) => c.includes("**Merge readiness:** Ready to merge."))).toBe(true);
   });
 
-  it("submits a native APPROVE review when merge-ready", async () => {
+  it("submits a native COMMENT review when merge-ready", async () => {
     const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const reviewCalls: string[][] = [];
     const ghSpawn = vi.fn((args: string[]) => {
@@ -59,7 +59,7 @@ describe("postPushReviewStep", () => {
       { report: vi.fn(async () => undefined) },
     );
 
-    expect(reviewCalls[0]).toContain("event=APPROVE");
+    expect(reviewCalls[0]).toContain("event=COMMENT");
     const bodyArg = reviewCalls[0].find((arg) => arg.startsWith("body="));
     expect(bodyArg).toContain("<!-- ai-implement native-review -->");
     expect(bodyArg).toContain("AI-Implement post-push review approved this PR.");
@@ -118,14 +118,14 @@ describe("postPushReviewStep", () => {
 
     expect(warnings).toContain("stderr=gh: Unprocessable Entity (HTTP 422)");
     expect(warnings).toContain("stdout={\"message\":\"Can not approve your own pull request\"}");
-    expect(warnings).toContain("event=APPROVE");
+    expect(warnings).toContain("event=COMMENT");
     expect(warnings).toContain("bodyChars=");
     expect(warnings).toContain("author=ai-implement[bot]");
     expect(warnings).toContain("head=ai-implement/aii-200-x@abc1234");
     expect(warnings).toContain("base=main@def9876");
   });
 
-  it("submits a native REQUEST_CHANGES review when blockers remain", async () => {
+  it("submits a native COMMENT review when blockers remain", async () => {
     const reviewerJson = JSON.stringify({
       approved: false,
       blocking_issues: [{ title: "Fix validation", problem: "Null owners pass.", required_fix: "Reject null owners." }],
@@ -150,7 +150,7 @@ describe("postPushReviewStep", () => {
       { report: vi.fn(async () => undefined) },
     );
 
-    expect(reviewCalls[0]).toContain("event=REQUEST_CHANGES");
+    expect(reviewCalls[0]).toContain("event=COMMENT");
     expect(reviewCalls[0].find((arg) => arg.startsWith("body="))).toContain("Fix validation");
   });
 
@@ -1538,7 +1538,7 @@ describe("postPushReviewStep", () => {
     );
 
     expect(out.approved).toBe(false);
-    expect(reviewCalls.some((call) => call.includes("event=APPROVE"))).toBe(false);
+    expect(reviewCalls.some((call) => call.some((arg) => arg.includes("approved this PR")))).toBe(false);
     expect(ghComments.some((c) => c.includes("did not complete") && c.includes("Manual review required"))).toBe(true);
   });
 

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -60,17 +60,32 @@ export function extractTelemetry(events: StreamEvent[]): RunTelemetry {
       costUsd: null,
       tokensIn: null,
       tokensOut: null,
+      cacheReadTokens: null,
+      cacheCreationTokens: null,
       toolTrace: extractToolTrace(events),
     };
   }
-  const usage = (result.usage ?? {}) as { input_tokens?: number; output_tokens?: number };
+  const usage = (result.usage ?? {}) as {
+    input_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+    output_tokens?: number;
+  };
+  // usage.input_tokens counts only the uncached slice; on long agentic runs
+  // nearly all input arrives via the cache counters, so report the full sum.
+  const uncachedIn = num(usage.input_tokens);
+  const cacheCreation = num(usage.cache_creation_input_tokens);
+  const cacheRead = num(usage.cache_read_input_tokens);
+  const inParts = [uncachedIn, cacheCreation, cacheRead].filter((v): v is number => v != null);
   return {
     outcome: mapOutcome(result.subtype),
     numTurns: num(result.num_turns),
     durationMs: num(result.duration_ms),
     costUsd: num(result.total_cost_usd),
-    tokensIn: num(usage.input_tokens),
+    tokensIn: inParts.length > 0 ? inParts.reduce((a, b) => a + b, 0) : null,
     tokensOut: num(usage.output_tokens),
+    cacheReadTokens: cacheRead,
+    cacheCreationTokens: cacheCreation,
     toolTrace: extractToolTrace(events),
   };
 }
@@ -176,6 +191,7 @@ function humanizeMs(ms: number): string {
 
 function kfmt(n: number | null): string {
   if (n == null) return "?";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
 }
 
@@ -186,7 +202,11 @@ export function summaryLine(t: RunTelemetry): string {
   // Omit cost when absent or zero (Bedrock typically reports no cost).
   if (t.costUsd != null && t.costUsd > 0) parts.push(`cost=$${t.costUsd.toFixed(2)}`);
   if (t.tokensIn != null || t.tokensOut != null) {
-    parts.push(`tokens=${kfmt(t.tokensIn)}/${kfmt(t.tokensOut)} (in/out)`);
+    const cacheRead = t.cacheReadTokens ?? null;
+    const cacheShare = t.tokensIn != null && t.tokensIn > 0 && cacheRead != null && cacheRead > 0
+      ? `, ${Math.round((cacheRead / t.tokensIn) * 100)}% cache reads`
+      : "";
+    parts.push(`tokens=${kfmt(t.tokensIn)}/${kfmt(t.tokensOut)} (in/out${cacheShare})`);
   }
   return parts.join(" ");
 }

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -581,9 +581,13 @@ function postPrComment(ghSpawn: (args: string[]) => SpawnResult, prNumber: strin
 function submitPrReview(
   ghSpawn: (args: string[]) => SpawnResult,
   prNumber: string,
-  event: "APPROVE" | "REQUEST_CHANGES",
   body: string,
 ): void {
+  // The reviewing identity is the same GitHub App installation that authored
+  // the PR, and GitHub rejects APPROVE/REQUEST_CHANGES on your own PR (422).
+  // COMMENT is the only review event allowed on a self-authored PR; the
+  // verdict itself is carried by the review body and the sticky PR comment.
+  const event = "COMMENT";
   const endpoint = `repos/:owner/:repo/pulls/${prNumber}/reviews`;
   const result = ghSpawn([
     "api",
@@ -851,7 +855,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
 
       if (approved) {
         const marker = `<!-- ai-implement post-push iter=${iteration} -->`;
-        submitPrReview(ghSpawn, prNumber, "APPROVE", `${AI_IMPLEMENT_NATIVE_REVIEW_MARKER}\nAI-Implement post-push review approved this PR.`);
+        submitPrReview(ghSpawn, prNumber, `${AI_IMPLEMENT_NATIVE_REVIEW_MARKER}\nAI-Implement post-push review approved this PR.`);
         postPrComment(
           ghSpawn,
           prNumber,
@@ -866,7 +870,6 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         submitPrReview(
           ghSpawn,
           prNumber,
-          "REQUEST_CHANGES",
           `${AI_IMPLEMENT_NATIVE_REVIEW_MARKER}\nAI-Implement post-push review found unresolved blockers.\n\n${formatIssueList(issues)}${externalReviewFindingsCommentBlock(externalFindings)}`,
         );
         postPrComment(
@@ -947,7 +950,6 @@ ${externalReviewFindingsBlock(externalFindings)}
         submitPrReview(
           ghSpawn,
           prNumber,
-          "REQUEST_CHANGES",
           `${AI_IMPLEMENT_NATIVE_REVIEW_MARKER}\nAI-Implement fix pass made no changes; blockers remain.${blockingIssuesBlock(issues, { heading: "Unresolved blocking issues:" })}${externalReviewFindingsCommentBlock(externalFindings)}`,
         );
         postPrComment(

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -102,8 +102,11 @@ export interface RunTelemetry {
   numTurns: number | null;
   durationMs: number | null;
   costUsd: number | null;
+  /** Total input tokens, including prompt-cache creation and cache reads. */
   tokensIn: number | null;
   tokensOut: number | null;
+  cacheReadTokens?: number | null;
+  cacheCreationTokens?: number | null;
   /** Compact per-call tool trace ("ToolName input-summary"), capped; last entry may be a truncation marker. */
   toolTrace?: string[];
 }


### PR DESCRIPTION
## Summary

Two fixes prompted by oddities in a client AI-Implement run log (meq-messaging PR #112):

### 1. Token metric undercounted input by ~5 orders of magnitude

The `[claude]` summary line read only `usage.input_tokens` from the CLI result event, which excludes prompt-cache traffic. On long agentic runs nearly all input arrives via `cache_read_input_tokens` / `cache_creation_input_tokens`, so a 104-turn, $5.08 run reported `tokens=90/89.9k (in/out)`.

- `tokensIn` is now uncached + cache-creation + cache-read input
- `RunTelemetry` keeps the cache breakdown (`cacheReadTokens`, `cacheCreationTokens`)
- The summary line formats million-scale counts and shows the cache share, e.g. `tokens=12.4M/89.9k (in/out, 97% cache reads)`

### 2. Native PR review always 422'd

`post-push-review` submitted its native GitHub review (`APPROVE` / `REQUEST_CHANGES`) with the same App installation token that authored the PR, which GitHub categorically rejects (`Can not approve your own pull request`), so every run logged a warning and no review ever landed. Reviews are now submitted as `COMMENT` — the only event GitHub allows from the PR author. The verdict is unchanged: it's carried by the review body (with the `ai-implement native-review` marker the webhook already ignores) and the sticky PR comment.

## Testing

- `npm test` — 119 files, 1974 tests pass
- `npm run typecheck` — clean
- New tests: cache-token summing, null cache counters, M-scale summary formatting, COMMENT-event submission on both approve and blocker paths; strengthened the fail-closed test whose `event=APPROVE` assertion had become vacuous

🤖 Generated with [Claude Code](https://claude.com/claude-code)