### PR TITLE
AII-286: persist a handled-marker for merged top-of-tree roll-ups

### DIFF
--- a/src/__tests__/merge-up-multilevel.test.ts
+++ b/src/__tests__/merge-up-multilevel.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { runMergeUps } from "../merge-up.js";
+import { resetRollUpHandledMarkers, runMergeUps } from "../merge-up.js";
 import type { RepoMapping } from "../config.js";
 import type { FeatureNodeRollUp } from "../providers/types.js";
 
+vi.mock("../dedup.js", async () => {
+  const Database = (await import("better-sqlite3")).default;
+  const db = new Database(":memory:");
+  return { getDb: () => db };
+});
 vi.mock("../github-app-auth.js", () => ({
   getInstallationToken: vi.fn(async () => "tok"),
 }));
@@ -45,6 +50,7 @@ const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetRollUpHandledMarkers();
   vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
   vi.mocked(createPullRequest).mockResolvedValue({ number: 7, url: "https://gh/pr/7" });
   vi.mocked(mergeBranch).mockResolvedValue("merged");

--- a/src/__tests__/merge-up.test.ts
+++ b/src/__tests__/merge-up.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { resetClosedVetoLogGuard, runMergeUps } from "../merge-up.js";
+import { resetClosedVetoLogGuard, resetRollUpHandledMarkers, runMergeUps } from "../merge-up.js";
 import type { RepoMapping } from "../config.js";
 import type { FeatureNodeRollUp } from "../providers/types.js";
 
+vi.mock("../dedup.js", async () => {
+  const Database = (await import("better-sqlite3")).default;
+  const db = new Database(":memory:");
+  return { getDb: () => db };
+});
 vi.mock("../github-app-auth.js", () => ({
   getInstallationToken: vi.fn(async () => "tok"),
 }));
@@ -41,6 +46,7 @@ const rollUp = (o: Partial<FeatureNodeRollUp> = {}): FeatureNodeRollUp => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetRollUpHandledMarkers();
   resetClosedVetoLogGuard();
   vi.mocked(findOpenPullRequest).mockResolvedValue(null);
   vi.mocked(findPullRequestByBranches).mockResolvedValue(null);
