### PR TITLE
feat: admin 'Poll now' — trigger an immediate poll cycle from the admin UI

### DIFF
--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1930,3 +1930,50 @@ describe("github-install-state endpoint", () => {
     expect(res.statusCode).toBe(500);
   });
 });
+
+describe("admin poll-now", () => {
+  async function pollNowRequest(
+    pollNow: (() => { started: boolean }) | undefined,
+    token?: string,
+  ): Promise<{ statusCode: number; body: string }> {
+    const req = new MockRequest("/api/poll-now", "POST", token ? { authorization: `Bearer ${token}` } : {});
+    const res = new MockResponse();
+    admin.handleAdminRequest(
+      req as never,
+      res as never,
+      { ...adminConfig("secret"), pollNow },
+      makeFakeRegistry(provider),
+    );
+    await res.done;
+    return { statusCode: res.statusCode, body: res.body };
+  }
+
+  it("triggers a poll cycle and reports it started", async () => {
+    const token = await login("secret");
+    const pollNow = vi.fn(() => ({ started: true }));
+    const res = await pollNowRequest(pollNow, token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ started: true });
+    expect(pollNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports poll_in_progress when a cycle is already running", async () => {
+    const token = await login("secret");
+    const res = await pollNowRequest(() => ({ started: false }), token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ started: false, reason: "poll_in_progress" });
+  });
+
+  it("requires auth", async () => {
+    const pollNow = vi.fn(() => ({ started: true }));
+    const res = await pollNowRequest(pollNow);
+    expect(res.statusCode).toBe(401);
+    expect(pollNow).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when the poll trigger is not wired", async () => {
+    const token = await login("secret");
+    const res = await pollNowRequest(undefined, token);
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/src/admin-ui/pages/overview.ts
+++ b/src/admin-ui/pages/overview.ts
@@ -6,6 +6,7 @@ export const overviewHtml = `
       <div class="page-subtitle" id="overview-subtitle">&mdash;</div>
     </div>
     <div class="page-header-actions">
+      <button class="btn btn-sm" id="overview-poll-now" onclick="pollNowClick()">&#9889; Poll now</button>
       <button class="btn btn-sm" onclick="loadOverview()">&#8635; Refresh</button>
     </div>
   </header>
@@ -476,6 +477,27 @@ export const overviewScript = `
   }
 
   window.loadOverview = loadOverview;
+
+  async function pollNowClick() {
+    const btn = document.getElementById('overview-poll-now');
+    const original = btn.innerHTML;
+    btn.disabled = true;
+    try {
+      const res = await window.api('/api/poll-now', { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) btn.textContent = (data && data.error) || 'Unavailable';
+      else btn.textContent = data.started ? 'Poll started' : 'Poll already running';
+    } catch (err) {
+      btn.textContent = 'Failed';
+      console.error('pollNow failed:', err);
+    }
+    setTimeout(function () {
+      btn.innerHTML = original;
+      btn.disabled = false;
+      loadOverview();
+    }, 2500);
+  }
+  window.pollNowClick = pollNowClick;
 
   window.registerPage('overview', function () {
     loadOverview();

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -172,6 +172,8 @@ export interface AdminConfig {
   flySessionsRegion: string | null;
   githubAppId: string;
   githubAppPrivateKey: string;
+  /** Triggers an immediate poll cycle; reports false if one is already running. Unset in tests that don't exercise it. */
+  pollNow?: () => { started: boolean };
 }
 
 export function handleAdminRequest(
@@ -315,6 +317,16 @@ export function handleAdminRequest(
       const n = parseInt(limitParam ?? "20", 10);
       const limit = Math.min(100, Number.isFinite(n) && n > 0 ? n : 20);
       json(res, 200, listReaperActions(limit));
+      return true;
+    }
+
+    if (url === "/api/poll-now" && method === "POST") {
+      if (!config.pollNow) {
+        json(res, 503, { error: "Poll trigger not available" });
+        return true;
+      }
+      const result = config.pollNow();
+      json(res, 200, result.started ? { started: true } : { started: false, reason: "poll_in_progress" });
       return true;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2633,6 +2633,12 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
         flySessionsRegion: config.flySessionsRegion,
         githubAppId: config.githubAppId,
         githubAppPrivateKey: config.githubAppPrivateKey,
+        pollNow: () => {
+          if (pollInProgress) return { started: false };
+          console.log("[poll] Immediate poll requested via admin UI");
+          void poll(config, registry);
+          return { started: true };
+        },
       }, registry)) return;
     }
 


### PR DESCRIPTION
## What

Adds an operator-facing way to trigger a poll cycle immediately instead of waiting up to `POLL_INTERVAL_MS` (60s) for the next tick:

- **`POST /api/poll-now`** in `src/admin.ts`, behind the existing admin session auth like every other `/api/*` route. Returns `{ started: true }` or `{ started: false, reason: "poll_in_progress" }` (200 either way); 503 if the trigger isn't wired (bare `handleAdminRequest` without the callback, e.g. tests).
- **Wiring in `src/index.ts`**: the callback checks the existing `pollInProgress` re-entrancy guard and fires `void poll(config, registry)`, logging `[poll] Immediate poll requested via admin UI` for log correlation.
- **⚡ Poll now button** in the Overview page header (`src/admin-ui/pages/overview.ts`), with inline "Poll started" / "Poll already running" feedback that reverts after 2.5s and refreshes the page.

## Why

Troubleshooting plumbing: when actively debugging orchestrator behavior, waiting up to a minute per iteration for the next `setInterval` tick is friction. This came out of evaluating a client request for a Jira-automation webhook that would dispatch tickets immediately — the webhook was rejected (the status-field + poll path already covers it, and a dispatch-from-webhook path would bypass capacity selection, dedup, and feature-branch grouping), but the "nudge" turned out to be useful for operators.

Deliberate scope exclusions: no public webhook endpoint, no new secret, no per-project filtering (`poll()` runs all mappings and is idempotent under the guard), no second dispatch path.

## Testing

- 4 new tests in `src/__tests__/admin.test.ts` (TDD: watched them 404 first): started, in-progress, auth required, unwired 503.
- Full suite: 2093 tests pass across 127 files; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)