### PR TITLE
fix: make the dev-run harness work against a bind-mounted workspace (AII-273)

### DIFF
--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -18,6 +18,10 @@ else
 fi
 log "Execution mode: $AI_IMPLEMENT_MODE"
 export AI_IMPLEMENT_MODE
+# The dev harness bind-mounts a live checkout at /workspace.
+# Neither the clone nor the recursive chown below may run against it.
+MOUNTED_WORKSPACE=0
+if [ "${AI_IMPLEMENT_WORKSPACE_MODE:-}" = "mounted" ]; then MOUNTED_WORKSPACE=1; fi
 
 # ── 2. Env validation ────────────────────────────────────────────────────────
 PROVIDER="${PROVIDER:-anthropic}"
@@ -70,12 +74,17 @@ git config --global user.name "ai-implement-bot"
 git config --global user.email "ai-implement-bot@users.noreply.github.com"
 git config --global init.defaultBranch "$GITHUB_DEFAULT_BRANCH"
 
-REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
-log "Cloning ${GITHUB_OWNER}/${GITHUB_REPO}..."
-git clone --depth=1 --branch "$GITHUB_DEFAULT_BRANCH" "$REPO_URL" /workspace
+if [ "$MOUNTED_WORKSPACE" = "1" ]; then
+  log "Mounted workspace: skipping clone; /workspace is supplied by the dev harness"
+else
+  REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git"
+  log "Cloning ${GITHUB_OWNER}/${GITHUB_REPO}..."
+  git clone --depth=1 --branch "$GITHUB_DEFAULT_BRANCH" "$REPO_URL" /workspace
+fi
 git config --global --add safe.directory /workspace
 cd /workspace
-if [ -n "$PR_NUMBER" ]; then
+# gh pr checkout would move the developer's own working tree onto the PR branch.
+if [ -n "$PR_NUMBER" ] && [ "$MOUNTED_WORKSPACE" = "0" ]; then
   log "Gap-fill: checking out PR #$PR_NUMBER"
   # --depth + --branch narrows origin's fetch refspec to the cloned base branch.
   # gh pr checkout needs the PR head to count as a trackable remote branch.
@@ -86,7 +95,11 @@ if [ -n "$PR_NUMBER" ]; then
 fi
 
 # ── 5. Workspace ownership for non-root Claude ───────────────────────────────
-chown -R coder:coder /workspace
+if [ "$MOUNTED_WORKSPACE" = "1" ]; then
+  adopt_workspace_ownership /workspace
+else
+  chown -R coder:coder /workspace
+fi
 cp /root/.gitconfig /home/coder/.gitconfig 2>/dev/null || true
 chown coder:coder /home/coder/.gitconfig 2>/dev/null || true
 

--- a/session/lib.sh
+++ b/session/lib.sh
@@ -29,3 +29,24 @@ require_one_of() {
   done
   fail "At least one of $* must be set"
 }
+
+# Make a bind-mounted workspace writable by `coder` without changing its ownership:
+# move coder onto the mount's uid/gid rather than chown-ing the host's files.
+# Usage: adopt_workspace_ownership <dir>
+adopt_workspace_ownership() {
+  local dir="$1" uid gid
+  uid="$(stat -c %u "$dir")"
+  gid="$(stat -c %g "$dir")"
+
+  # uid 0 means the mount presents as root-owned; re-numbering coder to 0 would
+  # defeat the non-root requirement, so leave it and let the probe decide.
+  if [ "$uid" != "0" ] && [ "$uid" != "$(id -u coder)" ]; then
+    # -o permits a uid/gid another image user already holds (base image: node=1000).
+    groupmod -o -g "$gid" coder 2>/dev/null || true
+    usermod -o -u "$uid" -g "$gid" coder
+    log "Adopted workspace ownership: coder is now ${uid}:${gid}"
+  fi
+
+  su -p coder -c "touch '$dir/.ai-implement-write-probe' && rm -f '$dir/.ai-implement-write-probe'" \
+    || fail "coder cannot write the mounted workspace at $dir (owned ${uid}:${gid}). Run the harness as the owner of that directory, or check your Docker file-sharing settings."
+}

