### PR TITLE
AII-341: Resolve credential feedback on PR #230

### DIFF
--- a/session/git-credential-helper.sh
+++ b/session/git-credential-helper.sh
@@ -49,6 +49,11 @@ EXPIRES_AT=$(jq -r '.expires_at // empty' "$TOKEN_FILE" 2>/dev/null) || true
 # estimate could lie; see AII-294 notes on widening getScopedInstallationToken
 # to surface the real expiry.
 CALLBACK_URL="${GIT_DEPENDENCY_CALLBACK_URL:-}"
+# Treat this environment value as untrusted input. Normalize all trailing
+# slashes so appending the exact route can never produce a double-slash path.
+while [ "${CALLBACK_URL%/}" != "$CALLBACK_URL" ]; do
+    CALLBACK_URL="${CALLBACK_URL%/}"
+done
 PROGRESS_TOKEN="${RUN_PROGRESS_TOKEN:-}"
 
 if [ -n "$EXPIRES_AT" ] && [ -n "$CALLBACK_URL" ] && [ -n "$PROGRESS_TOKEN" ]; then

--- a/src/__tests__/dependency-auth.test.ts
+++ b/src/__tests__/dependency-auth.test.ts
@@ -461,9 +461,9 @@ describe("dependencyAuthStep credential helper registration", () => {
   });
 
   it("writes token cache file and sets GIT_DEPENDENCY_TOKEN_FILE + GIT_DEPENDENCY_CALLBACK_URL", async () => {
-    const writeCalls: Array<{ path: string; data: string }> = [];
-    const mockWrite = vi.fn().mockImplementation((path: string, data: string) => {
-      writeCalls.push({ path, data });
+    const writeCalls: Array<{ path: string; data: string; options?: { mode?: number } }> = [];
+    const mockWrite = vi.fn().mockImplementation((path: string, data: string, options?: { mode?: number }) => {
+      writeCalls.push({ path, data, options });
     });
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -471,7 +471,7 @@ describe("dependencyAuthStep credential helper registration", () => {
       ctx(),
       {
         dependencyTokenScope: "installation",
-        callbackUrl: "https://orch.example",
+        callbackUrl: "https://orch.example///",
         fetchImpl: mockFetch(200, { token: "dep-tok-file", expires_at: "2030-06-01T12:00:00Z" }),
         spawnSyncImpl: vi.fn().mockReturnValue({ status: 0, stdout: Buffer.from(""), stderr: Buffer.from("") }),
         writeFileSyncImpl: mockWrite,
@@ -484,6 +484,7 @@ describe("dependencyAuthStep credential helper registration", () => {
     const written = JSON.parse(writeCalls[0].data) as { token: string; expires_at: string };
     expect(written.token).toBe("dep-tok-file");
     expect(written.expires_at).toBe("2030-06-01T12:00:00Z");
+    expect(writeCalls[0].options).toEqual({ mode: 0o600 });
     expect(process.env.GIT_DEPENDENCY_TOKEN_FILE).toBe(writeCalls[0].path);
     expect(process.env.GIT_DEPENDENCY_CALLBACK_URL).toBe("https://orch.example");
   });

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -103,9 +103,9 @@ describe("session/git-credential-helper.sh", () => {
     const dir = mkdtempSync(join(tmpdir(), "dep-token-test-"));
     const tokenFile = join(dir, "token.json");
 
-    let serverCalled = false;
-    const server = http.createServer((_req, res) => {
-      serverCalled = true;
+    let requestedUrl: string | undefined;
+    const server = http.createServer((req, res) => {
+      requestedUrl = req.url;
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
@@ -131,7 +131,7 @@ describe("session/git-credential-helper.sh", () => {
           env: {
             ...process.env,
             GIT_DEPENDENCY_TOKEN_FILE: tokenFile,
-            GIT_DEPENDENCY_CALLBACK_URL: `http://127.0.0.1:${port}`,
+            GIT_DEPENDENCY_CALLBACK_URL: `http://127.0.0.1:${port}///`,
             RUN_PROGRESS_TOKEN: "progress-tok",
           },
         });
@@ -147,7 +147,7 @@ describe("session/git-credential-helper.sh", () => {
         setTimeout(() => reject(new Error("helper timed out")), 15000);
       });
 
-      expect(serverCalled).toBe(true);
+      expect(requestedUrl).toBe("/api/runner/dependency-token");
       expect(stdout).toContain("password=refreshed-tok");
       // Helper must update the cache file with the refreshed token.
       const cached = JSON.parse(readFileSync(tokenFile, "utf-8")) as { token: string };

--- a/src/pipeline/steps/dependency-auth.ts
+++ b/src/pipeline/steps/dependency-auth.ts
@@ -14,7 +14,7 @@ interface DependencyAuthInputs extends Record<string, unknown> {
   /** Test-only injectable spawnSync implementation. */
   spawnSyncImpl?: typeof spawnSync;
   /** Test-only injectable fs.writeFileSync implementation. */
-  writeFileSyncImpl?: (path: string, data: string) => void;
+  writeFileSyncImpl?: (path: string, data: string, options?: { mode?: number }) => void;
   /** Override credential helper executable path (test environments only). */
   credentialHelperPath?: string;
 }
@@ -40,7 +40,7 @@ export async function fetchDependencyToken(params: {
   fetchImpl?: typeof fetch;
 }): Promise<DependencyTokenResponse> {
   const { callbackBase, progressToken, fetchImpl: fetchFn = fetch } = params;
-  const url = `${callbackBase.replace(/\/$/, "")}/api/runner/dependency-token`;
+  const url = `${callbackBase.replace(/\/+$/, "")}/api/runner/dependency-token`;
   const res = await fetchFn(url, {
     method: "POST",
     headers: { Authorization: `Bearer ${progressToken}` },
@@ -111,9 +111,11 @@ export const dependencyAuthStep: StepModule<DependencyAuthInputs, DependencyAuth
       // Write a token cache file that the credential helper reads on each git
       // invocation.  The helper overwrites this file when it refreshes.
       const tokenFilePath = join("/tmp", `ai-implement-dep-token-${process.pid}.json`);
-      writeFn(tokenFilePath, JSON.stringify({ token: result.token, expires_at: result.expires_at }));
+      writeFn(tokenFilePath, JSON.stringify({ token: result.token, expires_at: result.expires_at }), {
+        mode: 0o600,
+      });
       process.env.GIT_DEPENDENCY_TOKEN_FILE = tokenFilePath;
-      process.env.GIT_DEPENDENCY_CALLBACK_URL = callbackUrl;
+      process.env.GIT_DEPENDENCY_CALLBACK_URL = callbackUrl.replace(/\/+$/, "");
 
       // Register credential helper for https://github.com so git-based composer
       // installs can reach private sibling repos.


### PR DESCRIPTION
## Summary

Resolves the two remaining build-down findings on PR #230:

- normalizes trailing slashes in both callback URL paths so credential refresh cannot silently hit a double-slash route;
- writes the live dependency-token cache with mode `0600`.

Adds regression coverage for both normalization boundaries and the cache-file mode. The existing embedded-credential bypass safety test remains unchanged.

Tracked by [AII-341](https://linear.app/eudoxus/issue/AII-341/resolve-build-down-feedback-on-pr-230).

## Verification

- `npm test -- src/__tests__/dependency-auth.test.ts src/__tests__/entrypoint-shellcheck.test.ts` — 45 passed
- `npm run typecheck` — passed
- `npm test` — 2,278 passed across 131 files

Base is PR #230's implementation branch so this fix can land without directly pushing to the pipeline-owned branch.
