### PR TITLE
Fix multi-architecture Node image pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #
 # Keep the Node version aligned with the repo pins (.node-version / .nvmrc).
 # better-sqlite3 is a native addon whose lifecycle behavior can change across Node releases.
-FROM node:24.15.0-slim@sha256:152aceace5c03e2597988763165ee33e3fd3633636db0fc983cd2e126b02cfde AS builder
+FROM node:24.15.0-slim@sha256:4e6b70dd6cbfc88c8157ba19aa3d9f9cce6ba4703576d55459e45efcbc9c5f5d AS builder
 
 WORKDIR /app
 
@@ -27,7 +27,7 @@ RUN npm run build
 RUN npm prune --omit=dev
 
 # ---------- Production ----------
-FROM node:24.15.0-slim@sha256:152aceace5c03e2597988763165ee33e3fd3633636db0fc983cd2e126b02cfde
+FROM node:24.15.0-slim@sha256:4e6b70dd6cbfc88c8157ba19aa3d9f9cce6ba4703576d55459e45efcbc9c5f5d
 
 WORKDIR /app
 


### PR DESCRIPTION
## What changed

- Replace the amd64-only `node:24.15.0-slim` manifest digest in both Dockerfile stages with the multi-architecture OCI index digest.

## Why

The orchestrator image is also built for `linux/arm64`. Pinning a single amd64 manifest can make native arm64 builds fail or produce a mislabeled image that cannot start.

## Impact

Both amd64 and arm64 builders resolve the correct platform-specific Node image while retaining an immutable digest pin.

## Validation

- Verified the replacement digest is an OCI image index containing amd64 and arm64/v8 manifests.
- `npm run typecheck`
- `npm run build`
- `npm test` — 136 files / 2,314 tests
