### PR TITLE
AII-274: keep interactive shell container alive

### DIFF
--- a/src/__tests__/dev-harness-cli.test.ts
+++ b/src/__tests__/dev-harness-cli.test.ts
@@ -23,7 +23,10 @@ describe("runDevHarnessCli", () => {
       streamLogsUntilShellReady: vi.fn().mockResolvedValue({ ready: true, exitCode: 0 }),
       getRunStatus: vi.fn(),
       collectRunArtifacts: vi.fn(async () => { events.push("artifacts"); }),
-      spawnDocker: vi.fn((args) => { events.push(args[0] === "rm" ? "remove" : "shell"); }),
+      spawnDocker: vi.fn((args) => {
+        events.push(args[0] === "rm" ? "remove" : "shell");
+        return 0;
+      }),
       writeStdout: vi.fn(),
       writeStderr: vi.fn(),
       now: () => Date.now(),
@@ -35,6 +38,32 @@ describe("runDevHarnessCli", () => {
     );
 
     expect(exitCode).toBe(0);
+    expect(events).toEqual(["shell", "artifacts", "remove"]);
+  });
+
+  it("returns the docker exec failure after collecting artifacts and removing the container", async () => {
+    const events: string[] = [];
+    const deps: DevHarnessCliDependencies = {
+      startDevRun: vi.fn().mockResolvedValue(makeHandle()),
+      streamLogs: vi.fn().mockResolvedValue(undefined),
+      streamLogsUntilShellReady: vi.fn().mockResolvedValue({ ready: true, exitCode: 0 }),
+      getRunStatus: vi.fn(),
+      collectRunArtifacts: vi.fn(async () => { events.push("artifacts"); }),
+      spawnDocker: vi.fn((args) => {
+        events.push(args[0] === "rm" ? "remove" : "shell");
+        return args[0] === "exec" ? 125 : 0;
+      }),
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+      now: () => Date.now(),
+    };
+
+    const exitCode = await runDevHarnessCli(
+      ["--workspace", "/tmp/workspace", "--task", "/tmp/task.md", "--shell"],
+      deps,
+    );
+
+    expect(exitCode).toBe(125);
     expect(events).toEqual(["shell", "artifacts", "remove"]);
   });
 });

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runAutonomous, resolveLogLevel } from "../run-autonomous.js";
+import { runAutonomous, resolveLogLevel, waitForContainerRemoval } from "../run-autonomous.js";
 import { PipelineRunner } from "../pipeline/runner.js";
 import { NoopStepReporter } from "../pipeline/reporter.js";
 import { encodeRunConfig } from "../run-config.js";
@@ -1454,6 +1454,17 @@ describe("runAutonomous", () => {
       expect(feedbackMod.run).toHaveBeenCalledOnce();
       expect(pushMod.run).toHaveBeenCalledOnce();
     });
+  });
+});
+
+describe("waitForContainerRemoval", () => {
+  it("registers a referenced timer so an unresolved promise cannot let Node exit", () => {
+    const schedule = vi.fn();
+
+    void waitForContainerRemoval(schedule);
+
+    expect(schedule).toHaveBeenCalledOnce();
+    expect(schedule).toHaveBeenCalledWith(expect.any(Function), 60_000);
   });
 });
 

--- a/src/dev-harness/cli.ts
+++ b/src/dev-harness/cli.ts
@@ -14,7 +14,7 @@ export interface DevHarnessCliDependencies {
   streamLogsUntilShellReady: typeof streamLogsUntilShellReady;
   getRunStatus: typeof getRunStatus;
   collectRunArtifacts: typeof collectRunArtifacts;
-  spawnDocker: (args: string[], stdio: "inherit" | "ignore") => void;
+  spawnDocker: (args: string[], stdio: "inherit" | "ignore") => number;
   writeStdout: (text: string) => void;
   writeStderr: (text: string) => void;
   now: () => number;
@@ -26,7 +26,7 @@ const DEFAULT_DEPENDENCIES: DevHarnessCliDependencies = {
   streamLogsUntilShellReady,
   getRunStatus,
   collectRunArtifacts,
-  spawnDocker: (args, stdio) => { spawnSync("docker", args, { stdio }); },
+  spawnDocker: (args, stdio) => spawnSync("docker", args, { stdio }).status ?? 1,
   writeStdout: (text) => process.stdout.write(text),
   writeStderr: (text) => process.stderr.write(text),
   now: () => Date.now(),
@@ -88,10 +88,11 @@ export async function runDevHarnessCli(
         `[dev:run] hook env exports sourced from /tmp/dev-run-env.sh\n` +
         `[dev:run] attaching shell at /workspace — type "exit" when done\n`,
       );
-      deps.spawnDocker(
+      const shellExitCode = deps.spawnDocker(
         ["exec", "-it", "--workdir", "/workspace", handle.containerName, "bash", "--init-file", "/tmp/dev-run-env.sh"],
         "inherit",
       );
+      if (shellExitCode !== 0) finalExitCode = shellExitCode;
 
       try {
         await deps.collectRunArtifacts(handle, finalExitCode);

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -131,6 +131,15 @@ export function isLocalDevHarness(env: NodeJS.ProcessEnv = process.env): boolean
   return env.AI_IMPLEMENT_MODE === "local" && env.AI_IMPLEMENT_WORKSPACE_MODE === "mounted";
 }
 
+export function waitForContainerRemoval(
+  schedule: (callback: () => void, delayMs: number) => unknown = (callback, delayMs) =>
+    setInterval(callback, delayMs),
+): Promise<never> {
+  return new Promise<never>(() => {
+    schedule(() => undefined, 60_000);
+  });
+}
+
 /** Single-quote a shell value, escaping embedded single-quotes. */
 function shellQuote(val: string): string {
   return "'" + val.replace(/'/g, "'\\''") + "'";
@@ -600,8 +609,9 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         // a bash session via `docker exec -it` and remove the container when
         // the user exits. The exit code is embedded so the CLI can preserve it.
         process.stdout.write(`[dev:run] shell-ready exit=${r.exitCode}\n`);
-        // Keep the container alive until the Docker daemon kills the process.
-        await new Promise<never>(() => {});
+        // A pending Promise alone does not keep Node's event loop alive. The
+        // referenced interval keeps the runner process alive until docker rm.
+        await waitForContainerRemoval();
       }
       process.exit(r.exitCode);
     })


### PR DESCRIPTION
## Summary
- keep the local runner process alive while the interactive shell container is running
- propagate docker exec failures instead of masking them as exit 0
- preserve artifact collection and container cleanup on shell exit

## Why
A live combined-image smoke found that awaiting an unresolved Promise does not keep Node's event loop alive. The container exited before docker exec could attach, while the CLI still reported success.

## Verification
- npm run typecheck
- npm test: 130 files, 2211 tests
- combined with testing/AII-273: 136 files, 2314 tests
- live Docker shell smoke: setup ran as uid 501/gid 20, shell attached at /workspace, MOUNTED_SETUP_REACHED=true, artifacts saved, container removed, exit 0
- independent code review: no actionable findings