### PR TITLE
AII-273: make mounted dev runs safe

### DIFF
--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # entrypoint.sh — Thin bootstrap. All pipeline logic lives in TS at /app/dist.
-# Responsibilities: env validation per mode, token acquisition, clone, chown,
-# then exec the phase-appropriate TS entry (run-autonomous.js / run-planning.js)
-# under dbus + non-root.
+# Responsibilities: env validation, workspace bootstrap, then exec the
+# phase-appropriate TS entry under dbus + non-root.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib.sh"
 trap 'log "ERROR: line $LINENO failed: $BASH_COMMAND (exit $?)"' ERR
+WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
+WORKSPACE_MODE="${AI_IMPLEMENT_WORKSPACE_MODE:-cloned}"
 
 # ── 1. Mode detection ────────────────────────────────────────────────────────
 if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
@@ -49,7 +50,6 @@ export GITHUB_OWNER GITHUB_REPO
 export PR_NUMBER="${PR_NUMBER:-}"
 
 # ── 3. Token acquisition ─────────────────────────────────────────────────────
-# Both GHA (workflow-minted) and fly/local (orchestrator-minted) receive GITHUB_TOKEN directly.
 export GH_TOKEN="$GITHUB_TOKEN"
 
 # ── 4. Git config + clone ────────────────────────────────────────────────────
@@ -61,7 +61,6 @@ if [ -z "${GITHUB_DEFAULT_BRANCH:-}" ]; then
   fi
 fi
 export GITHUB_DEFAULT_BRANCH
-# For non-gap-fill runs, envelope baseBranch wins over dispatch-layer env (feature-branch grouping).
 if [ -z "${PR_NUMBER:-}" ] && [ -n "${AI_IMPLEMENT_RUN_CONFIG:-}" ]; then
   _rb="$(node -e 'try{const c=JSON.parse(Buffer.from(process.env.AI_IMPLEMENT_RUN_CONFIG,"base64").toString());process.stdout.write(c.baseBranch||"")}catch(e){}' 2>/dev/null||true)"
   if [ -n "$_rb" ]; then log "run_config.baseBranch=${_rb}"; GITHUB_DEFAULT_BRANCH="$_rb"; fi
@@ -70,28 +69,36 @@ git config --global user.name "ai-implement-bot"
 git config --global user.email "ai-implement-bot@users.noreply.github.com"
 git config --global init.defaultBranch "$GITHUB_DEFAULT_BRANCH"
 
-REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
-log "Cloning ${GITHUB_OWNER}/${GITHUB_REPO}..."
-git clone --depth=1 --branch "$GITHUB_DEFAULT_BRANCH" "$REPO_URL" /workspace
-git config --global --add safe.directory /workspace
-cd /workspace
-if [ -n "$PR_NUMBER" ]; then
-  log "Gap-fill: checking out PR #$PR_NUMBER"
-  # --depth + --branch narrows origin's fetch refspec to the cloned base branch.
-  # gh pr checkout needs the PR head to count as a trackable remote branch.
-  git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
-  gh pr checkout "$PR_NUMBER"
-  GITHUB_DEFAULT_BRANCH="$(git branch --show-current)"
-  export GITHUB_DEFAULT_BRANCH
+if [ "$WORKSPACE_MODE" = "mounted" ]; then
+  log "Using bind-mounted workspace at $WORKSPACE_DIR"
+  git config --global --add safe.directory "$WORKSPACE_DIR"
+  cd "$WORKSPACE_DIR"
+else
+  REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
+  log "Cloning ${GITHUB_OWNER}/${GITHUB_REPO}..."
+  git clone --depth=1 --branch "$GITHUB_DEFAULT_BRANCH" "$REPO_URL" "$WORKSPACE_DIR"
+  git config --global --add safe.directory "$WORKSPACE_DIR"
+  cd "$WORKSPACE_DIR"
+  if [ -n "$PR_NUMBER" ]; then
+    log "Gap-fill: checking out PR #$PR_NUMBER"
+    git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+    gh pr checkout "$PR_NUMBER"
+    GITHUB_DEFAULT_BRANCH="$(git branch --show-current)"
+    export GITHUB_DEFAULT_BRANCH
+  fi
 fi
 
 # ── 5. Workspace ownership for non-root Claude ───────────────────────────────
-chown -R coder:coder /workspace
+if [ "$WORKSPACE_MODE" = "mounted" ]; then
+  prepare_coder_identity "${AI_IMPLEMENT_HOST_UID:-}" "${AI_IMPLEMENT_HOST_GID:-}"
+else
+  chown -R coder:coder "$WORKSPACE_DIR"
+fi
 cp /root/.gitconfig /home/coder/.gitconfig 2>/dev/null || true
 chown coder:coder /home/coder/.gitconfig 2>/dev/null || true
 
 # ── 6. Invoke TS pipeline ────────────────────────────────────────────────────
