### PR TITLE
feat: SSO (Google + Microsoft OIDC) for the admin UI (AII-147)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,10 +101,36 @@ NOTIFY_TYPE=slack            # slack | teams
 NOTIFY_WEBHOOK_URL=          # leave blank to disable
 
 # =============================================================================
-# Admin UI (optional — UI disabled if unset)
+# Admin UI auth (optional — UI disabled if neither SSO nor the access code is set)
 # =============================================================================
 
+# Deprecated shared access code (fallback). Prefer SSO below. The UI is enabled
+# if this OR any OAuth provider is set; using it logs a deprecation warning.
 ADMIN_ACCESS_CODE=your-secret-access-code
+
+# --- SSO via OIDC (Google and/or Microsoft) ----------------------------------
+
+# Base URL for OAuth redirect URIs — where providers redirect back after login
+# (e.g. https://your-orchestrator.fly.dev; http://localhost:8080 locally).
+OAUTH_REDIRECT_BASE_URL=
+
+# Google — create a Web OAuth client at console.cloud.google.com → Credentials;
+# redirect URI ${OAUTH_REDIRECT_BASE_URL}/api/auth/google/callback.
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+
+# Microsoft (Entra) — register a Web app; redirect URI
+# ${OAUTH_REDIRECT_BASE_URL}/api/auth/microsoft/callback. TENANT must be a
+# specific single-tenant GUID — a multi-tenant value (common/organizations/
+# consumers) disables Microsoft SSO, since the tid-based verification is unsafe there.
+MICROSOFT_OAUTH_CLIENT_ID=
+MICROSOFT_OAUTH_CLIENT_SECRET=
+MICROSOFT_OAUTH_TENANT=
+
+# Authorization allowlist (fail-closed) — a verified email must match one of these
+# to be admitted. Comma-separated. Empty = deny everyone (SSO effectively locked out).
+OAUTH_ALLOWED_DOMAINS=your-company.com
+OAUTH_ALLOWED_EMAILS=
 
 # =============================================================================
 # Service

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ npm run dev:local      # rebuilds local session image, then runs local Docker jo
 ```
 
 Health check: `curl http://localhost:8080/`
-Admin UI: `http://localhost:8080/admin` (requires ADMIN_ACCESS_CODE)
+Admin UI: `http://localhost:8080/admin` (requires an OAuth provider configured **or** ADMIN_ACCESS_CODE set)
 
 ## Running tests
 
@@ -121,7 +121,11 @@ All tables live in a single SQLite file at `DEDUP_DB_PATH` (default `/data/dedup
 | `GITHUB_APP_PRIVATE_KEY` | Yes | GitHub App RSA private key (PEM, `\n`-escaped) |
 | `NOTIFY_TYPE` | No | `slack` (default) or `teams` |
 | `NOTIFY_WEBHOOK_URL` | No | Webhook URL; notifications skipped if unset |
-| `ADMIN_ACCESS_CODE` | No | Admin UI password; UI disabled if unset |
+| `ADMIN_ACCESS_CODE` | No | **Deprecated** admin-UI password fallback (prefer SSO below). UI is enabled if this **or** any OAuth provider is set. |
+| `OAUTH_REDIRECT_BASE_URL` | No | Base URL for OAuth redirect URIs (`https://<app>.fly.dev`; `http://localhost:8080` locally) |
+| `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` | No | Google OIDC credentials — enables the Google SSO button |
+| `MICROSOFT_OAUTH_CLIENT_ID` / `MICROSOFT_OAUTH_CLIENT_SECRET` / `MICROSOFT_OAUTH_TENANT` | No | Microsoft (Entra) OIDC credentials; `_TENANT` is the directory (tenant) ID |
+| `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` | No | Comma-separated allowlist; a verified identity must match a domain or email (fail-closed) |
 | `DEDUP_DB_PATH` | No | SQLite path (default `/data/dedup.sqlite`) |
 | `POLL_INTERVAL_MS` | No | Poll interval ms (default `60000`) |
 | `PORT` | No | HTTP port (default `8080`) |
@@ -143,6 +147,12 @@ The **Sync workflows** button on each project row re-runs the sync manually at a
 
 The GitHub App must have **Workflows** permission in addition to **Contents** permission. GitHub rejects writes under `.github/workflows/` without it, so the sync will fail (surfaced as a "permission denied" message) before opening or updating the target-repo PR.
 
+## Admin authentication
+
+The admin UI supports **SSO via OIDC** (Google + Microsoft) with a **deprecated shared access-code** fallback. The UI is enabled when at least one is configured, and returns 503 when neither is.
+
+- **SSO (preferred):** configure one or more providers (`GOOGLE_OAUTH_*` / `MICROSOFT_OAUTH_*`) plus `OAUTH_REDIRECT_BASE_URL`, and an allowlist (`OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS`). Sign-in yields an httpOnly session cookie; authorization is **fail-closed** against the email/domain allowlist — a verified `email` must match `OAUTH_ALLOWED_EMAILS`, or its domain must match `OAUTH_ALLOWED_DOMAINS`. The session stores the provider's stable `sub` as its identity reference (email is mutable). Claims are normalized across providers in `src/oauth/oidc.ts`.
+- **Access code (deprecated):** `ADMIN_ACCESS_CODE` remains for local dev/bootstrapping. It uses a timing-safe compare and logs a deprecation warning on each use.
 
 ## admin-ui
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^11.0.0",
+        "openid-client": "^6.8.4",
         "picomatch": "^4.0.0",
         "yaml": "^2.8.3"
       },
@@ -1637,6 +1638,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jsdom": {
       "version": "29.1.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
@@ -2056,6 +2066,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2074,6 +2093,19 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/parse5": {

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.0.0",
+    "openid-client": "^6.8.4",
     "picomatch": "^4.0.0",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",
-    "@types/picomatch": "^4.0.0",
     "@types/jsdom": "^28.0.1",
     "@types/node": "^24.12.4",
+    "@types/picomatch": "^4.0.0",
     "jsdom": "^29.1.0",
     "tsx": "^4.0.0",
     "typescript": "^5.7.0",

