### PR TITLE
feat: notify Slack/Teams on orchestrator redeploy (AII-255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ All tables live in a single SQLite file at `DEDUP_DB_PATH` (default `/data/dedup
 | `dispatched` | Dedup — issue IDs dispatched in the last 24h |
 | `mappings` | Team key → GitHub repo config |
 | `dispatch_log` | Audit log, last 500 dispatches |
+| `settings` | Key-value store — runner mode, Fly session config, deploy-notification state |
 
 `dedup.ts` owns the DB singleton (`getDb()`). All other modules import `getDb` from `dedup.ts`.
 
@@ -168,6 +169,10 @@ Six routes (`channels`, `policies`, `secrets`, `mcp`, `webhooks`, `updates`) are
 ## Notification adapter
 
 `src/notify.ts` exports a single `notify(type, webhookUrl, notification)` function. Set `NOTIFY_TYPE=slack` or `NOTIFY_TYPE=teams` to switch providers. Adding a new provider means adding a private function in `notify.ts` and a new case in the switch.
+
+The orchestrator also announces its own deploys. On shutdown it posts an `@channel` heads-up that dispatches are pausing; on the next boot it compares `FLY_IMAGE_REF` against the value it stored in the `settings` table and posts either "redeployed" (the image changed) or "restarted" (it did not), with how long it was down. A first boot on a fresh volume records the reference silently.
+
+Both notices are gated on `FLY_IMAGE_REF`, which only exists inside a Fly Machine — local runs never post. Failures are logged and swallowed, and the shutdown notice is bounded to a fraction of the shutdown budget so it cannot outlive `kill_timeout`.
 
 ## Workflow templates
 

--- a/fly.toml
+++ b/fly.toml
@@ -2,6 +2,7 @@
 # (or use `clients/<slug>.toml` with the multi-client deploy workflow).
 app = "ai-implement"
 primary_region = "iad"
+kill_timeout = 15
 
 [build]
 

--- a/src/__tests__/deploy-notify.test.ts
+++ b/src/__tests__/deploy-notify.test.ts
@@ -1,0 +1,265 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as DedupModule from "../dedup.js";
+import type * as DeployNotifyModule from "../deploy-notify.js";
+import type * as NotifyModule from "../notify.js";
+
+// The formatters are covered by notify.test.ts; here we only care that the right
+// payload reaches them, so the whole notify module is replaced by a spy.
+vi.mock("../notify.js", () => ({ notifyDeploy: vi.fn() }));
+
+const IMAGE_A = "registry.fly.io/orch:deployment-AAA";
+const IMAGE_B = "registry.fly.io/orch:deployment-BBB";
+const LAST_IMAGE_REF_KEY = "deploy_last_image_ref";
+const LAST_SHUTDOWN_AT_KEY = "deploy_last_shutdown_at";
+
+const config = { notifyType: "slack", notifyWebhookUrl: "https://hook.example.com" };
+
+let dbPath: string;
+let dedup: typeof DedupModule;
+let deployNotify: typeof DeployNotifyModule;
+let notify: typeof NotifyModule;
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `deploy-notify-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  const runnerMode = await import("../runner-mode.js");
+  runnerMode.initSettingsTable();
+  deployNotify = await import("../deploy-notify.js");
+  notify = await import("../notify.js");
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
+});
+
+/** Puts the process in "running as a Fly Machine on this image" state. */
+function onFly(imageRef: string): void {
+  vi.stubEnv("FLY_IMAGE_REF", imageRef);
+  vi.stubEnv("FLY_APP_NAME", "ai-implement-testing-orchestrator");
+  vi.stubEnv("FLY_REGION", "iad");
+}
+
+function readKey(key: string): string | null {
+  const row = dedup.getDb().prepare("SELECT value FROM settings WHERE key = ?").get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value ?? null;
+}
+
+function writeKey(key: string, value: string): void {
+  dedup.getDb().prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)").run(key, value);
+}
+
+// ---------- The decision, as a table. No database, no clock, no network. ----------
+
+describe("decideBootNotification", () => {
+  const base = { currentImageRef: IMAGE_B, prevImageRef: IMAGE_A, lastShutdownAt: 1_000, now: 4_000 };
+
+  it("stays silent on the first boot of a fresh volume", () => {
+    expect(deployNotify.decideBootNotification({ ...base, prevImageRef: null })).toBeNull();
+  });
+
+  it("reports a deploy when the image ref changed", () => {
+    expect(deployNotify.decideBootNotification(base)).toEqual({ kind: "deployed", downtimeMs: 3_000 });
+  });
+
+  // A SIGKILLed process runs no handler, so there is no timestamp — but the stored ref
+  // survives from the last successful boot, so the classification still holds.
+  it("reports a deploy after a hard kill, without a downtime figure", () => {
+    expect(deployNotify.decideBootNotification({ ...base, lastShutdownAt: null })).toEqual({
+      kind: "deployed",
+      downtimeMs: null,
+    });
+  });
+
+  it("reports a restart when the ref is unchanged and a shutdown was announced", () => {
+    expect(deployNotify.decideBootNotification({ ...base, currentImageRef: IMAGE_A })).toEqual({
+      kind: "restarted",
+      downtimeMs: 3_000,
+    });
+  });
+
+  // Nothing told the channel this process stopped, so nothing needs to tell it we are back.
+  it("stays silent when the ref is unchanged and nothing announced a stop", () => {
+    expect(
+      deployNotify.decideBootNotification({ ...base, currentImageRef: IMAGE_A, lastShutdownAt: null }),
+    ).toBeNull();
+  });
+
+  it("clamps downtime to zero rather than reporting a negative duration", () => {
+    expect(deployNotify.decideBootNotification({ ...base, now: 500 })).toEqual({
+      kind: "deployed",
+      downtimeMs: 0,
+    });
+  });
+});
+
+// ---------- The shell around it ----------
+
+describe("recordShutdown", () => {
+  it("records a timestamp when running on Fly", () => {
+    onFly(IMAGE_A);
+    deployNotify.recordShutdown();
+    expect(Number(readKey(LAST_SHUTDOWN_AT_KEY))).toBeGreaterThan(0);
+  });
+
+  it("records nothing off Fly", () => {
+    deployNotify.recordShutdown();
+    expect(readKey(LAST_SHUTDOWN_AT_KEY)).toBeNull();
+  });
+});
+
+describe("postShutdownNotice", () => {
+  it("posts a shutdown notice with no downtime figure", async () => {
+    onFly(IMAGE_A);
+    await deployNotify.postShutdownNotice(config);
+
+    expect(notify.notifyDeploy).toHaveBeenCalledOnce();
+    const [type, url, payload] = vi.mocked(notify.notifyDeploy).mock.calls[0];
+    expect(type).toBe("slack");
+    expect(url).toBe(config.notifyWebhookUrl);
+    expect(payload).toMatchObject({
+      kind: "shutdown",
+      appName: "ai-implement-testing-orchestrator",
+      region: "iad",
+      imageRef: IMAGE_A,
+      downtimeMs: null,
+    });
+  });
+
+  it("stays silent off Fly", async () => {
+    await deployNotify.postShutdownNotice(config);
+    expect(notify.notifyDeploy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when no webhook is configured", async () => {
+    onFly(IMAGE_A);
+    await deployNotify.postShutdownNotice({ ...config, notifyWebhookUrl: null });
+    expect(notify.notifyDeploy).not.toHaveBeenCalled();
+  });
+
+  // A dead webhook must never wedge a shutdown that Fly is already counting down.
+  it("swallows a webhook failure", async () => {
+    onFly(IMAGE_A);
+    vi.mocked(notify.notifyDeploy).mockRejectedValueOnce(new Error("Slack webhook failed: 500"));
+    await expect(deployNotify.postShutdownNotice(config)).resolves.toBeUndefined();
+  });
+});
+
+describe("postBootNotice", () => {
+  it("stays silent and writes nothing off Fly", async () => {
+    await deployNotify.postBootNotice(config);
+    expect(notify.notifyDeploy).not.toHaveBeenCalled();
+    expect(readKey(LAST_IMAGE_REF_KEY)).toBeNull();
+  });
+
+  it("records the ref silently on a first boot", async () => {
+    onFly(IMAGE_A);
+    await deployNotify.postBootNotice(config);
+
+    expect(notify.notifyDeploy).not.toHaveBeenCalled();
+    expect(readKey(LAST_IMAGE_REF_KEY)).toBe(IMAGE_A);
+  });
+
+  it("announces a deploy and advances the stored ref", async () => {
+    writeKey(LAST_IMAGE_REF_KEY, IMAGE_A);
+    onFly(IMAGE_B);
+    await deployNotify.postBootNotice(config);
+
+    expect(vi.mocked(notify.notifyDeploy).mock.calls[0][2]).toMatchObject({ kind: "deployed", imageRef: IMAGE_B });
+    expect(readKey(LAST_IMAGE_REF_KEY)).toBe(IMAGE_B);
+  });
+
+  // Otherwise a later restart would measure its downtime from a deploy that already resolved.
+  it("clears the shutdown record once it has been consumed", async () => {
+    writeKey(LAST_IMAGE_REF_KEY, IMAGE_A);
+    writeKey(LAST_SHUTDOWN_AT_KEY, String(Date.now() - 5_000));
+    onFly(IMAGE_B);
+    await deployNotify.postBootNotice(config);
+
+    expect(readKey(LAST_SHUTDOWN_AT_KEY)).toBeNull();
+  });
+
+  // State is bookkeeping, not a side effect of notifying: if it only advanced when a webhook
+  // was set, enabling notifications later would announce a deploy that happened weeks ago.
+  it("advances state even when no webhook is configured", async () => {
+    writeKey(LAST_IMAGE_REF_KEY, IMAGE_A);
+    onFly(IMAGE_B);
+    await deployNotify.postBootNotice({ ...config, notifyWebhookUrl: null });
+
+    expect(notify.notifyDeploy).not.toHaveBeenCalled();
+    expect(readKey(LAST_IMAGE_REF_KEY)).toBe(IMAGE_B);
+  });
+
+  it("swallows a webhook failure", async () => {
+    writeKey(LAST_IMAGE_REF_KEY, IMAGE_A);
+    onFly(IMAGE_B);
+    vi.mocked(notify.notifyDeploy).mockRejectedValueOnce(new Error("Slack webhook failed: 500"));
+    await expect(deployNotify.postBootNotice(config)).resolves.toBeUndefined();
+  });
+
+  // index.ts calls this fire-and-forget so a hanging webhook cannot stall startup, which is
+  // only safe while every write sits above the first await. A webhook that never settles must
+  // therefore still leave the state fully advanced once control returns.
+  it("persists state synchronously, before the webhook is awaited", () => {
+    writeKey(LAST_IMAGE_REF_KEY, IMAGE_A);
+    writeKey(LAST_SHUTDOWN_AT_KEY, String(Date.now() - 5_000));
+    onFly(IMAGE_B);
+    vi.mocked(notify.notifyDeploy).mockReturnValueOnce(new Promise(() => { /* never settles */ }));
+
+    void deployNotify.postBootNotice(config); // deliberately not awaited
+
+    expect(readKey(LAST_IMAGE_REF_KEY)).toBe(IMAGE_B);
+    expect(readKey(LAST_SHUTDOWN_AT_KEY)).toBeNull();
+  });
+
+  it("ignores a corrupt shutdown timestamp rather than reporting a nonsense duration", async () => {
+    writeKey(LAST_IMAGE_REF_KEY, IMAGE_A);
+    writeKey(LAST_SHUTDOWN_AT_KEY, "not-a-number");
+    onFly(IMAGE_B);
+    await deployNotify.postBootNotice(config);
+
+    expect(vi.mocked(notify.notifyDeploy).mock.calls[0][2]).toMatchObject({ downtimeMs: null });
+  });
+});
+
+// ---------- The two halves in sequence, which is how they actually run ----------
+
+describe("shutdown → boot cycle", () => {
+  it("reports a deploy with measured downtime across a version change", async () => {
+    onFly(IMAGE_A);
+    await deployNotify.postBootNotice(config); // first boot: records IMAGE_A silently
+    vi.mocked(notify.notifyDeploy).mockClear();
+
+    deployNotify.recordShutdown();
+    await deployNotify.postShutdownNotice(config);
+
+    onFly(IMAGE_B); // the replacement machine
+    await deployNotify.postBootNotice(config);
+
+    const kinds = vi.mocked(notify.notifyDeploy).mock.calls.map((c) => c[2].kind);
+    expect(kinds).toEqual(["shutdown", "deployed"]);
+    expect(vi.mocked(notify.notifyDeploy).mock.calls[1][2].downtimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports a restart when the same image comes back", async () => {
+    onFly(IMAGE_A);
+    await deployNotify.postBootNotice(config);
+    vi.mocked(notify.notifyDeploy).mockClear();
+
+    deployNotify.recordShutdown();
+    await deployNotify.postShutdownNotice(config);
+    await deployNotify.postBootNotice(config); // same IMAGE_A
+
+    const kinds = vi.mocked(notify.notifyDeploy).mock.calls.map((c) => c[2].kind);
+    expect(kinds).toEqual(["shutdown", "restarted"]);
+  });
+});

--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { notify, notifyCompletion } from "../notify.js";
-import type { Notification } from "../notify.js";
+import { notify, notifyCompletion, notifyDeploy } from "../notify.js";
+import type { DeployNotification, Notification } from "../notify.js";
 
 const notification: Notification = {
   issueIdentifier: "TEST-5",
@@ -271,6 +271,138 @@ describe("notifyCompletion", () => {
       vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500, text: async () => "err" } as Response);
       await expect(
         notifyCompletion("teams", "https://hook.example.com", { ...completionBase, status: "completed" }),
+      ).rejects.toThrow("500");
+    });
+  });
+});
+
+describe("notifyDeploy", () => {
+  const deployBase: DeployNotification = {
+    kind: "deployed",
+    appName: "ai-implement-testing-orchestrator",
+    region: "iad",
+    imageRef: "registry.fly.io/ai-implement-testing-orchestrator:deployment-01H9RK9EYO9PGNBYAKGXSHV0PH",
+    downtimeMs: 42_000,
+  };
+
+  const sentBody = () => JSON.parse((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string);
+  const slackText = (): string => sentBody().blocks[0].text.text;
+  const teamsFacts = (): Array<{ title: string; value: string }> =>
+    sentBody().attachments[0].content.body.find((b: { type: string }) => b.type === "FactSet").facts;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    vi.mocked(fetch).mockResolvedValue({ ok: true, status: 200 } as Response);
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  describe("slack", () => {
+    // The broadcast is the whole point of AII-255: the team must be pinged that dispatches are
+    // pausing. The two boot notices answer that ping, so they must stay quiet.
+    it("broadcasts to the channel on shutdown", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", {
+        ...deployBase, kind: "shutdown", downtimeMs: null,
+      });
+      expect(slackText()).toContain("<!channel>");
+      expect(slackText()).toContain("Orchestrator restarting");
+    });
+
+    it.each(["deployed", "restarted"] as const)("does not broadcast on %s", async (kind) => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", { ...deployBase, kind });
+      expect(slackText()).not.toContain("<!channel>");
+    });
+
+    it("omits the version on shutdown and shows it once back up", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", {
+        ...deployBase, kind: "shutdown", downtimeMs: null,
+      });
+      expect(slackText()).not.toContain("Version:");
+
+      vi.mocked(fetch).mockClear();
+      await notifyDeploy("slack", "https://webhook.example.com/slack", deployBase);
+      expect(slackText()).toContain("Version:");
+    });
+
+    // Only the deployment tag is readable; the registry host is noise that would wrap the line.
+    it("renders the deployment tag rather than the whole image reference", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", deployBase);
+      expect(slackText()).toContain("`deployment-01H9RK9EYO9PGNBYAKGXSHV0PH`");
+      expect(slackText()).not.toContain("registry.fly.io");
+    });
+
+    it("falls back to the whole reference when it carries no tag", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", {
+        ...deployBase, imageRef: "some-untagged-reference",
+      });
+      expect(slackText()).toContain("`some-untagged-reference`");
+    });
+
+    it("renders downtime through formatDuration", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", { ...deployBase, downtimeMs: 125_000 });
+      expect(slackText()).toContain("Down for 2m 5s");
+    });
+
+    // A boot with no preceding shutdown record (hard kill, first boot) has nothing to measure.
+    it("omits downtime when it was not measured", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", { ...deployBase, downtimeMs: null });
+      expect(slackText()).not.toContain("Down for");
+    });
+
+    it("omits the region when unknown", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", { ...deployBase, region: null });
+      expect(slackText()).not.toContain("Region:");
+      expect(slackText()).toContain("App: `ai-implement-testing-orchestrator`");
+    });
+
+    it("uses slack by default when type is unrecognised", async () => {
+      await notifyDeploy("unknown-type", "https://webhook.example.com/hook", deployBase);
+      expect(sentBody().blocks).toBeDefined();
+    });
+
+    it("throws on non-ok response", async () => {
+      vi.mocked(fetch).mockResolvedValue({ ok: false, status: 500, text: async () => "err" } as Response);
+      await expect(
+        notifyDeploy("slack", "https://webhook.example.com/slack", deployBase),
+      ).rejects.toThrow("500");
+    });
+  });
+
+  describe("teams", () => {
+    it("carries app, region, version and downtime as facts", async () => {
+      await notifyDeploy("teams", "https://webhook.example.com/teams", deployBase);
+      const byTitle = Object.fromEntries(teamsFacts().map((f) => [f.title, f.value]));
+      expect(byTitle).toEqual({
+        App: "ai-implement-testing-orchestrator",
+        Region: "iad",
+        Version: "deployment-01H9RK9EYO9PGNBYAKGXSHV0PH",
+        "Down for": "42s",
+      });
+    });
+
+    it("titles the card by event kind", async () => {
+      await notifyDeploy("teams", "https://webhook.example.com/teams", { ...deployBase, kind: "restarted" });
+      expect(sentBody().attachments[0].content.body[0].text).toContain("Orchestrator back up");
+    });
+
+    it("omits the version fact on shutdown", async () => {
+      await notifyDeploy("teams", "https://webhook.example.com/teams", {
+        ...deployBase, kind: "shutdown", downtimeMs: null,
+      });
+      expect(teamsFacts().some((f) => f.title === "Version")).toBe(false);
+    });
+
+    // Slack broadcast syntax has no Teams equivalent — it would render as literal text in the card.
+    it("never emits slack mention syntax", async () => {
+      await notifyDeploy("teams", "https://webhook.example.com/teams", {
+        ...deployBase, kind: "shutdown", downtimeMs: null,
+      });
+      expect((vi.mocked(fetch).mock.calls[0][1] as RequestInit).body as string).not.toContain("<!channel>");
+    });
+
+    it("throws on non-ok response", async () => {
+      vi.mocked(fetch).mockResolvedValue({ ok: false, status: 500, text: async () => "err" } as Response);
+      await expect(
+        notifyDeploy("teams", "https://webhook.example.com/teams", deployBase),
       ).rejects.toThrow("500");
     });
   });

