### PR TITLE
AII-306: runner-mode failover hardening — eligibility guard + swap observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,14 @@ When adding a new page: create the page module, append both strings to the lists
 
 Six routes (`channels`, `policies`, `secrets`, `mcp`, `webhooks`, `updates`) are still stubbed in `src/admin-ui/pages/stubs.ts` with "Coming soon" placeholders (badged "Not implemented yet" or "Partially implemented") that explain what exists today and link to the related built pages.
 
+## Backend outage playbook (runner-mode failover)
+
+When GitHub Actions (or Fly) is degraded, the global **runner mode** is the failover lever: `/admin#runners` (or `POST /api/runner-mode`) with `fly` forces every new dispatch onto Fly Machines; `gha` forces GitHub Actions; `default` restores per-project modes. In-flight runs keep their monitors — only new dispatches reroute.
+
+- **Prerequisite for `fly`:** the orchestrator must have a Fly session backend (`FLY_SESSIONS_APP` + Fly API token) and the mapping must be Fly-capable. **Ineligible mappings are skipped at dispatch** (provider=`bedrock` is GHA-only; no sessions app configured) — they stay queued, dedup untouched, with one log line per poll, and are listed in the Runners-page override banner and the `GET /api/runner-mode` response (`ineligible`).
+- Every mode change is logged (`old → new`) and fires a plain-text notification when `NOTIFY_WEBHOOK_URL` is set.
+- Flip back to `default` after the outage; skipped issues dispatch normally on the next poll.
+
 ## Notification adapter
 
 `src/notify.ts` exports a single `notify(type, webhookUrl, notification)` function. Set `NOTIFY_TYPE=slack` or `NOTIFY_TYPE=teams` to switch providers. Adding a new provider means adding a private function in `notify.ts` and a new case in the switch.

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -15,6 +15,12 @@ import { FakeProvider } from "./providers/fake.js";
 import type { TicketIssue } from "../providers/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 