-export WORKSPACE_DIR=/workspace
+export WORKSPACE_DIR
 RUNNER_PHASE="${RUNNER_PHASE:-implementation}"
 export RUNNER_PHASE
 # Only "planning" has a dedicated entry. "implementation" and "gap-analysis"

--- a/session/lib.sh
+++ b/session/lib.sh
@@ -29,3 +29,19 @@ require_one_of() {
   done
   fail "At least one of $* must be set"
 }
+
+# Match the non-root runner account to the owner of a host bind mount without
+# recursively changing ownership of the host checkout.
+prepare_coder_identity() {
+  local host_uid="$1" host_gid="$2" host_group
+  [[ "$host_uid" =~ ^[1-9][0-9]*$ ]] || fail "AI_IMPLEMENT_HOST_UID must be a positive integer"
+  [[ "$host_gid" =~ ^[1-9][0-9]*$ ]] || fail "AI_IMPLEMENT_HOST_GID must be a positive integer"
+  host_group="$(getent group "$host_gid" | cut -d: -f1 || true)"
+  if [ -n "$host_group" ]; then
+    usermod -g "$host_group" coder
+  else
+    groupmod -o -g "$host_gid" coder
+  fi
+  usermod -o -u "$host_uid" coder
+  chown -R coder:"$(id -gn coder)" /home/coder
+}

--- a/src/__tests__/dev-harness.test.ts
+++ b/src/__tests__/dev-harness.test.ts
@@ -137,6 +137,29 @@ describe("startDevRun", () => {
     expect(capturedArgs).toContain("AI_IMPLEMENT_WORKSPACE_MODE=mounted");
   });
 