@@ -208,6 +214,30 @@ describe("runMergeUps", () => {
       expect(vetoLines).toHaveLength(1);
       // the veto is still respected on every cycle — no PR ever re-opened
       expect(vi.mocked(createPullRequest)).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("handles a merged roll-up exactly once — repeats short-circuit with zero API calls (AII-286)", async () => {
+    vi.mocked(findPullRequestByBranches).mockResolvedValue({
+      number: 108, url: "https://gh/pr/108", state: "closed", merged: true,
+    });
+    const finalizeMerged = vi.fn(async () => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      for (let i = 0; i < 3; i++) {
+        await runMergeUps(
+          [rollUp({ issueId: "uuid-286", identifier: "OOL-126", parent: null })],
+          deps(() => mapping(), finalizeMerged),
+        );
+      }
+      // first pass acts + logs; passes 2-3 short-circuit BEFORE any GitHub/Linear call
+      expect(vi.mocked(findPullRequestByBranches)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(deleteBranch)).toHaveBeenCalledTimes(1);
+      expect(finalizeMerged).toHaveBeenCalledTimes(1);
+      const lines = logSpy.mock.calls.filter((c) => String(c[0]).includes("deleted branch + finalized"));
+      expect(lines).toHaveLength(1);
     } finally {
       logSpy.mockRestore();
     }

--- a/src/merge-up.ts
+++ b/src/merge-up.ts
@@ -1,5 +1,6 @@
 import type { RepoMapping } from "./config.js";
 import type { FeatureNodeRollUp } from "./providers/types.js";
+import { getDb } from "./dedup.js";
 import { getInstallationToken } from "./github-app-auth.js";
 import { buildGroupingBranchName } from "./pipeline/branch-name.js";
 import { compareBranches, createPullRequest, deleteBranch, findPullRequestByBranches, mergeBranch } from "./github.js";
@@ -32,6 +33,40 @@ export interface MergeUpDeps {
    *  scopeKey is the roll-up's authoritative capacity-bucket key (Jira needs it to pick the
    *  right mapping; Linear ignores it). */
   finalizeMerged: (issueId: string, scopeKey: string) => Promise<void>;
+}
+
+// AII-286: persisted handled-marker for merged top-of-tree roll-ups. fetchFeatureNodeRollUps
+// keeps a completed feature node in the candidate set for the full 14-day lookback, so
+// without a marker the merged path re-ran its PR lookup + deleteBranch (4xx on the gone
+// branch) + Linear read per candidate per poll — and re-logged "merged; deleted branch +
+// finalized" forever. Persisted (not in-memory log-once) because this path performs actions;
+// the marker short-circuits BEFORE any GitHub/Linear call and survives restarts.
+const HANDLED_KEY_PREFIX = "mergeup:handled:";
+
+function handledKey(owner: string, repo: string, branch: string): string {
+  return `${HANDLED_KEY_PREFIX}${owner}/${repo}:${branch}`;
+}
+
+function ensureSettingsTable(): void {
+  getDb().exec(`CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)`);
+}
+
+export function isRollUpHandled(owner: string, repo: string, branch: string): boolean {
+  ensureSettingsTable();
+  return getDb().prepare("SELECT 1 FROM settings WHERE key = ?").get(handledKey(owner, repo, branch)) !== undefined;
+}
+
+export function markRollUpHandled(owner: string, repo: string, branch: string): void {
+  ensureSettingsTable();
+  getDb()
+    .prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+    .run(handledKey(owner, repo, branch), new Date().toISOString());
+}
+
+/** Test hook: clear all persisted handled-markers. */
+export function resetRollUpHandledMarkers(): void {
+  ensureSettingsTable();
+  getDb().prepare("DELETE FROM settings WHERE key LIKE ?").run(`${HANDLED_KEY_PREFIX}%`);
 }
 
 // Log-once guard for closed-without-merging (vetoed) roll-up PRs — the skip itself must
@@ -88,12 +123,16 @@ async function rollUpOne(rollUp: FeatureNodeRollUp, deps: MergeUpDeps): Promise<
     return;
   }
 
-  // Top of the tree: check PR state first — robust to squash/rebase merge where git
+  // Top of the tree: already handled? Short-circuit before any GitHub/Linear call (AII-286).
+  if (isRollUpHandled(owner, repo, branch)) return;
+
+  // Check PR state first — robust to squash/rebase merge where git
   // ancestry alone falsely shows the feature branch as "ahead" of base.
   const pr = await findPullRequestByBranches(ghToken, owner, repo, branch, target);
   if (pr?.merged) {
     await deleteBranch(ghToken, owner, repo, branch);
     await deps.finalizeMerged(rollUp.issueId, rollUp.scopeKey);
+    markRollUpHandled(owner, repo, branch);
     console.log(`[merge-up] ${branch} merged; deleted branch + finalized ${rollUp.identifier}`);
     return;
   }


### PR DESCRIPTION
Fixes the r9-observed re-fire: `[merge-up] ai-implement/feature/ool-126 merged; deleted branch + finalized OOL-126` repeating every poll for the full 14-day roll-up lookback.

**Root cause:** `fetchFeatureNodeRollUps` keeps completed feature nodes as candidates for 14 days; nothing recorded that the roll-up was already handled, so each poll re-ran one GitHub PR lookup + one `deleteBranch` against the already-deleted branch (4xx) + one Linear read (`markMerged` early-returns, so no repeat mutations and no updatedAt self-refresh — it ages out rather than growing forever).

**Fix:** persisted handled-marker in the `settings` table (`mergeup:handled:<owner>/<repo>:<branch>`), set after `deleteBranch` + `finalizeMerged` succeed, checked **before** any GitHub/Linear call, restart-safe. Persisted rather than log-once because this path performs actions — same failure family as the closed-roll-up veto (`85147e1`), on the merged-successfully path.

**Tests:** regression (3 passes → each action + the log line fire exactly once, later passes make zero API calls); merge-up suites now run on an in-memory sqlite. Full suite 2169/2169 + typecheck clean.

Acceptance (per AII-286): boot the orchestrator, watch two poll cycles — the cleanup line for any previously-merged branch appears at most once per process lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)