--- a/session/lib.sh
+++ b/session/lib.sh
@@ -42,8 +42,18 @@ adopt_workspace_ownership() {
   # defeat the non-root requirement, so leave it and let the probe decide.
   if [ "$uid" != "0" ] && [ "$uid" != "$(id -u coder)" ]; then
     # -o permits a uid/gid another image user already holds (base image: node=1000).
-    groupmod -o -g "$gid" coder 2>/dev/null || true
-    usermod -o -u "$uid" -g "$gid" coder
+    # Guard gid 0 symmetrically: assigning coder to the root group is as hazardous
+    # as numbering it to uid 0, so skip the group change and keep coder's existing gid.
+    if [ "$gid" != "0" ]; then
+      groupmod -o -g "$gid" coder 2>/dev/null || true
+      usermod -o -u "$uid" -g "$gid" coder
+    else
+      usermod -o -u "$uid" coder
+    fi
+    # Re-chown coder's container-local home: the on-disk uid/gid no longer matches
+    # the renumbered coder after usermod, so coder would lose write access to $HOME
+    # (new entries under ~/.claude, ~/.npm, ~/.cache, etc. would fail with EACCES).
+    chown -R coder:coder /home/coder
     log "Adopted workspace ownership: coder is now ${uid}:${gid}"
   fi
 

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -9,9 +9,24 @@ describe("session/entrypoint.sh", () => {
     expect(r.status).toBe(0);
   });
 
-  it("is under 115 lines (bootstrap, not monolith)", () => {
+  it("is under 135 lines (bootstrap, not monolith)", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
-    expect(content.split("\n").length).toBeLessThan(115);
+    expect(content.split("\n").length).toBeLessThan(135);
+  });
+
+  it("skips the clone and the recursive chown for a mounted workspace", () => {
+    const content = readFileSync("session/entrypoint.sh", "utf-8");
+    // The dev harness bind-mounts a live checkout. Cloning into it fails outright,
+    // and `chown -R` would rewrite the developer's files on the host.
+    expect(content).toContain('if [ "${AI_IMPLEMENT_WORKSPACE_MODE:-}" = "mounted" ]; then MOUNTED_WORKSPACE=1; fi');
+    expect(content).toMatch(/if \[ "\$MOUNTED_WORKSPACE" = "1" \][\s\S]*git clone --depth=1/);
+    expect(content).toMatch(/if \[ "\$MOUNTED_WORKSPACE" = "1" \][\s\S]*adopt_workspace_ownership \/workspace[\s\S]*chown -R coder:coder \/workspace/);
+  });
+
+  it("does not run gh pr checkout against a mounted workspace", () => {
+    const content = readFileSync("session/entrypoint.sh", "utf-8");
+    // gh pr checkout would move the developer's own working tree onto the PR branch.
+    expect(content).toContain('if [ -n "$PR_NUMBER" ] && [ "$MOUNTED_WORKSPACE" = "0" ]; then');
   });
 
   it("exec's the phase-selected TS runner as the final step", () => {

--- a/src/__tests__/session-lib.test.ts
+++ b/src/__tests__/session-lib.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 const isWindows = process.platform === "win32";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 
 function runBash(script: string) {
   return spawnSync("bash", ["-lc", script], {
@@ -45,5 +46,23 @@ describe.skipIf(isWindows)("session/lib.sh", () => {
     const result = runBash("source session/lib.sh; require_one_of A B C");
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("FATAL: At least one of A B C must be set");
+  });
+
+  it("adopt_workspace_ownership re-chowns /home/coder after renumbering coder", () => {
+    const content = readFileSync("session/lib.sh", "utf-8");
+    // After usermod re-numbers coder, /home/coder retains the old on-disk uid/gid.
+    // Without this chown, coder loses write access to $HOME (EACCES on ~/.claude, etc.).
+    expect(content).toContain("chown -R coder:coder /home/coder");
+    // The chown must appear inside the renumber branch, after the usermod call.
+    const usermodIdx = content.indexOf("usermod -o -u");
+    const chownIdx = content.indexOf("chown -R coder:coder /home/coder");
+    expect(chownIdx).toBeGreaterThan(usermodIdx);
+  });
+
+  it("adopt_workspace_ownership guards gid 0 symmetrically with uid 0", () => {
+    const content = readFileSync("session/lib.sh", "utf-8");
+    // Assigning coder to the root group (gid 0) is as hazardous as numbering it
+    // to uid 0; the gid guard must prevent groupmod and the -g flag from doing so.
+    expect(content).toMatch(/\[ "\$gid" != "0" \]/);
   });
 });

--- a/src/__tests__/steps-install.test.ts
+++ b/src/__tests__/steps-install.test.ts
@@ -65,6 +65,27 @@ describe("installStep", () => {
     expect(spawn).toHaveBeenCalledWith("npm", ["ci"], expect.anything());
   });
 
+  it("skips the install for a mounted workspace but still reports the package manager", async () => {
+    // The mounted workspace is the developer's live checkout: `npm ci` would delete
+    // their node_modules and rebuild native modules for linux-x64. preflight reads
+    // packageManager from these outputs, so it has to survive the skip.
+    vi.stubEnv("AI_IMPLEMENT_WORKSPACE_MODE", "mounted");
+    mockRootPackageJson((p) => p.endsWith("yarn.lock"));
+
+    const outputs = await installStep.run(
+      makeContext(),
+      { workspaceDir: "/tmp/test" },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.packageManager).toBe("yarn");
+    expect(outputs.installMethod).toBe("skipped: mounted workspace");
+    expect(outputs.durationMs).toBe(0);
+    expect(spawn).not.toHaveBeenCalled();
+
+    vi.unstubAllEnvs();
+  });
+
   it("detects yarn when yarn.lock exists", async () => {
     mockRootPackageJson((p) => p.endsWith("yarn.lock"));
 

--- a/src/pipeline/steps/install.ts
+++ b/src/pipeline/steps/install.ts
@@ -110,6 +110,18 @@ export const installStep: StepModule<InstallInputs, InstallOutputs> = {
     }
 
     const packageManager = config.packageManager ?? detectPackageManager(workspaceDir);
+
+    // The workspace is the developer's live checkout. `npm ci` deletes node_modules and rebuilds native modules for linux-x64, breaking their host toolchain.
+    if (process.env.AI_IMPLEMENT_WORKSPACE_MODE === "mounted") {
+      return {
+        packageManager,
+        installMethod: "skipped: mounted workspace",
+        durationMs: 0,
+        repoModels: config.models ?? {},
+        reviewProviders: config.reviewProviders,
+      };
+    }
+
     const installMethod = buildInstallCommand(packageManager);
 
     const start = Date.now();


### PR DESCRIPTION
## Summary

`npm run dev:run` has never worked. It was added five days ago, exists only on `testing`, and dies at
`session/entrypoint.sh` before the TypeScript pipeline is reached — `git clone` into the non-empty
bind mount fails outright, so the mounted-mode branch in the clone step was unreachable code. This
makes the harness run for the first time.

The break is universal, not environment-specific: the harness always bind-mounts, the entrypoint
always clones, and `git clone` into a non-empty directory is fatal everywhere.

## The hazard that shaped the fix

Guarding only the clone would have been worse than the bug. Four lines later the entrypoint runs
`chown -R coder:coder /workspace`, which on a bind mount writes through to the host — so the first
*successful* run would have rewritten the developer's real checkout to uid 1001, a uid that is nobody
on their machine.

The obvious portable alternative, `--user $(id -u)`, does not work on this image: a host uid with no
`/etc/passwd` entry gets `HOME=/`, which is unwritable, so `git config --global` fails under `set -e`
before any of our code runs. Confirmed with uid 501, the common macOS case. It appears to work on a
uid-1000 host only because 1000 collides with the base image's existing `node` user.

So the container keeps starting as root — leaving the GitHub Actions and Fly paths untouched — and
mounted mode instead moves `coder` onto the mount's uid/gid, then proves it can write before
continuing.

## What changed

- **`session/lib.sh`** — new `adopt_workspace_ownership()`. Reads the mount's owner, re-numbers
  `coder` to match (`-o`, because host uids commonly collide with an existing image user), then
  verifies writability with a real create-and-delete rather than a permission-bit check. On failure it
  aborts with the detected ownership, which is what makes this portable across file-sharing backends
  whose ownership semantics we can't predict.
- **`session/entrypoint.sh`** — a `MOUNTED_WORKSPACE` flag beside the existing mode detection,
  guarding the clone, the gap-fill `gh pr checkout` (which would move the developer's working tree
  onto the PR branch), and the recursive chown.
- **`src/pipeline/steps/install.ts`** — mounted mode skips the dependency install. `npm ci` against a
  live checkout deletes `node_modules` and rebuilds native modules for linux-x64, leaving the
  developer's own `npm test` broken with "Module did not self-register". Follows the file's existing
  early-return idiom and still reports `packageManager`, which `preflight` consumes.
- **Tests** — entrypoint line cap raised to 135, two new assertions covering the guards, and an
  install test asserting `spawn` is never called while `packageManager` survives.

## Acceptance criteria

| Criterion | How it's met | Key files |
|---|---|---|
| The harness reaches the pipeline | End-to-end run completes: implement → review → exit 0 | `session/entrypoint.sh` |
| The developer's files keep their ownership | Every path in the workspace still owned by the host user after a run | `session/lib.sh` |
| A mount it cannot write fails clearly | Root-owned read-only mount exits 1 naming the detected ownership | `session/lib.sh` |
| `node_modules` is not destroyed | Sentinel file survives a run with a lockfile present | `src/pipeline/steps/install.ts` |
| Nothing is pushed | No commits created, branch unchanged | existing `push.ts` no-op |
| Other execution modes unchanged | Guards are gated on mounted mode only; suite green | `session/entrypoint.sh` |

## Verification

`npm run typecheck` clean; 135 test files / 2302 tests passing on Node 24.

End to end, a real run against a throwaway checkout created the requested file, left the
`node_modules` sentinel intact with a lockfile present, kept every path owned by the host user, and
pushed nothing. The failure path was exercised separately against a root-owned read-only mount.

The end-to-end run earned its keep — it caught that the image had not been rebuilt after the
`install.ts` change, so the first attempt ran `npm ci` for real. Unit tests could not have shown that,
because they mock the container away.

## Follow-ups

- **AII-347** — that first successful run exposed two mounted-mode reporting defects: an approved run
  is classified `REVIEW_UNAPPROVED` and writes a failure autopsy, and `git add -N .` leaves untracked
  files staged in the developer's index. Both are independent of this change and only became
  observable once the harness ran.
- **AII-274** is In Progress with an open pull request extending this harness with `--until` and
  `--shell`. Its acceptance criteria were not verifiable before this lands; that PR touches only the
  harness and pipeline runner, so there is no overlap with this one.
- The harness never removes its containers — exited `ai-implement-dev-*` containers accumulate.
- macOS is unverified by us. `docker run --rm -v "$PWD:/workspace" --entrypoint sh <image> -c 'stat -c
  "%u:%g" /workspace; id'` reports whether the adapt path or the fail-loud path fires there.

Fixes AII-273