+  it("passes the host uid and gid so the container user can write without chowning the mount", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "");
+    makeSpawnSyncMock("");
+
+    const capturedArgs: string[] = [];
+    vi.mocked(rawExecFile).mockImplementation(
+      (_cmd: unknown, args: unknown, cb: unknown) => {
+        capturedArgs.push(...(args as string[]));
+        (cb as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+          stdout: "cid\n",
+          stderr: "",
+        });
+        return {} as ReturnType<typeof rawExecFile>;
+      },
+    );
+
+    await startDevRun({ workspace: "/tmp/repo", task: "task.md" });
+
+    expect(capturedArgs).toContain(`AI_IMPLEMENT_HOST_UID=${process.getuid!()}`);
+    expect(capturedArgs).toContain(`AI_IMPLEMENT_HOST_GID=${process.getgid!()}`);
+  });
+
   it("includes workspace bind-mount arg in docker run command", async () => {
     vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
     vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "");

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function writeShim(binDir: string, name: string, body: string): void {
+  const shim = join(binDir, name);
+  writeFileSync(shim, `#!/usr/bin/env bash\n${body}\n`);
+  chmodSync(shim, 0o755);
+}
 
 describe("session/entrypoint.sh", () => {
   it("passes shellcheck cleanly", () => {
@@ -55,7 +69,7 @@ describe("session/entrypoint.sh", () => {
   it("marks the cloned workspace safe before the gap-fill PR checkout", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     const cloneIdx = content.indexOf('git clone --depth=1 --branch "$GITHUB_DEFAULT_BRANCH"');
-    const safeDirectoryIdx = content.indexOf("git config --global --add safe.directory /workspace");
+    const safeDirectoryIdx = content.indexOf('git config --global --add safe.directory "$WORKSPACE_DIR"', cloneIdx);
     const checkoutIdx = content.indexOf('gh pr checkout "$PR_NUMBER"');
 
     expect(cloneIdx).toBeGreaterThan(-1);
@@ -108,5 +122,51 @@ describe("session/entrypoint.sh", () => {
     expect(content).toMatch(/if \[ -n "\$\{AI_IMPLEMENT_RUN_CONFIG:-\}" \]; then/);
     expect(content).toContain('require_env ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION');
     expect(content).toContain("export ISSUE_ID ISSUE_IDENTIFIER ISSUE_TITLE ISSUE_DESCRIPTION");
+  });
+
+  it("consumes mounted workspace mode before clone and never changes bind-mount ownership", () => {
+    const root = mkdtempSync(join(tmpdir(), "entrypoint-mounted-"));
+    tempDirs.push(root);
+    const binDir = join(root, "bin");
+    const workspace = join(root, "workspace");
+    const commandLog = join(root, "commands.log");
+    spawnSync("mkdir", ["-p", binDir, workspace]);
+
+    for (const name of ["git", "usermod", "groupmod", "chown", "cp", "dbus-run-session"]) {
+      writeShim(binDir, name, `printf '%s %s\\n' '${name}' \"$*\" >> \"$COMMAND_LOG\"`);
+    }
+    writeShim(binDir, "getent", "printf 'hostgroup:x:2345:\\n'");
+    writeShim(binDir, "id", "[ \"${1:-}\" = '-gn' ] && printf 'hostgroup\\n'");
+
+    const result = spawnSync("bash", ["session/entrypoint.sh"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH}`,
+        COMMAND_LOG: commandLog,
+        WORKSPACE_DIR: workspace,
+        AI_IMPLEMENT_MODE: "local",
+        AI_IMPLEMENT_WORKSPACE_MODE: "mounted",
+        AI_IMPLEMENT_HOST_UID: "1234",
+        AI_IMPLEMENT_HOST_GID: "2345",
+        ANTHROPIC_API_KEY: "test-key",
+        GITHUB_TOKEN: "test-token",
+        GITHUB_OWNER: "BuildDownAI",
+        GITHUB_REPO: "fixture",
+        GITHUB_DEFAULT_BRANCH: "testing",
+        ISSUE_ID: "issue-id",
+        ISSUE_IDENTIFIER: "DEV-1",
+        ISSUE_TITLE: "Test",
+        ISSUE_DESCRIPTION: "Test mounted mode",
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const commands = readFileSync(commandLog, "utf8");
+    expect(commands).not.toMatch(/git clone/);
+    expect(commands).not.toContain(`chown -R coder:coder ${workspace}`);
+    expect(commands).toContain(`git config --global --add safe.directory ${workspace}`);
+    expect(commands).toContain("usermod -o -u 1234 coder");
+    expect(commands).toContain("dbus-run-session -- su -p coder");
   });
 });

--- a/src/__tests__/steps-install.test.ts
+++ b/src/__tests__/steps-install.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { installStep } from "../pipeline/steps/install.js";
 import { DefaultPipelineContext } from "../pipeline/context.js";
 import { NoopStepReporter } from "../pipeline/reporter.js";
@@ -49,6 +49,26 @@ describe("installStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSpawnSuccess();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does not mutate dependencies in a mounted host workspace", async () => {
+    vi.stubEnv("AI_IMPLEMENT_WORKSPACE_MODE", "mounted");
+    mockRootPackageJson((p) => p.endsWith("package-lock.json"));
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.packageManager).toBe("npm");
+    expect(outputs.installMethod).toBe("skipped: mounted workspace");
+    expect(outputs.durationMs).toBe(0);
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it("detects npm when no lock files exist", async () => {

--- a/src/dev-harness/index.ts
+++ b/src/dev-harness/index.ts
@@ -168,6 +168,8 @@ export async function startDevRun(opts: DevRunOptions): Promise<DevRunHandle> {
     MACHINE_NONCE: runId,
     SESSION_MODE: "autonomous",
     RUNNER_PHASE: "implementation",
+    ...(process.getuid ? { AI_IMPLEMENT_HOST_UID: String(process.getuid()) } : {}),
+    ...(process.getgid ? { AI_IMPLEMENT_HOST_GID: String(process.getgid()) } : {}),
     ...(anthropicApiKey ? { ANTHROPIC_API_KEY: anthropicApiKey } : {}),
     ...(claudeOAuthToken ? { CLAUDE_CODE_OAUTH_TOKEN: claudeOAuthToken } : {}),
     ...(opts.env ?? {}),

--- a/src/pipeline/steps/install.ts
+++ b/src/pipeline/steps/install.ts
@@ -99,6 +99,16 @@ export const installStep: StepModule<InstallInputs, InstallOutputs> = {
     const config = readAiImplementConfig(workspaceDir);
     const hasPackageJson = fs.existsSync(path.join(workspaceDir, "package.json"));
 
+    if (process.env.AI_IMPLEMENT_WORKSPACE_MODE === "mounted") {
+      return {
+        packageManager: config.packageManager ?? (hasPackageJson ? detectPackageManager(workspaceDir) : "none"),
+        installMethod: "skipped: mounted workspace",
+        durationMs: 0,
+        repoModels: config.models ?? {},
+        reviewProviders: config.reviewProviders,
+      };
+    }
+
     if (!hasPackageJson) {
       return {
         packageManager: config.packageManager ?? "none",


### PR DESCRIPTION
## Summary

Fixes the reopened mounted-workspace failure in the ticket-free dev harness.

- honor `AI_IMPLEMENT_WORKSPACE_MODE=mounted` in the shell entrypoint before clone
- preserve host checkout ownership by matching the container `coder` UID/GID instead of recursively chowning the bind mount
- skip dependency installation in mounted mode so host `node_modules` is not replaced with Linux artifacts
- add an executable entrypoint regression that crosses the TypeScript-to-shell env boundary

Fixes AII-273

## Verification

- `npm run typecheck`
- `npm test` (135 files, 2302 tests)
- `npm run build:runner:local`
- live Docker smoke against a temporary mounted repo with a deliberately failing setup hook: entrypoint reached the hook as host uid/gid, did not clone, did not create `node_modules`, preserved file ownership, stopped before model invocation, and wrote `run.log` artifacts