### PR TITLE
Fix gap-fill checkout after shallow single-branch clone

### DIFF
--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -77,6 +77,9 @@ git config --global --add safe.directory /workspace
 cd /workspace
 if [ -n "$PR_NUMBER" ]; then
   log "Gap-fill: checking out PR #$PR_NUMBER"
+  # --depth + --branch narrows origin's fetch refspec to the cloned base branch.
+  # gh pr checkout needs the PR head to count as a trackable remote branch.
+  git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
   gh pr checkout "$PR_NUMBER"
   GITHUB_DEFAULT_BRANCH="$(git branch --show-current)"
   export GITHUB_DEFAULT_BRANCH

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -63,6 +63,17 @@ describe("session/entrypoint.sh", () => {
     expect(safeDirectoryIdx).toBeLessThan(checkoutIdx);
   });
 
+  it("expands the shallow clone refspec before tracking a gap-fill PR branch", () => {
+    const content = readFileSync("session/entrypoint.sh", "utf-8");
+    const refspecIdx = content.indexOf(
+      "git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'",
+    );
+    const checkoutIdx = content.indexOf('gh pr checkout "$PR_NUMBER"');
+
+    expect(refspecIdx).toBeGreaterThan(-1);
+    expect(refspecIdx).toBeLessThan(checkoutIdx);
+  });
+
   it("decodes prNumber from the envelope before the gap-fill checkout when PR_NUMBER is empty", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     // Decode line must extract prNumber from the envelope JSON


### PR DESCRIPTION
## Summary

- widen the shallow clone's `remote.origin.fetch` refspec before gap-fill PR checkout
- let `gh pr checkout` fetch and track the PR head as a normal remote branch
- add a regression test that pins refspec expansion before the checkout command

## Root cause

The runner clones only the configured base branch with `git clone --depth=1 --branch ...`. Git records that restriction in `remote.origin.fetch`, so the later gap-fill `gh pr checkout` cannot treat the PR head as a trackable remote branch even though the repository itself cloned successfully.

This is the second checkout precondition exposed after #228 fixed the earlier safe-directory failure.

## Impact

Gap-fill jobs retain the fast shallow initial clone but can check out a PR branch before invoking the implementation pipeline.

## Validation

- `bash -n session/entrypoint.sh`
- `shellcheck session/entrypoint.sh`
- `npm run typecheck`
- `npm test` — 134 files, 2,265 tests passed
- `npm test -- src/__tests__/entrypoint-shellcheck.test.ts` — 13 tests passed
- `git diff --check`

Observed failure: https://github.com/BuildDownAI/AI-Implement/pull/225#issuecomment-5212167994

Failing job: https://github.com/BuildDownAI/AI-Implement/actions/runs/31145839773/job/92764981501