--- a/src/deploy-notify.ts
+++ b/src/deploy-notify.ts
@@ -1,0 +1,120 @@
+import { getDb } from "./dedup.js";
+import { notifyDeploy, type DeployNotification } from "./notify.js";
+
+export interface BootStateInput {
+  currentImageRef: string;
+  prevImageRef: string | null;
+  lastShutdownAt: number | null;
+  now: number;
+}
+
+export interface BootDecision {
+  kind: "deployed" | "restarted";
+  downtimeMs: number | null;
+}
+
+export interface DeployNotifyConfig {
+  notifyType: string;
+  notifyWebhookUrl: string | null;
+}
+
+const LAST_IMAGE_REF_KEY = "deploy_last_image_ref";
+const LAST_SHUTDOWN_AT_KEY = "deploy_last_shutdown_at";
+
+function readSetting(key: string): string | null {
+  try {
+    const db = getDb();
+    const row = db.prepare("SELECT value FROM settings WHERE key = ?").get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSetting(key: string, value: string | null): void {
+  const db = getDb();
+  if (value === null) {
+    db.prepare("DELETE FROM settings WHERE key = ?").run(key);
+  } else {
+    db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)").run(key, value);
+  }
+}
+
+export function decideBootNotification(input: BootStateInput): BootDecision | null {
+  const { currentImageRef, prevImageRef, lastShutdownAt, now } = input;
+
+  // best-effort, a clean shutdown records a timestamp while a hard kill does not
+  const downtimeMs = lastShutdownAt != null ? Math.max(0, now - lastShutdownAt) : null;
+
+  // Nothing remembered — first boot on a fresh volume. announcing a "deploy" here would fire on every new client app's first start.
+  if (prevImageRef === null) return null;
+
+  if (prevImageRef !== currentImageRef) return { kind: "deployed", downtimeMs };
+
+  // Same version. Only speak if a shutdown notice went out, so the notification pair stays matched;
+  // otherwise this is a boot nobody was told about.
+  return lastShutdownAt != null ? { kind: "restarted", downtimeMs } : null;
+}
+
+/** Present only inside a Fly Machine, so it doubles as the "this is a real deployment" gate. */
+function flyImageRef(): string | null {
+  return process.env.FLY_IMAGE_REF || null;
+}
+
+function describe(kind: DeployNotification["kind"], imageRef: string, downtimeMs: number | null): DeployNotification {
+  return {
+    kind,
+    appName: process.env.FLY_APP_NAME || "orchestrator",
+    region: process.env.FLY_REGION || null,
+    imageRef,
+    downtimeMs,
+  };
+}
+
+/** Records the stop so the next boot can measure downtime. Must run before closeDb(). */
+export function recordShutdown(): void {
+  if (!flyImageRef()) return;
+  try {
+    writeSetting(LAST_SHUTDOWN_AT_KEY, String(Date.now()));
+  } catch (err) {
+    console.error("[deploy-notify] failed to record shutdown:", err);
+  }
+}
+
+export async function postShutdownNotice(config: DeployNotifyConfig): Promise<void> {
+  const imageRef = flyImageRef();
+  if (!imageRef || !config.notifyWebhookUrl) return;
+  try {
+    await notifyDeploy(config.notifyType, config.notifyWebhookUrl, describe("shutdown", imageRef, null));
+  } catch (err) {
+    console.error("[deploy-notify] shutdown notice failed:", err);
+  }
+}
+
+export async function postBootNotice(config: DeployNotifyConfig): Promise<void> {
+  const imageRef = flyImageRef();
+  if (!imageRef) return;
+
+  const decision = decideBootNotification({
+    currentImageRef: imageRef,
+    prevImageRef: readSetting(LAST_IMAGE_REF_KEY),
+    lastShutdownAt: Number(readSetting(LAST_SHUTDOWN_AT_KEY)) || null,
+    now: Date.now(),
+  });
+
+  // State advances even when nothing is posted, and even when the webhook is unset — otherwise
+  // a run with notifications disabled would leave a stale ref and mis-classify the next boot.
+  try {
+    writeSetting(LAST_IMAGE_REF_KEY, imageRef);
+    writeSetting(LAST_SHUTDOWN_AT_KEY, null);
+  } catch (err) {
+    console.error("[deploy-notify] failed to persist deploy state:", err);
+  }
+
+  if (!decision || !config.notifyWebhookUrl) return;
+  try {
+    await notifyDeploy(config.notifyType, config.notifyWebhookUrl, describe(decision.kind, imageRef, decision.downtimeMs));
+  } catch (err) {
+    console.error("[deploy-notify] boot notice failed:", err);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import type { TicketingProvider, IssueLifecycleState, FeatureNodeRollUp } from "
 import type { TicketIssue } from "./providers/types.js";
 import { selectIssuesToDispatch } from "./poll-selection.js";
 import { notify, notifyCompletion, notifyText } from "./notify.js";
+import { postBootNotice, postShutdownNotice, recordShutdown } from "./deploy-notify.js";
 import { remediateStuckJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
 import { handleAdminRequest } from "./admin.js";
@@ -2630,6 +2631,11 @@ async function main(): Promise<void> {
 
   const server = startServer(config, registry);
 
+  // Fire-and-forget: a hanging webhook must not delay reconciliation or the first poll.
+  // Safe because everything postBootNotice persists happens synchronously before its first await,
+  // so the stored image ref is committed by the time this returns.
+  void postBootNotice(config);
+
   // Reconcile machines from any previous run before starting the poll loop
   await startupReconciliation(config, registry);
 
@@ -2641,26 +2647,35 @@ async function main(): Promise<void> {
     poll(config, registry);
   }, config.pollIntervalMs);
 
-  // Graceful shutdown
-  const shutdown = (signal: string) => {
+  // total amount of time allotted for a graceful shutdown, otherwise the shutdown is forced
+  const SHUTDOWN_BUDGET_MS = 10_000; // 10s
+  const shutdown = async (signal: string) => {
     console.log(`[main] Received ${signal}, shutting down...`);
     clearInterval(interval);
+
+    // forced exit armed before any awaiting, so shutdowns aren't dependent on notifications settling
+    setTimeout(() => {
+      console.error(`[main] Forced shutdown after timeout`);
+      closeDb();
+      process.exit(1);
+    }, SHUTDOWN_BUDGET_MS).unref();
+
+    // Written before closeDb() so the next boot can measure how long we were gone.
+    recordShutdown();
+    await Promise.race([
+      postShutdownNotice(config),
+      new Promise((resolve) => setTimeout(resolve, SHUTDOWN_BUDGET_MS * 0.3).unref()),
+    ]);
+
     server.close(() => {
       closeDb();
       console.log(`[main] Shutdown complete`);
       process.exit(0);
     });
-
-    // Force exit after 10 seconds if graceful shutdown hangs
-    setTimeout(() => {
-      console.error(`[main] Forced shutdown after timeout`);
-      closeDb();
-      process.exit(1);
-    }, 10_000).unref();
   };
 
-  process.on("SIGTERM", () => shutdown("SIGTERM"));
-  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
+  process.on("SIGINT", () => { void shutdown("SIGINT"); });
 }
 
 main().catch((err) => {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -45,12 +45,52 @@ export interface CompletionNotification {
   docsUrl?: string;
 }
 
+export interface DeployNotification {
+  kind: "shutdown" | "deployed" | "restarted";
+  appName: string;
+  region: string | null;
+  imageRef: string | null; // Full FLY_IMAGE_REF, only the deployment-<id> tag is displayed.
+  downtimeMs?: number | null; // Gap between the shutdown notice and the boot that answered it, when both were observed.
+}
+
 // Human label for a run phase, reused across notification kinds (dispatch, completion, …).
 // Keyed on NotificationPhase, so widening that union is a compile error here until the new phase gets a label — no silent fallthrough.
 const PHASE_LABELS: Record<NotificationPhase, string> = {
   planning: "AI Planning",
   implementation: "AI Implementation",
   "dispatch-failed": "Dispatch Failed",
+};
+
+const DEPLOY_EVENTS: Record<DeployNotification["kind"], {
+  slackEmoji: string;
+  teamsIcon: string;
+  title: string;
+  summary: string;
+  broadcast: boolean
+}> = {
+  // Only the shutdown notice broadcasts since the boot notices answer it.
+  // (broadcasting those too would double-ping the channel per deploy)
+  shutdown: {
+    slackEmoji: ":warning:",
+    teamsIcon: "&#x26A0;",
+    title: "Orchestrator restarting",
+    summary: "Dispatches are paused until it returns.",
+    broadcast: true,
+  },
+  deployed: {
+    slackEmoji: ":rocket:",
+    teamsIcon: "&#x2705;",
+    title: "Orchestrator redeployed",
+    summary: "A new version is live and polling.",
+    broadcast: false,
+  },
+  restarted: {
+    slackEmoji: ":white_check_mark:",
+    teamsIcon: "&#x21BB;",
+    title: "Orchestrator back up",
+    summary: "Same version — a restart, not a new deploy.",
+    broadcast: false,
+  },
 };
 
 export async function notifyStuckGiveUp(
@@ -102,6 +142,20 @@ export async function notifyCompletion(
     case "slack":
     default:
       return notifyCompletionSlack(webhookUrl, n);
+  }
+}
+
+export async function notifyDeploy(
+  type: string,
+  webhookUrl: string,
+  n: DeployNotification,
+): Promise<void> {
+  switch (type.toLowerCase()) {
+    case "teams":
+      return notifyDeployTeams(webhookUrl, n);
+    case "slack":
+    default:
+      return notifyDeploySlack(webhookUrl, n);
   }
 }
 
@@ -290,6 +344,172 @@ async function notifyCompletionSlack(
   }
 }
 
+async function notifyCompletionTeams(
+  webhookUrl: string,
+  n: CompletionNotification,
+): Promise<void> {
+  const icon = completionTeamsIcon(n.status);
+  const label = completionLabel(n.status, n.phase);
+
+  const facts = [
+    {
+      title: "Issue",
+      value: `[${n.issueIdentifier}: ${n.issueTitle}](${n.issueUrl})`,
+    },
+    {
+      title: "Repo",
+      value: n.repoFullName,
+    },
+  ];
+  if (n.prUrl) {
+    facts.push({ title: "PR", value: `[View Pull Request](${n.prUrl})` });
+  }
+  if (n.runUrl) {
+    facts.push({ title: "Run", value: `[View Workflow Run](${n.runUrl})` });
+  }
+  if (n.durationMs != null) {
+    facts.push({ title: "Duration", value: formatDuration(n.durationMs) });
+  }
+
+  const classification: string[] = [];
+  if (n.summary) classification.push(n.summary);
+  if (n.detail) classification.push(n.detail);
+  if (n.remediation) classification.push(`**Next step:** ${n.remediation}`);
+  if (n.docsUrl) classification.push(`[Troubleshooting guide](${n.docsUrl})`);
+
+  const card = {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          type: "AdaptiveCard",
+          version: "1.4",
+          body: [
+            {
+              type: "TextBlock",
+              text: `${icon} ${label}`,
+              weight: "Bolder",
+              size: "Medium",
+            },
+            {
+              type: "FactSet",
+              facts,
+            },
+            ...(classification.length
+              ? [{
+                  type: "TextBlock",
+                  text: classification.join("\n\n"),
+                  wrap: true
+                }]
+              : []),
+          ],
+        },
+      },
+    ],
+  };
+
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(card),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Teams webhook failed: ${res.status} — ${body}`);
+  }
+}
+
+// ---------- Deploy lifecycle notifications ----------
+
+/** extracts the tag from `registry.fly.io/my-app:deployment-01H9RK…` → `deployment-01H9RK…` */
+function imageTag(imageRef: string | null): string | null {
+  if (!imageRef) return null;
+  return imageRef.slice(imageRef.lastIndexOf(":") + 1) || imageRef;
+}
+
+// The shutdown notice runs in the outgoing process, so its ref is the version being replaced:
+// printing it would be ambiguous (two differing versions for same deploy, same version twice for a restart)
+function displayedVersion(n: DeployNotification): string | null {
+  return n.kind === "shutdown" ? null : imageTag(n.imageRef);
+}
+
+async function notifyDeploySlack(webhookUrl: string, n: DeployNotification): Promise<void> {
+  const event = DEPLOY_EVENTS[n.kind];
+  const mention = event.broadcast ? "<!channel> " : "";
+
+  const details = [`App: \`${n.appName}\``];
+  if (n.region) details.push(`Region: \`${n.region}\``);
+  const version = displayedVersion(n);
+  if (version) details.push(`Version: \`${version}\``);
+  if (n.downtimeMs != null) details.push(`Down for ${formatDuration(n.downtimeMs)}`);
+
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `${event.slackEmoji} ${mention}*${event.title}* — ${event.summary}\n${details.join(" · ")}`,
+          },
+        },
+      ],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Slack webhook failed: ${res.status} — ${body}`);
+  }
+}
+
+async function notifyDeployTeams(webhookUrl: string, n: DeployNotification): Promise<void> {
+  const event = DEPLOY_EVENTS[n.kind];
+
+  // No mention syntax: Teams has no incoming-webhook equivalent, and `<!channel>`
+  // would render literally in the card.
+  const facts = [{ title: "App", value: n.appName }];
+  if (n.region) facts.push({ title: "Region", value: n.region });
+  const version = displayedVersion(n);
+  if (version) facts.push({ title: "Version", value: version });
+  if (n.downtimeMs != null) facts.push({ title: "Down for", value: formatDuration(n.downtimeMs) });
+
+  const card = {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          type: "AdaptiveCard",
+          version: "1.4",
+          body: [
+            { type: "TextBlock", text: `${event.teamsIcon} ${event.title}`, weight: "Bolder", size: "Medium" },
+            { type: "TextBlock", text: event.summary, wrap: true },
+            { type: "FactSet", facts },
+          ],
+        },
+      },
+    ],
+  };
+
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(card),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Teams webhook failed: ${res.status} — ${body}`);
+  }
+}
+
 // ---------- Reaper burst alerts ----------
 
 async function notifyStuckGiveUpSlack(
@@ -417,84 +637,6 @@ async function notifyReaperBurstTeams(
                 { title: "Threshold", value: String(n.threshold) },
               ],
             },
