### PR TITLE
AII-274: resolve staged harness review feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ Admin UI: `http://localhost:8080/admin` (requires an OAuth provider configured *
 
 ```bash
 npm run dev:run -- --workspace ../target-repo --task task.md
+npm run dev:run -- --workspace ../target-repo --task task.md --until setup
+npm run dev:run -- --workspace ../target-repo --task task.md --until setup --shell
 ```
 
 **Task file format** (`task.md`):
@@ -115,6 +117,8 @@ Issue description / implementation instructions go here.
 
 **How it works:**
 - `--workspace <dir>` bind-mounts the local checkout at `/workspace` inside the container.
+- `--until <step>` stops after that pipeline step, including when the step is skipped. Unknown step names fail before execution instead of falling through to a full implementation run. `--until setup` is the token-free setup-hook loop.
+- `--shell` keeps the local container alive after the selected boundary and attaches an interactive shell in `/workspace`; setup-hook `$GITHUB_ENV` exports are loaded into that shell. Exiting collects artifacts and then removes the container.
 - The clone step detects `AI_IMPLEMENT_WORKSPACE_MODE=mounted` and skips `git fetch/reset` entirely, so uncommitted edits to `WORKFLOW.md` and hook scripts take effect immediately.
 - Mounted mode **never pushes** — the push step is a no-op whenever `AI_IMPLEMENT_WORKSPACE_MODE=mounted`. The mount is your live checkout, dirty by design (the uncommitted `WORKFLOW.md`/hook edits under test), so a push would sweep in-progress work into the commit. The mutated working tree is left in the mount for inspection with `git diff`; commit/push the parts you want to keep yourself.
 - Logs are streamed to the terminal in real time. Per-run artifacts (log, diff, telemetry) are saved to `.dev-runs/<timestamp>/` (gitignored).

--- a/src/__tests__/dev-harness-cli.test.ts
+++ b/src/__tests__/dev-harness-cli.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { runDevHarnessCli, type DevHarnessCliDependencies } from "../dev-harness/cli.js";
+import type { DevRunHandle } from "../dev-harness/index.js";
+
+function makeHandle(): DevRunHandle {
+  return {
+    runId: "run-1",
+    containerId: "container-123456789",
+    containerName: "dev-container",
+    artifactsDir: "/tmp/artifacts",
+    startedAt: new Date(),
+    task: { identifier: "DEV-1", title: "Test", description: "Test" },
+    workspace: "/tmp/workspace",
+  };
+}
+
+describe("runDevHarnessCli", () => {
+  it("collects shell-mode artifacts before removing the container", async () => {
+    const events: string[] = [];
+    const deps: DevHarnessCliDependencies = {
+      startDevRun: vi.fn().mockResolvedValue(makeHandle()),
+      streamLogs: vi.fn().mockResolvedValue(undefined),
+      streamLogsUntilShellReady: vi.fn().mockResolvedValue({ ready: true, exitCode: 0 }),
+      getRunStatus: vi.fn(),
+      collectRunArtifacts: vi.fn(async () => { events.push("artifacts"); }),
+      spawnDocker: vi.fn((args) => { events.push(args[0] === "rm" ? "remove" : "shell"); }),
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+      now: () => Date.now(),
+    };
+
+    const exitCode = await runDevHarnessCli(
+      ["--workspace", "/tmp/workspace", "--task", "/tmp/task.md", "--shell"],
+      deps,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(events).toEqual(["shell", "artifacts", "remove"]);
+  });
+});

--- a/src/__tests__/pipeline-runner.test.ts
+++ b/src/__tests__/pipeline-runner.test.ts
@@ -270,7 +270,23 @@ describe("PipelineRunner", () => {
       expect(afterMod.run).not.toHaveBeenCalled();
     });
 
-    it("stopAfterStep: no-op when the named step is not in the pipeline", async () => {
+    it("stopAfterStep: stops when the named boundary step is skipped", async () => {
+      const afterSetupMod = makeModule({});
+      const pipeline: PipelineDefinition = {
+        id: "test",
+        steps: [
+          { id: "setup", type: "custom", moduleId: "setup", skip: () => true },
+          { id: "after-setup", type: "custom", moduleId: "after-setup" },
+        ],
+      };
+      const runner = new PipelineRunner().register("after-setup", afterSetupMod);
+
+      await runner.run(pipeline, makeContext(), new NoopStepReporter(), { stopAfterStep: "setup" });
+
+      expect(afterSetupMod.run).not.toHaveBeenCalled();
+    });
+
+    it("stopAfterStep: rejects an unknown boundary instead of running the full pipeline", async () => {
       const allMods = [makeModule({}), makeModule({}), makeModule({})];
       const pipeline: PipelineDefinition = {
         id: "test",
@@ -286,9 +302,11 @@ describe("PipelineRunner", () => {
         .register("install", allMods[1])
         .register("setup", allMods[2]);
 
-      await runner.run(pipeline, makeContext(), new NoopStepReporter(), { stopAfterStep: "nonexistent" });
+      await expect(
+        runner.run(pipeline, makeContext(), new NoopStepReporter(), { stopAfterStep: "nonexistent" }),
+      ).rejects.toThrow('Unknown stopAfterStep "nonexistent"');
 
-      for (const mod of allMods) expect(mod.run).toHaveBeenCalledOnce();
+      for (const mod of allMods) expect(mod.run).not.toHaveBeenCalled();
     });
 
     it("throws when no module is registered for the step type", async () => {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1352,6 +1352,11 @@ describe("runAutonomous", () => {
   });
 
   describe("AI_IMPLEMENT_UNTIL_STEP staged execution", () => {
+    beforeEach(() => {
+      vi.stubEnv("AI_IMPLEMENT_MODE", "local");
+      vi.stubEnv("AI_IMPLEMENT_WORKSPACE_MODE", "mounted");
+    });
+
     it("stops after the named step and returns exitCode 0 without running later steps", async () => {
       vi.stubEnv("AI_IMPLEMENT_UNTIL_STEP", "setup");
 
@@ -1422,6 +1427,32 @@ describe("runAutonomous", () => {
 
       expect(result.exitCode).toBe(0);
       expect(existsSync(join(workspaceDir, "teardown-ran.marker"))).toBe(true);
+    });
+
+    it("ignores staged execution env outside the local mounted dev harness", async () => {
+      vi.stubEnv("AI_IMPLEMENT_MODE", "fly");
+      vi.stubEnv("AI_IMPLEMENT_WORKSPACE_MODE", "cloned");
+      vi.stubEnv("AI_IMPLEMENT_UNTIL_STEP", "setup");
+      vi.stubEnv("AI_IMPLEMENT_SHELL_MODE", "true");
+      const feedbackMod: StepModule = { run: vi.fn().mockResolvedValue({ approved: true, iterations: 1 }) };
+      const pushMod: StepModule = { run: vi.fn().mockResolvedValue({ prUrl: "https://github.com/pr/1" }) };
+      const { pipeline, runner } = makeStepsPipeline([
+        ["setup", { run: vi.fn().mockResolvedValue({}) }],
+        ["feedback-loop", feedbackMod],
+        ["push", pushMod],
+      ]);
+
+      const result = await runAutonomous({
+        workspaceDir,
+        pipeline,
+        runner,
+        reporter: new NoopStepReporter(),
+        llmExecutor: makeMockExecutor(0),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(feedbackMod.run).toHaveBeenCalledOnce();
+      expect(pushMod.run).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/dev-harness/cli.ts
+++ b/src/dev-harness/cli.ts
@@ -8,9 +8,34 @@ import {
   streamLogsUntilShellReady,
 } from "./index.js";
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
+export interface DevHarnessCliDependencies {
+  startDevRun: typeof startDevRun;
+  streamLogs: typeof streamLogs;
+  streamLogsUntilShellReady: typeof streamLogsUntilShellReady;
+  getRunStatus: typeof getRunStatus;
+  collectRunArtifacts: typeof collectRunArtifacts;
+  spawnDocker: (args: string[], stdio: "inherit" | "ignore") => void;
+  writeStdout: (text: string) => void;
+  writeStderr: (text: string) => void;
+  now: () => number;
+}
 
+const DEFAULT_DEPENDENCIES: DevHarnessCliDependencies = {
+  startDevRun,
+  streamLogs,
+  streamLogsUntilShellReady,
+  getRunStatus,
+  collectRunArtifacts,
+  spawnDocker: (args, stdio) => { spawnSync("docker", args, { stdio }); },
+  writeStdout: (text) => process.stdout.write(text),
+  writeStderr: (text) => process.stderr.write(text),
+  now: () => Date.now(),
+};
+
+export async function runDevHarnessCli(
+  args: string[],
+  deps: DevHarnessCliDependencies = DEFAULT_DEPENDENCIES,
+): Promise<number> {
   let workspace = "";
   let task = "";
   let image: string | undefined;
@@ -19,27 +44,21 @@ async function main(): Promise<void> {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if ((arg === "--workspace" || arg === "-w") && args[i + 1]) {
-      workspace = args[++i] as string;
-    } else if ((arg === "--task" || arg === "-t") && args[i + 1]) {
-      task = args[++i] as string;
-    } else if (arg === "--image" && args[i + 1]) {
-      image = args[++i];
-    } else if (arg === "--until" && args[i + 1]) {
-      untilStep = args[++i];
-    } else if (arg === "--shell") {
-      shell = true;
-    }
+    if ((arg === "--workspace" || arg === "-w") && args[i + 1]) workspace = args[++i] as string;
+    else if ((arg === "--task" || arg === "-t") && args[i + 1]) task = args[++i] as string;
+    else if (arg === "--image" && args[i + 1]) image = args[++i];
+    else if (arg === "--until" && args[i + 1]) untilStep = args[++i];
+    else if (arg === "--shell") shell = true;
   }
 
   if (!workspace || !task) {
-    process.stderr.write(
+    deps.writeStderr(
       "Usage: npm run dev:run -- --workspace <dir> --task <task.md> [--image <image>] [--until <step>] [--shell]\n",
     );
-    process.exit(1);
+    return 1;
   }
 
-  const handle = await startDevRun({
+  const handle = await deps.startDevRun({
     workspace: resolve(workspace),
     task: resolve(task),
     image,
@@ -47,7 +66,7 @@ async function main(): Promise<void> {
     shell,
   });
 
-  process.stderr.write(
+  deps.writeStderr(
     `[dev:run] task=${handle.task.identifier} "${handle.task.title}"\n` +
     `[dev:run] container=${handle.containerName} (${handle.containerId.slice(0, 12)})\n` +
     `[dev:run] artifacts=${handle.artifactsDir}\n` +
@@ -56,75 +75,64 @@ async function main(): Promise<void> {
   );
 
   if (shell) {
-    // Watch logs for the shell-ready sentinel "[dev:run] shell-ready exit=N".
-    // Non-sentinel lines go to stdout as usual.
-    const { ready, exitCode: pipelineExitCode } = await streamLogsUntilShellReady(
+    const { ready, exitCode: pipelineExitCode } = await deps.streamLogsUntilShellReady(
       handle,
-      (line) => process.stdout.write(`${line}\n`),
+      (line) => deps.writeStdout(`${line}\n`),
     );
-
     let finalExitCode: number | null = pipelineExitCode;
+    let artifactsCollected = false;
 
     if (ready) {
-      process.stderr.write(
+      deps.writeStderr(
         `[dev:run] pipeline complete (exit=${pipelineExitCode})\n` +
         `[dev:run] hook env exports sourced from /tmp/dev-run-env.sh\n` +
         `[dev:run] attaching shell at /workspace — type "exit" when done\n`,
       );
-
-      // Attach an interactive bash session. --init-file sources the env file
-      // written by run-autonomous.ts so hook-exported GITHUB_ENV vars are
-      // visible in the shell. --workdir /workspace starts in the mounted repo.
-      // spawnSync with stdio:inherit passes the terminal through for readline.
-      spawnSync(
-        "docker",
+      deps.spawnDocker(
         ["exec", "-it", "--workdir", "/workspace", handle.containerName, "bash", "--init-file", "/tmp/dev-run-env.sh"],
-        { stdio: "inherit" },
+        "inherit",
       );
 
-      process.stderr.write(`[dev:run] shell exited; removing container...\n`);
-      // Force-remove the container (it is still alive, waiting for SIGKILL).
-      spawnSync("docker", ["rm", "-f", handle.containerId], { stdio: "ignore" });
+      try {
+        await deps.collectRunArtifacts(handle, finalExitCode);
+        artifactsCollected = true;
+      } finally {
+        deps.writeStderr("[dev:run] shell exited; removing container...\n");
+        deps.spawnDocker(["rm", "-f", handle.containerId], "ignore");
+      }
     } else {
-      // Container exited before the sentinel (shouldn't happen when SHELL_MODE is
-      // set, but handle it gracefully — get the real exit code from inspect).
-      const state = await getRunStatus(handle);
+      const state = await deps.getRunStatus(handle);
       finalExitCode = state.exitCode;
     }
 
-    const durationSec = ((Date.now() - handle.startedAt.getTime()) / 1000).toFixed(1);
-    await collectRunArtifacts(handle, finalExitCode);
-
-    process.stderr.write(
+    if (!artifactsCollected) await deps.collectRunArtifacts(handle, finalExitCode);
+    const durationSec = ((deps.now() - handle.startedAt.getTime()) / 1000).toFixed(1);
+    deps.writeStderr(
       `[dev:run] done: exit=${finalExitCode ?? "unknown"} duration=${durationSec}s\n` +
       `[dev:run] artifacts saved to ${handle.artifactsDir}/\n` +
       `[dev:run] inspect changes: cd ${handle.workspace} && git diff\n`,
     );
-
-    process.exit(finalExitCode ?? 1);
+    return finalExitCode ?? 1;
   }
 
-  // Non-shell mode: stream logs until the container exits.
-  await streamLogs(handle, (line) => process.stdout.write(`${line}\n`));
-
-  const state = await getRunStatus(handle);
+  await deps.streamLogs(handle, (line) => deps.writeStdout(`${line}\n`));
+  const state = await deps.getRunStatus(handle);
   const exitCode = state.exitCode;
-  const durationSec = ((Date.now() - handle.startedAt.getTime()) / 1000).toFixed(1);
-
-  await collectRunArtifacts(handle, exitCode);
-
-  process.stderr.write(
+  const durationSec = ((deps.now() - handle.startedAt.getTime()) / 1000).toFixed(1);
+  await deps.collectRunArtifacts(handle, exitCode);
+  deps.writeStderr(
     `[dev:run] done: exit=${exitCode ?? "unknown"} duration=${durationSec}s\n` +
     `[dev:run] artifacts saved to ${handle.artifactsDir}/\n` +
     `[dev:run] inspect changes: cd ${handle.workspace} && git diff\n`,
   );
-
-  process.exit(exitCode ?? 1);
+  return exitCode ?? 1;
 }
 
-main().catch((err) => {
-  process.stderr.write(
-    `[dev:run] fatal: ${err instanceof Error ? err.message : String(err)}\n`,
-  );
-  process.exit(1);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runDevHarnessCli(process.argv.slice(2))
+    .then((exitCode) => process.exit(exitCode))
+    .catch((err) => {
+      process.stderr.write(`[dev:run] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/src/pipeline/runner.ts
+++ b/src/pipeline/runner.ts
@@ -70,6 +70,10 @@ export class PipelineRunner {
     reporter: StepReporter,
     opts: { stopAfterStep?: string } = {},
   ): Promise<void> {
+    if (opts.stopAfterStep && !pipeline.steps.some((step) => step.id === opts.stopAfterStep)) {
+      throw new Error(`Unknown stopAfterStep "${opts.stopAfterStep}" in pipeline "${pipeline.id}"`);
+    }
+
     for (const definition of pipeline.steps) {
       if (definition.skip?.(context)) {
         const skipped: Step = {
@@ -85,6 +89,7 @@ export class PipelineRunner {
         };
         await reporter.report(skipped);
         context.setOutputs(definition.id, {});
+        if (opts.stopAfterStep === definition.id) return;
         continue;
       }
 
@@ -155,4 +160,3 @@ async function defaultImportStepModule(resolvedPath: string): Promise<StepModule
   }
   return undefined;
 }
-

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -127,6 +127,10 @@ export function resolveLogLevel(raw: string | undefined): LogLevel {
   return raw === "stream" ? "stream" : "summary";
 }
 
+export function isLocalDevHarness(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.AI_IMPLEMENT_MODE === "local" && env.AI_IMPLEMENT_WORKSPACE_MODE === "mounted";
+}
+
 /** Single-quote a shell value, escaping embedded single-quotes. */
 function shellQuote(val: string): string {
   return "'" + val.replace(/'/g, "'\\''") + "'";
@@ -440,8 +444,9 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
 
   let disposition: string | undefined;
 
-  const untilStep = optionalEnv("AI_IMPLEMENT_UNTIL_STEP") ?? undefined;
-  const shellMode = process.env.AI_IMPLEMENT_SHELL_MODE === "true";
+  const devHarnessMode = isLocalDevHarness();
+  const untilStep = devHarnessMode ? optionalEnv("AI_IMPLEMENT_UNTIL_STEP") ?? undefined : undefined;
+  const shellMode = devHarnessMode && process.env.AI_IMPLEMENT_SHELL_MODE === "true";
   // Snapshot env before the pipeline runs so we can diff after to find hook exports.
   const envSnap: Record<string, string | undefined> = shellMode ? { ...process.env } : {};
 
@@ -589,7 +594,7 @@ function resolveRunnerPhase(rawPhase: string | undefined, prNumber: string): "im
 if (import.meta.url === `file://${process.argv[1]}`) {
   runAutonomous()
     .then(async (r) => {
-      if (process.env.AI_IMPLEMENT_SHELL_MODE === "true") {
+      if (isLocalDevHarness() && process.env.AI_IMPLEMENT_SHELL_MODE === "true") {
         // Signal the dev-harness CLI that the pipeline has finished and the
         // container is ready for interactive inspection. The CLI will attach
         // a bash session via `docker exec -it` and remove the container when


### PR DESCRIPTION
## Summary

Resolves all actionable review feedback on #208.

- stop at a skipped `--until` boundary so `--until setup` cannot fall through to a model call
- reject unknown step names before pipeline execution
- collect shell-mode artifacts before removing the container, with an ordering regression test
- gate staged and shell env switches to the local mounted dev harness so production modes cannot be affected by leaked env
- document `--until` and `--shell` usage

## Verification

- `npm run typecheck`
- targeted tests: 77 passed
- full branch suite: 130 files, 2209 tests passed
- `npm run build`
- independent code review: no actionable findings

Targets the implementation branch for #208; it does not modify the pipeline-owned branch directly.