+const notifyTextMock = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("../notify.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../notify.js")>()),
+  notifyText: notifyTextMock,
+}));
+
 vi.mock("../workflow-sync.js", () => ({
   syncWorkflowTemplates: vi.fn(),
   classifySyncError: (err: unknown) => ({
@@ -1003,6 +1009,54 @@ describe("admin runner-mode", () => {
     // Confirm it survives a fresh GET
     const get = await request("/api/runner-mode", "GET", "secret", undefined, token);
     expect(JSON.parse(get.body).mode).toBe("shadow");
+  });
+
+  it("GET /api/runner-mode lists ineligible mappings when a force is active (AII-306)", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", { teamKey: "BED", owner: "o", repo: "r", provider: "bedrock", awsRegion: "us-west-2" }, token);
+    expect(create.statusCode, create.body).toBeLessThan(300);
+    await request("/api/runner-mode", "POST", "secret", { mode: "fly" }, token);
+    const res = await request("/api/runner-mode", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.mode).toBe("fly");
+    expect(Array.isArray(body.ineligible)).toBe(true);
+    const bed = body.ineligible.find((m: { teamKey: string }) => m.teamKey === "BED");
+    expect(bed).toBeDefined();
+    expect(bed.reason).toMatch(/bedrock/i);
+  });
+
+  it("GET /api/runner-mode has no ineligible list under non-forcing modes (AII-306)", async () => {
+    const token = await login("secret");
+    await request("/api/mappings", "POST", "secret", { teamKey: "BED", owner: "o", repo: "r", provider: "bedrock", awsRegion: "us-west-2" }, token);
+    const res = await request("/api/runner-mode", "GET", "secret", undefined, token);
+    const body = JSON.parse(res.body);
+    expect(body.mode).toBe("default");
+    expect(body.ineligible ?? []).toEqual([]);
+  });
+
+  it("POST /api/runner-mode fires the notify hook with old→new when a webhook is configured (AII-306)", async () => {
+    notifyTextMock.mockClear();
+    const token = await login("secret");
+    const cfg = { ...adminConfig("secret"), notifyWebhookUrl: "https://hooks.example/x" };
+    const req = new MockRequest("/api/runner-mode", "POST", { authorization: `Bearer ${token}` }, JSON.stringify({ mode: "fly" }));
+    const res = new MockResponse();
+    admin.handleAdminRequest(req as never, res as never, cfg as never, makeFakeRegistry(provider));
+    await res.done;
+    expect(res.statusCode).toBe(200);
+    expect(notifyTextMock).toHaveBeenCalledTimes(1);
+    const [url, message] = notifyTextMock.mock.calls[0] as unknown as [string, string];
+    expect(url).toBe("https://hooks.example/x");
+    expect(message).toMatch(/default/);
+    expect(message).toMatch(/fly/);
+  });
+
+  it("POST /api/runner-mode does not notify when no webhook is configured (AII-306)", async () => {
+    notifyTextMock.mockClear();
+    const token = await login("secret");
+    const res = await request("/api/runner-mode", "POST", "secret", { mode: "fly" }, token);
+    expect(res.statusCode).toBe(200);
+    expect(notifyTextMock).not.toHaveBeenCalled();
   });
 
   it("POST /api/runner-mode rejects an invalid mode with 400", async () => {

--- a/src/__tests__/runner-mode.test.ts
+++ b/src/__tests__/runner-mode.test.ts
@@ -209,4 +209,38 @@ describe("runner-mode", () => {
       }
     });
   });
+
+  describe("checkForcedPathEligibility (AII-306)", () => {
+    const ghaMapping = { executionMode: "github-actions" as const, provider: "anthropic" };
+    const bedrockMapping = { executionMode: "github-actions" as const, provider: "bedrock" };
+
+    it("forced fly + bedrock mapping → ineligible, reason names bedrock", () => {
+      const r = runnerMode.checkForcedPathEligibility("fly", bedrockMapping, true);
+      expect(r.eligible).toBe(false);
+      expect(r.reason).toMatch(/bedrock/i);
+    });
+
+    it("forced fly + no sessions app → ineligible, reason names FLY_SESSIONS_APP", () => {
+      const r = runnerMode.checkForcedPathEligibility("fly", ghaMapping, false);
+      expect(r.eligible).toBe(false);
+      expect(r.reason).toMatch(/FLY_SESSIONS_APP/);
+    });
+
+    it("forced fly + fly-capable mapping → eligible", () => {
+      const r = runnerMode.checkForcedPathEligibility("fly", ghaMapping, true);
+      expect(r).toEqual({ eligible: true, reason: null });
+    });
+
+    it("non-forcing modes are always eligible (default/gha), even for bedrock without sessions app", () => {
+      for (const mode of ["default", "gha"] as const) {
+        expect(runnerMode.checkForcedPathEligibility(mode, bedrockMapping, false).eligible).toBe(true);
+      }
+    });
+
+    it("bedrock ineligibility wins over missing sessions app in the reason", () => {
+      const r = runnerMode.checkForcedPathEligibility("fly", bedrockMapping, false);
+      expect(r.eligible).toBe(false);
+      expect(r.reason).toMatch(/bedrock/i);
+    });
+  });
 });

--- a/src/admin-ui/pages/runners.ts
+++ b/src/admin-ui/pages/runners.ts
@@ -132,8 +132,15 @@ export const runnersScript = `
 
     if (runnerMode.mode !== 'default') {
       const bannerKind = runnerMode.mode === 'shadow' ? 'warn' : 'info';
+      // AII-306: ineligible mappings are skipped at dispatch under a force — surface them.
+      let ineligibleHtml = '';
+      if (Array.isArray(runnerMode.ineligible) && runnerMode.ineligible.length > 0) {
+        ineligibleHtml = '<div class="alert-desc" style="margin-top:4px"><strong>Skipped (ineligible for this mode):</strong> ' +
+          runnerMode.ineligible.map(function (m) { return window.esc(m.teamKey) + ' — ' + window.esc(m.reason); }).join('; ') +
+          '. These projects queue until the override clears.</div>';
+      }
       bannerEl.className = 'alert ' + bannerKind;
-      bannerEl.innerHTML = '<div style="flex:1"><div class="alert-title">Runner mode override active: ' + window.esc(runnerMode.mode) + '</div><div class="alert-desc">All projects route through ' + window.esc(runnerMode.mode) + ' regardless of their per-project mode.</div></div>';
+      bannerEl.innerHTML = '<div style="flex:1"><div class="alert-title">Runner mode override active: ' + window.esc(runnerMode.mode) + '</div><div class="alert-desc">All projects route through ' + window.esc(runnerMode.mode) + ' regardless of their per-project mode.</div>' + ineligibleHtml + '</div>';
       bannerEl.hidden = false;
     }
 

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -23,9 +23,11 @@ import {
   VALID_RUNNER_MODES,
   isRunnerMode,
   setFlySecretsMinVersion,
+  checkForcedPathEligibility,
 } from "./runner-mode.js";
 import { listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
 import { createSession, isValidSession, getRequestToken, accessCodeMatches } from "./admin-session.js";
+import { notifyText } from "./notify.js";
 import { getLastSweepAt } from "./reaper.js";
 import { listLog, getInFlightJobs, getInFlightIssueIds, updateJobStatus, getJobById, getPulls } from "./log.js";
 import { getStepsByJobId } from "./step-log.js";
@@ -172,6 +174,8 @@ export interface AdminConfig {
   flySessionsRegion: string | null;
   githubAppId: string;
   githubAppPrivateKey: string;
+  /** AII-306: runner-mode swaps fire a plain-text notification when set. */
+  notifyWebhookUrl?: string | null;
 }
 
 export function handleAdminRequest(
@@ -331,12 +335,19 @@ export function handleAdminRequest(
     }
 
     if (url === "/api/runner-mode" && method === "GET") {
-      json(res, 200, getRunnerMode());
+      const status = getRunnerMode();
+      // AII-306: under a forcing mode, surface which mappings the force cannot
+      // apply to (they are skipped at dispatch, staying queued).
+      const ineligible = Object.entries(getMappings())
+        .map(([teamKey, m]) => ({ teamKey, ...checkForcedPathEligibility(status.mode, m, Boolean(config.flySessionsApp)) }))
+        .filter((e) => !e.eligible)
+        .map((e) => ({ teamKey: e.teamKey, reason: e.reason }));
+      json(res, 200, { ...status, ineligible });
       return true;
     }
 
     if (url === "/api/runner-mode" && method === "POST") {
-      handleSetRunnerMode(req, res);
+      handleSetRunnerMode(req, res, config);
       return true;
     }
 
@@ -525,6 +536,7 @@ async function handleListIssues(
 async function handleSetRunnerMode(
   req: http.IncomingMessage,
   res: http.ServerResponse,
+  config: AdminConfig,
 ): Promise<void> {
   try {
     const body = JSON.parse(await readBody(req)) as { mode?: string };
@@ -532,8 +544,20 @@ async function handleSetRunnerMode(
       json(res, 400, { error: `mode must be one of: ${VALID_RUNNER_MODES.join(", ")}` });
       return;
     }
+    const previous = getRunnerMode();
     setRunnerMode(body.mode);
     const status = getRunnerMode();
+    // AII-306: swap observability — an execution-mode change is an operational
+    // event, not a quiet preference. Log it and fire the notify hook best-effort.
+    if (previous.mode !== status.mode) {
+      console.log(`[admin] Runner mode changed: ${previous.mode} → ${status.mode} (via admin API)`);
+      if (config.notifyWebhookUrl) {
+        notifyText(
+          config.notifyWebhookUrl,
+          `⚙️ AI-Implement runner mode changed: ${previous.mode} → ${status.mode} (via admin API)`,
+        ).catch((err) => console.error("[admin] runner-mode notify failed:", err));
+      }
+    }
     // The DB write succeeded but the RUNNER_MODE env var still wins at
     // runtime. Return 409 so direct API callers (not the UI, which already
     // disables the buttons) can tell their write was overridden.

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ import { postStatusComment } from "./status-events.js";
 import { classifyCompletion, renderClassification } from "./completion-classification.js";
 import { createMachine, getMachine, listMachines, destroyMachine, generateSessionToken, generateMachineNonce, buildSessionMachineConfig, listAppSecrets, fetchMachineLogs, updateMachineMetadata, readMachineExitCode } from "./fly-machines.js";
 import { safeDestroyMachine, sweepOrphanedMachines, SWEEP_MACHINE_MAX_AGE_MS } from "./reaper.js";
-import { getRunnerMode, getFlySecretsMinVersion, initSettingsTable, resolveExecutionPath, resolvePlanningExecutionPath, resolveRunnerCallbackBaseUrl } from "./runner-mode.js";
+import { getRunnerMode, getFlySecretsMinVersion, initSettingsTable, resolveExecutionPath, resolvePlanningExecutionPath, resolveRunnerCallbackBaseUrl, checkForcedPathEligibility } from "./runner-mode.js";
 import { handleGitHubWebhook } from "./webhook.js";
 import { enqueueReconciliation, hasReconciliationForPr, initReconciliationTable } from "./reconciliation.js";
 import { runReconciliations } from "./reconcile-merged.js";
@@ -442,6 +442,18 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
           const { mode: runnerMode } = getRunnerMode();
           const execPath = resolveExecutionPath(runnerMode, mapping.executionMode);
 
+          // AII-306: a forced global mode can point at a backend this mapping
+          // cannot run on (bedrock is GHA-only; Fly needs a sessions app).
+          // Skip — issue stays queued, dedup untouched — instead of
+          // dispatching a run that cannot work.
+          const eligibility = checkForcedPathEligibility(runnerMode, mapping, Boolean(config.flySessionsApp));
+          if (!eligibility.eligible) {
+            console.log(
+              `[poll] Skipping ${issue.identifier}: forced runner mode "${runnerMode}" but team ${issue.scopeKey} is ineligible — ${eligibility.reason}`,
+            );
+            continue;
+          }
+
           // Resolve the base branch once per issue (feature-branch grouping). Doing it
           // here — before the exec-path switch — guarantees the "both" shadow path's two
           // dispatches agree on one base, and never creates the branch twice. The token
@@ -747,6 +759,15 @@ async function dispatchPlanning(
   // Shadow collapses to GHA-only: planning posts user-visible Linear comments,
   // so a shadow second backend would double-post.
   const execPath = resolvePlanningExecutionPath(runnerMode, mapping.executionMode);
+
+  // AII-306: same forced-mode eligibility guard as implementation dispatch.
+  const planningEligibility = checkForcedPathEligibility(runnerMode, mapping, Boolean(config.flySessionsApp));
+  if (!planningEligibility.eligible) {
+    console.log(
+      `[poll] Skipping planning for ${issue.identifier}: forced runner mode "${runnerMode}" but team ${issue.scopeKey} is ineligible — ${planningEligibility.reason}`,
+    );
+    return;
+  }
 
   // Build planning context (PARENT/SIBLINGS/DEPENDENCIES) for all execution paths.
   const planningContextInputs = await buildPlanningContextInputs({
@@ -2770,6 +2791,7 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
         flySessionsRegion: config.flySessionsRegion,
         githubAppId: config.githubAppId,
         githubAppPrivateKey: config.githubAppPrivateKey,
+        notifyWebhookUrl: config.notifyWebhookUrl,
       }, registry)) return;
     }
 

--- a/src/runner-mode.ts
+++ b/src/runner-mode.ts
@@ -79,6 +79,34 @@ export function resolveExecutionPath(
   return mappingMode;
 }
 
+export interface ForcedPathEligibility {
+  eligible: boolean;
+  reason: string | null;
+}
+
+/**
+ * AII-306: when the global runner mode FORCES a path a mapping cannot run on,
+ * the dispatch must be skipped (issue stays queued) instead of launching a run
+ * that cannot work. Pure — no I/O. Only mode "fly" forces an incapable path
+ * today: bedrock is GHA-only, and Fly machine creation needs a sessions app.
+ * Non-forcing modes (and "gha"/"local", which every mapping can run) are
+ * always eligible.
+ */
+export function checkForcedPathEligibility(
+  runnerMode: RunnerMode,
+  mapping: { executionMode: "github-actions" | "fly-machines"; provider?: string },
+  hasFlySessionsApp: boolean,
+): ForcedPathEligibility {
+  if (runnerMode !== "fly") return { eligible: true, reason: null };
+  if (mapping.provider === "bedrock") {
+    return { eligible: false, reason: "provider=bedrock is GHA-only (no role-assumption on Fly)" };
+  }
+  if (!hasFlySessionsApp) {
+    return { eligible: false, reason: "no Fly sessions app configured (FLY_SESSIONS_APP)" };
+  }
+  return { eligible: true, reason: null };
+}
+
 /**
  * Planning-specific execution path resolution. Identical to resolveExecutionPath
  * except shadow ("both") collapses to "github-actions": planning posts user-visible


### PR DESCRIPTION
## Summary

v1 of the execution-mode failover work ([AII-306](https://linear.app/eudoxus/issue/AII-306)): the global runner-mode switch already existed — this makes it **safe to throw** during a backend outage.

- **Eligibility guard** — `checkForcedPathEligibility()` (pure, `src/runner-mode.ts`): under a forced `fly` mode, mappings that cannot run on Fly (provider=`bedrock`; no `FLY_SESSIONS_APP`) are **skipped at dispatch** — one clear log line, issue stays queued, dedup untouched. Wired into both the implementation and planning dispatch sites.
- **Swap observability** — `POST /api/runner-mode` logs `old → new` and fires a plain-text notification when `NOTIFY_WEBHOOK_URL` is set; `GET /api/runner-mode` returns the `ineligible` mapping list under a force; the Runners-page override banner renders it.
- **Runbook** — CLAUDE.md "Backend outage playbook" section.

Motivated by the 2026-08-06 GitHub Actions outage (AII-300/AII-301 evidence): with this + the sessions backend provisioned (AII-307), a GHA outage becomes one admin click instead of a stalled pipeline.

## Test plan

- TDD: new tests in `runner-mode.test.ts` (eligibility matrix, 5 cases) and `admin.test.ts` (notify fires with old→new / silent without webhook / GET ineligible list under force / absent under default)
- Full suite: **2220/2220** + `tsc --noEmit` clean
- Implemented locally per the local-fix-loop discipline (GitHub Actions was mid-incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