--- a/src/__tests__/admin-session.test.ts
+++ b/src/__tests__/admin-session.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type http from "node:http";
+import { SESSION_COOKIE_NAME } from "../cookies.js";
+
+// dedup.ts freezes its DB path at import time, so each test sets a unique DEDUP_DB_PATH and
+// re-imports the modules fresh (the same isolation pattern admin.test.ts uses).
+let session: typeof import("../admin-session.js");
+let dedup: typeof import("../dedup.js");
+let dbPath: string;
+
+const mkReq = (headers: Record<string, string>) => ({ headers }) as unknown as http.IncomingMessage;
+
+function sessionRow(token: string) {
+  return dedup
+    .getDb()
+    .prepare("SELECT token, expires_at, email, sub, provider, name FROM admin_sessions WHERE token = ?")
+    .get(token) as
+    | { token: string; expires_at: number; email: string | null; sub: string | null; provider: string | null; name: string | null }
+    | undefined;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `admin-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  session = await import("../admin-session.js");
+  dedup = await import("../dedup.js");
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("createSession", () => {
+  it("mints a unique 64-hex token", () => {
+    const a = session.createSession();
+    const b = session.createSession();
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).not.toBe(b);
+  });
+
+  it("leaves the identity columns NULL when no identity is passed (access-code path)", () => {
+    const token = session.createSession();
+    const row = sessionRow(token);
+    expect(row).toBeDefined();
+    expect(row!.email).toBeNull();
+    expect(row!.sub).toBeNull();
+    expect(row!.provider).toBeNull();
+    expect(row!.name).toBeNull();
+    expect(row!.expires_at).toBeGreaterThan(Date.now());
+  });
+
+  it("stores the identity columns when an identity is passed (SSO path)", () => {
+    const token = session.createSession({ email: "ada@eudoxus.ai", sub: "google|123", provider: "google", name: "Ada" });
+    const row = sessionRow(token)!;
+    expect(row.email).toBe("ada@eudoxus.ai");
+    expect(row.sub).toBe("google|123");
+    expect(row.provider).toBe("google");
+    expect(row.name).toBe("Ada");
+  });
+
+  it("stores a NULL name when the optional name is omitted", () => {
+    const token = session.createSession({ email: "grace@eudoxus.ai", sub: "google|9", provider: "google" });
+    expect(sessionRow(token)!.name).toBeNull();
+  });
+});
+
+describe("isValidSession", () => {
+  it("returns false for an undefined or unknown token", () => {
+    expect(session.isValidSession(undefined)).toBe(false);
+    expect(session.isValidSession("not-a-real-token")).toBe(false);
+  });
+
+  it("returns true for a fresh session", () => {
+    const token = session.createSession();
+    expect(session.isValidSession(token)).toBe(true);
+  });
+
+  it("returns false and lazily deletes the row when the session has expired", () => {
+    const token = session.createSession();
+    dedup.getDb().prepare("UPDATE admin_sessions SET expires_at = ? WHERE token = ?").run(Date.now() - 1, token);
+    expect(session.isValidSession(token)).toBe(false);
+    expect(sessionRow(token)).toBeUndefined();
+  });
+});
+
+describe("revokeSession", () => {
+  it("drops the row so the token no longer validates (server-side logout)", () => {
+    const token = session.createSession();
+    expect(session.isValidSession(token)).toBe(true);
+    session.revokeSession(token);
+    expect(session.isValidSession(token)).toBe(false);
+    expect(sessionRow(token)).toBeUndefined();
+  });
+});
+
+describe("getRequestToken", () => {
+  it("prefers the session cookie", () => {
+    const token = session.getRequestToken(mkReq({ cookie: `${SESSION_COOKIE_NAME}=cookie-tok; theme=dark` }));
+    expect(token).toBe("cookie-tok");
+  });
+
+  it("lets the cookie win when both a cookie and a Bearer header are present", () => {
+    const token = session.getRequestToken(
+      mkReq({ cookie: `${SESSION_COOKIE_NAME}=cookie-tok`, authorization: "Bearer bearer-tok" }),
+    );
+    expect(token).toBe("cookie-tok");
+  });
+
+  it("falls back to the Bearer header when no session cookie is present", () => {
+    expect(session.getRequestToken(mkReq({ authorization: "Bearer bearer-tok" }))).toBe("bearer-tok");
+  });
+
+  it("returns undefined when neither a cookie nor a Bearer header is present", () => {
+    expect(session.getRequestToken(mkReq({}))).toBeUndefined();
+  });
+
+  it("ignores a non-Bearer authorization header", () => {
+    expect(session.getRequestToken(mkReq({ authorization: "Basic abc123" }))).toBeUndefined();
+  });
+});
+
+describe("accessCodeMatches", () => {
+  it("returns true for identical codes", () => {
+    expect(session.accessCodeMatches("s3cret-code", "s3cret-code")).toBe(true);
+  });
+
+  it("returns false for different codes of the same length", () => {
+    expect(session.accessCodeMatches("s3cret-aaa", "s3cret-bbb")).toBe(false);
+  });
+
+  it("returns false for different-length inputs without throwing (hash-first avoids timingSafeEqual's length throw)", () => {
+    expect(() => session.accessCodeMatches("short", "a-much-longer-access-code")).not.toThrow();
+    expect(session.accessCodeMatches("short", "a-much-longer-access-code")).toBe(false);
+    expect(session.accessCodeMatches("", "nonempty")).toBe(false);
+  });
+});

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -106,7 +106,7 @@ afterEach(() => {
   try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
 });
 
-function adminConfig(accessCode: string): Parameters<typeof admin.handleAdminRequest>[2] {
+function adminConfig(accessCode: string | null): Parameters<typeof admin.handleAdminRequest>[2] {
   return {
     adminAccessCode: accessCode,
     flySessionsToken: null,
@@ -117,7 +117,7 @@ function adminConfig(accessCode: string): Parameters<typeof admin.handleAdminReq
   };
 }
 
-async function request(url: string, method: string, accessCode: string, body?: unknown, token?: string): Promise<{ statusCode: number; body: string }> {
+async function request(url: string, method: string, accessCode: string | null, body?: unknown, token?: string): Promise<{ statusCode: number; body: string }> {
   let requestBody = body;
   if (
     url === "/api/mappings" &&
@@ -136,7 +136,7 @@ async function request(url: string, method: string, accessCode: string, body?: u
   return requestRaw(url, method, accessCode, requestBody, token);
 }
 
-async function requestRaw(url: string, method: string, accessCode: string, body?: unknown, token?: string): Promise<{ statusCode: number; body: string }> {
+async function requestRaw(url: string, method: string, accessCode: string | null, body?: unknown, token?: string): Promise<{ statusCode: number; body: string }> {
   const req = new MockRequest(url, method, token ? { authorization: `Bearer ${token}` } : {}, body === undefined ? undefined : JSON.stringify(body));
   const res = new MockResponse();
   admin.handleAdminRequest(req as never, res as never, adminConfig(accessCode), makeFakeRegistry(provider));
@@ -161,9 +161,32 @@ describe("admin auth", () => {
     expect(res.statusCode).toBe(403);
   });
 
+  it("returns 403 when access-code login is disabled (adminAccessCode is null)", async () => {
+    const res = await requestRaw("/api/auth", "POST", null, { code: "anything" });
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/disabled/);
+  });
+
+  it("a null code cannot bypass a disabled access code", async () => {
+    const res = await requestRaw("/api/auth", "POST", null, { code: null });
+    expect(res.statusCode).toBe(403);
+  });
+
   it("returns 401 on protected routes without token", async () => {
     const res = await request("/api/mappings", "GET", "secret");
     expect(res.statusCode).toBe(401);
+  });
+
+  it("serves the SPA shell for GET /admin, ignoring any query string (e.g. the OAuth ?auth_error= redirect)", async () => {
+    // Control: the bare path serves the shell.
+    const plain = await requestRaw("/admin", "GET", "secret");
+    expect(plain.statusCode).toBe(200);
+    expect(plain.body).toContain('id="login-page"');
+
+    // Regression: a query string must not cause a 404 — the callback's failure redirect lands here.
+    const withQuery = await requestRaw("/admin?auth_error=denied", "GET", "secret");
+    expect(withQuery.statusCode).toBe(200);
+    expect(withQuery.body).toContain('id="login-page"');
   });
 
   it("session token survives a module reload (simulates server restart)", async () => {

--- a/src/__tests__/authorize.test.ts
+++ b/src/__tests__/authorize.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  configureAuthorizationPolicy,
+  authorize,
+  getAuthorizationPolicy,
+  __resetAuthorizationPolicyForTest,
+} from "../oauth/authorize.js";
+import type { VerifiedIdentity } from "../oauth/oidc.js";
+
+const identity = (over: Partial<VerifiedIdentity>): VerifiedIdentity => ({
+  provider: "google",
+  sub: "google|1",
+  email: "ada@eudoxus.ai",
+  emailVerified: true,
+  name: "Ada",
+  hd: "eudoxus.ai",
+  tid: null,
+  rawClaims: {},
+  ...over,
+});
+
+beforeEach(() => __resetAuthorizationPolicyForTest());
+
+describe("authorize", () => {
+  it("denies everyone when the policy is empty (fail-closed)", () => {
+    expect(authorize(identity({})).ok).toBe(false);
+  });
+
+  it("allows a verified email whose domain is on the allowlist", () => {
+    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    expect(authorize(identity({ email: "ada@eudoxus.ai" }))).toEqual({ ok: true });
+  });
+
+  it("allows a verified email listed explicitly, even off an allowed domain", () => {
+    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: ["contractor@gmail.com"] });
+    expect(authorize(identity({ email: "contractor@gmail.com" }))).toEqual({ ok: true });
+  });
+
+  it("denies an unverified email regardless of the allowlist", () => {
+    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    const result = authorize(identity({ email: "ada@eudoxus.ai", emailVerified: false }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/not verified/);
+  });
+
+  it("denies when the provider returned no email", () => {
+    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    const result = authorize(identity({ email: null }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/no email/);
+  });
+
+  it("denies a verified email that is neither listed nor on an allowed domain", () => {
+    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    expect(authorize(identity({ email: "someone@evil.com" })).ok).toBe(false);
+  });
+
+  it("matches case-insensitively on email and domain, trimming/dropping empty config entries", () => {
+    configureAuthorizationPolicy({ allowedDomains: [" Eudoxus.AI ", ""], allowedEmails: [] });
+    expect(authorize(identity({ email: "Ada@EUDOXUS.ai" }))).toEqual({ ok: true });
+  });
+
+  it("does not treat a malformed, @-less identifier as a domain", () => {
+    // "noatsign".split("@").pop() === "noatsign" === email → the domain check must be skipped
+    configureAuthorizationPolicy({ allowedDomains: ["noatsign"], allowedEmails: [] });
+    expect(authorize(identity({ email: "noatsign" })).ok).toBe(false);
+  });
+
+  it("stores the normalized (lowercased, trimmed, compacted) policy", () => {
+    configureAuthorizationPolicy({ allowedDomains: ["Eudoxus.AI"], allowedEmails: ["Ada@Eudoxus.ai", "  "] });
+    expect(getAuthorizationPolicy()).toEqual({
+      allowedDomains: ["eudoxus.ai"],
+      allowedEmails: ["ada@eudoxus.ai"],
+    });
+  });
+});

--- a/src/__tests__/cookies.test.ts
+++ b/src/__tests__/cookies.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  SESSION_COOKIE_NAME,
+  parseCookies,
+  serializeSessionCookie,
+  clearSessionCookie,
+} from "../cookies.js";
+
+// Split a Set-Cookie value ("name=v; HttpOnly; ...") into its attribute segments so we can
+// assert on presence/absence without worrying about substring collisions.
+const attrsOf = (setCookie: string): string[] => setCookie.split("; ");
+
+describe("parseCookies", () => {
+  it("returns an empty map when the header is absent or empty", () => {
+    expect(parseCookies(undefined)).toEqual({});
+    expect(parseCookies("")).toEqual({});
+  });
+
+  it("parses a single name=value pair", () => {
+    expect(parseCookies("ai_admin_session=abc123")).toEqual({ ai_admin_session: "abc123" });
+  });
+
+  it("parses multiple pairs and trims the leading space after each '; '", () => {
+    expect(parseCookies("ai_admin_session=abc123; theme=dark")).toEqual({
+      ai_admin_session: "abc123",
+      theme: "dark",
+    });
+  });
+
+  it("splits only at the first '=' so values may contain '='", () => {
+    expect(parseCookies("token=b=c")).toEqual({ token: "b=c" });
+  });
+
+  it("URL-decodes the value", () => {
+    expect(parseCookies("k=a%20b")).toEqual({ k: "a b" });
+  });
+
+  it("skips malformed parts with no '=' and parts with an empty name", () => {
+    expect(parseCookies("a=1; garbage; =novalue; b=2")).toEqual({ a: "1", b: "2" });
+  });
+});
+
+describe("serializeSessionCookie", () => {
+  it("carries the URL-encoded token under the session cookie name", () => {
+    const value = serializeSessionCookie("tok/en=1", 1000, false);
+    expect(attrsOf(value)[0]).toBe(`${SESSION_COOKIE_NAME}=tok%2Fen%3D1`);
+  });
+
+  it("sets the security attributes and converts Max-Age from ms to whole seconds", () => {
+    const attrs = attrsOf(serializeSessionCookie("t", 86_400_000, false));
+    expect(attrs).toContain("HttpOnly");
+    expect(attrs).toContain("SameSite=Lax");
+    expect(attrs).toContain("Path=/");
+    expect(attrs).toContain("Max-Age=86400");
+  });
+
+  it("floors a fractional-second Max-Age", () => {
+    expect(attrsOf(serializeSessionCookie("t", 1500, false))).toContain("Max-Age=1");
+  });
+
+  it("includes Secure only when secure is true", () => {
+    expect(attrsOf(serializeSessionCookie("t", 1000, true))).toContain("Secure");
+    expect(attrsOf(serializeSessionCookie("t", 1000, false))).not.toContain("Secure");
+  });
+});
+
+describe("clearSessionCookie", () => {
+  it("expires the cookie immediately with an empty value", () => {
+    const attrs = attrsOf(clearSessionCookie(false));
+    expect(attrs[0]).toBe(`${SESSION_COOKIE_NAME}=`);
+    expect(attrs).toContain("Max-Age=0");
+    expect(attrs).toContain("Path=/");
+  });
+
+  it("mirrors the Secure flag so the browser matches and clears the right cookie", () => {
+    expect(attrsOf(clearSessionCookie(true))).toContain("Secure");
+    expect(attrsOf(clearSessionCookie(false))).not.toContain("Secure");
+  });
+});
+
+describe("round-trip: what we Set-Cookie parses back cleanly as a Cookie header", () => {
+  it("recovers the original token through encode → decode", () => {
+    // The browser sends back only the "name=value" segment (no attributes), so that's what we parse.
+    const nameValue = attrsOf(serializeSessionCookie("tok en/with=special", 1000, false))[0];
+    expect(parseCookies(nameValue)).toEqual({ [SESSION_COOKIE_NAME]: "tok en/with=special" });
+  });
+});

--- a/src/__tests__/oauth-providers.test.ts
+++ b/src/__tests__/oauth-providers.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  configureOAuthProviders,
+  getProvider,
+  listConfiguredProviders,
+  isOAuthConfigured,
+  providersFromEnv,
+  __resetOAuthProvidersForTest,
+  type OidcProviderConfig,
+} from "../oauth/providers.js";
+
+const google: OidcProviderConfig = {
+  id: "google",
+  label: "Google",
+  issuer: "https://accounts.google.com",
+  clientId: "gid",
+  clientSecret: "gsecret",
+  scopes: ["openid", "email", "profile"],
+};
+const microsoft: OidcProviderConfig = {
+  id: "microsoft",
+  label: "Microsoft",
+  issuer: "https://login.microsoftonline.com/tenant/v2.0",
+  clientId: "mid",
+  clientSecret: "msecret",
+  scopes: ["openid", "email", "profile"],
+};
+
+beforeEach(() => __resetOAuthProvidersForTest());
+
+describe("provider registry", () => {
+  it("reports unconfigured before any providers are set", () => {
+    expect(isOAuthConfigured()).toBe(false);
+    expect(listConfiguredProviders()).toEqual([]);
+    expect(getProvider("google")).toBeNull();
+  });
+
+  it("registers configured providers and looks them up by id", () => {
+    configureOAuthProviders([google, microsoft]);
+    expect(isOAuthConfigured()).toBe(true);
+    expect(getProvider("google")).toEqual(google);
+    expect(getProvider("microsoft")).toEqual(microsoft);
+    expect(getProvider("unknown")).toBeNull();
+  });
+
+  it("exposes only id+label publicly — never the client secret", () => {
+    configureOAuthProviders([google, microsoft]);
+    const listed = listConfiguredProviders();
+    expect(listed).toEqual([
+      { id: "google", label: "Google" },
+      { id: "microsoft", label: "Microsoft" },
+    ]);
+    expect(JSON.stringify(listed)).not.toContain("gsecret");
+    expect(JSON.stringify(listed)).not.toContain("msecret");
+  });
+
+  it("replaces the set on reconfigure", () => {
+    configureOAuthProviders([google, microsoft]);
+    configureOAuthProviders([google]);
+    expect(listConfiguredProviders()).toEqual([{ id: "google", label: "Google" }]);
+    expect(getProvider("microsoft")).toBeNull();
+  });
+});
+
+describe("providersFromEnv", () => {
+  const scopes = ["openid", "email", "profile"];
+
+  it("returns [] when no provider is credentialed", () => {
+    expect(providersFromEnv({})).toEqual([]);
+  });
+
+  it("includes Google when its id + secret are set", () => {
+    expect(providersFromEnv({ GOOGLE_OAUTH_CLIENT_ID: "gid", GOOGLE_OAUTH_CLIENT_SECRET: "gs" })).toEqual([
+      { id: "google", label: "Google", issuer: "https://accounts.google.com", clientId: "gid", clientSecret: "gs", scopes },
+    ]);
+  });
+
+  it("includes Microsoft only when id + secret + tenant are all set (issuer embeds the tenant)", () => {
+    expect(providersFromEnv({ MICROSOFT_OAUTH_CLIENT_ID: "m", MICROSOFT_OAUTH_CLIENT_SECRET: "s" })).toEqual([]);
+    expect(
+      providersFromEnv({ MICROSOFT_OAUTH_CLIENT_ID: "m", MICROSOFT_OAUTH_CLIENT_SECRET: "s", MICROSOFT_OAUTH_TENANT: "t1" }),
+    ).toEqual([
+      { id: "microsoft", label: "Microsoft", issuer: "https://login.microsoftonline.com/t1/v2.0", clientId: "m", clientSecret: "s", scopes },
+    ]);
+  });
+
+  it("includes both when both are credentialed, google first", () => {
+    const list = providersFromEnv({
+      GOOGLE_OAUTH_CLIENT_ID: "g",
+      GOOGLE_OAUTH_CLIENT_SECRET: "gs",
+      MICROSOFT_OAUTH_CLIENT_ID: "m",
+      MICROSOFT_OAUTH_CLIENT_SECRET: "ms",
+      MICROSOFT_OAUTH_TENANT: "t",
+    });
+    expect(list.map((p) => p.id)).toEqual(["google", "microsoft"]);
+  });
+});

--- a/src/__tests__/oauth-routes.test.ts
+++ b/src/__tests__/oauth-routes.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type http from "node:http";
+import type { AuthStart, VerifiedIdentity } from "../oauth/oidc.js";
+import type { OidcProviderConfig } from "../oauth/providers.js";
+
+// oidc.ts is the only network-touching module; mock it so we exercise the routes without openid-client.
+vi.mock("../oauth/oidc.js", () => ({
+  buildAuthUrl: vi.fn(),
+  completeAuth: vi.fn(),
+}));
+
+const baseUrl = "http://localhost:8080";
+
+const googleProvider: OidcProviderConfig = {
+  id: "google",
+  label: "Google",
+  issuer: "https://accounts.google.com",
+  clientId: "gid",
+  clientSecret: "gsecret",
+  scopes: ["openid", "email", "profile"],
+};
+
+const identity = (over: Partial<VerifiedIdentity> = {}): VerifiedIdentity => ({
+  provider: "google",
+  sub: "google|1",
+  email: "ada@eudoxus.ai",
+  emailVerified: true,
+  name: "Ada",
+  hd: "eudoxus.ai",
+  tid: null,
+  rawClaims: {},
+  ...over,
+});
+
+class MockResponse {
+  statusCode = 0;
+  headers: Record<string, string | string[]> = {};
+  body = "";
+  writeHead(status: number, headers?: Record<string, string | string[]>): this {
+    this.statusCode = status;
+    if (headers) Object.assign(this.headers, headers);
+    return this;
+  }
+  end(chunk?: string): void {
+    if (chunk) this.body += chunk;
+  }
+}
+
+const mkReq = (url: string, headers: Record<string, string> = {}) =>
+  ({ url, headers }) as unknown as http.IncomingMessage;
+const asRes = (res: MockResponse) => res as unknown as http.ServerResponse;
+
+let routes: typeof import("../oauth/routes.js");
+let providers: typeof import("../oauth/providers.js");
+let authz: typeof import("../oauth/authorize.js");
+let oidc: typeof import("../oauth/oidc.js");
+let store: typeof import("../oauth/state-store.js");
+let session: typeof import("../admin-session.js");
+let dedup: typeof import("../dedup.js");
+let dbPath: string;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  dbPath = path.join(os.tmpdir(), `oauth-routes-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  routes = await import("../oauth/routes.js");
+  providers = await import("../oauth/providers.js");
+  authz = await import("../oauth/authorize.js");
+  oidc = await import("../oauth/oidc.js");
+  store = await import("../oauth/state-store.js");
+  session = await import("../admin-session.js");
+  dedup = await import("../dedup.js");
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+const START: AuthStart = { authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth?x=1", state: "st", nonce: "no", codeVerifier: "cv" };
+
+describe("handleOAuthProviders", () => {
+  it("returns configured providers (id+label only) and the access-code flag", () => {
+    providers.configureOAuthProviders([googleProvider]);
+    const res = new MockResponse();
+    routes.handleOAuthProviders(asRes(res), true);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ providers: [{ id: "google", label: "Google" }], accessCode: true });
+  });
+});
+
+describe("handleOAuthStart", () => {
+  it("mints a transaction and 302-redirects to the provider", async () => {
+    providers.configureOAuthProviders([googleProvider]);
+    vi.mocked(oidc.buildAuthUrl).mockResolvedValue(START);
+
+    const res = new MockResponse();
+    await routes.handleOAuthStart(mkReq("/api/auth/google/start?next=/admin/pipelines"), asRes(res), "google", baseUrl);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["Location"]).toBe(START.authorizationUrl);
+    expect(vi.mocked(oidc.buildAuthUrl)).toHaveBeenCalledWith(googleProvider, "http://localhost:8080/api/auth/google/callback");
+
+    const row = dedup
+      .getDb()
+      .prepare("SELECT provider, nonce, code_verifier, redirect_to FROM oauth_transactions WHERE state = ?")
+      .get("st");
+    expect(row).toEqual({ provider: "google", nonce: "no", code_verifier: "cv", redirect_to: "/admin/pipelines" });
+  });
+
+  it("404s for an unknown provider", async () => {
+    const res = new MockResponse();
+    await routes.handleOAuthStart(mkReq("/api/auth/nope/start"), asRes(res), "nope", baseUrl);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects an off-site next, storing /admin instead", async () => {
+    providers.configureOAuthProviders([googleProvider]);
+    vi.mocked(oidc.buildAuthUrl).mockResolvedValue({ ...START, state: "st2" });
+    const res = new MockResponse();
+    await routes.handleOAuthStart(mkReq("/api/auth/google/start?next=//evil.com/x"), asRes(res), "google", baseUrl);
+    const row = dedup.getDb().prepare("SELECT redirect_to FROM oauth_transactions WHERE state = ?").get("st2") as { redirect_to: string };
+    expect(row.redirect_to).toBe("/admin");
+  });
+});
+
+describe("handleOAuthCallback", () => {
+  // Failure branches redirect to the login screen with a generic auth_error category (no code/state
+  // left in the URL); the specific reason is console.warn'd server-side, never sent to the browser.
+  it("redirects to auth_error=expired when the state is unknown", async () => {
+    providers.configureOAuthProviders([googleProvider]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const res = new MockResponse();
+    await routes.handleOAuthCallback(mkReq("/api/auth/google/callback?state=missing&code=c"), asRes(res), "google", baseUrl, false);
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["Location"]).toBe("/admin?auth_error=expired");
+    expect(res.headers["Set-Cookie"]).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  it("redirects to auth_error=expired when the transaction was for a different provider", async () => {
+    providers.configureOAuthProviders([googleProvider]);
+    store.putTransaction({ state: "mm", provider: "microsoft", codeVerifier: "v", nonce: "n", redirectTo: "/admin" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const res = new MockResponse();
+    await routes.handleOAuthCallback(mkReq("/api/auth/google/callback?state=mm&code=c"), asRes(res), "google", baseUrl, false);
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["Location"]).toBe("/admin?auth_error=expired");
+    warn.mockRestore();
+  });
+
+  it("redirects to auth_error=failed and logs the exception when the code exchange fails", async () => {
+    providers.configureOAuthProviders([googleProvider]);
+    store.putTransaction({ state: "ex", provider: "google", codeVerifier: "v", nonce: "n", redirectTo: "/admin" });
+    vi.mocked(oidc.completeAuth).mockRejectedValue(new Error("bad code"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const res = new MockResponse();
+    await routes.handleOAuthCallback(mkReq("/api/auth/google/callback?state=ex&code=c"), asRes(res), "google", baseUrl, false);
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["Location"]).toBe("/admin?auth_error=failed");
+    expect(warn).toHaveBeenCalled(); // the exchange error is surfaced server-side, not swallowed
+    warn.mockRestore();
+  });
+
+  it("redirects to auth_error=denied with no session when the identity is not allowed", async () => {
+    providers.configureOAuthProviders([googleProvider]);
+    authz.configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    store.putTransaction({ state: "dn", provider: "google", codeVerifier: "v", nonce: "n", redirectTo: "/admin" });
+    vi.mocked(oidc.completeAuth).mockResolvedValue(identity({ email: "stranger@evil.com" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = new MockResponse();
+    await routes.handleOAuthCallback(mkReq("/api/auth/google/callback?state=dn&code=c"), asRes(res), "google", baseUrl, false);
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["Location"]).toBe("/admin?auth_error=denied");
+    expect(res.headers["Set-Cookie"]).toBeUndefined();
+    const count = dedup.getDb().prepare("SELECT COUNT(*) AS c FROM admin_sessions").get() as { c: number };
+    expect(count.c).toBe(0);
+    warn.mockRestore();
+  });
+
+  it("on success sets a session cookie and 302-redirects to the stored path", async () => {
+    providers.configureOAuthProviders([googleProvider]);
+    authz.configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    store.putTransaction({ state: "ok", provider: "google", codeVerifier: "v", nonce: "n", redirectTo: "/admin/pipelines" });
+    vi.mocked(oidc.completeAuth).mockResolvedValue(identity({ email: "ada@eudoxus.ai" }));
+
+    const res = new MockResponse();
+    await routes.handleOAuthCallback(mkReq("/api/auth/google/callback?state=ok&code=c"), asRes(res), "google", baseUrl, false);
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers["Location"]).toBe("/admin/pipelines");
+    const setCookie = res.headers["Set-Cookie"] as string;
+    expect(setCookie).toContain("ai_admin_session=");
+    const token = decodeURIComponent(setCookie.split(";")[0].split("=")[1]);
+    expect(session.isValidSession(token)).toBe(true);
+  });
+});
+
+describe("handleOAuthLogout", () => {
+  it("revokes the session and clears the cookie", () => {
+    const token = session.createSession({ email: "ada@eudoxus.ai", sub: "s", provider: "google", name: "Ada" });
+    expect(session.isValidSession(token)).toBe(true);
+
+    const res = new MockResponse();
+    routes.handleOAuthLogout(mkReq("/api/auth/logout", { cookie: `ai_admin_session=${token}` }), asRes(res), false);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["Set-Cookie"] as string).toContain("Max-Age=0");
+    expect(session.isValidSession(token)).toBe(false);
+  });
+});

--- a/src/__tests__/oidc.test.ts
+++ b/src/__tests__/oidc.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Configuration } from "openid-client";
+import type { OidcProviderConfig } from "../oauth/providers.js";
+
+// oidc.ts is the only importer of openid-client, so we replace the whole library with mocks
+// and stage discovery / the code grant without any network.
+vi.mock("openid-client", () => ({
+  discovery: vi.fn(),
+  buildAuthorizationUrl: vi.fn(),
+  authorizationCodeGrant: vi.fn(),
+  randomPKCECodeVerifier: vi.fn(() => "verifier-123"),
+  calculatePKCECodeChallenge: vi.fn(async () => "challenge-abc"),
+  randomState: vi.fn(() => "state-xyz"),
+  randomNonce: vi.fn(() => "nonce-789"),
+}));
+
+const google: OidcProviderConfig = {
+  id: "google",
+  label: "Google",
+  issuer: "https://accounts.google.com",
+  clientId: "gid",
+  clientSecret: "gsecret",
+  scopes: ["openid", "email", "profile"],
+};
+
+const fakeConfig = {} as unknown as Configuration;
+
+let client: typeof import("openid-client");
+let oidc: typeof import("../oauth/oidc.js");
+
+// Shape a fake authorizationCodeGrant result exposing just the claims() helper oidc.ts reads.
+const grantResult = (claims: Record<string, unknown> | undefined) =>
+  ({ claims: () => claims }) as unknown as Awaited<ReturnType<typeof client.authorizationCodeGrant>>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks(); // reset call history so per-test call-count assertions don't include sibling-test calls
+  client = await import("openid-client");
+  oidc = await import("../oauth/oidc.js");
+});
+
+describe("buildAuthUrl", () => {
+  it("discovers the provider and builds an authorization URL with PKCE, state, and nonce", async () => {
+    vi.mocked(client.discovery).mockResolvedValue(fakeConfig);
+    vi.mocked(client.buildAuthorizationUrl).mockReturnValue(
+      new URL("https://accounts.google.com/o/oauth2/v2/auth?x=1"),
+    );
+
+    const start = await oidc.buildAuthUrl(google, "http://localhost:8080/api/auth/google/callback");
+
+    // discovery got the issuer URL + client credentials
+    const [server, clientId, secret] = vi.mocked(client.discovery).mock.calls[0];
+    expect(server.href).toBe("https://accounts.google.com/");
+    expect(clientId).toBe("gid");
+    expect(secret).toBe("gsecret");
+
+    // the authorization request carries redirect_uri, scope, and the security params
+    expect(vi.mocked(client.buildAuthorizationUrl).mock.calls[0][1]).toMatchObject({
+      redirect_uri: "http://localhost:8080/api/auth/google/callback",
+      scope: "openid email profile",
+      code_challenge: "challenge-abc",
+      code_challenge_method: "S256",
+      state: "state-xyz",
+      nonce: "nonce-789",
+    });
+
+    expect(start).toEqual({
+      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth?x=1",
+      state: "state-xyz",
+      nonce: "nonce-789",
+      codeVerifier: "verifier-123",
+    });
+  });
+
+  it("caches discovery per provider, and a failed discovery does not stick", async () => {
+    vi.mocked(client.buildAuthorizationUrl).mockReturnValue(new URL("https://p/auth"));
+    vi.mocked(client.discovery)
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValue(fakeConfig);
+
+    await expect(oidc.buildAuthUrl(google, "http://cb")).rejects.toThrow(/network down/);
+    // the poisoned entry was evicted → the next call re-discovers and succeeds
+    await oidc.buildAuthUrl(google, "http://cb");
+    // now cached → no third discovery
+    await oidc.buildAuthUrl(google, "http://cb");
+    expect(vi.mocked(client.discovery)).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("completeAuth", () => {
+  const expected = { state: "state-xyz", nonce: "nonce-789", codeVerifier: "verifier-123" };
+  const cbUrl = new URL("http://localhost:8080/api/auth/google/callback?code=abc&state=state-xyz");
+
+  it("exchanges the code with the expected checks and normalizes Google-shaped claims", async () => {
+    vi.mocked(client.discovery).mockResolvedValue(fakeConfig);
+    const claims = { sub: "google|123", email: "ada@eudoxus.ai", email_verified: true, name: "Ada", hd: "eudoxus.ai" };
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue(grantResult(claims));
+
+    const identity = await oidc.completeAuth(google, cbUrl, expected);
+
+    expect(vi.mocked(client.authorizationCodeGrant)).toHaveBeenCalledWith(fakeConfig, cbUrl, {
+      expectedState: "state-xyz",
+      expectedNonce: "nonce-789",
+      pkceCodeVerifier: "verifier-123",
+    });
+    expect(identity).toEqual({
+      provider: "google",
+      sub: "google|123",
+      email: "ada@eudoxus.ai",
+      emailVerified: true,
+      name: "Ada",
+      hd: "eudoxus.ai",
+      tid: null,
+      rawClaims: claims,
+    });
+  });
+
+  it("guards against missing/non-standard claims (a string email_verified is NOT verified)", async () => {
+    vi.mocked(client.discovery).mockResolvedValue(fakeConfig);
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue(grantResult({ sub: "ms|9", email_verified: "true" }));
+
+    const identity = await oidc.completeAuth(google, cbUrl, expected);
+    expect(identity.email).toBeNull();
+    expect(identity.emailVerified).toBe(false);
+    expect(identity.name).toBeNull();
+    expect(identity.hd).toBeNull();
+    expect(identity.tid).toBeNull();
+  });
+
+  it("throws when the provider returns no ID token", async () => {
+    vi.mocked(client.discovery).mockResolvedValue(fakeConfig);
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue(grantResult(undefined));
+    await expect(oidc.completeAuth(google, cbUrl, expected)).rejects.toThrow(/no ID token/);
+  });
+
+  // Microsoft ID tokens carry no `email_verified`; verification comes from the org tenant id.
+  it("treats a Microsoft work/school account (org tid, no email_verified) as verified", async () => {
+    vi.mocked(client.discovery).mockResolvedValue(fakeConfig);
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue(
+      grantResult({ sub: "ms|1", email: "ada@eudoxus.ai", tid: "org-tenant-guid" }),
+    );
+    const identity = await oidc.completeAuth(google, cbUrl, expected);
+    expect(identity.email).toBe("ada@eudoxus.ai");
+    expect(identity.emailVerified).toBe(true);
+    expect(identity.tid).toBe("org-tenant-guid");
+  });
+
+  it("does NOT rescue a personal Microsoft account (reserved MSA tenant id)", async () => {
+    vi.mocked(client.discovery).mockResolvedValue(fakeConfig);
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue(
+      grantResult({ sub: "ms|2", email: "x@outlook.com", tid: "9188040d-6c67-4c5b-b112-36a304b66dad" }),
+    );
+    expect((await oidc.completeAuth(google, cbUrl, expected)).emailVerified).toBe(false);
+  });
+
+  it("respects an explicit email_verified:false when there is no org tenant (unverified Google email)", async () => {
+    vi.mocked(client.discovery).mockResolvedValue(fakeConfig);
+    vi.mocked(client.authorizationCodeGrant).mockResolvedValue(
+      grantResult({ sub: "g|3", email: "x@gmail.com", email_verified: false }),
+    );
+    expect((await oidc.completeAuth(google, cbUrl, expected)).emailVerified).toBe(false);
+  });
+});

--- a/src/__tests__/state-store.test.ts
+++ b/src/__tests__/state-store.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { OAuthTransaction } from "../oauth/state-store.js";
+
+// Temp-file DB per test (same isolation pattern as admin-session.test.ts).
+let store: typeof import("../oauth/state-store.js");
+let dedup: typeof import("../dedup.js");
+let dbPath: string;
+
+const tx = (over: Partial<OAuthTransaction> = {}): OAuthTransaction => ({
+  state: "state-1",
+  provider: "google",
+  codeVerifier: "verifier-1",
+  nonce: "nonce-1",
+  redirectTo: "/admin",
+  ...over,
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `state-store-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  store = await import("../oauth/state-store.js");
+  dedup = await import("../dedup.js");
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("oauth transaction store", () => {
+  it("round-trips a stored transaction by state", () => {
+    store.putTransaction(tx({ state: "abc", provider: "microsoft", codeVerifier: "v", nonce: "n", redirectTo: "/admin#x" }));
+    expect(store.takeTransaction("abc")).toEqual({
+      state: "abc",
+      provider: "microsoft",
+      codeVerifier: "v",
+      nonce: "n",
+      redirectTo: "/admin#x",
+    });
+  });
+
+  it("is single-use: a second take of the same state returns null", () => {
+    store.putTransaction(tx({ state: "once" }));
+    expect(store.takeTransaction("once")).not.toBeNull();
+    expect(store.takeTransaction("once")).toBeNull();
+  });
+
+  it("returns null for an unknown state", () => {
+    expect(store.takeTransaction("nope")).toBeNull();
+  });
+
+  it("returns null for an expired transaction, but still consumes the row", () => {
+    store.putTransaction(tx({ state: "old" }));
+    dedup.getDb().prepare("UPDATE oauth_transactions SET expires_at = ? WHERE state = ?").run(Date.now() - 1, "old");
+    expect(store.takeTransaction("old")).toBeNull();
+    const row = dedup.getDb().prepare("SELECT 1 FROM oauth_transactions WHERE state = ?").get("old");
+    expect(row).toBeUndefined();
+  });
+
+  it("keeps distinct states independent", () => {
+    store.putTransaction(tx({ state: "a", provider: "google" }));
+    store.putTransaction(tx({ state: "b", provider: "microsoft" }));
+    expect(store.takeTransaction("a")?.provider).toBe("google");
+    expect(store.takeTransaction("b")?.provider).toBe("microsoft");
+  });
+
+  it("stores an expiry exactly OAUTH_TX_TTL_MS after creation", () => {
+    store.putTransaction(tx({ state: "ttl" }));
+    const row = dedup
+      .getDb()
+      .prepare("SELECT expires_at, created_at FROM oauth_transactions WHERE state = ?")
+      .get("ttl") as { expires_at: number; created_at: number };
+    expect(row.expires_at - row.created_at).toBe(store.OAUTH_TX_TTL_MS);
+  });
+});

--- a/src/admin-session.ts
+++ b/src/admin-session.ts
@@ -1,0 +1,76 @@
+/**
+ * Admin session tokens — mint, validate, revoke, and resolve them from a request.
+ * Extracted from admin.ts so the OAuth routes (and index.ts) can share the session layer without importing the heavy admin module.
+ * Kept dependency-light: only the DB + cookie helper.
+ */
+
+import crypto from "node:crypto";
+import type http from "node:http";
+import { getDb } from "./dedup.js";
+import { parseCookies, SESSION_COOKIE_NAME } from "./cookies.js";
+
+export const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/** Identity attached to an SSO session; the access-code path mints a session without one. */
+export interface SessionIdentity {
+  email: string;
+  sub: string;
+  provider: string;
+  name?: string | null;
+}
+
+/** Mint a session token. SSO passes the verified identity; the access-code path passes nothing (identity columns stay NULL). */
+export function createSession(identity?: SessionIdentity): string {
+  const token = crypto.randomBytes(32).toString("hex");
+  getDb()
+    .prepare(
+      "INSERT INTO admin_sessions (token, expires_at, email, sub, provider, name) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .run(
+      token,
+      Date.now() + SESSION_TTL_MS,
+      identity?.email ?? null,
+      identity?.sub ?? null,
+      identity?.provider ?? null,
+      identity?.name ?? null,
+    );
+  return token;
+}
+
+export function isValidSession(token: string | undefined): boolean {
+  if (!token) return false;
+  const row = getDb()
+    .prepare("SELECT expires_at FROM admin_sessions WHERE token = ?")
+    .get(token) as { expires_at: number } | undefined;
+  if (!row) return false;
+  if (Date.now() > row.expires_at) {
+    getDb().prepare("DELETE FROM admin_sessions WHERE token = ?").run(token);
+    return false;
+  }
+  return true;
+}
+
+/** Server-side logout: drop the row so a replayed cookie or bearer token no longer validates. */
+export function revokeSession(token: string): void {
+  getDb().prepare("DELETE FROM admin_sessions WHERE token = ?").run(token);
+}
+
+/** Resolve the session token from a request — the httpOnly cookie first, then the legacy Authorization: Bearer header. */
+export function getRequestToken(req: http.IncomingMessage): string | undefined {
+  const fromCookie = parseCookies(req.headers.cookie)[SESSION_COOKIE_NAME];
+  if (fromCookie) return fromCookie;
+  const auth = req.headers.authorization;
+  if (auth?.startsWith("Bearer ")) return auth.slice(7);
+  return undefined;
+}
+
+/**
+ * Constant-time compare of a submitted access code against the configured one.
+ * 
+ * Hashing both to a fixed-length digest first keeps it timing-safe even when lengths differ and leaks no length.
+ */
+export function accessCodeMatches(submitted: string, configured: string): boolean {
+  const a = crypto.createHash("sha256").update(submitted).digest();
+  const b = crypto.createHash("sha256").update(configured).digest();
+  return crypto.timingSafeEqual(a, b);
+}

--- a/src/admin-ui/auth.ts
+++ b/src/admin-ui/auth.ts
@@ -11,15 +11,22 @@ export const authJs = `
     return d.innerHTML;
   }
   window.esc = esc;
+  // Brand marks for the provider tiles; unknown providers render label-only.
+  var PROVIDER_ICONS = {
+    google: '<svg viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.28-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/></svg>',
+    microsoft: '<svg viewBox="0 0 21 21"><rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/></svg>'
+  };
 
   async function api(path, opts) {
     opts = opts || {};
     const headers = { 'Content-Type': 'application/json' };
     if (token) headers['Authorization'] = 'Bearer ' + token;
-    const res = await fetch(API + path, Object.assign({}, opts, { headers }));
+    // credentials:'include' so the httpOnly session cookie rides along with every API call.
+    const res = await fetch(API + path, Object.assign({}, opts, { headers, credentials: 'include' }));
     if (res.status === 401) {
       localStorage.removeItem('admin_token');
       token = null;
+      await renderLogin();
       showLogin();
       throw new Error('Unauthorized');
     }
@@ -43,6 +50,54 @@ export const authJs = `
   }
   window.showAdmin = showAdmin;
 
+  // Login screen is built from server config: 
+  // (which SSO providers exist + whether the deprecated access-code box still applies)
+  async function renderLogin() {
+    let providers = [], accessCode = true;
+    try {
+      const res = await fetch(API + '/api/auth/providers', { credentials: 'include' });
+      const data = await res.json();
+      providers = data.providers || [];
+      accessCode = !!data.accessCode;
+    } catch (e) { /* leave defaults so the access-code fallback stays reachable */ }
+
+    document.getElementById('sso-buttons').innerHTML = providers.map(function (p) {
+      return '<a class="sso-tile" href="' + API + '/api/auth/' + encodeURIComponent(p.id) + '/start">' +
+             (PROVIDER_ICONS[p.id] || '') + '<span>' + esc(p.label) + '</span></a>';
+    }).join('');
+
+    var hasSso = providers.length > 0;
+    document.getElementById('sso-label').classList.toggle('hidden', !hasSso);
+    document.getElementById('login-divider').classList.toggle('hidden', !(hasSso && accessCode));
+    document.getElementById('access-code-notice').classList.toggle('hidden', !(accessCode && !hasSso));
+    document.getElementById('access-code-box').classList.toggle('hidden', !accessCode);
+  }
+
+  // Generic banner for the callback's ?auth_error=... redirect. The specific reason stays server-side
+  function showAuthError() {
+    const err = new URLSearchParams(location.search).get('auth_error');
+    if (!err) return;
+    const messages = {
+      denied: "This account isn't authorized for the admin UI.",
+      expired: 'Your sign-in expired. Please try again.',
+      failed: 'Sign-in failed. Please try again.'
+    };
+    const el = document.getElementById('auth-error');
+    el.textContent = messages[err] || messages.failed;
+    el.classList.remove('hidden');
+    history.replaceState(null, '', location.pathname + location.hash); // drop the query so a refresh won't re-show it
+  }
+
+  // Ask the server whether we're authed. 200 => authed, 401 => not.
+  async function probeSession() {
+    const headers = {};
+    if (token) headers['Authorization'] = 'Bearer ' + token;
+    try {
+      const res = await fetch(API + '/api/admin/config-status', { credentials: 'include', headers });
+      return res.ok;
+    } catch (e) { return false; }
+  }
+
   async function login() {
     const code = document.getElementById('access-code').value;
     const res = await fetch(API + '/api/auth', {
@@ -63,18 +118,27 @@ export const authJs = `
   }
   window.login = login;
 
-  function logout() {
+  async function logout() {
+    try { await fetch(API + '/api/auth/logout', { method: 'POST', credentials: 'include' }); } catch (e) { /* ignore */ }
     localStorage.removeItem('admin_token');
     token = null;
+    await renderLogin(); // repaint the buttons — bootstrap skipped them when we were authed
     showLogin();
   }
   window.logout = logout;
 
-  // Wire up Enter key on login box
-  document.addEventListener('DOMContentLoaded', function () {
+  document.addEventListener('DOMContentLoaded', async function () {
+    // Wire up Enter key on login box
     const ac = document.getElementById('access-code');
     if (ac) ac.addEventListener('keydown', function (e) { if (e.key === 'Enter') login(); });
-    if (token) showAdmin();
+
+    showAuthError();
+    if (await probeSession()) {
+      showAdmin();
+    } else {
+      await renderLogin();
+      showLogin();
+    }
   });
 })();
 `;

--- a/src/admin-ui/components.ts
+++ b/src/admin-ui/components.ts
@@ -897,6 +897,65 @@ deck-stage, .dc-artboard { background: var(--bg-app); }
   font-size: 12.5px;
 }
 
+/* ── Login: panel + SSO tiles (AII-147) ────────────────────── */
+.login-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: 400px;
+  max-width: 92vw;
+}
+.login-title {
+  margin: 0;
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+.login-panel .login-box { width: 100%; }
+
+.divider-labeled { display: flex; align-items: center; margin: 16px 0; }
+.divider-labeled::before,
+.divider-labeled::after { content: ""; flex: 1; height: 1px; background: var(--border-subtle); }
+.divider-labeled span {
+  padding: 0 10px;
+  font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--fg-tertiary);
+  white-space: nowrap;
+}
+
+#sso-buttons {
+  display: grid;
+  grid-template-columns:
+  repeat(auto-fit, minmax(96px, 1fr));
+  gap: 8px;
+}
+.sso-label {
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 13px;
+  color: var(--fg-secondary);
+  margin-bottom: 10px;
+}
+.sso-tile {
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px;
+  padding: 14px 8px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-sm);
+  background: var(--bg-elev);
+  color: var(--fg-primary);
+  font-size: 12px; font-weight: 500;
+  text-decoration: none;
+  transition: background 80ms ease, border-color 80ms ease;
+  }
+.sso-tile:hover { background: var(--bg-hover); border-color: var(--border-strong); }
+.sso-tile svg { width: 22px; height: 22px; display: block; }
+
+#auth-error { margin-bottom: 12px; }
+#access-code-box { margin-top: 16px; }
+.ac-row { display: flex; gap: 8px; }
+.ac-row .input { flex: 1; min-width: 0; }
+
 /* ── Native <dialog> for legacy mapping form ─────────────────────────── */
 dialog {
   border: none;

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -57,11 +57,25 @@ const shell = `<div id="admin-page" class="app-shell hidden">
 
 const body = `<body>
 <div id="login-page" class="login-wrap">
-  <div class="login-box card">
-    <h2>Admin Access</h2>
-    <input type="password" id="access-code" placeholder="Access code" autofocus>
-    <button class="btn btn-primary" onclick="login()">Enter</button>
-    <div id="login-error" class="error hidden"></div>
+  <div class="login-panel">
+    <h1 class="login-title">Admin Access</h1>
+    <div class="login-box card">
+      <div id="auth-error" class="error hidden"></div>
+      <div id="sso-label" class="sso-label hidden">Sign in with your provider</div>
+      <div id="sso-buttons"></div>
+      <div id="login-divider" class="divider-labeled hidden"><span>or use an access code</span></div>
+      <div id="access-code-notice" class="warning hidden">
+        Signing in with an access code is <strong>deprecated</strong>.<br>
+        Configure SSO via the <span class="mono">&lt;provider&gt;_OAUTH_*</span> environment variables for per-user login.
+      </div>
+      <div id="access-code-box">
+        <div class="ac-row">
+          <input type="password" id="access-code" class="input" placeholder="Access code (deprecated)">
+          <button class="btn btn-primary" onclick="login()">Enter</button>
+        </div>
+        <div id="login-error" class="error hidden"></div>
+      </div>
+    </div>
   </div>
 </div>
 ${shell}

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1,5 +1,4 @@
 import http from "node:http";
-import crypto from "node:crypto";
 import {
   getMappings,
   DEFAULT_MAX_IN_PROGRESS_AI_ISSUES,
@@ -25,7 +24,8 @@ import {
   isRunnerMode,
   setFlySecretsMinVersion,
 } from "./runner-mode.js";
-import { getDb, listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
+import { listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
+import { createSession, isValidSession, getRequestToken, accessCodeMatches } from "./admin-session.js";
 import { getLastSweepAt } from "./reaper.js";
 import { listLog, getInFlightJobs, updateJobStatus, getJobById, getPulls } from "./log.js";
 import { getStepsByJobId } from "./step-log.js";
@@ -111,8 +111,6 @@ function normalizeSensitiveGlobs(raw: unknown): string[] | null {
   return globs;
 }
 
-const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
 let _adminJiraClient: JiraClient | null = null;
 function getAdminJiraClient(): JiraClient | null {
   if (_adminJiraClient) return _adminJiraClient;
@@ -125,27 +123,6 @@ function getAdminJiraClient(): JiraClient | null {
   if (email ? !siteUrl : !cloudId) return null;
   _adminJiraClient = new JiraClient({ token, email, siteUrl, cloudId });
   return _adminJiraClient;
-}
-
-function createSession(): string {
-  const token = crypto.randomBytes(32).toString("hex");
-  getDb()
-    .prepare("INSERT INTO admin_sessions (token, expires_at) VALUES (?, ?)")
-    .run(token, Date.now() + SESSION_TTL_MS);
-  return token;
-}
-
-function isValidSession(token: string | undefined): boolean {
-  if (!token) return false;
-  const row = getDb()
-    .prepare("SELECT expires_at FROM admin_sessions WHERE token = ?")
-    .get(token) as { expires_at: number } | undefined;
-  if (!row) return false;
-  if (Date.now() > row.expires_at) {
-    getDb().prepare("DELETE FROM admin_sessions WHERE token = ?").run(token);
-    return false;
-  }
-  return true;
 }
 
 function readBody(req: http.IncomingMessage): Promise<string> {
@@ -188,14 +165,8 @@ function validateTicketingMapping(body: { ticketingProvider?: unknown; ticketing
   return { ticketingProvider: provider, ticketingConfig: config };
 }
 
-function getToken(req: http.IncomingMessage): string | undefined {
-  const auth = req.headers.authorization;
-  if (auth?.startsWith("Bearer ")) return auth.slice(7);
-  return undefined;
-}
-
 export interface AdminConfig {
-  adminAccessCode: string;
+  adminAccessCode: string | null;
   flySessionsToken: string | null;
   flySessionsApp: string | null;
   flySessionsRegion: string | null;
@@ -213,7 +184,7 @@ export function handleAdminRequest(
   const method = req.method || "GET";
 
   // Serve admin HTML
-  if (url === "/admin" && method === "GET") {
+  if (url.split("?")[0] === "/admin" && method === "GET") {
     res.writeHead(200, { "Content-Type": "text/html" });
     res.end(adminHtml);
     return true;
@@ -227,7 +198,7 @@ export function handleAdminRequest(
 
   // All other /api routes require auth
   if (url.startsWith("/api/")) {
-    if (!isValidSession(getToken(req))) {
+    if (!isValidSession(getRequestToken(req))) {
       json(res, 401, { error: "Unauthorized" });
       return true;
     }
@@ -662,11 +633,17 @@ async function handleDestroySession(
 async function handleAuth(
   req: http.IncomingMessage,
   res: http.ServerResponse,
-  accessCode: string,
+  accessCode: string | null,
 ): Promise<void> {
+  if (accessCode === null) {
+    json(res, 403, { error: "Access-code login is disabled" });
+    return;
+  }
+
   try {
     const body = JSON.parse(await readBody(req)) as { code?: string };
-    if (body.code === accessCode) {
+    if (typeof body.code === "string" && accessCodeMatches(body.code, accessCode)) {
+      console.warn("[admin] access-code login is deprecated; configure SSO (OAuth) providers instead");
       const token = createSession();
       json(res, 200, { token });
     } else {

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -1,0 +1,40 @@
+/**
+ * Cookie helpers for the admin session.
+ * SSO establishes the session through a browser redirect, so the token travels in an httpOnly cookie instead.
+ */
+
+export const SESSION_COOKIE_NAME = "ai_admin_session";
+
+/** Parse a `Cookie:` request header into a name→value map. Returns {} when absent or empty. */
+export function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+
+  for (const part of header.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (name) out[name] = decodeURIComponent(part.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+/** Build a Set-Cookie value carrying the session token. `secure` is derived from the request scheme. */
+export function serializeSessionCookie(token: string, maxAgeMs: number, secure: boolean): string {
+  const attrs = [
+    `${SESSION_COOKIE_NAME}=${encodeURIComponent(token)}`,
+    "HttpOnly",
+    "SameSite=Lax",
+    "Path=/",
+    `Max-Age=${Math.floor(maxAgeMs / 1000)}`, // Max-Age is in seconds
+  ];
+  if (secure) attrs.push("Secure");
+  return attrs.join("; ");
+}
+
+/** Build a Set-Cookie value that immediately expires the session cookie (server-side logout). */
+export function clearSessionCookie(secure: boolean): string {
+  const attrs = [`${SESSION_COOKIE_NAME}=`, "HttpOnly", "SameSite=Lax", "Path=/", "Max-Age=0"];
+  if (secure) attrs.push("Secure");
+  return attrs.join("; ");
+}

--- a/src/dedup.ts
+++ b/src/dedup.ts
@@ -32,6 +32,18 @@ function ensureDispatchedColumns(): void {
   }
 }
 
+function ensureAdminSessionColumns(): void {
+  if (!db) return;
+  const info = db.prepare("PRAGMA table_info(admin_sessions)").all() as Array<{ name: string }>;
+  const names = new Set(info.map((c) => c.name));
+
+  // SSO sessions carry the signed-in user's identity; access-code sessions leave these NULL.
+  if (!names.has("email")) db.exec("ALTER TABLE admin_sessions ADD COLUMN email TEXT");
+  if (!names.has("sub")) db.exec("ALTER TABLE admin_sessions ADD COLUMN sub TEXT");
+  if (!names.has("provider")) db.exec("ALTER TABLE admin_sessions ADD COLUMN provider TEXT");
+  if (!names.has("name")) db.exec("ALTER TABLE admin_sessions ADD COLUMN name TEXT");
+}
+
 function createRunnerTokensTable(): void {
   if (!db) return;
   db.exec(`
@@ -216,7 +228,20 @@ export function getDb(): Database.Database {
         expires_at INTEGER NOT NULL
       )
     `);
+    ensureAdminSessionColumns();
     db.prepare("DELETE FROM admin_sessions WHERE expires_at < ?").run(Date.now());
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS oauth_transactions (
+        state         TEXT PRIMARY KEY,
+        provider      TEXT NOT NULL,
+        code_verifier TEXT NOT NULL,
+        nonce         TEXT NOT NULL,
+        redirect_to   TEXT NOT NULL,
+        created_at    INTEGER NOT NULL,
+        expires_at    INTEGER NOT NULL
+      )
+    `);
+    db.prepare("DELETE FROM oauth_transactions WHERE expires_at < ?").run(Date.now());
     db.exec(`
       CREATE TABLE IF NOT EXISTS reaper_actions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ import { initLogTable, appendLog, countPriorDispatches, completeOrphanedPlanning
 import type { Job, JobStatus } from "./log.js";
 import { getInstallationToken } from "./github-app-auth.js";
 import { configureLinearAuth } from "./linear-app-auth.js";
+import { configureOAuthProviders, isOAuthConfigured, providersFromEnv } from "./oauth/providers.js";
+import { configureAuthorizationPolicy } from "./oauth/authorize.js";
+import { handleOAuthCallback, handleOAuthLogout, handleOAuthProviders, handleOAuthStart } from "./oauth/routes.js";
 import { handleTokenRequest } from "./token-vending.js";
 import { handleStatusUpdate, handleStepReport } from "./session-api.js";
 import { postStatusComment } from "./status-events.js";
@@ -66,6 +69,7 @@ interface AppConfig {
   notifyWebhookUrl: string | null;
   notifyType: string;
   adminAccessCode: string | null;
+  oauthRedirectBaseUrl: string | null;
   pollIntervalMs: number;
   healthPort: number;
   // Fly Machines (optional — only needed if any mapping uses fly-machines mode)
@@ -97,10 +101,41 @@ function loadConfig(): AppConfig {
     if (!val) throw new Error(`Missing required env var: ${key}`);
     return val;
   };
-
+  
+  // Microsoft's tid-based "email verified" only holds for a single-tenant issuer
+  // so it's dropped as an OAuth provider if a multi-tenant env value is provided
+  let oauthProviders = providersFromEnv(process.env);
+  const msMultiTenant = oauthProviders.some((p) => p.id === "microsoft") &&
+    ["common", "organizations", "consumers"].includes((process.env.MICROSOFT_OAUTH_TENANT || "").toLowerCase());
+  if (msMultiTenant) {
+    oauthProviders = oauthProviders.filter((p) => p.id !== "microsoft");
+    console.warn("[main] MICROSOFT_OAUTH_TENANT is a multi-tenant value — Microsoft SSO disabled. Pin a specific tenant GUID (single-tenant).");
+  }
+  
+  // Resolved admin-auth posture — now that both access-code and SSO are known.
   const adminAccessCode = process.env.ADMIN_ACCESS_CODE || null;
-  if (!adminAccessCode) {
-    console.warn("[main] ADMIN_ACCESS_CODE not set — admin UI disabled");
+  const oauthConfigured = oauthProviders.length > 0; // derive from the list, not the not-yet-seeded singleton
+  if (!adminAccessCode && !oauthConfigured) {
+    console.warn("[main] admin UI disabled — set ADMIN_ACCESS_CODE and/or configure OAuth providers");
+  } else {
+    const modes: string[] = [];
+    if (oauthConfigured) {
+      configureOAuthProviders(oauthProviders);
+      configureAuthorizationPolicy({
+        allowedDomains: (process.env.OAUTH_ALLOWED_DOMAINS || "").split(",").map((s) => s.trim()).filter(Boolean),
+        allowedEmails: (process.env.OAUTH_ALLOWED_EMAILS || "").split(",").map((s) => s.trim()).filter(Boolean),
+      });
+
+      modes.push(`SSO (${oauthProviders.map((p) => p.id).join(", ")})`);
+    }
+    if (adminAccessCode) modes.push("access code");
+
+    console.log(`[main] admin auth: ${modes.join(" + ")}`);
+  }
+
+  const oauthRedirectBaseUrl = process.env.OAUTH_REDIRECT_BASE_URL || null;
+  if (oauthConfigured && !oauthRedirectBaseUrl) {
+    console.warn("[main] OAuth providers configured but OAUTH_REDIRECT_BASE_URL not set — SSO redirect URIs can't be built");
   }
 
   const notifyWebhookUrl = process.env.NOTIFY_WEBHOOK_URL || null;
@@ -147,6 +182,7 @@ function loadConfig(): AppConfig {
     notifyWebhookUrl,
     notifyType,
     adminAccessCode,
+    oauthRedirectBaseUrl,
     pollIntervalMs: parseInt(process.env.POLL_INTERVAL_MS || "60000", 10),
     healthPort: parseInt(process.env.PORT || "8080", 10),
     flySessionsToken: process.env.FLY_SESSIONS_TOKEN || null,
@@ -2539,12 +2575,53 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
       return;
     }
 
-    // Admin routes
-    if (url === "/admin" || url.startsWith("/api/")) {
-      if (!config.adminAccessCode) {
+    // OAuth / SSO — its own auth model (public providers endpoint + the OAuth flow);
+    // mounted before the admin 503-gate so it works when ADMIN_ACCESS_CODE is unset.
+    if (url.startsWith("/api/auth/")) {
+      const pathname = url.split("?")[0];
+      // `secure` reflects the real scheme from Fly's proxy-set x-forwarded-proto.
+      // The app is only reachable through that proxy, so the header is trusted; don't copy this to a directly-exposed server.
+      const secure = String(req.headers["x-forwarded-proto"] ?? "").includes("https");
+
+      if (pathname === "/api/auth/providers" && req.method === "GET") {
+        handleOAuthProviders(res, config.adminAccessCode !== null);
+        return;
+      }
+      if (pathname === "/api/auth/logout" && req.method === "POST") {
+        handleOAuthLogout(req, res, secure);
+        return;
+      }
+      const m = pathname.match(/^\/api\/auth\/([^/]+)\/(start|callback)$/);
+      if (m && req.method === "GET") {
+        const [, providerId, action] = m;
+        if (!config.oauthRedirectBaseUrl) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "OAuth is not configured (OAUTH_REDIRECT_BASE_URL is unset)." }));
+          return;
+        }
+        const oauthResult = action === "start"
+          ? handleOAuthStart(req, res, providerId, config.oauthRedirectBaseUrl)
+          : handleOAuthCallback(req, res, providerId, config.oauthRedirectBaseUrl, secure);
+        oauthResult.catch((err) => {
+          console.error("[oauth] Unhandled error:", err);
+          if (!res.headersSent) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "Internal server error" }));
+          }
+        });
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+      return;
+    }
+
+    // Admin routes - match on the path only, so query params can still be read when needed
+    if (url.split("?")[0] === "/admin" || url.startsWith("/api/")) {
+      if (!config.adminAccessCode && !isOAuthConfigured()) {
         res.writeHead(503, { "Content-Type": "application/json" });
         res.end(JSON.stringify({
-          error: "Admin UI is disabled because the ADMIN_ACCESS_CODE secret is not set. Set it and redeploy to enable the admin UI.",
+          error: "Admin UI is disabled. Configure SSO (OAuth providers + the OAUTH_ALLOWED_* allowlist) or set ADMIN_ACCESS_CODE, then redeploy to enable the Admin UI.",
         }));
         return;
       }

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -1,0 +1,51 @@
+/**
+ * Authorization policy — decides whether an authenticated identity may access the admin UI.
+ * Provider-agnostic so the same gate covers Google, Microsoft, and any future IdP.
+ * Fail-closed: an empty allowlist denies everyone.
+ */
+
+import type { VerifiedIdentity } from "./oidc.js";
+
+/** Who may access the admin UI. Empty lists deny everyone. */
+export interface AuthorizationPolicy {
+  allowedDomains: string[]; // email domains, e.g. ["eudoxus.ai"]
+  allowedEmails: string[]; // explicit individual emails
+}
+
+// Singleton state: the normalized (lowercased) policy, empty until configured.
+let policy: AuthorizationPolicy = { allowedDomains: [], allowedEmails: [] };
+
+/** Seed the allowlist once at startup. Values are lowercased so matching is case-insensitive. */
+export function configureAuthorizationPolicy(p: AuthorizationPolicy): void {
+  policy = {
+    allowedDomains: p.allowedDomains.map((d) => d.trim().toLowerCase()).filter(Boolean),
+    allowedEmails: p.allowedEmails.map((e) => e.trim().toLowerCase()).filter(Boolean),
+  };
+}
+
+export function getAuthorizationPolicy(): AuthorizationPolicy {
+  return policy;
+}
+
+/** Decide whether a verified identity is allowed in. reason is for server-side logging, not the end user. */
+export function authorize(identity: VerifiedIdentity): { ok: true } | { ok: false; reason: string } {
+  if (!identity.emailVerified) {
+    return { ok: false, reason: `email address is not verified by the ${identity.provider}` };
+  }
+  if (!identity.email) {
+    return { ok: false, reason: `${identity.provider} returned no email address` };
+  }
+
+  const email = identity.email.trim().toLowerCase();
+  const domain = email.split("@").pop() ?? "";
+
+  if (policy.allowedEmails.includes(email)) return { ok: true };
+  if (domain !== email && policy.allowedDomains.includes(domain)) return { ok: true };
+
+  return { ok: false, reason: `${identity.email} is not on the access allowlist` };
+}
+
+/** Test hook: clear the policy back to the empty (deny-all) state. */
+export function __resetAuthorizationPolicyForTest(): void {
+  policy = { allowedDomains: [], allowedEmails: [] };
+}

--- a/src/oauth/oidc.ts
+++ b/src/oauth/oidc.ts
@@ -1,0 +1,100 @@
+/**
+ * OIDC engine — the only module that talks to openid-client.
+ * Runs the authorization-code flow:
+ * - discover the provider's metadata
+ * - build the redirect URL (with PKCE + state + nonce)
+ * - exchange the returned code
+ * - normalize the claims into our VerifiedIdentity.
+ * the sibling providers.ts decides WHICH providers exist
+ */
+
+import * as client from "openid-client";
+import type { OidcProviderConfig } from "./providers.js";
+
+/** A provider's identity, normalized to a common shape. rawClaims is kept for a future tenant/group policy. */
+export interface VerifiedIdentity {
+  provider: string;
+  sub: string;
+  email: string | null;
+  emailVerified: boolean;
+  name: string | null;
+  hd: string | null; // Google Workspace hosted domain, when present
+  tid: string | null; // Microsoft tenant id, when present
+  rawClaims: Record<string, unknown>;
+}
+
+/** What the caller must stash server-side between the redirect and the callback. */
+export interface AuthStart {
+  authorizationUrl: string;
+  state: string;
+  nonce: string;
+  codeVerifier: string;
+}
+
+// discovery() fetches <issuer>/.well-known/openid-configuration over the network,
+// so cache the resolved Configuration per provider id for the process lifetime.
+const configCache = new Map<string, Promise<client.Configuration>>();
+
+function getConfig(p: OidcProviderConfig): Promise<client.Configuration> {
+  let config = configCache.get(p.id);
+  if (!config) {
+    config = client.discovery(new URL(p.issuer), p.clientId, p.clientSecret);
+    config.catch(() => configCache.delete(p.id)); // drop the entry on rejection so the next attempt retries. successful configs stay cached.
+    configCache.set(p.id, config);
+  }
+  return config;
+}
+
+/** Build the provider redirect URL and mint the PKCE/state/nonce the callback will verify against. */
+export async function buildAuthUrl(p: OidcProviderConfig, redirectUri: string): Promise<AuthStart> {
+  const config = await getConfig(p);
+  const codeVerifier = client.randomPKCECodeVerifier();
+  const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
+  const state = client.randomState();
+  const nonce = client.randomNonce();
+
+  const authorizationUrl = client.buildAuthorizationUrl(config, {
+    redirect_uri: redirectUri,
+    scope: p.scopes.join(" "),
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state,
+    nonce,
+  });
+
+  return { authorizationUrl: authorizationUrl.href, state, nonce, codeVerifier };
+}
+
+/** Exchange the callback's code (validating state/nonce/PKCE), then normalize the ID-token claims. */
+export async function completeAuth(
+  p: OidcProviderConfig,
+  currentUrl: URL,
+  expected: { state: string; nonce: string; codeVerifier: string },
+): Promise<VerifiedIdentity> {
+  const config = await getConfig(p);
+  const tokens = await client.authorizationCodeGrant(config, currentUrl, {
+    expectedState: expected.state,
+    expectedNonce: expected.nonce,
+    pkceCodeVerifier: expected.codeVerifier,
+  });
+
+  const claims = tokens.claims();
+  if (!claims) throw new Error(`${p.id}: no ID token returned`);
+
+  // Microsoft emits no `email_verified` — trust a work/school account via its org `tid`, excluding the reserved personal-MSA tenant.
+  // Ref: https://learn.microsoft.com/en-us/entra/identity-platform/id-token-claims-reference
+  const MSA_TENANT_ID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+  const emailVerified =
+    claims.email_verified === true || (typeof claims.tid === "string" && claims.tid !== MSA_TENANT_ID);
+
+  return {
+    provider: p.id,
+    sub: claims.sub,
+    email: typeof claims.email === "string" ? claims.email : null,
+    emailVerified,
+    name: typeof claims.name === "string" ? claims.name : null,
+    hd: typeof claims.hd === "string" ? claims.hd : null,
+    tid: typeof claims.tid === "string" ? claims.tid : null,
+    rawClaims: claims as Record<string, unknown>,
+  };
+}

--- a/src/oauth/providers.ts
+++ b/src/oauth/providers.ts
@@ -1,0 +1,69 @@
+/**
+ * OAuth/OIDC provider registry — the seam that makes Google, Microsoft, and any future OIDC issuer just configuration.
+ * Seeded once at startup from env, read by the OAuth routes and the login screen.
+ */
+
+/** A configured OIDC identity provider. `issuer` is the discovery URL openid-client resolves metadata from. */
+export interface OidcProviderConfig {
+  id: string;       // stable key used in routes and the provider tag, e.g. "google", "microsoft"
+  label: string;    // human label for the login button, e.g. "Google"
+  issuer: string;   // OIDC issuer / discovery base URL
+  clientId: string;
+  clientSecret: string;
+  scopes: string[]; // requested scopes, e.g. ["openid", "email", "profile"]
+}
+
+// Singleton state: the providers this orchestrator was configured with (empty until configured).
+let providers: OidcProviderConfig[] = [];
+
+/** Seed the configured providers once at startup. Callers pass only fully-credentialed entries. */
+export function configureOAuthProviders(list: OidcProviderConfig[]): void {
+  providers = list;
+}
+
+/** Look up a provider by id, or null when it isn't configured. */
+export function getProvider(id: string): OidcProviderConfig | null {
+  return providers.find((p) => p.id === id) ?? null;
+}
+
+/** The id+label of every configured provider — what the login screen needs to render its buttons. */
+export function listConfiguredProviders(): Array<{ id: string; label: string }> {
+  return providers.map((p) => ({ id: p.id, label: p.label }));
+}
+
+/** Whether any OIDC provider is configured — the "is SSO available?" signal (used by the 503-gate). */
+export function isOAuthConfigured(): boolean {
+  return providers.length > 0;
+}
+
+/** Build the provider list from env — Google and/or Microsoft, each included only when fully credentialed. */
+export function providersFromEnv(env: NodeJS.ProcessEnv): OidcProviderConfig[] {
+  const scopes = ["openid", "email", "profile"];
+  const list: OidcProviderConfig[] = [];
+  if (env.GOOGLE_OAUTH_CLIENT_ID && env.GOOGLE_OAUTH_CLIENT_SECRET) {
+    list.push({
+      id: "google",
+      label: "Google",
+      issuer: "https://accounts.google.com",
+      clientId: env.GOOGLE_OAUTH_CLIENT_ID,
+      clientSecret: env.GOOGLE_OAUTH_CLIENT_SECRET,
+      scopes,
+    });
+  }
+  if (env.MICROSOFT_OAUTH_CLIENT_ID && env.MICROSOFT_OAUTH_CLIENT_SECRET && env.MICROSOFT_OAUTH_TENANT) {
+    list.push({
+      id: "microsoft",
+      label: "Microsoft",
+      issuer: `https://login.microsoftonline.com/${env.MICROSOFT_OAUTH_TENANT}/v2.0`,
+      clientId: env.MICROSOFT_OAUTH_CLIENT_ID,
+      clientSecret: env.MICROSOFT_OAUTH_CLIENT_SECRET,
+      scopes,
+    });
+  }
+  return list;
+}
+
+/** Test hook: clear configured providers back to the empty (unconfigured) state. */
+export function __resetOAuthProvidersForTest(): void {
+  providers = [];
+}

--- a/src/oauth/routes.ts
+++ b/src/oauth/routes.ts
@@ -1,0 +1,114 @@
+/**
+ * OAuth login routes — where the provider seam, OIDC engine, authorization policy, transaction store,
+ * session layer, and cookies wire together into the actual endpoints.
+ */
+
+import type http from "node:http";
+import { getProvider, listConfiguredProviders } from "./providers.js";
+import { buildAuthUrl, completeAuth } from "./oidc.js";
+import { authorize } from "./authorize.js";
+import { putTransaction, takeTransaction } from "./state-store.js";
+import { createSession, revokeSession, getRequestToken, SESSION_TTL_MS } from "../admin-session.js";
+import { serializeSessionCookie, clearSessionCookie } from "../cookies.js";
+
+function json(res: http.ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+function redirect(res: http.ServerResponse, location: string, setCookie?: string): void {
+  const headers: Record<string, string> = { Location: location };
+  if (setCookie) headers["Set-Cookie"] = setCookie;
+  res.writeHead(302, headers);
+  res.end();
+}
+
+/** Only same-origin absolute paths are valid post-login targets — never an off-site URL. */
+function safeLocalPath(next: string | null | undefined, fallback = "/admin"): string {
+  if (!next || next[0] !== "/") return fallback;
+  if (next[1] === "/" || next[1] === "\\") return fallback; // "//host" or "/\host" can escape to another origin
+  return next;
+}
+
+/** Unauthenticated: which provider buttons to render + whether the (deprecated) access-code box applies. */
+export function handleOAuthProviders(res: http.ServerResponse, accessCodeEnabled: boolean): void {
+  json(res, 200, { providers: listConfiguredProviders(), accessCode: accessCodeEnabled });
+}
+
+/** Start: mint the security values, stash them server-side, redirect the browser to the provider. */
+export async function handleOAuthStart(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  providerId: string,
+  baseUrl: string,
+): Promise<void> {
+  const provider = getProvider(providerId);
+  if (!provider) return json(res, 404, { error: "unknown provider" });
+
+  const url = new URL(req.url ?? "", baseUrl);
+  const redirectTo = safeLocalPath(url.searchParams.get("next"));
+  const redirectUri = `${baseUrl}/api/auth/${providerId}/callback`;
+
+  const start = await buildAuthUrl(provider, redirectUri);
+  putTransaction({
+    state: start.state,
+    provider: providerId,
+    codeVerifier: start.codeVerifier,
+    nonce: start.nonce,
+    redirectTo,
+  });
+  redirect(res, start.authorizationUrl);
+}
+
+/** Callback: consume the transaction, exchange the code, authorize the identity, mint the session cookie. */
+export async function handleOAuthCallback(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  providerId: string,
+  baseUrl: string,
+  secure: boolean,
+): Promise<void> {
+  const provider = getProvider(providerId);
+  if (!provider) return json(res, 404, { error: "unknown provider" });
+
+  const currentUrl = new URL(req.url ?? "", baseUrl);
+  const txn = takeTransaction(currentUrl.searchParams.get("state") ?? "");
+  if (!txn || txn.provider !== providerId) {
+    console.warn(`[oauth] ${providerId} callback rejected: invalid or expired login state`);
+    return redirect(res, "/admin?auth_error=expired");
+  }
+
+  let identity;
+  try {
+    identity = await completeAuth(provider, currentUrl, {
+      state: txn.state,
+      nonce: txn.nonce,
+      codeVerifier: txn.codeVerifier,
+    });
+  } catch (err) {
+    console.warn(`[oauth] ${providerId} code exchange failed:`, err); // was `catch {}` — the exception used to vanish
+    return redirect(res, "/admin?auth_error=failed");
+  }
+
+  const decision = authorize(identity);
+  if (!decision.ok) {
+    console.warn(`[oauth] denied ${identity.email ?? "?"} via ${providerId}: ${decision.reason}`);
+    return redirect(res, "/admin?auth_error=denied");
+  }
+
+  const token = createSession({
+    email: identity.email!, // authorize() guarantees a verified, non-null email on success
+    sub: identity.sub,
+    provider: identity.provider,
+    name: identity.name,
+  });
+  redirect(res, safeLocalPath(txn.redirectTo), serializeSessionCookie(token, SESSION_TTL_MS, secure));
+}
+
+/** Logout: revoke the session row and clear the cookie; the SPA handles navigation. */
+export function handleOAuthLogout(req: http.IncomingMessage, res: http.ServerResponse, secure: boolean): void {
+  const token = getRequestToken(req);
+  if (token) revokeSession(token);
+  res.writeHead(200, { "Content-Type": "application/json", "Set-Cookie": clearSessionCookie(secure) });
+  res.end(JSON.stringify({ ok: true }));
+}

--- a/src/oauth/state-store.ts
+++ b/src/oauth/state-store.ts
@@ -1,0 +1,43 @@
+/**
+ * Transient OAuth login state — the state/nonce/PKCE-verifier the callback must verify against, held server-side keyed by the unguessable `state`.
+ * Single-use and short-lived: consumed on read, swept after expiry.
+ * Distinct from admin_sessions (a different lifecycle).
+ */
+
+import { getDb } from "../dedup.js";
+
+export const OAUTH_TX_TTL_MS = 10 * 60 * 1000; // 10 minutes — a login round-trip is quick
+
+export interface OAuthTransaction {
+  state: string;
+  provider: string;
+  codeVerifier: string;
+  nonce: string;
+  redirectTo: string; // validated local path to return to after login
+}
+
+/** Persist the per-login state the callback will verify. */
+export function putTransaction(tx: OAuthTransaction): void {
+  const now = Date.now();
+  getDb()
+    .prepare(
+      "INSERT INTO oauth_transactions (state, provider, code_verifier, nonce, redirect_to, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(tx.state, tx.provider, tx.codeVerifier, tx.nonce, tx.redirectTo, now, now + OAUTH_TX_TTL_MS);
+}
+
+/** Consume a transaction by state: single-use (deleted on read) and only valid if unexpired. */
+export function takeTransaction(state: string): OAuthTransaction | null {
+  const db = getDb();
+  const row = db
+    .prepare("SELECT provider, code_verifier, nonce, redirect_to, expires_at FROM oauth_transactions WHERE state = ?")
+    .get(state) as
+    | { provider: string; code_verifier: string; nonce: string; redirect_to: string; expires_at: number }
+    | undefined;
+  if (!row) return null;
+
+  // Delete unconditionally — a state is spent the moment it's presented, valid or not.
+  db.prepare("DELETE FROM oauth_transactions WHERE state = ?").run(state);
+  if (Date.now() > row.expires_at) return null;
+  return { state, provider: row.provider, codeVerifier: row.code_verifier, nonce: row.nonce, redirectTo: row.redirect_to };
+}


### PR DESCRIPTION
## Summary

Replace the shared `ADMIN_ACCESS_CODE` with per-user SSO for the orchestrator admin UI: Google + Microsoft OIDC (`openid-client` v6), httpOnly cookie sessions, a fail-closed domain/email allowlist, and the access code retained as a **deprecated** fallback. Verified end-to-end against real Google + Microsoft providers.

## What changed

- **OAuth/OIDC** (`src/oauth/`): provider registry (`providers.ts`); OIDC engine (`oidc.ts` — the only `openid-client` importer: discovery + PKCE/state/nonce + code exchange + cross-provider claim normalization); fail-closed authZ (`authorize.ts`); single-use transaction store (`state-store.ts`); HTTP routes (`routes.ts`: `/api/auth/{providers, :provider/start, :provider/callback, logout}`).
- **Sessions/transport**: `admin-session.ts` (extracted from `admin.ts` — mint/validate/revoke, cookie-or-Bearer resolution, timing-safe access-code compare); `cookies.ts` (httpOnly/SameSite=Lax/Secure).
- **Wiring** (`index.ts`): env-driven providers + allowlist in `loadConfig`; `/api/auth/` mounted before the admin 503-gate; gate opens on `ADMIN_ACCESS_CODE` **or** any configured provider.
- **Admin UI** (`admin-ui/`): SSO provider tiles; **server-validated bootstrap** (probe `config-status` with the cookie rather than trusting localStorage); server logout; `auth_error` banner; deprecated access-code box.
- **Access code**: deprecated fallback — timing-safe `crypto.timingSafeEqual` compare + a deprecation warning on use.
- **Schema** (`dedup.ts`): nullable identity columns on `admin_sessions`; new `oauth_transactions` table.
- Docs (`CLAUDE.md`) + the `openid-client` dependency.

## Provider claim handling (doc-verified)

- **Google:** `email_verified` boolean + `hd`; identity keyed on `sub`.
- **Microsoft:** no `email_verified` claim — a work/school account is trusted via its org `tid` (single-tenant issuer), excluding the reserved personal-MSA tenant; `email` via the optional claim.

## Verification

- Full suite **2051 green**; typechecks clean.
- Real-provider e2e (Google Workspace + a Microsoft Entra tenant): SSO happy path → httpOnly session cookie → admin dashboard; **fail-closed allowlist deny** (incl. a real Microsoft identity rejected by the allowlist); server-side-revoking logout; deprecated access-code login (with warning).
- Adversarial security review of the auth surface: **no HIGH/MEDIUM findings**.

## Acceptance criteria

| Criterion | How it's met |
|---|---|
| Per-user SSO login (Google + Microsoft) | `src/oauth/*` + provider tiles |
| httpOnly cookie session (no XSS-exposed token) | `cookies.ts` + server-validated bootstrap |
| Fail-closed allowlist (domain + email) | `authorize.ts` |
| Access code retained but deprecated | timing-safe compare + warn + docs |
| SSO-only deploy works (no access code) | 503-gate opens on provider config |

## Follow-ups (not in scope)

- Optional hardening for a later pass: bind the OAuth `state` to a pre-auth cookie (closes a negligible login-CSRF residual).
- A v2 could make the allowlist DB-backed and editable from the admin UI (currently env-configured).
