### PR TITLE
Deploy guard: scripts/deploy-orchestrator.sh — correct flags + loud sidecar serve check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,15 +234,19 @@ The KG repository is private. A **BuildKit `--build-secret` mount** clones it at
 # Local Docker build:
 docker build --secret id=kg_token,env=GH_TOKEN .
 
-# Fly deploy (the standard command for testing/production):
-#   --no-cache is REQUIRED: a --build-secret is NOT part of the layer cache key,
-#   so without it a repeat deploy silently reuses a stale (possibly sidecar-less)
-#   image and the clone/materialize RUN never re-executes.
-#   Also: export GH_TOKEN first — `GH_TOKEN=... fly deploy ... "$GH_TOKEN"` does
-#   NOT work (the inline prefix doesn't affect same-line expansion → empty secret).
-export GH_TOKEN="$(gh auth token)"
-fly deploy --remote-only --no-cache --build-secret kg_token="$GH_TOKEN"
+# Fly deploy — ALWAYS use the wrapper script (it encodes the required flags and
+# verifies the deployed sidecar actually serves):
+./scripts/deploy-orchestrator.sh                      # testing orchestrator (default)
+./scripts/deploy-orchestrator.sh <other-app-name>     # any other orchestrator app
 ```
+
+> **Never deploy with a plain `fly deploy`** — it silently produces a sidecar-less
+> image (`/mcp` → 503). The script exists because this has happened three times:
+> the KG clone needs the build secret, `--no-cache` is required (a build secret is
+> not part of the layer cache key, so repeat deploys silently reuse stale layers),
+> and `GH_TOKEN` must be exported (an inline prefix passes an empty secret). The
+> script ends by asserting `/mcp` answers 401 — a deploy that ships without a
+> working sidecar fails loudly instead of being discovered days later.
 
 The sidecar clone copies the KG's `sources.yml` (which pins the IRI `namespace:`)
 alongside the code — without it the server falls back to the placeholder

--- a/scripts/deploy-orchestrator.sh
+++ b/scripts/deploy-orchestrator.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Deploy an orchestrator WITH its KG sidecar — the standard deploy command.
+#
+# Why this script exists (learned the hard way, three times):
+#   1. A plain `fly deploy` silently produces a SIDECAR-LESS image (/mcp -> 503):
+#      the KG is cloned at build time via a BuildKit secret, and without the
+#      secret the build fail-softs to "no kg/".
+#   2. `--no-cache` is REQUIRED even with the secret: a --build-secret is NOT
+#      part of the layer cache key, so a repeat deploy silently reuses a stale
+#      (possibly sidecar-less) clone/materialize layer.
+#   3. GH_TOKEN must be EXPORTED — an inline `GH_TOKEN=... fly deploy ... "$GH_TOKEN"`
+#      prefix doesn't affect same-line expansion and passes an empty secret.
+#
+# Usage:
+#   ./scripts/deploy-orchestrator.sh [app-name]     # default: ai-implement-testing-orchestrator
+#
+# Requires: fly (authed), gh (authed with read access to the private KG repo).
+set -euo pipefail
+
+APP="${1:-ai-implement-testing-orchestrator}"
+
+export GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
+if [ -z "$GH_TOKEN" ]; then
+    echo "❌ no GitHub token — run 'gh auth login' first (the KG repo is private)" >&2
+    exit 1
+fi
+
+echo "==> deploying $APP (KG sidecar build, --no-cache)"
+fly deploy --remote-only --no-cache --build-secret kg_token="$GH_TOKEN" --app "$APP"
+
+# ---- post-deploy serve check (boots != serves) ------------------------------
+# /mcp must answer 401 (alive, OAuth-gated). 503 means the image shipped
+# without the sidecar — the exact failure this script exists to prevent.
+echo "==> verifying /mcp on https://$APP.fly.dev"
+for i in $(seq 1 12); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 -X POST "https://$APP.fly.dev/mcp" -d '{}' || echo 000)
+    [ "$code" = "401" ] && break
+    sleep 5
+done
+if [ "$code" = "401" ]; then
+    echo "✅ /mcp is OAuth-gated (sidecar up and configured)"
+else
+    echo "❌ /mcp returned $code — the deployed image has NO working KG sidecar." >&2
+    echo "   Most likely: the build secret was missing/empty, or a cached sidecar-less" >&2
+    echo "   layer was reused. Re-run this script (it always passes both flags)." >&2
+    exit 1
+fi


### PR DESCRIPTION
**Why now:** third occurrence of the silent sidecar-loss, first time biting a teammate — a plain `fly deploy` (v89/v90, 2026-08-10) shipped a KG-less image and `/mcp` sat at 503 until discovered during MCP-auth testing two days after the last good deploy.

**What it does:**
- `scripts/deploy-orchestrator.sh [app]` — encodes the three hard-won requirements in one place: exported `GH_TOKEN`, `--no-cache` (build secrets aren't cache keys → stale sidecar-less layers get silently reused), `--build-secret kg_token`.
- **Loud serve check:** after the deploy it polls `/mcp` and **fails the deploy** unless it answers 401 (alive + OAuth-gated). Boots ≠ serves — a sidecar-less image now fails at deploy time, not days later.
- CLAUDE.md deploy section now points at the script as the only sanctioned command.

No orchestrator code changes — script + docs only. After merge, the immediate use is redeploying the testing orchestrator to restore its sidecar (currently 503 from the v89/v90 image).

Related: AII-322 (the durable-deploy machinery this guards), AII-344 (docs gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)