### PR TITLE
Fix gap-fill checkout ownership

### DIFF
--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -73,6 +73,7 @@ git config --global init.defaultBranch "$GITHUB_DEFAULT_BRANCH"
 REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
 log "Cloning ${GITHUB_OWNER}/${GITHUB_REPO}..."
 git clone --depth=1 --branch "$GITHUB_DEFAULT_BRANCH" "$REPO_URL" /workspace
+git config --global --add safe.directory /workspace
 cd /workspace
 if [ -n "$PR_NUMBER" ]; then
   log "Gap-fill: checking out PR #$PR_NUMBER"
@@ -85,7 +86,6 @@ fi
 chown -R coder:coder /workspace
 cp /root/.gitconfig /home/coder/.gitconfig 2>/dev/null || true
 chown coder:coder /home/coder/.gitconfig 2>/dev/null || true
-git config --global --add safe.directory /workspace
 
 # ── 6. Invoke TS pipeline ────────────────────────────────────────────────────
 export WORKSPACE_DIR=/workspace

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -52,6 +52,17 @@ describe("session/entrypoint.sh", () => {
     expect(content).toMatch(/GITHUB_DEFAULT_BRANCH="\$\(git branch --show-current\)"/);
   });
 
+  it("marks the cloned workspace safe before the gap-fill PR checkout", () => {
+    const content = readFileSync("session/entrypoint.sh", "utf-8");
+    const cloneIdx = content.indexOf('git clone --depth=1 --branch "$GITHUB_DEFAULT_BRANCH"');
+    const safeDirectoryIdx = content.indexOf("git config --global --add safe.directory /workspace");
+    const checkoutIdx = content.indexOf('gh pr checkout "$PR_NUMBER"');
+
+    expect(cloneIdx).toBeGreaterThan(-1);
+    expect(safeDirectoryIdx).toBeGreaterThan(cloneIdx);
+    expect(safeDirectoryIdx).toBeLessThan(checkoutIdx);
+  });
+
   it("decodes prNumber from the envelope before the gap-fill checkout when PR_NUMBER is empty", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     // Decode line must extract prNumber from the envelope JSON


### PR DESCRIPTION
## Summary

- mark `/workspace` as a Git safe directory immediately after cloning
- ensure the exception exists before `gh pr checkout` runs for gap-fill jobs
- add a regression test that pins the required clone → safe-directory → PR-checkout ordering

## Root cause

The entrypoint configured `safe.directory` only after the gap-fill checkout. In GitHub Actions, `gh pr checkout` invokes Git while `/workspace` has ownership Git considers dubious, so the job failed before reaching the existing safety configuration.

## Impact

Gap-fill runs can check out their target PR successfully. The same root Git configuration is still copied to the non-root `coder` user before the TypeScript runner starts.

## Validation

- `bash -n session/entrypoint.sh`
- `shellcheck session/entrypoint.sh`
- `npm run typecheck`
- `npm test` — 134 files, 2,264 tests passed
- `git diff --check`

Related failure: https://github.com/BuildDownAI/AI-Implement/pull/225#issuecomment-5211127837