-          ],
-        },
-      },
-    ],
-  };
-
-  const res = await fetch(webhookUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(card),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`Teams webhook failed: ${res.status} — ${body}`);
-  }
-}
-
-async function notifyCompletionTeams(
-  webhookUrl: string,
-  n: CompletionNotification,
-): Promise<void> {
-  const icon = completionTeamsIcon(n.status);
-  const label = completionLabel(n.status, n.phase);
-
-  const facts = [
-    {
-      title: "Issue",
-      value: `[${n.issueIdentifier}: ${n.issueTitle}](${n.issueUrl})`,
-    },
-    {
-      title: "Repo",
-      value: n.repoFullName,
-    },
-  ];
-  if (n.prUrl) {
-    facts.push({ title: "PR", value: `[View Pull Request](${n.prUrl})` });
-  }
-  if (n.runUrl) {
-    facts.push({ title: "Run", value: `[View Workflow Run](${n.runUrl})` });
-  }
-  if (n.durationMs != null) {
-    facts.push({ title: "Duration", value: formatDuration(n.durationMs) });
-  }
-
-  const classification: string[] = [];
-  if (n.summary) classification.push(n.summary);
-  if (n.detail) classification.push(n.detail);
-  if (n.remediation) classification.push(`**Next step:** ${n.remediation}`);
-  if (n.docsUrl) classification.push(`[Troubleshooting guide](${n.docsUrl})`);
-
-  const card = {
-    type: "message",
-    attachments: [
-      {
-        contentType: "application/vnd.microsoft.card.adaptive",
-        content: {
-          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-          type: "AdaptiveCard",
-          version: "1.4",
-          body: [
-            {
-              type: "TextBlock",
-              text: `${icon} ${label}`,
-              weight: "Bolder",
-              size: "Medium",
-            },
-            {
-              type: "FactSet",
-              facts,
-            },
-            ...(classification.length
-              ? [{
-                  type: "TextBlock",
-                  text: classification.join("\n\n"),
-                  wrap: true 
-                }]
-              : []),
           ],
         },
       },


### PR DESCRIPTION
## Summary

The orchestrator now announces its own deploys to Slack as a matched pair: an `@channel` heads-up as the outgoing process shuts down, and a plain confirmation once the new version is serving — naming the version and how long it was down.

Deploys to `testing`/`main` run through Fly's native GitHub integration, so no workflow in this repo executes at deploy time, and Fly documents no deploy webhook. That leaves the orchestrator process as the only component that observes every deploy, on every path (Fly-native auto-deploy, `deploy-clients.yml`, manual `flyctl deploy`). Since each Fly app that opted into notifications already carries its own `NOTIFY_WEBHOOK_URL`, this covers every deployed app with no per-app configuration.

A deploy that starts and never comes back is visible as an unanswered heads-up — which a boot-only notification could not do, and a shutdown-only notification could not resolve.

## What changed

**`src/notify.ts`** — adds `DeployNotification` and `notifyDeploy`, following the existing `notifyReaperBurst` shape: a typed payload, a Slack/Teams switch, and two private formatters. Presentation only; no knowledge of deploys, Fly, or state.

**`src/deploy-notify.ts`** (new) — owns the persisted state, the decision, and the two senders:

- `decideBootNotification` is pure — no database, clock, or network — so every edge case is testable as a plain table.
- Boot compares `FLY_IMAGE_REF` against the value stored in the `settings` table on the `/data` volume, the only state that survives the process death. Changed → *redeployed*; unchanged with a shutdown record → *restarted*; nothing stored, or unchanged with no shutdown record → silent.
- State advances even when nothing is posted, so enabling a webhook later cannot announce a deploy that happened weeks earlier.
- Every path swallows its errors: a dead webhook must never fail a boot or wedge a shutdown.

**`src/index.ts`** — calls the boot notice after `startServer` (so a slow webhook cannot delay readiness) and, in the signal handler, records the stop before `closeDb()` and posts within a bounded slice of the shutdown budget.

**`fly.toml`** — `kill_timeout = 15`. Fly's 5s default made the pre-existing 10s force-exit timer strictly unreachable on Fly; 15s covers the notice plus a graceful close and makes that fallback real in production for the first time.

### Design notes

**Only the shutdown notice broadcasts.** It is the one the team must act on; the boot notices answer it, so broadcasting those too would double-ping the channel on every deploy.

**The shutdown notice omits the version.** It runs in the outgoing process, so its ref is the version being replaced — printing it would show two versions for one deploy, or the same one twice on a restart.

**The gate is `FLY_IMAGE_REF`, not `FLY_APP_NAME`.** The latter is documented in `.env.example` as the local tenant-id fallback for `CLIENT_SLUG`, so gating on it would `@channel` the team on every local `Ctrl-C`. `FLY_IMAGE_REF` is injected only by the Fly runtime, and the version diff needs it anyway.

**No new environment variables.** The feature keys off `FLY_IMAGE_REF` plus the existing `NOTIFY_WEBHOOK_URL`.

## Acceptance criteria

| Criterion | How it's met | Key files |
|---|---|---|
| The team is `@channel`'d when a redeploy is happening | Shutdown notice carries `<!channel>`; asserted in both directions | `src/notify.ts`, `src/__tests__/notify.test.ts` |
| Works without a deploy-time GitHub workflow | Driven by the process lifecycle, not CI | `src/index.ts`, `src/deploy-notify.ts` |
| A redeploy is distinguished from a restart | `FLY_IMAGE_REF` diff against persisted state | `src/deploy-notify.ts` |
| Local runs never post | Gated on `FLY_IMAGE_REF`, absent off Fly | `src/deploy-notify.ts` |
| A notification failure cannot affect the orchestrator | All senders catch and log; shutdown notice time-bounded | `src/deploy-notify.ts`, `src/index.ts` |
| Teams remains supported | Adaptive Card path, no Slack mention syntax | `src/notify.ts` |

## Verification

Full suite **2015 tests / 120 files passing**; `npm run typecheck` clean (plus an explicit pass on the new test files, which `tsconfig.json` excludes); `npm run build` compiles.

**34 new tests.** The decision as a pure matrix — first boot, version change, hard kill with no shutdown record, unchanged version with and without an announced stop, negative-duration clamping — plus the shell's gates, corrupt-timestamp handling, and both halves run in sequence.

**End-to-end across separate processes,** each phase its own `node` invocation sharing only the SQLite file, against a local webhook capturing payloads:

| Phase | Result |
|---|---|
| First boot on image A | silent, ref recorded |
| Shutdown | `@channel` heads-up, no version |
| Boot on image B | *redeployed* · `Version: deployment-BBB` · `Down for 2s` |
| Shutdown, boot same image | *restarted*, same version |
| Boot with `FLY_IMAGE_REF` unset | silent |

The measured downtime matched a deliberate two-second gap, confirming the timestamp survived a process death and was read back by a different process — the claim the whole design rests on.

**Not covered locally:** Fly's actual signal delivery and the new `kill_timeout`. The first deploy to `ai-implement-testing-orchestrator` after merge is the true test, and it announces itself.

## Follow-ups

- **Shared typed accessor for the `settings` table.** The `getDb()` → `SELECT value FROM settings WHERE key = ?` / `INSERT OR REPLACE` pattern is now hand-rolled in three modules, each with its own defensive parsing and no shared key registry. Kept out of this diff since it touches two unrelated modules.
- **CLAUDE.md documents 3 of 16 SQLite tables.** This PR adds the `settings` row it actively extends; the remaining twelve are a documentation pass. Not drift — the list has been partial since the root commit.
- **Host-agnostic gate.** A fallback to an operator-set deploy identifier would cover a non-Fly host and give local testing a documented switch. Deferred: every deploy path is Fly today.
