### PR TITLE
AII-207: Refresh runner GitHub tokens during long sessions

### DIFF
--- a/src/__tests__/github-app-auth.test.ts
+++ b/src/__tests__/github-app-auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { getInstallationToken, getInstallation, getAppSlug, installationIncludesRepo, clearTokenCache, createAppJwt } from "../github-app-auth.js";
+import { getInstallationToken, refreshInstallationToken, getInstallation, getAppSlug, installationIncludesRepo, clearTokenCache, createAppJwt } from "../github-app-auth.js";
 
 // Generate a real RSA key pair for tests so JWT signing works correctly
 const { privateKey } = generateKeyPairSync("rsa", {
@@ -96,6 +96,20 @@ describe("getInstallationToken", () => {
     expect(t1).toBe("ghs_cached");
     expect(t2).toBe("ghs_cached");
     expect(fetch).toHaveBeenCalledTimes(2); // only called once per token, not twice per call
+  });
+
+  it("force-refreshes and replaces a still-valid cached token", async () => {
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 42 } },
+      { ok: true, json: { token: "ghs_boot", expires_at: "" } },
+      { ok: true, json: { id: 42 } },
+      { ok: true, json: { token: "ghs_fresh", expires_at: "" } },
+    ]));
+
+    expect(await getInstallationToken(APP_ID, privateKey, "my-org")).toBe("ghs_boot");
+    expect(await refreshInstallationToken(APP_ID, privateKey, "my-org")).toBe("ghs_fresh");
+    expect(await getInstallationToken(APP_ID, privateKey, "my-org")).toBe("ghs_fresh");
+    expect(fetch).toHaveBeenCalledTimes(4);
   });
 
   it("maintains separate caches per owner", async () => {

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -213,6 +213,8 @@ describe("loadPipelineDefinition", () => {
     expect(inputs.githubToken).toBe("tok");
     expect(inputs.branch).toBe("main");
     expect(inputs.workspaceDir).toBe("/tmp/repo");
+    expect(inputs.orchestratorUrl).toBe("http://localhost:8080");
+    expect(inputs.machineNonce).toBe("nonce");
   });
 
   it("applies feedback-loop input wiring from clone, install, and ctx.data", () => {
@@ -295,6 +297,8 @@ describe("loadPipelineDefinition", () => {
     expect(inputs.repoOwner).toBe("acme");
     expect(inputs.repoRepo).toBe("api");
     expect(inputs.githubToken).toBe("tok");
+    expect(inputs.orchestratorUrl).toBe("http://localhost:8080");
+    expect(inputs.machineNonce).toBe("nonce");
     expect(inputs.branchName).toBe("ai-implement/eng-42-add-profile-page");
     expect(inputs.baseBranch).toBe("main");
     expect(inputs.prTitle).toBe("ENG-42: Add profile page");

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -158,8 +158,12 @@ describe("postPushReviewStep", () => {
     const notApproved = JSON.stringify({ approved: false, issues: ["bug"], feedback: "fix the bug", score: 4, progress_delta: 0 });
     const ghComments: string[] = [];
     const gitPushCalls: string[][] = [];
+    const pushOrder: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
-      if (args[0] === "push") gitPushCalls.push(args);
+      if (args[0] === "push") {
+        gitPushCalls.push(args);
+        pushOrder.push("push");
+      }
       if (args[0] === "status") return { stdout: "M file.ts\n", exitCode: 0 };
       if (args[0] === "rev-parse" && args[1] === "--short") return { stdout: "abc1234\n", exitCode: 0 };
       if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "ai-implement/aii-200-x\n", exitCode: 0 };
@@ -176,9 +180,12 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const ctx = makeCtx(vi.fn(async () => ({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })));
+    const refreshCredentials = vi.fn(async () => {
+      pushOrder.push("refresh");
+    });
     const out = await postPushReviewStep.run(
       ctx,
-      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn, refreshCredentials },
       { report: vi.fn(async () => undefined) },
     );
     expect(out.approved).toBe(false);
@@ -190,6 +197,8 @@ describe("postPushReviewStep", () => {
       "HEAD:refs/heads/ai-implement/aii-200-x",
       "--force-with-lease=refs/heads/ai-implement/aii-200-x:beadfeed",
     ]);
+    expect(refreshCredentials).toHaveBeenCalledTimes(1);
+    expect(pushOrder).toEqual(["refresh", "push"]);
     expect(ghComments.some((c) => c.includes("fix-complete") && c.includes("abc1234"))).toBe(true);
     expect(ghComments.some((c) => c.includes("Changes pushed:") && c.includes("Modified: `app/api/parse/route.ts`"))).toBe(true);
     expect(ghComments.some((c) => c.includes("Added: `app/api/parse/route.test.ts`"))).toBe(true);

--- a/src/__tests__/refresh-runner-github-credentials.test.ts
+++ b/src/__tests__/refresh-runner-github-credentials.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+vi.mock("../runner-token.js", () => ({
+  refreshRunnerGithubCredentials: vi.fn(),
+}));
+
+import { spawnSync } from "node:child_process";
+import { refreshRunnerGithubCredentials } from "../runner-token.js";
+import { refreshRunnerGithubCredentialsFromEnvironment } from "../refresh-runner-github-credentials.js";
+
+describe("refreshRunnerGithubCredentialsFromEnvironment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("GITHUB_OWNER", "BuildDownAI");
+    vi.stubEnv("GITHUB_REPO", "AI-Implement");
+    vi.stubEnv("GITHUB_TOKEN", "dispatch-token");
+    vi.stubEnv("ORCHESTRATOR_URL", "https://orchestrator.example");
+    vi.stubEnv("MACHINE_NONCE", "machine-nonce");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the latest token stored in origin as the fallback for the next refresh", async () => {
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+      stdout: Buffer.from("https://x-access-token:latest-token@github.com/BuildDownAI/AI-Implement.git\n"),
+      stderr: Buffer.alloc(0),
+    } as ReturnType<typeof spawnSync>);
+    vi.mocked(refreshRunnerGithubCredentials).mockResolvedValue("fresh-token");
+
+    await refreshRunnerGithubCredentialsFromEnvironment("/workspace");
+
+    expect(refreshRunnerGithubCredentials).toHaveBeenCalledWith({
+      currentToken: "latest-token",
+      orchestratorUrl: "https://orchestrator.example",
+      machineNonce: "machine-nonce",
+      owner: "BuildDownAI",
+      repo: "AI-Implement",
+      workspaceDir: "/workspace",
+    });
+  });
+});

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -336,7 +336,7 @@ describe("runAutonomous", () => {
     expect(capturedPrompt).toContain("Do NOT commit, push, or open a pull request");
   });
 
-  it("does not append new-implementation git instructions for gap-fill runs", async () => {
+  it("appends a credential refresh command for gap-fill pushes", async () => {
     vi.stubEnv("PR_NUMBER", "42");
 
     let capturedPrompt: string | undefined;
@@ -358,6 +358,9 @@ describe("runAutonomous", () => {
 
     expect(capturedPrompt).toContain("Gap-fill run");
     expect(capturedPrompt).not.toContain("Pipeline-owned Git and PR handling");
+    expect(capturedPrompt).toContain("Runner GitHub credential refresh");
+    expect(capturedPrompt).toContain("refresh-runner-github-credentials.js");
+    expect(capturedPrompt).toContain("Immediately before every `git push`");
     expect(capturedPrompt).not.toContain("Operator instruction for this run");
   });
 

--- a/src/__tests__/runner-token.test.ts
+++ b/src/__tests__/runner-token.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
-import { refreshRunnerGithubToken } from "../runner-token.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(),
+}));
+
+import { spawnSync } from "node:child_process";
+import { refreshRunnerGithubCredentials, refreshRunnerGithubToken } from "../runner-token.js";
 
 describe("refreshRunnerGithubToken", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("vends a token with the machine nonce and repository owner", async () => {
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,
@@ -38,6 +48,40 @@ describe("refreshRunnerGithubToken", () => {
       owner: "BuildDownAI",
       fetchImpl,
     })).resolves.toBe("boot-token");
+  });
+
+  it("reapplies the previous token to the environment and origin when vending is unavailable", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("connection refused"));
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+    } as ReturnType<typeof spawnSync>);
+    vi.stubEnv("GITHUB_TOKEN", "stale-env-token");
+    vi.stubEnv("GH_TOKEN", "stale-env-token");
+
+    await expect(refreshRunnerGithubCredentials({
+      currentToken: "previous-token",
+      orchestratorUrl: "https://orchestrator.example",
+      machineNonce: "machine-nonce",
+      owner: "BuildDownAI",
+      repo: "AI-Implement",
+      workspaceDir: "/workspace",
+      fetchImpl,
+    })).resolves.toBe("previous-token");
+
+    expect(process.env.GITHUB_TOKEN).toBe("previous-token");
+    expect(process.env.GH_TOKEN).toBe("previous-token");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      [
+        "remote",
+        "set-url",
+        "origin",
+        "https://x-access-token:previous-token@github.com/BuildDownAI/AI-Implement.git",
+      ],
+      expect.objectContaining({ cwd: "/workspace" }),
+    );
   });
 
   it("rejects nonce and owner validation failures instead of masking them", async () => {

--- a/src/__tests__/runner-token.test.ts
+++ b/src/__tests__/runner-token.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { refreshRunnerGithubToken } from "../runner-token.js";
+
+describe("refreshRunnerGithubToken", () => {
+  it("vends a token with the machine nonce and repository owner", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: "fresh-token", expires_at: "2026-08-07T01:00:00Z" }),
+    } as Response);
+
+    const token = await refreshRunnerGithubToken({
+      currentToken: "boot-token",
+      orchestratorUrl: "https://orchestrator.example/",
+      machineNonce: "machine-nonce",
+      owner: "BuildDownAI",
+      fetchImpl,
+    });
+
+    expect(token).toBe("fresh-token");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://orchestrator.example/api/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nonce: "machine-nonce", owner: "BuildDownAI" }),
+      }),
+    );
+  });
+
+  it("keeps the boot token when vending is unavailable", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("connection refused"));
+
+    await expect(refreshRunnerGithubToken({
+      currentToken: "boot-token",
+      orchestratorUrl: "https://orchestrator.example",
+      machineNonce: "machine-nonce",
+      owner: "BuildDownAI",
+      fetchImpl,
+    })).resolves.toBe("boot-token");
+  });
+
+  it("rejects nonce and owner validation failures instead of masking them", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 403 } as Response);
+
+    await expect(refreshRunnerGithubToken({
+      currentToken: "boot-token",
+      orchestratorUrl: "https://orchestrator.example",
+      machineNonce: "invalid-nonce",
+      owner: "BuildDownAI",
+      fetchImpl,
+    })).rejects.toThrow(/rejected with HTTP 403/);
+  });
+
+  it("does not call the orchestrator without both URL and nonce", async () => {
+    const fetchImpl = vi.fn();
+
+    await expect(refreshRunnerGithubToken({
+      currentToken: "workflow-token",
+      owner: "BuildDownAI",
+      fetchImpl,
+    })).resolves.toBe("workflow-token");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/steps-clone.test.ts
+++ b/src/__tests__/steps-clone.test.ts
@@ -160,6 +160,42 @@ describe("cloneStep", () => {
     expect(outputs.workspaceDir).toBe("/tmp/workspace");
   });
 
+  it("refreshes credentials after clone so gap-fill runs inherit a current token", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.stubEnv("GITHUB_TOKEN", "secret-token");
+    vi.stubEnv("GH_TOKEN", "secret-token");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ token: "fresh-token" }),
+    } as Response));
+    mockSpawn([
+      { status: 0 },
+      { status: 0, stdout: "sha1\n" },
+      { status: 0 },
+    ]);
+
+    try {
+      const outputs = await cloneStep.run(makeContext(), {
+        ...PR_INPUTS,
+        orchestratorUrl: "https://orchestrator.example",
+        machineNonce: "machine-nonce",
+        baseBranch: undefined,
+      }, new NoopStepReporter());
+
+      expect(outputs.githubToken).toBe("fresh-token");
+      expect(process.env.GH_TOKEN).toBe("fresh-token");
+      expect(spawnSync).toHaveBeenLastCalledWith(
+        "git",
+        ["remote", "set-url", "origin", "https://x-access-token:fresh-token@github.com/acme/app.git"],
+        expect.objectContaining({ cwd: "/tmp/workspace" }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.unstubAllEnvs();
+    }
+  });
+
   describe("PR-targeted (gap-fill) runs: base branch fetch", () => {
     it("fetches base branch after clone and verifies merge-base on a fresh clone", async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -79,6 +79,66 @@ describe("pushStep", () => {
     expect(outputs.commitSha).toBe("abc123");
   });
 
+  it("uses a freshly vended token for remote lookup, push, and PR creation", async () => {
+    mockGitSuccess("abc123");
+    vi.stubEnv("GITHUB_TOKEN", "gh-token");
+    vi.stubEnv("GH_TOKEN", "gh-token");
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ token: "fresh-token", expires_at: "2026-08-07T01:00:00Z" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ html_url: "https://github.com/acme/app/pull/7", number: 7 }),
+        text: async () => "",
+      } as Response);
+
+    try {
+      await pushStep.run(
+        makeContext(),
+        {
+          ...BASE_INPUTS,
+          orchestratorUrl: "https://orchestrator.example",
+          machineNonce: "machine-nonce",
+        },
+        new NoopStepReporter(),
+      );
+
+      const tokenRequest = vi.mocked(fetch).mock.calls[0];
+      expect(tokenRequest[0]).toBe("https://orchestrator.example/api/token");
+
+      const remoteCalls = vi.mocked(spawnSync).mock.calls.filter(([, args]) =>
+        ["ls-remote", "push"].includes((args as string[])[0]),
+      );
+      expect(remoteCalls).toHaveLength(2);
+      for (const [, args] of remoteCalls) {
+        expect((args as string[]).join(" ")).toContain("fresh-token");
+        expect((args as string[]).join(" ")).not.toContain("gh-token");
+      }
+
+      expect(spawnSync).toHaveBeenCalledWith(
+        "git",
+        [
+          "remote",
+          "set-url",
+          "origin",
+          "https://x-access-token:fresh-token@github.com/acme/app.git",
+        ],
+        expect.objectContaining({ cwd: "/tmp/workspace" }),
+      );
+      expect(process.env.GITHUB_TOKEN).toBe("fresh-token");
+      expect(process.env.GH_TOKEN).toBe("fresh-token");
+
+      const prRequest = vi.mocked(fetch).mock.calls[1];
+      expect(prRequest[1]?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer fresh-token" }));
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("uses the context branch as the PR base when baseBranch input is omitted", async () => {
     mockGitSuccess("abc123");
     vi.mocked(fetch).mockResolvedValueOnce({

--- a/src/__tests__/token-vending.test.ts
+++ b/src/__tests__/token-vending.test.ts
@@ -8,7 +8,7 @@ import type * as LogModule from "../log.js";
 import type * as DedupModule from "../dedup.js";
 
 vi.mock("../github-app-auth.js", () => ({
-  getInstallationToken: vi.fn(),
+  refreshInstallationToken: vi.fn(),
   clearTokenCache: vi.fn(),
 }));
 
@@ -53,7 +53,7 @@ let tokenVending: typeof TokenVendingModule;
 let log: typeof LogModule;
 let dedup: typeof DedupModule;
 
-let mockGetInstallationToken: ReturnType<typeof vi.fn>;
+let mockRefreshInstallationToken: ReturnType<typeof vi.fn>;
 
 beforeEach(async () => {
   vi.resetModules();
@@ -63,7 +63,7 @@ beforeEach(async () => {
   log = await import("../log.js");
   tokenVending = await import("../token-vending.js");
   const ghAuth = await import("../github-app-auth.js");
-  mockGetInstallationToken = vi.mocked(ghAuth.getInstallationToken);
+  mockRefreshInstallationToken = vi.mocked(ghAuth.refreshInstallationToken);
   log.initLogTable();
 });
 
@@ -89,14 +89,14 @@ describe("token-vending", () => {
       repo: "acme/my-repo",
       machineNonce: "valid-nonce-123",
     });
-    mockGetInstallationToken.mockResolvedValueOnce("ghs_test_token");
+    mockRefreshInstallationToken.mockResolvedValueOnce("ghs_test_token");
 
     const res = await callTokenEndpoint({ nonce: "valid-nonce-123", owner: "acme" });
     expect(res.statusCode).toBe(200);
     const data = JSON.parse(res.body);
     expect(data.token).toBe("ghs_test_token");
     expect(data.expires_at).toBeTruthy();
-    expect(mockGetInstallationToken).toHaveBeenCalledWith("app-id", "fake-private-key", "acme");
+    expect(mockRefreshInstallationToken).toHaveBeenCalledWith("app-id", "fake-private-key", "acme");
   });
 
   it("returns 403 for unknown nonce", async () => {
@@ -147,7 +147,7 @@ describe("token-vending", () => {
       machineNonce: "fail-nonce",
     });
 
-    mockGetInstallationToken.mockRejectedValueOnce(new Error("Bad credentials"));
+    mockRefreshInstallationToken.mockRejectedValueOnce(new Error("Bad credentials"));
 
     const res = await callTokenEndpoint({ nonce: "fail-nonce", owner: "acme" });
     expect(res.statusCode).toBe(500);

--- a/src/github-app-auth.ts
+++ b/src/github-app-auth.ts
@@ -10,6 +10,7 @@ export interface InstallationDetails {
 // Cache: org → { token, expiresAt }
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 let cachedAppSlug: string | null = null;
+const TOKEN_CACHE_TTL_MS = 50 * 60 * 1000;
 
 /**
  * Wraps raw bytes in an ASN.1 TLV (tag-length-value) structure.
@@ -229,8 +230,21 @@ export async function getInstallationToken(
   if (cached && Date.now() < cached.expiresAt) {
     return cached.token;
   }
+  return refreshInstallationToken(appId, privateKey, owner);
+}
+
+/**
+ * Mint and cache a new installation token even when an older cached token is
+ * still within the dispatch cache window. Runner vending uses this path so a
+ * refresh request cannot receive the same near-expiry token it booted with.
+ */
+export async function refreshInstallationToken(
+  appId: string,
+  privateKey: string,
+  owner: string,
+): Promise<string> {
   const { token } = await getInstallation(appId, privateKey, owner);
-  tokenCache.set(owner, { token, expiresAt: Date.now() + 50 * 60 * 1000 });
+  tokenCache.set(owner, { token, expiresAt: Date.now() + TOKEN_CACHE_TTL_MS });
   return token;
 }
 

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -87,6 +87,8 @@ function applyWiring(step: YamlStep): StepDefinition {
           workspaceDir: ctx.data.workspaceDir,
           baseBranch: ctx.data.baseBranch,
           prNumber: ctx.data.prNumber,
+          orchestratorUrl: ctx.data.orchestratorUrl,
+          machineNonce: ctx.data.nonce,
         }),
       };
 
@@ -171,6 +173,8 @@ function applyWiring(step: YamlStep): StepDefinition {
             repoOwner: ctx.getOutputs("clone").repoOwner,
             repoRepo: ctx.getOutputs("clone").repoRepo,
             githubToken: ctx.getOutputs("clone").githubToken,
+            orchestratorUrl: ctx.data.orchestratorUrl,
+            machineNonce: ctx.data.nonce,
             branchName: buildIssueBranchName(ctx.data.issueIdentifier, ctx.data.issueTitle, ctx.data.branchPrefix),
             baseBranch: ctx.getOutputs("clone").branch,
             prTitle: `${ctx.data.issueIdentifier}: ${ctx.data.issueTitle}`,

--- a/src/pipeline/steps/clone.ts
+++ b/src/pipeline/steps/clone.ts
@@ -145,8 +145,8 @@ export const cloneStep: StepModule<CloneInputs, CloneOutputs> = {
     const clonedRef = revResult.stdout.toString().trim();
 
     // Give long-running and gap-fill sessions a newly minted token immediately
-    // after clone. Push refreshes again at its own write boundary, but gap-fill
-    // runs deliberately skip pushStep and let Claude push the existing PR branch.
+    // after clone. Push refreshes again at its own write boundary; gap-fill
+    // prompts refresh the origin again immediately before Claude-owned pushes.
     const activeGithubToken = await refreshRunnerGithubCredentials({
       currentToken: githubToken,
       orchestratorUrl: inputs.orchestratorUrl,

--- a/src/pipeline/steps/clone.ts
+++ b/src/pipeline/steps/clone.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { prepareScratchExclusion } from "../scratch-exclude.js";
+import { refreshRunnerGithubCredentials } from "../../runner-token.js";
 
 interface CloneInputs extends Record<string, unknown> {
   repoOwner: string;
@@ -12,6 +13,8 @@ interface CloneInputs extends Record<string, unknown> {
   workspaceDir: string;
   baseBranch?: string;
   prNumber?: string;
+  orchestratorUrl?: string;
+  machineNonce?: string;
 }
 
 interface CloneOutputs extends Record<string, unknown> {
@@ -141,6 +144,18 @@ export const cloneStep: StepModule<CloneInputs, CloneOutputs> = {
     }
     const clonedRef = revResult.stdout.toString().trim();
 
-    return { workspaceDir, clonedRef, cloneMethod, repoOwner, repoRepo, branch, githubToken };
+    // Give long-running and gap-fill sessions a newly minted token immediately
+    // after clone. Push refreshes again at its own write boundary, but gap-fill
+    // runs deliberately skip pushStep and let Claude push the existing PR branch.
+    const activeGithubToken = await refreshRunnerGithubCredentials({
+      currentToken: githubToken,
+      orchestratorUrl: inputs.orchestratorUrl,
+      machineNonce: inputs.machineNonce,
+      owner: repoOwner,
+      repo: repoRepo,
+      workspaceDir,
+    });
+
+    return { workspaceDir, clonedRef, cloneMethod, repoOwner, repoRepo, branch, githubToken: activeGithubToken };
   },
 };

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import type { StepModule, StepReporter } from "../types.js";
+import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { formatGitNameStatusSummary } from "../step-utils.js";
 import { extractFirstJsonObject } from "../json-extract.js";
+import { refreshRunnerGithubCredentials } from "../../runner-token.js";
 import {
   AI_IMPLEMENT_NATIVE_REVIEW_MARKER,
   collectExternalReviewFindingsFromGh,
@@ -24,6 +25,8 @@ interface PostPushReviewInputs extends Record<string, unknown> {
   ghSpawn?: (args: string[]) => SpawnResult;
   gitSpawn?: (args: string[]) => SpawnResult;
   sleep?: (ms: number) => Promise<void>;
+  /** Injectable credential refresh for tests. */
+  refreshCredentials?: () => Promise<void>;
 }
 
 type ExternalReviewState = "skipped" | "absent" | "running" | "completed";
@@ -51,6 +54,32 @@ const DEFAULT_MAX_ITERATIONS = 3;
 const GITHUB_CLAUDE_CODE_REVIEW_PROVIDER = "github-claude-code-review";
 const DEFAULT_REVIEW_WAIT_POLL_MS = 5000;
 const DEFAULT_REVIEW_WAIT_TIMEOUT_MS = 300000;
+
+async function refreshCredentialsBeforePush(
+  context: PipelineContext,
+  inputs: PostPushReviewInputs,
+): Promise<void> {
+  if (inputs.refreshCredentials) {
+    await inputs.refreshCredentials();
+    return;
+  }
+
+  const currentToken = process.env.GITHUB_TOKEN?.trim()
+    || process.env.GH_TOKEN?.trim()
+    || context.data.githubToken?.trim();
+  const owner = context.data.githubOwner?.trim();
+  const repo = context.data.githubRepo?.trim();
+  if (!currentToken || !owner || !repo) return;
+
+  await refreshRunnerGithubCredentials({
+    currentToken,
+    orchestratorUrl: context.data.orchestratorUrl,
+    machineNonce: context.data.nonce,
+    owner,
+    repo,
+    workspaceDir: inputs.workspaceDir,
+  });
+}
 
 interface ReviewFinding {
   iteration: number;
@@ -975,6 +1004,10 @@ ${externalReviewFindingsBlock(externalFindings)}
 
       const branchName = currentBranchName(gitSpawn);
       const remoteRef = `refs/heads/${branchName}`;
+      // A fix pass can run long enough to outlive the token minted by pushStep.
+      // Re-vend at the actual write boundary; transient vending failures retain
+      // the latest token already present in the environment and origin URL.
+      await refreshCredentialsBeforePush(context, inputs);
       const expectedRemoteSha = remoteBranchSha(gitSpawn, branchName);
       const push = gitSpawn([
         "push",

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -3,6 +3,7 @@ import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { formatGitNameStatusSummary } from "../step-utils.js";
 import { span } from "../timing.js";
 import { findSensitiveFiles, SensitiveFilesError } from "../sensitive-files.js";
+import { refreshRunnerGithubCredentials } from "../../runner-token.js";
 
 const LS_REMOTE_MAX_ATTEMPTS = 3;
 const LS_REMOTE_RETRY_DELAYS_MS = [250, 1000];
@@ -22,6 +23,8 @@ interface PushInputs extends Record<string, unknown> {
   repoOwner: string;
   repoRepo: string;
   githubToken: string;
+  orchestratorUrl?: string;
+  machineNonce?: string;
   branchName: string;
   baseBranch?: string;
   prTitle?: string;
@@ -139,12 +142,26 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     const changedFilesSummary = summarizeCommittedChanges(workspaceDir, githubToken, agentCommitted ? baseBranch : undefined);
     const prBody = buildPullRequestBody(context, inputs, changedFilesSummary);
 
+    // The dispatch-time installation token may already be close to its one-hour
+    // expiry. Fly/local-docker runners re-vend immediately before the first
+    // authenticated remote write; GHA has no orchestrator URL/nonce and keeps
+    // using its workflow-minted token. A vending outage falls back to the boot
+    // token so an otherwise-valid credential can still complete the run.
+    const activeGithubToken = await refreshRunnerGithubCredentials({
+      currentToken: githubToken,
+      orchestratorUrl: inputs.orchestratorUrl,
+      machineNonce: inputs.machineNonce,
+      owner: repoOwner,
+      repo: repoRepo,
+      workspaceDir,
+    });
+
     // Embed token in URL but use stdio: "pipe" so it is never printed to inherited
     // stdout/stderr. Token is redacted from any error messages.
-    const remote = `https://x-access-token:${githubToken}@github.com/${repoOwner}/${repoRepo}.git`;
+    const remote = `https://x-access-token:${activeGithubToken}@github.com/${repoOwner}/${repoRepo}.git`;
     const remoteRef = `refs/heads/${branchName}`;
     const expectedRemoteSha = await span("git-ls-remote", async () =>
-      resolveRemoteBranchSha(workspaceDir, remote, branchName, githubToken),
+      resolveRemoteBranchSha(workspaceDir, remote, branchName, activeGithubToken),
     );
     const tracePush = process.env.AI_IMPLEMENT_LOG_LEVEL === "stream";
     const { args: pushArgs, env: pushEnv } = buildGitPushInvocation(
@@ -170,11 +187,11 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
         .map((s) => s.trim())
         .filter(Boolean)
         .join("\n")
-        .replaceAll(githubToken, "***");
+        .replaceAll(activeGithubToken, "***");
       if (trace) console.error(`[git-push trace]\n${trace}`);
     }
     if (pushResult.status !== 0) {
-      const stderr = (pushResult.stderr?.toString() ?? "").replaceAll(githubToken, "***");
+      const stderr = (pushResult.stderr?.toString() ?? "").replaceAll(activeGithubToken, "***");
       throw new Error(`git push failed (exit ${pushResult.status ?? "null"}): ${stderr}`);
     }
 
@@ -182,7 +199,7 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     // Span covers the POST and the 422 list-open-PRs fallback so re-runs (which
     // hit 422 and pay an extra round-trip) are timed in full, not just the POST.
     const pr = await span("pr-create", async () =>
-      createOrFindPullRequest({ repoOwner, repoRepo, githubToken, prTitle, branchName, baseBranch, prBody, draft }),
+      createOrFindPullRequest({ repoOwner, repoRepo, githubToken: activeGithubToken, prTitle, branchName, baseBranch, prBody, draft }),
     );
     return { prUrl: pr.url, prNumber: pr.number, branchPushed: true, commitSha, draft: pr.draft };
   },

--- a/src/refresh-runner-github-credentials.ts
+++ b/src/refresh-runner-github-credentials.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { refreshRunnerGithubCredentials } from "./runner-token.js";
+
+export function tokenFromOrigin(workspaceDir: string): string | null {
+  const result = spawnSync("git", ["remote", "get-url", "origin"], {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) return null;
+
+  try {
+    const remote = new URL(result.stdout.toString().trim());
+    if (remote.username !== "x-access-token" || !remote.password) return null;
+    return decodeURIComponent(remote.password);
+  } catch {
+    return null;
+  }
+}
+
+export function repositoryCoordinates(): { owner: string; repo: string } {
+  const [repositoryOwner = "", repositoryName = ""] =
+    (process.env.GITHUB_REPOSITORY ?? "").split("/", 2);
+  const owner = process.env.GITHUB_OWNER?.trim() || repositoryOwner.trim();
+  const repo = process.env.GITHUB_REPO?.trim() || repositoryName.trim();
+  if (!owner || !repo) {
+    throw new Error("Missing GITHUB_OWNER/GITHUB_REPO (or GITHUB_REPOSITORY)");
+  }
+  return { owner, repo };
+}
+
+export async function refreshRunnerGithubCredentialsFromEnvironment(
+  workspaceDir = process.cwd(),
+): Promise<void> {
+  const currentToken = tokenFromOrigin(workspaceDir)
+    || process.env.GITHUB_TOKEN?.trim()
+    || process.env.GH_TOKEN?.trim();
+  if (!currentToken) throw new Error("Missing current GitHub token");
+
+  const { owner, repo } = repositoryCoordinates();
+  await refreshRunnerGithubCredentials({
+    currentToken,
+    orchestratorUrl: process.env.ORCHESTRATOR_URL,
+    machineNonce: process.env.MACHINE_NONCE,
+    owner,
+    repo,
+    workspaceDir,
+  });
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (invokedPath === import.meta.url) {
+  await refreshRunnerGithubCredentialsFromEnvironment().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[runner-token] Credential refresh failed: ${message}`);
+    process.exitCode = 1;
+  });
+}

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { ClaudeCliExecutor } from "./pipeline/executor.js";
 import { DefaultPipelineContext } from "./pipeline/context.js";
 import { PipelineRunner } from "./pipeline/runner.js";
@@ -99,7 +100,20 @@ ${issueDescription}`;
 }
 
 function appendPipelineOwnedGitInstructions(prompt: string, prNumber: string): string {
-  if (prNumber) return prompt;
+  if (prNumber) {
+    if (prompt.includes("Runner GitHub credential refresh")) return prompt;
+    const refreshScript = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "refresh-runner-github-credentials.js",
+    );
+    return `${prompt.trimEnd()}
+
+## Runner GitHub credential refresh
+
+Immediately before every \`git push\`, run \`node ${JSON.stringify(refreshScript)}\`.
+This re-vends the GitHub token and updates \`origin\`; if vending is temporarily
+unavailable, it keeps the latest token already stored in \`origin\`.`;
+  }
   if (prompt.includes("Pipeline-owned Git")) return prompt;
   return `${prompt.trimEnd()}
 

--- a/src/runner-token.ts
+++ b/src/runner-token.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_TOKEN_REQUEST_TIMEOUT_MS = 5_000;
+
+interface RefreshRunnerGithubTokenInputs {
+  currentToken: string;
+  orchestratorUrl?: string;
+  machineNonce?: string;
+  owner: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+interface RefreshRunnerGithubCredentialsInputs extends RefreshRunnerGithubTokenInputs {
+  repo: string;
+  workspaceDir: string;
+}
+
+/**
+ * Obtain a current GitHub installation token for a Fly/local-docker runner.
+ *
+ * GitHub Actions intentionally has no orchestrator URL or machine nonce, so it
+ * keeps using the workflow-minted token. Vending is best-effort: a temporary
+ * orchestrator outage must not discard a boot token that may still be valid.
+ */
+export async function refreshRunnerGithubToken(
+  inputs: RefreshRunnerGithubTokenInputs,
+): Promise<string> {
+  const orchestratorUrl = inputs.orchestratorUrl?.trim();
+  const machineNonce = inputs.machineNonce?.trim();
+  if (!orchestratorUrl || !machineNonce) return inputs.currentToken;
+
+  const fetchImpl = inputs.fetchImpl ?? fetch;
+  const timeoutMs = inputs.timeoutMs ?? DEFAULT_TOKEN_REQUEST_TIMEOUT_MS;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(`${orchestratorUrl.replace(/\/$/, "")}/api/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ nonce: machineNonce, owner: inputs.owner }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`[runner-token] Token refresh unavailable (${reason}); using the boot token.`);
+    return inputs.currentToken;
+  }
+
+  if (!response.ok) {
+    if (response.status >= 500) {
+      console.warn(
+        `[runner-token] Token refresh failed with HTTP ${response.status}; using the boot token.`,
+      );
+      return inputs.currentToken;
+    }
+    throw new Error(`[runner-token] Token refresh rejected with HTTP ${response.status}`);
+  }
+
+  const body = (await response.json()) as { token?: unknown };
+  if (typeof body.token !== "string" || body.token.length === 0) {
+    throw new Error("[runner-token] Token refresh returned no token");
+  }
+
+  console.log("[runner-token] Obtained a current GitHub token from the orchestrator.");
+  return body.token;
+}
+
+/**
+ * Refresh the token and apply it to the credential paths used by later runner
+ * steps: `gh` reads GH_TOKEN, while post-push git operations use `origin`.
+ */
+export async function refreshRunnerGithubCredentials(
+  inputs: RefreshRunnerGithubCredentialsInputs,
+): Promise<string> {
+  const canVend = Boolean(inputs.orchestratorUrl?.trim() && inputs.machineNonce?.trim());
+  const token = await refreshRunnerGithubToken(inputs);
+  if (!canVend) return token;
+
+  process.env.GITHUB_TOKEN = token;
+  process.env.GH_TOKEN = token;
+
+  const remote = `https://x-access-token:${token}@github.com/${inputs.owner}/${inputs.repo}.git`;
+  const result = spawnSync("git", ["remote", "set-url", "origin", remote], {
+    cwd: inputs.workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    const stderr = (result.stderr?.toString() ?? "").replaceAll(token, "***");
+    throw new Error(`git remote set-url failed (exit ${result.status ?? "null"}): ${stderr}`);
+  }
+
+  return token;
+}

--- a/src/runner-token.ts
+++ b/src/runner-token.ts
@@ -43,14 +43,14 @@ export async function refreshRunnerGithubToken(
     });
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    console.warn(`[runner-token] Token refresh unavailable (${reason}); using the boot token.`);
+    console.warn(`[runner-token] Token refresh unavailable (${reason}); using the previous token.`);
     return inputs.currentToken;
   }
 
   if (!response.ok) {
     if (response.status >= 500) {
       console.warn(
-        `[runner-token] Token refresh failed with HTTP ${response.status}; using the boot token.`,
+        `[runner-token] Token refresh failed with HTTP ${response.status}; using the previous token.`,
       );
       return inputs.currentToken;
     }

--- a/src/token-vending.ts
+++ b/src/token-vending.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import { getJobByNonce } from "./log.js";
-import { getInstallationToken } from "./github-app-auth.js";
+import { refreshInstallationToken } from "./github-app-auth.js";
 
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -46,7 +46,7 @@ export async function handleTokenRequest(
       return;
     }
 
-    const token = await getInstallationToken(githubAppId, githubAppPrivateKey, body.owner);
+    const token = await refreshInstallationToken(githubAppId, githubAppPrivateKey, body.owner);
     const expiresAt = new Date(Date.now() + 55 * 60 * 1000).toISOString();
 
     json(res, 200, { token, expires_at: expiresAt });


### PR DESCRIPTION
## Summary

- force `POST /api/token` to mint and cache a new GitHub installation token instead of returning the dispatch-time cached token
- refresh Fly/local-docker credentials immediately after clone and again at every runner-owned push boundary
- refresh each post-push review fix pass immediately before its lease lookup and force-push
- give gap-fill agents a runner credential command to invoke immediately before each Claude-owned push
- update `GITHUB_TOKEN`, `GH_TOKEN`, and the checkout's `origin` whenever credentials refresh
- retain the latest previous token on network/5xx vending outages while failing explicitly on nonce/owner validation errors and malformed responses

## Root cause

The runner received one installation token at dispatch. Because the orchestrator caches installation tokens for 50 minutes, a Machine could start with only about 10 minutes of token lifetime remaining. Long implementation, review, and fix phases then reached `git push` with an expired credential.

The existing token-vending endpoint also used the same cache, so simply calling it did not guarantee a newly minted token.

## Impact

Fly and local-docker sessions now refresh through the nonce-authenticated orchestrator endpoint without placing the GitHub App private key on the session Machine. Post-push fix loops and gap-fill pushes no longer rely solely on the token minted earlier in the run. GitHub Actions behavior remains unchanged.

Linear: [AII-207](https://linear.app/eudoxus/issue/AII-207/refresh-the-runners-github-token-mid-session-via-apitoken-long-session)

## Validation

- `npm test` — 134 files, 2,253 tests passed
- `npm run typecheck`
- `npm run build`
