### PR TITLE
Isolate Jira email in endpoint tests

### DIFF
--- a/src/__tests__/admin/jira-endpoints.test.ts
+++ b/src/__tests__/admin/jira-endpoints.test.ts
@@ -70,6 +70,7 @@ const fetchMock = vi.fn();
 const origToken = process.env.JIRA_TOKEN;
 const origCloud = process.env.JIRA_CLOUD_ID;
 const origSite = process.env.JIRA_SITE_URL;
+const origEmail = process.env.JIRA_EMAIL;
 const origClientId = process.env.LINEAR_CLIENT_ID;
 const origClientSecret = process.env.LINEAR_CLIENT_SECRET;
 
@@ -77,6 +78,7 @@ beforeEach(async () => {
   vi.resetModules();
   fetchMock.mockReset();
   global.fetch = fetchMock as unknown as typeof fetch;
+  delete process.env.JIRA_EMAIL;
   dbPath = path.join(os.tmpdir(), `admin-jira-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
   process.env.DEDUP_DB_PATH = dbPath;
   provider = new FakeProvider();
@@ -107,6 +109,8 @@ afterEach(() => {
   else process.env.JIRA_CLOUD_ID = origCloud;
   if (origSite === undefined) delete process.env.JIRA_SITE_URL;
   else process.env.JIRA_SITE_URL = origSite;
+  if (origEmail === undefined) delete process.env.JIRA_EMAIL;
+  else process.env.JIRA_EMAIL = origEmail;
   if (origClientId === undefined) delete process.env.LINEAR_CLIENT_ID;
   else process.env.LINEAR_CLIENT_ID = origClientId;
   if (origClientSecret === undefined) delete process.env.LINEAR_CLIENT_SECRET;


### PR DESCRIPTION
## What changed

- Save and restore `JIRA_EMAIL` in the Jira endpoint test suite.
- Clear `JIRA_EMAIL` before each test module import.

## Why

A developer's exported `JIRA_EMAIL` selected the Basic-auth configuration path even when the suite cleared the token, cloud ID, and site URL. That caused eight environment-dependent failures returning 501 instead of the expected 200 or 400.

## Impact

The suite now behaves consistently regardless of the caller's Jira environment while preserving the original environment after each test.

## Validation

- Hostile environment regression: `JIRA_EMAIL=tester@example.com` with the other Jira variables unset — 16/16 passed.
- `npm run typecheck`
- `npm run build`
- `npm test` — 136 files / 2,314 tests
