### PR TITLE
AII-322 fix: copy KG sources.yml (namespace) in the sidecar build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,8 +231,20 @@ The KG repository is private. A **BuildKit `--build-secret` mount** clones it at
 docker build --secret id=kg_token,env=GH_TOKEN .
 
 # Fly deploy (the standard command for testing/production):
-fly deploy --remote-only --build-secret kg_token="$(gh auth token)"
+#   --no-cache is REQUIRED: a --build-secret is NOT part of the layer cache key,
+#   so without it a repeat deploy silently reuses a stale (possibly sidecar-less)
+#   image and the clone/materialize RUN never re-executes.
+#   Also: export GH_TOKEN first — `GH_TOKEN=... fly deploy ... "$GH_TOKEN"` does
+#   NOT work (the inline prefix doesn't affect same-line expansion → empty secret).
+export GH_TOKEN="$(gh auth token)"
+fly deploy --remote-only --no-cache --build-secret kg_token="$GH_TOKEN"
 ```
+
+The sidecar clone copies the KG's `sources.yml` (which pins the IRI `namespace:`)
+alongside the code — without it the server falls back to the placeholder
+namespace and every type-filtered `kg_*` tool silently returns empty (the graph
+loads, but queries match nothing). Verify a deploy with a real query
+(`kg_search` returns non-empty), not just that `/mcp` answers.
 
 **Build without the KG sidecar** (sidecar-less / degraded — `/mcp` returns 503, all other routes remain healthy):
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,9 @@ RUN --mount=type=secret,id=kg_token,required=false \
         && for d in kg_query kg_ingest snapshot; do \
                [ -d /tmp/kg-src/$d ] && cp -r /tmp/kg-src/$d /app/kg/ || true; \
            done \
-        && [ -f /tmp/kg-src/requirements.txt ] && cp /tmp/kg-src/requirements.txt /app/kg/ || true \
+        && for f in requirements.txt sources.yml; do \
+               [ -f /tmp/kg-src/$f ] && cp /tmp/kg-src/$f /app/kg/ || true; \
+           done \
         && printf '#!/bin/sh\ncd "$(dirname "$0")"\nexport KG_HTTP=1 KG_HTTP_PORT=8765 KG_HTTP_HOST=127.0.0.1 KG_BACKEND=rdflib PYTHONPATH=.\nexec .venv/bin/python -m kg_query.server\n' > /app/kg/start.sh \
         && chmod +x /app/kg/start.sh \
         && rm -rf /tmp/kg-src; \


### PR DESCRIPTION
**Critical correctness fix** to the merged AII-322 durable sidecar deploy — verified live on ai-implement-testing-orchestrator.

**Bug:** the Dockerfile clone copied `kg_query/kg_ingest/snapshot/requirements.txt` but **not `sources.yml`**, which pins the KG's IRI `namespace:`. Without it, `kg_ingest.iris.NAMESPACE` fell back to the placeholder `https://example.org/kg/`, while the committed graph has real `kg.builddown.dev` IRIs. Consequence: the graph loaded (10,576 triples), raw `dcterms:` queries worked, but **every type-filtered `kg_*` tool matched nothing** — `kg_search` returned 0. The sidecar booted, was "ready", listed tools — and served empty.

**Fix:** copy `sources.yml` alongside `requirements.txt`. Verified live post-deploy: `NAMESPACE = https://kg.builddown.dev/`, `kg_search("orchestrator") = 3`, `hybrid("orchestrator failover")` count=3 **degraded=False** (semantic search serving real results).

**Also documents** two deploy gotchas found the hard way: `--no-cache` is required with `--build-secret` (secrets aren't a cache key → stale-image reuse), and `export GH_TOKEN` before the deploy (inline prefix doesn't affect same-line expansion).

Only caught by asserting a real query returns non-empty data — the "boots ≠ serves" rule. Related: AII-322, AII-323 (embeddings reliability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)