### PR TITLE
Harden request, runner token, and MCP paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,7 @@ KG_SIDECAR_URL=
 # MCP clients authenticate via OAuth 2.0 (no pre-shared secret).
 # Requires OAUTH_REDIRECT_BASE_URL + at least one OAuth provider configured above.
 # The /mcp endpoint returns 401 → /.well-known/oauth-protected-resource → browser SSO.
-# Dynamic clients may use loopback HTTP callbacks. Comma-separate any HTTPS
+# Dynamic clients may use loopback IP-literal HTTP callbacks. Comma-separate any HTTPS
 # origins that should also be accepted; arbitrary HTTPS callbacks are denied.
 MCP_ALLOWED_REDIRECT_ORIGINS=
 # MCP OIDC redirect URIs to register in Google/Microsoft consoles:

--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,9 @@ KG_SIDECAR_URL=
 # MCP clients authenticate via OAuth 2.0 (no pre-shared secret).
 # Requires OAUTH_REDIRECT_BASE_URL + at least one OAuth provider configured above.
 # The /mcp endpoint returns 401 → /.well-known/oauth-protected-resource → browser SSO.
+# Dynamic clients may use loopback HTTP callbacks. Comma-separate any HTTPS
+# origins that should also be accepted; arbitrary HTTPS callbacks are denied.
+MCP_ALLOWED_REDIRECT_ORIGINS=
 # MCP OIDC redirect URIs to register in Google/Microsoft consoles:
 #   ${OAUTH_REDIRECT_BASE_URL}/mcp/callback/google
 #   ${OAUTH_REDIRECT_BASE_URL}/mcp/callback/microsoft

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,8 +236,8 @@ docker build --secret id=kg_token,env=GH_TOKEN .
 
 # Fly deploy — ALWAYS use the wrapper script (it encodes the required flags and
 # verifies the deployed sidecar actually serves):
-./scripts/deploy-orchestrator.sh                      # testing orchestrator (default)
-./scripts/deploy-orchestrator.sh <other-app-name>     # any other orchestrator app
+./scripts/deploy-orchestrator.sh ai-implement-testing-orchestrator  # testing orchestrator
+./scripts/deploy-orchestrator.sh <other-app-name>                    # any other orchestrator app
 ```
 
 > **Never deploy with a plain `fly deploy`** — it silently produces a sidecar-less

--- a/scripts/deploy-orchestrator.sh
+++ b/scripts/deploy-orchestrator.sh
@@ -12,12 +12,17 @@
 #      prefix doesn't affect same-line expansion and passes an empty secret.
 #
 # Usage:
-#   ./scripts/deploy-orchestrator.sh [app-name]     # default: ai-implement-testing-orchestrator
+#   ./scripts/deploy-orchestrator.sh <app-name>
 #
 # Requires: fly (authed), gh (authed with read access to the private KG repo).
 set -euo pipefail
 
-APP="${1:-ai-implement-testing-orchestrator}"
+if [ "$#" -ne 1 ] || [ -z "$1" ]; then
+    echo "Usage: $0 <app-name>" >&2
+    echo "An explicit Fly app is required to prevent deploying a fork to the upstream app." >&2
+    exit 64
+fi
+APP="$1"
 
 export GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
 if [ -z "$GH_TOKEN" ]; then
@@ -33,6 +38,7 @@ fly deploy --remote-only --no-cache --build-secret kg_token="$GH_TOKEN" --app "$
 # without the sidecar — the exact failure this script exists to prevent.
 echo "==> verifying /mcp on https://$APP.fly.dev"
 for i in $(seq 1 12); do
+    echo "==> MCP readiness attempt $i/12"
     code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 -X POST "https://$APP.fly.dev/mcp" -d '{}' || echo 000)
     [ "$code" = "401" ] && break
     sleep 5

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -46,7 +46,7 @@ else
   require_env GITHUB_TOKEN GITHUB_OWNER GITHUB_REPO
 fi
 export GITHUB_OWNER GITHUB_REPO
-[ -z "${PR_NUMBER:-}" ] && [ -n "${AI_IMPLEMENT_RUN_CONFIG:-}" ] && PR_NUMBER="$(node -e "try{const c=JSON.parse(Buffer.from(process.env.AI_IMPLEMENT_RUN_CONFIG,'base64').toString());process.stdout.write(c.prNumber||'')}catch{}")"
+[ -z "${PR_NUMBER:-}" ] && [ -n "${AI_IMPLEMENT_RUN_CONFIG:-}" ] && PR_NUMBER="$(node -e "try{const c=JSON.parse(Buffer.from(process.env.AI_IMPLEMENT_RUN_CONFIG,'base64').toString());process.stdout.write(String(c.prNumber||''))}catch{}" 2>/dev/null||true)"
 export PR_NUMBER="${PR_NUMBER:-}"
 
 # ── 3. Token acquisition ─────────────────────────────────────────────────────

--- a/src/__tests__/cookies.test.ts
+++ b/src/__tests__/cookies.test.ts
@@ -35,6 +35,14 @@ describe("parseCookies", () => {
     expect(parseCookies("k=a%20b")).toEqual({ k: "a b" });
   });
 
+  it("preserves malformed percent-encoding instead of throwing", () => {
+    expect(parseCookies("k=%; other=%zz; truncated=%E0%A4%A")).toEqual({
+      k: "%",
+      other: "%zz",
+      truncated: "%E0%A4%A",
+    });
+  });
+
   it("skips malformed parts with no '=' and parts with an empty name", () => {
     expect(parseCookies("a=1; garbage; =novalue; b=2")).toEqual({ a: "1", b: "2" });
   });

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -17,10 +17,23 @@ function writeShim(binDir: string, name: string, body: string): void {
 }
 
 describe("session/entrypoint.sh", () => {
-  it("passes shellcheck cleanly", () => {
-    const r = spawnSync("shellcheck", ["session/entrypoint.sh"], { stdio: ["ignore", "pipe", "pipe"] });
+  it("passes shellcheck for every deploy-critical entrypoint", () => {
+    const r = spawnSync(
+      "shellcheck",
+      ["session/entrypoint.sh", "docker-entrypoint.sh", "scripts/deploy-orchestrator.sh"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
     if (r.error?.code === "ENOENT") return; // skip when shellcheck not installed
-    expect(r.status).toBe(0);
+    expect(r.status, r.stderr?.toString()).toBe(0);
+  });
+
+  it("requires an explicit Fly app before deploy tooling runs", () => {
+    const r = spawnSync("/bin/bash", ["scripts/deploy-orchestrator.sh"], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: "" },
+    });
+    expect(r.status).toBe(64);
+    expect(r.stderr).toContain("explicit Fly app is required");
   });
 
   it("is under 115 lines (bootstrap, not monolith)", () => {
@@ -97,6 +110,8 @@ describe("session/entrypoint.sh", () => {
     const checkoutIdx = content.indexOf("gh pr checkout");
     expect(decodeIdx).toBeGreaterThan(-1);
     expect(decodeIdx).toBeLessThan(checkoutIdx);
+    expect(content).toContain("String(c.prNumber||'')");
+    expect(content).toMatch(/c\.prNumber[^\n]+2>\/dev\/null\|\|true/);
   });
 
   it("does not pass duplicate preserve-environment flags to su", () => {

--- a/src/__tests__/http-server.test.ts
+++ b/src/__tests__/http-server.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import type http from "node:http";
+import { withRequestErrorBoundary } from "../http-server.js";
+
+function response(headersSent = false) {
+  return {
+    headersSent,
+    writeHead: vi.fn(),
+    end: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as http.ServerResponse;
+}
+
+describe("withRequestErrorBoundary", () => {
+  const req = {} as http.IncomingMessage;
+
+  it("turns a synchronous handler throw into one 500 response", () => {
+    const res = response();
+    const log = vi.fn();
+    const listener = withRequestErrorBoundary(() => { throw new Error("boom"); }, log);
+
+    listener(req, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(500, { "Content-Type": "application/json" });
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ error: "Internal server error" }));
+    expect(log).toHaveBeenCalledOnce();
+  });
+
+  it("turns an asynchronous handler rejection into one 500 response", async () => {
+    const res = response();
+    const listener = withRequestErrorBoundary(async () => { throw new Error("boom"); }, vi.fn());
+
+    listener(req, res);
+    await vi.waitFor(() => expect(res.end).toHaveBeenCalledOnce());
+  });
+
+  it("destroys an already-started response instead of writing a second header", () => {
+    const res = response(true);
+    const listener = withRequestErrorBoundary(() => { throw new Error("boom"); }, vi.fn());
+
+    listener(req, res);
+
+    expect(res.destroy).toHaveBeenCalledOnce();
+    expect(res.writeHead).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -232,6 +232,28 @@ describe("jobs table", () => {
     const all = log.listLog({ limit: 600 });
     expect(all.length).toBeLessThanOrEqual(500);
   });
+
+  it("retains rows with active machine nonces beyond the log window", () => {
+    log.appendLog({ issueId: "active-run", machineNonce: "active-nonce" });
+
+    for (let i = 0; i < 501; i++) {
+      log.appendLog({ issueId: `later-${i}` });
+    }
+
+    expect(log.getJobByNonce("active-nonce")?.issueId).toBe("active-run");
+  });
+
+  it("clears terminal nonces and allows their rows to be pruned", () => {
+    const terminalId = log.appendLog({ issueId: "terminal-run", machineNonce: "terminal-nonce" });
+    log.updateJobStatus(terminalId, "failed", "failure");
+    dedup.getDb().prepare("UPDATE dispatch_log SET dispatched_at = 0 WHERE id = ?").run(terminalId);
+
+    expect(log.getJobByNonce("terminal-nonce")).toBeNull();
+    for (let i = 0; i < 501; i++) {
+      log.appendLog({ issueId: `later-terminal-${i}` });
+    }
+    expect(log.getJobById(terminalId)).toBeNull();
+  });
 });
 
 describe("listLog time filtering", () => {

--- a/src/__tests__/mcp-oauth.test.ts
+++ b/src/__tests__/mcp-oauth.test.ts
@@ -24,6 +24,15 @@ const googleProvider: OidcProviderConfig = {
   scopes: ["openid", "email", "profile"],
 };
 
+const microsoftProvider: OidcProviderConfig = {
+  id: "microsoft",
+  label: "Microsoft",
+  issuer: "https://login.microsoftonline.com/common/v2.0",
+  clientId: "mid",
+  clientSecret: "msecret",
+  scopes: ["openid", "email", "profile"],
+};
+
 const identity = (over: Partial<VerifiedIdentity> = {}): VerifiedIdentity => ({
   provider: "google",
   sub: "google|1",
@@ -98,6 +107,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   dedup.closeDb();
   try {
     fs.unlinkSync(dbPath);
@@ -221,6 +231,47 @@ describe("handleMcpClientRegistration", () => {
     expect(data.grant_types).toContain("refresh_token");
   });
 
+  it("accepts localhost or loopback redirect URIs", async () => {
+    const body = JSON.stringify({
+      redirect_uris: [
+        "http://127.0.0.1:8080/callback",
+        "http://localhost:3000/callback",
+        "http://[::1]:4000/callback",
+      ],
+    });
+    const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("rejects an arbitrary HTTPS redirect origin by default", async () => {
+    const body = JSON.stringify({ redirect_uris: ["https://attacker.example/callback"] });
+    const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_redirect_uri");
+  });
+
+  it("accepts HTTPS callbacks only from an explicitly allowed origin", async () => {
+    vi.stubEnv("MCP_ALLOWED_REDIRECT_ORIGINS", "https://client.example.com");
+    const body = JSON.stringify({ redirect_uris: ["https://client.example.com/callback"] });
+    const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("rejects private-use scheme redirect URIs", async () => {
+    const body = JSON.stringify({ redirect_uris: ["com.example.app:/oauth2redirect"] });
+    const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_redirect_uri");
+  });
+
   it("rejects missing redirect_uris", async () => {
     const body = JSON.stringify({ client_name: "No URIs" });
     const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
@@ -245,6 +296,55 @@ describe("handleMcpClientRegistration", () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toBe("invalid_request");
   });
+
+  it("rejects oversized registration bodies without buffering them", async () => {
+    const req = mkReq(
+      "/mcp/register",
+      "POST",
+      { "content-type": "application/json" },
+      JSON.stringify({ redirect_uris: ["https://client.example/cb"], padding: "x".repeat(70_000) }),
+    );
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_request");
+  });
+
+  it("rate-limits anonymous registrations within the durable hourly window", async () => {
+    const insert = dedup.getDb().prepare(
+      "INSERT INTO mcp_clients (client_id, redirect_uris, client_name, created_at) VALUES (?, ?, NULL, ?)",
+    );
+    const now = Date.now();
+    for (let i = 0; i < 100; i++) {
+      insert.run(`existing-${i}`, '["https://client.example/cb"]', now);
+    }
+
+    const req = mkReq(
+      "/mcp/register",
+      "POST",
+      { "content-type": "application/json" },
+      JSON.stringify({ redirect_uris: ["http://127.0.0.1/cb"] }),
+    );
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["Retry-After"]).toBe("3600");
+  });
+
+  it("sweeps abandoned registrations but retains clients that completed authorization", () => {
+    const stale = Date.now() - 25 * 60 * 60 * 1000;
+    dedup.getDb().prepare(
+      "INSERT INTO mcp_clients (client_id, redirect_uris, client_name, created_at, used_at) VALUES (?, ?, NULL, ?, ?)",
+    ).run("abandoned", '["https://client.example/cb"]', stale, null);
+    dedup.getDb().prepare(
+      "INSERT INTO mcp_clients (client_id, redirect_uris, client_name, created_at, used_at) VALUES (?, ?, NULL, ?, ?)",
+    ).run("used", '["https://client.example/cb"]', stale, stale);
+
+    mcpOauth.initMcpOAuthTables();
+
+    const rows = dedup.getDb().prepare("SELECT client_id FROM mcp_clients ORDER BY client_id").all() as Array<{ client_id: string }>;
+    expect(rows.map((row) => row.client_id)).toEqual(["used"]);
+  });
 });
 
 // ---------- Unit: authorize endpoint ----------
@@ -255,6 +355,31 @@ describe("handleMcpAuthorize", () => {
     const { res } = await startAuthorize(clientId);
     expect(res.statusCode).toBe(302);
     expect(res.headers["Location"]).toContain("accounts.google.com");
+  });
+
+  it("honors an explicit provider choice when multiple providers are configured", async () => {
+    providers.configureOAuthProviders([googleProvider, microsoftProvider]);
+    const clientId = await registerClient();
+    const codeChallenge = pkceChallenge("verifier");
+    const req = mkReq(
+      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://localhost:8080/callback")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256&provider=microsoft`,
+    );
+    const res = new MockResponse();
+    await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
+    expect(res.statusCode).toBe(302);
+    expect(oidc.buildAuthUrl).toHaveBeenCalledWith(expect.objectContaining({ id: "microsoft" }), expect.any(String));
+  });
+
+  it("rejects an unknown explicit provider", async () => {
+    const clientId = await registerClient();
+    const codeChallenge = pkceChallenge("verifier");
+    const req = mkReq(
+      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://localhost:8080/callback")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256&provider=unknown`,
+    );
+    const res = new MockResponse();
+    await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_description).toBe("Unknown provider");
   });
 
   it("rejects unknown client_id", async () => {

--- a/src/__tests__/mcp-oauth.test.ts
+++ b/src/__tests__/mcp-oauth.test.ts
@@ -128,7 +128,7 @@ function pkceChallenge(verifier: string): string {
 }
 
 // Register a client and return its client_id
-async function registerClient(redirectUris: string[] = ["http://localhost:8080/callback"]): Promise<string> {
+async function registerClient(redirectUris: string[] = ["http://127.0.0.1:8080/callback"]): Promise<string> {
   const body = JSON.stringify({ redirect_uris: redirectUris, client_name: "test-client" });
   const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
   const res = new MockResponse();
@@ -138,7 +138,7 @@ async function registerClient(redirectUris: string[] = ["http://localhost:8080/c
 }
 
 // Full authorize flow — starts auth, returns the captured OIDC state
-async function startAuthorize(clientId: string, redirectUri = "http://localhost:8080/callback"): Promise<{ res: MockResponse; codeVerifier: string; codeChallenge: string }> {
+async function startAuthorize(clientId: string, redirectUri = "http://127.0.0.1:8080/callback"): Promise<{ res: MockResponse; codeVerifier: string; codeChallenge: string }> {
   const codeVerifier = "test-verifier-0123456789abcdefghij";
   const codeChallenge = pkceChallenge(codeVerifier);
   const req = mkReq(
@@ -166,7 +166,7 @@ async function doCallback(id: VerifiedIdentity = identity()): Promise<{ res: Moc
 }
 
 // Exchange a code for an MCP token
-async function exchangeToken(code: string, codeVerifier: string, redirectUri = "http://localhost:8080/callback"): Promise<{ res: MockResponse; token?: string }> {
+async function exchangeToken(code: string, codeVerifier: string, redirectUri = "http://127.0.0.1:8080/callback"): Promise<{ res: MockResponse; token?: string }> {
   const clientId = await registerClient([redirectUri]);
   // Re-use the authorize flow to ensure the code row has the right client_id
   // (In real usage the client_id comes from the registration before authorize)
@@ -218,24 +218,24 @@ describe("handleMcpAuthorizationServerMetadata", () => {
 
 describe("handleMcpClientRegistration", () => {
   it("registers a client and returns a client_id", async () => {
-    const body = JSON.stringify({ redirect_uris: ["http://localhost/cb"], client_name: "My Client" });
+    const body = JSON.stringify({ redirect_uris: ["http://127.0.0.1/cb"], client_name: "My Client" });
     const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
     const res = new MockResponse();
     await mcpOauth.handleMcpClientRegistration(req, asRes(res));
     expect(res.statusCode).toBe(201);
     const data = JSON.parse(res.body);
     expect(typeof data.client_id).toBe("string");
-    expect(data.redirect_uris).toEqual(["http://localhost/cb"]);
+    expect(data.redirect_uris).toEqual(["http://127.0.0.1/cb"]);
     expect(data.client_name).toBe("My Client");
     expect(data.grant_types).toContain("authorization_code");
     expect(data.grant_types).toContain("refresh_token");
   });
 
-  it("accepts localhost or loopback redirect URIs", async () => {
+  it("accepts IPv4 and IPv6 loopback IP redirect URIs", async () => {
     const body = JSON.stringify({
       redirect_uris: [
         "http://127.0.0.1:8080/callback",
-        "http://localhost:3000/callback",
+        "http://127.0.0.2:3000/callback",
         "http://[::1]:4000/callback",
       ],
     });
@@ -243,6 +243,15 @@ describe("handleMcpClientRegistration", () => {
     const res = new MockResponse();
     await mcpOauth.handleMcpClientRegistration(req, asRes(res));
     expect(res.statusCode).toBe(201);
+  });
+
+  it("rejects localhost hostname redirects in favor of loopback IP literals", async () => {
+    const body = JSON.stringify({ redirect_uris: ["http://localhost:8080/callback"] });
+    const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe("invalid_redirect_uri");
   });
 
   it("rejects an arbitrary HTTPS redirect origin by default", async () => {
@@ -362,7 +371,7 @@ describe("handleMcpAuthorize", () => {
     const clientId = await registerClient();
     const codeChallenge = pkceChallenge("verifier");
     const req = mkReq(
-      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://localhost:8080/callback")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256&provider=microsoft`,
+      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://127.0.0.1:8080/callback")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256&provider=microsoft`,
     );
     const res = new MockResponse();
     await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
@@ -374,7 +383,7 @@ describe("handleMcpAuthorize", () => {
     const clientId = await registerClient();
     const codeChallenge = pkceChallenge("verifier");
     const req = mkReq(
-      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://localhost:8080/callback")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256&provider=unknown`,
+      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://127.0.0.1:8080/callback")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256&provider=unknown`,
     );
     const res = new MockResponse();
     await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
@@ -385,7 +394,7 @@ describe("handleMcpAuthorize", () => {
   it("rejects unknown client_id", async () => {
     const codeChallenge = pkceChallenge("verifier");
     const req = mkReq(
-      `/mcp/authorize?response_type=code&client_id=unknown&redirect_uri=${encodeURIComponent("http://localhost/cb")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256`,
+      `/mcp/authorize?response_type=code&client_id=unknown&redirect_uri=${encodeURIComponent("http://127.0.0.1/cb")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256`,
     );
     const res = new MockResponse();
     await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
@@ -394,7 +403,7 @@ describe("handleMcpAuthorize", () => {
   });
 
   it("rejects unregistered redirect_uri", async () => {
-    const clientId = await registerClient(["http://localhost/cb"]);
+    const clientId = await registerClient(["http://127.0.0.1/cb"]);
     const codeChallenge = pkceChallenge("verifier");
     const req = mkReq(
       `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://evil.com/cb")}&state=s&code_challenge=${codeChallenge}&code_challenge_method=S256`,
@@ -408,7 +417,7 @@ describe("handleMcpAuthorize", () => {
   it("rejects missing code_challenge", async () => {
     const clientId = await registerClient();
     const req = mkReq(
-      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://localhost:8080/callback")}&state=s`,
+      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://127.0.0.1:8080/callback")}&state=s`,
     );
     const res = new MockResponse();
     await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
@@ -419,7 +428,7 @@ describe("handleMcpAuthorize", () => {
   it("rejects unsupported response_type", async () => {
     const clientId = await registerClient();
     const req = mkReq(
-      `/mcp/authorize?response_type=token&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://localhost:8080/callback")}&state=s&code_challenge=x&code_challenge_method=S256`,
+      `/mcp/authorize?response_type=token&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://127.0.0.1:8080/callback")}&state=s&code_challenge=x&code_challenge_method=S256`,
     );
     const res = new MockResponse();
     await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
@@ -430,7 +439,7 @@ describe("handleMcpAuthorize", () => {
   it("rejects non-S256 code_challenge_method", async () => {
     const clientId = await registerClient();
     const req = mkReq(
-      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://localhost:8080/callback")}&state=s&code_challenge=x&code_challenge_method=plain`,
+      `/mcp/authorize?response_type=code&client_id=${clientId}&redirect_uri=${encodeURIComponent("http://127.0.0.1:8080/callback")}&state=s&code_challenge=x&code_challenge_method=plain`,
     );
     const res = new MockResponse();
     await mcpOauth.handleMcpAuthorize(req, asRes(res), BASE_URL);
@@ -448,7 +457,7 @@ describe("handleMcpOidcCallback", () => {
     expect(res.statusCode).toBe(302);
     expect(code).toBeTruthy();
     const location = res.headers["Location"] as string;
-    expect(location).toContain("localhost:8080");
+    expect(location).toContain("127.0.0.1:8080");
     expect(new URL(location).searchParams.get("state")).toBe("clientstate");
   });
 
@@ -519,7 +528,7 @@ async function exchangeCode(code: string, codeVerifier: string, clientId: string
   const body = new URLSearchParams({
     grant_type: "authorization_code",
     code,
-    redirect_uri: "http://localhost:8080/callback",
+    redirect_uri: "http://127.0.0.1:8080/callback",
     client_id: clientId,
     code_verifier: codeVerifier,
   }).toString();
@@ -538,7 +547,7 @@ describe("handleMcpTokenRequest", () => {
     const body = new URLSearchParams({
       grant_type: "authorization_code",
       code,
-      redirect_uri: "http://localhost:8080/callback",
+      redirect_uri: "http://127.0.0.1:8080/callback",
       client_id: clientId,
       code_verifier: codeVerifier,
     }).toString();
@@ -558,7 +567,7 @@ describe("handleMcpTokenRequest", () => {
     const body = new URLSearchParams({
       grant_type: "authorization_code",
       code,
-      redirect_uri: "http://localhost:8080/callback",
+      redirect_uri: "http://127.0.0.1:8080/callback",
       client_id: clientId,
       code_verifier: "wrong-verifier",
     }).toString();
@@ -574,7 +583,7 @@ describe("handleMcpTokenRequest", () => {
     const body = new URLSearchParams({
       grant_type: "authorization_code",
       code: "nonexistentcode",
-      redirect_uri: "http://localhost:8080/callback",
+      redirect_uri: "http://127.0.0.1:8080/callback",
       client_id: clientId,
       code_verifier: codeVerifier,
     }).toString();
@@ -590,7 +599,7 @@ describe("handleMcpTokenRequest", () => {
     const params = new URLSearchParams({
       grant_type: "authorization_code",
       code,
-      redirect_uri: "http://localhost:8080/callback",
+      redirect_uri: "http://127.0.0.1:8080/callback",
       client_id: clientId,
       code_verifier: codeVerifier,
     }).toString();
@@ -619,7 +628,7 @@ describe("handleMcpTokenRequest", () => {
     const body = JSON.stringify({
       grant_type: "authorization_code",
       code,
-      redirect_uri: "http://localhost:8080/callback",
+      redirect_uri: "http://127.0.0.1:8080/callback",
       client_id: clientId,
       code_verifier: codeVerifier,
     });
@@ -755,7 +764,7 @@ describe("verifyMcpToken", () => {
     const body = new URLSearchParams({
       grant_type: "authorization_code",
       code: code!,
-      redirect_uri: "http://localhost:8080/callback",
+      redirect_uri: "http://127.0.0.1:8080/callback",
       client_id: clientId,
       code_verifier: codeVerifier,
     }).toString();

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -198,6 +198,7 @@ describe("handleMcpRequest", () => {
       );
       const hdrs = capturedOpts.value!.headers as Record<string, string>;
       expect(hdrs.authorization).toBeUndefined();
+      expect(hdrs.cookie).toBeUndefined();
       expect(hdrs["content-type"]).toBe("application/json");
     });
 

--- a/src/__tests__/refresh-runner-github-credentials.test.ts
+++ b/src/__tests__/refresh-runner-github-credentials.test.ts
@@ -43,6 +43,7 @@ describe("refreshRunnerGithubCredentialsFromEnvironment", () => {
       owner: "BuildDownAI",
       repo: "AI-Implement",
       workspaceDir: "/workspace",
+      strict: true,
     });
   });
 });

--- a/src/__tests__/runner-token.test.ts
+++ b/src/__tests__/runner-token.test.ts
@@ -84,7 +84,7 @@ describe("refreshRunnerGithubToken", () => {
     );
   });
 
-  it("rejects nonce and owner validation failures instead of masking them", async () => {
+  it("keeps the boot token when vending rejects an automated refresh", async () => {
     const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 403 } as Response);
 
     await expect(refreshRunnerGithubToken({
@@ -93,7 +93,32 @@ describe("refreshRunnerGithubToken", () => {
       machineNonce: "invalid-nonce",
       owner: "BuildDownAI",
       fetchImpl,
+    })).resolves.toBe("boot-token");
+  });
+
+  it("rejects vending failures in strict mode", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 403 } as Response);
+
+    await expect(refreshRunnerGithubToken({
+      currentToken: "boot-token",
+      orchestratorUrl: "https://orchestrator.example",
+      machineNonce: "invalid-nonce",
+      owner: "BuildDownAI",
+      fetchImpl,
+      strict: true,
     })).rejects.toThrow(/rejected with HTTP 403/);
+  });
+
+  it("still rejects unexpected client errors in automated mode", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 400 } as Response);
+
+    await expect(refreshRunnerGithubToken({
+      currentToken: "boot-token",
+      orchestratorUrl: "https://orchestrator.example",
+      machineNonce: "machine-nonce",
+      owner: "BuildDownAI",
+      fetchImpl,
+    })).rejects.toThrow(/rejected with HTTP 400/);
   });
 
   it("does not call the orchestrator without both URL and nonce", async () => {

--- a/src/__tests__/steps-clone.test.ts
+++ b/src/__tests__/steps-clone.test.ts
@@ -196,6 +196,37 @@ describe("cloneStep", () => {
     }
   });
 
+  it("keeps the boot token when credential vending rejects the refresh", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+    } as Response));
+    mockSpawn([
+      { status: 0 },
+      { status: 0, stdout: "sha1\n" },
+      { status: 0 },
+    ]);
+
+    try {
+      const outputs = await cloneStep.run(makeContext(), {
+        ...PR_INPUTS,
+        orchestratorUrl: "https://orchestrator.example",
+        machineNonce: "machine-nonce",
+        baseBranch: undefined,
+      }, new NoopStepReporter());
+
+      expect(outputs.githubToken).toBe("secret-token");
+      expect(spawnSync).toHaveBeenLastCalledWith(
+        "git",
+        ["remote", "set-url", "origin", "https://x-access-token:secret-token@github.com/acme/app.git"],
+        expect.objectContaining({ cwd: "/tmp/workspace" }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   describe("PR-targeted (gap-fill) runs: base branch fetch", () => {
     it("fetches base branch after clone and verifies merge-base on a fresh clone", async () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -139,6 +139,42 @@ describe("pushStep", () => {
     }
   });
 
+  it("completes the push with the boot token when credential vending returns 403", async () => {
+    mockGitSuccess("abc123");
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({ html_url: "https://github.com/acme/app/pull/7", number: 7 }),
+        text: async () => "",
+      } as Response);
+
+    const outputs = await pushStep.run(
+      makeContext(),
+      {
+        ...BASE_INPUTS,
+        orchestratorUrl: "https://orchestrator.example",
+        machineNonce: "machine-nonce",
+      },
+      new NoopStepReporter(),
+    );
+
+    expect(outputs.prNumber).toBe(7);
+    const remoteCalls = vi.mocked(spawnSync).mock.calls.filter(([, args]) =>
+      ["ls-remote", "push"].includes((args as string[])[0]),
+    );
+    expect(remoteCalls).toHaveLength(2);
+    for (const [, args] of remoteCalls) {
+      expect((args as string[]).join(" ")).toContain("gh-token");
+    }
+    const prRequest = vi.mocked(fetch).mock.calls[1];
+    expect(prRequest[1]?.headers).toEqual(expect.objectContaining({ Authorization: "Bearer gh-token" }));
+  });
+
   it("uses the context branch as the PR base when baseBranch input is omitted", async () => {
     mockGitSuccess("abc123");
     vi.mocked(fetch).mockResolvedValueOnce({

--- a/src/cookies.ts
+++ b/src/cookies.ts
@@ -14,7 +14,15 @@ export function parseCookies(header: string | undefined): Record<string, string>
     const eq = part.indexOf("=");
     if (eq === -1) continue;
     const name = part.slice(0, eq).trim();
-    if (name) out[name] = decodeURIComponent(part.slice(eq + 1).trim());
+    if (!name) continue;
+    const raw = part.slice(eq + 1).trim();
+    try {
+      out[name] = decodeURIComponent(raw);
+    } catch {
+      // Cookie parsing runs before authentication on every admin request. A
+      // malformed percent escape is untrusted input, not a process-level error.
+      out[name] = raw;
+    }
   }
   return out;
 }

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,41 @@
+import type http from "node:http";
+
+type RequestHandler = (
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+) => void | Promise<void>;
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+/**
+ * Keep an unexpected request-handler failure scoped to that request. Async
+ * route handlers should still handle their own expected errors close to the
+ * source; this is the final process-safety boundary.
+ */
+export function withRequestErrorBoundary(
+  handler: RequestHandler,
+  logError: (message: string, error: unknown) => void = console.error,
+): http.RequestListener {
+  return (req, res) => {
+    const respond = (error: unknown): void => {
+      logError("[server] Unhandled request error:", error);
+      if (res.headersSent) {
+        res.destroy(asError(error));
+        return;
+      }
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal server error" }));
+    };
+
+    try {
+      const result = handler(req, res);
+      if (result && typeof result.then === "function") {
+        void result.catch(respond);
+      }
+    } catch (error) {
+      respond(error);
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import type { RunnerProgressBody, RunnerResultBody } from "./runner-callback.js"
 import { mintRunToken, PLANNING_TTL_SECONDS, IMPLEMENTATION_TTL_SECONDS } from "./runner-tokens.js";
 import { handleGapFillTrigger } from "./gap-fill-trigger.js";
 import { handleMcpRequest } from "./mcp.js";
+import { withRequestErrorBoundary } from "./http-server.js";
 import {
   initMcpOAuthTables,
   handleMcpProtectedResourceMetadata,
@@ -2546,8 +2547,9 @@ function readBody(req: http.IncomingMessage): Promise<string> {
 }
 
 function startServer(config: AppConfig, registry: ProviderRegistry): http.Server {
-  const server = http.createServer((req, res) => {
+  const handleRequest: http.RequestListener = (req, res) => {
     const url = req.url || "/";
+    const pathname = url.split("?")[0];
 
     // Health check
     if (url === "/" && req.method === "GET") {
@@ -2770,19 +2772,19 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
     }
 
     // MCP well-known metadata endpoints (public — no auth required)
-    if (url.split("?")[0] === "/.well-known/oauth-protected-resource" && req.method === "GET") {
-      if (!config.oauthRedirectBaseUrl) {
+    if (pathname === "/.well-known/oauth-protected-resource" && req.method === "GET") {
+      if (!config.oauthRedirectBaseUrl || !config.kgSidecarUrl) {
         res.writeHead(503, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "MCP OAuth not configured (OAUTH_REDIRECT_BASE_URL is unset)" }));
+        res.end(JSON.stringify({ error: "MCP OAuth not configured (OAUTH_REDIRECT_BASE_URL or KG_SIDECAR_URL is unset)" }));
         return;
       }
       handleMcpProtectedResourceMetadata(res, config.oauthRedirectBaseUrl);
       return;
     }
-    if (url.split("?")[0] === "/.well-known/oauth-authorization-server" && req.method === "GET") {
-      if (!config.oauthRedirectBaseUrl) {
+    if (pathname === "/.well-known/oauth-authorization-server" && req.method === "GET") {
+      if (!config.oauthRedirectBaseUrl || !config.kgSidecarUrl) {
         res.writeHead(503, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "MCP OAuth not configured (OAUTH_REDIRECT_BASE_URL is unset)" }));
+        res.end(JSON.stringify({ error: "MCP OAuth not configured (OAUTH_REDIRECT_BASE_URL or KG_SIDECAR_URL is unset)" }));
         return;
       }
       handleMcpAuthorizationServerMetadata(res, config.oauthRedirectBaseUrl);
@@ -2790,11 +2792,10 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
     }
 
     // MCP OAuth routes — dynamic client registration, authorization, token exchange
-    if (url.startsWith("/mcp/") || url === "/mcp/register" || url === "/mcp/authorize" || url === "/mcp/token") {
-      const pathname = url.split("?")[0];
-      if (!config.oauthRedirectBaseUrl) {
+    if (pathname.startsWith("/mcp/")) {
+      if (!config.oauthRedirectBaseUrl || !config.kgSidecarUrl) {
         res.writeHead(503, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "MCP OAuth not configured (OAUTH_REDIRECT_BASE_URL is unset)" }));
+        res.end(JSON.stringify({ error: "MCP OAuth not configured (OAUTH_REDIRECT_BASE_URL or KG_SIDECAR_URL is unset)" }));
         return;
       }
       if (pathname === "/mcp/register" && req.method === "POST") {
@@ -2842,7 +2843,7 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
     }
 
     // MCP endpoint — OAuth bearer token authenticated
-    if (url === "/mcp") {
+    if (pathname === "/mcp") {
       handleMcpRequest(req, res, config.kgSidecarUrl, config.oauthRedirectBaseUrl).catch((err) => {
         console.error("[mcp] Unhandled error:", err);
         if (!res.headersSent) {
@@ -2856,7 +2857,6 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
     // OAuth / SSO — its own auth model (public providers endpoint + the OAuth flow);
     // mounted before the admin 503-gate so it works when ADMIN_ACCESS_CODE is unset.
     if (url.startsWith("/api/auth/")) {
-      const pathname = url.split("?")[0];
       // `secure` reflects the real scheme from Fly's proxy-set x-forwarded-proto.
       // The app is only reachable through that proxy, so the header is trusted; don't copy this to a directly-exposed server.
       const secure = String(req.headers["x-forwarded-proto"] ?? "").includes("https");
@@ -2916,7 +2916,8 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
 
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "Not found" }));
-  });
+  };
+  const server = http.createServer(withRequestErrorBoundary(handleRequest));
 
   server.listen(config.healthPort, () => {
     console.log(`[server] Listening on port ${config.healthPort}`);

--- a/src/log.ts
+++ b/src/log.ts
@@ -200,9 +200,13 @@ export function appendLog(entry: {
     entry.groupingParent ? 1 : 0,
   );
 
-  // Keep only the most recent MAX_LOG_ENTRIES rows
+  // Keep only the most recent MAX_LOG_ENTRIES rows, but never evict a row while
+  // its machine nonce is active. Token vending and callbacks depend on that row
+  // for the run lifetime; invalidateNonce() makes it prunable when terminal.
   db.prepare(
-    "DELETE FROM dispatch_log WHERE id NOT IN (SELECT id FROM dispatch_log ORDER BY dispatched_at DESC LIMIT ?)",
+    `DELETE FROM dispatch_log
+     WHERE machine_nonce IS NULL
+       AND id NOT IN (SELECT id FROM dispatch_log ORDER BY dispatched_at DESC LIMIT ?)`,
   ).run(MAX_LOG_ENTRIES);
 
   return Number(result.lastInsertRowid);
@@ -263,13 +267,17 @@ export function updateJobStatus(
   // must not wipe the link on completion.
   getDb()
     .prepare(
-      "UPDATE dispatch_log SET status = ?, conclusion = ?, pr_url = COALESCE(?, pr_url), completed_at = ? WHERE id = ?",
+      `UPDATE dispatch_log
+       SET status = ?, conclusion = ?, pr_url = COALESCE(?, pr_url), completed_at = ?,
+           machine_nonce = CASE WHEN ? = 1 THEN NULL ELSE machine_nonce END
+       WHERE id = ?`,
     )
     .run(
       status,
       conclusion ?? null,
       prUrl ?? null,
       isTerminal ? Date.now() : null,
+      isTerminal ? 1 : 0,
       jobId,
     );
 }

--- a/src/mcp-oauth.ts
+++ b/src/mcp-oauth.ts
@@ -31,6 +31,10 @@ export const MCP_TOKEN_TTL_MS: number = (() => {
 const MCP_REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;                  // 10 minutes
 const AUTH_CODE_TTL_MS = 5 * 60 * 1000;                     // 5 minutes
+const UNUSED_CLIENT_TTL_MS = 24 * 60 * 60 * 1000;            // 24 hours to complete first auth
+const REGISTRATION_WINDOW_MS = 60 * 60 * 1000;                // 1 hour
+const MAX_REGISTRATIONS_PER_WINDOW = 100;
+const MAX_REQUEST_BODY_BYTES = 64 * 1024;
 
 function json(res: http.ServerResponse, status: number, data: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -46,9 +50,17 @@ export function initMcpOAuthTables(): void {
       client_id     TEXT PRIMARY KEY,
       redirect_uris TEXT NOT NULL,
       client_name   TEXT,
-      created_at    INTEGER NOT NULL
+      created_at    INTEGER NOT NULL,
+      used_at       INTEGER
     )
   `);
+  const clientColumns = db.prepare("PRAGMA table_info(mcp_clients)").all() as Array<{ name: string }>;
+  if (!clientColumns.some((column) => column.name === "used_at")) {
+    db.exec("ALTER TABLE mcp_clients ADD COLUMN used_at INTEGER");
+    // Existing registrations predate usage tracking and must remain valid.
+    db.exec("UPDATE mcp_clients SET used_at = created_at");
+  }
+  db.exec("CREATE INDEX IF NOT EXISTS idx_mcp_clients_created_at ON mcp_clients(created_at)");
   db.exec(`
     CREATE TABLE IF NOT EXISTS mcp_oauth_states (
       oidc_state            TEXT PRIMARY KEY,
@@ -104,10 +116,47 @@ export function initMcpOAuthTables(): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_mcp_refresh_tokens_family ON mcp_refresh_tokens(family_id)`);
   // Sweep stale rows on startup
   const now = Date.now();
+  db.prepare("DELETE FROM mcp_clients WHERE used_at IS NULL AND created_at < ?").run(now - UNUSED_CLIENT_TTL_MS);
   db.prepare("DELETE FROM mcp_oauth_states WHERE expires_at < ?").run(now);
   db.prepare("DELETE FROM mcp_auth_codes WHERE expires_at < ?").run(now);
   db.prepare("DELETE FROM mcp_tokens WHERE expires_at < ?").run(now);
   db.prepare("DELETE FROM mcp_refresh_tokens WHERE expires_at < ?").run(now);
+}
+
+function isAllowedRedirectUri(redirectUri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+
+  if (parsed.username || parsed.password) {
+    return false;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (parsed.protocol === "http:") {
+    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+  }
+
+  if (parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const allowedOrigins = (process.env.MCP_ALLOWED_REDIRECT_ORIGINS ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .flatMap((value) => {
+      try {
+        const url = new URL(value);
+        return url.protocol === "https:" && !url.username && !url.password ? [url.origin] : [];
+      } catch {
+        return [];
+      }
+    });
+  return allowedOrigins.includes(parsed.origin);
 }
 
 // ---------- Token verification ----------
@@ -188,19 +237,33 @@ export async function handleMcpClientRegistration(
   if (
     !Array.isArray(redirectUris) ||
     redirectUris.length === 0 ||
-    redirectUris.some((u) => typeof u !== "string")
+    redirectUris.some((u) => typeof u !== "string" || !isAllowedRedirectUri(u))
   ) {
     return json(res, 400, {
       error: "invalid_redirect_uri",
-      error_description: "redirect_uris must be a non-empty array of strings",
+      error_description: "redirect_uris must use loopback HTTP or an explicitly allowed HTTPS origin",
     });
   }
 
   const clientName = typeof payload.client_name === "string" ? payload.client_name : null;
-  const clientId = crypto.randomBytes(16).toString("hex");
   const now = Date.now();
+  const db = getDb();
+  // Startup cleanup is not enough for a long-running orchestrator. Reap
+  // registrations that never completed an authorized flow before enforcing the
+  // durable write budget so anonymous rows stay bounded between deploys too.
+  db.prepare("DELETE FROM mcp_clients WHERE used_at IS NULL AND created_at < ?").run(now - UNUSED_CLIENT_TTL_MS);
+  const recentRegistrations = db
+    .prepare("SELECT COUNT(*) AS count FROM mcp_clients WHERE created_at >= ?")
+    .get(now - REGISTRATION_WINDOW_MS) as { count: number };
+  if (recentRegistrations.count >= MAX_REGISTRATIONS_PER_WINDOW) {
+    res.writeHead(429, { "Content-Type": "application/json", "Retry-After": "3600" });
+    res.end(JSON.stringify({ error: "temporarily_unavailable", error_description: "Registration limit exceeded" }));
+    return;
+  }
 
-  getDb()
+  const clientId = crypto.randomBytes(16).toString("hex");
+
+  db
     .prepare("INSERT INTO mcp_clients (client_id, redirect_uris, client_name, created_at) VALUES (?, ?, ?, ?)")
     .run(clientId, JSON.stringify(redirectUris), clientName, now);
 
@@ -261,15 +324,14 @@ export async function handleMcpAuthorize(
     return json(res, 400, { error: "invalid_redirect_uri", error_description: "redirect_uri not registered" });
   }
 
-  // Pick the first configured provider (SSO provider selection happens at the OIDC level)
   const providers = listConfiguredProviders();
   if (providers.length === 0) {
     return json(res, 503, { error: "server_error", error_description: "No OAuth providers configured" });
   }
-  const providerId = providers[0].id;
+  const providerId = url.searchParams.get("provider") ?? providers[0].id;
   const provider = getProvider(providerId);
   if (!provider) {
-    return json(res, 503, { error: "server_error", error_description: "Provider not found" });
+    return json(res, 400, { error: "invalid_request", error_description: "Unknown provider" });
   }
 
   const oidcRedirectUri = `${baseUrl}/mcp/callback/${providerId}`;
@@ -354,6 +416,8 @@ export async function handleMcpOidcCallback(
     console.warn(`[mcp-oauth] denied ${identity.email ?? "?"} via ${providerId}: ${decision.reason}`);
     return redirectWithError(res, stateRow.redirect_uri, stateRow.client_state, "access_denied");
   }
+
+  db.prepare("UPDATE mcp_clients SET used_at = ? WHERE client_id = ?").run(Date.now(), stateRow.client_id);
 
   // Mint a short-lived authorization code
   const code = crypto.randomBytes(32).toString("hex");
@@ -567,9 +631,24 @@ function hashToken(token: string): string {
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk) => chunks.push(chunk));
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-    req.on("error", reject);
+    let size = 0;
+    let rejected = false;
+    req.on("data", (chunk: Buffer) => {
+      if (rejected) return;
+      size += chunk.length;
+      if (size > MAX_REQUEST_BODY_BYTES) {
+        rejected = true;
+        reject(new Error("Request body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (!rejected) resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    req.on("error", (error) => {
+      if (!rejected) reject(error);
+    });
   });
 }
 

--- a/src/mcp-oauth.ts
+++ b/src/mcp-oauth.ts
@@ -18,6 +18,7 @@
 
 import crypto from "node:crypto";
 import type http from "node:http";
+import { isIP } from "node:net";
 import { getDb } from "./dedup.js";
 import { getProvider, listConfiguredProviders } from "./oauth/providers.js";
 import { buildAuthUrl, completeAuth } from "./oauth/oidc.js";
@@ -135,9 +136,10 @@ function isAllowedRedirectUri(redirectUri: string): boolean {
     return false;
   }
 
-  const host = parsed.hostname.toLowerCase();
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (parsed.protocol === "http:") {
-    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+    const ipVersion = isIP(host);
+    return ipVersion === 6 ? host === "::1" : ipVersion === 4 && host.startsWith("127.");
   }
 
   if (parsed.protocol !== "https:") {
@@ -241,7 +243,7 @@ export async function handleMcpClientRegistration(
   ) {
     return json(res, 400, {
       error: "invalid_redirect_uri",
-      error_description: "redirect_uris must use loopback HTTP or an explicitly allowed HTTPS origin",
+      error_description: "redirect_uris must use a loopback IP literal over HTTP or an explicitly allowed HTTPS origin",
     });
   }
 

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -36,6 +36,7 @@ export async function handleMcpRequest(
   const forwardHeaders = { ...req.headers };
   delete forwardHeaders.authorization;
   delete forwardHeaders.host;
+  delete forwardHeaders.cookie;
 
   const options: http.RequestOptions = {
     hostname: target.hostname,

--- a/src/refresh-runner-github-credentials.ts
+++ b/src/refresh-runner-github-credentials.ts
@@ -46,6 +46,7 @@ export async function refreshRunnerGithubCredentialsFromEnvironment(
     owner,
     repo,
     workspaceDir,
+    strict: true,
   });
 }
 

--- a/src/runner-token.ts
+++ b/src/runner-token.ts
@@ -9,6 +9,8 @@ interface RefreshRunnerGithubTokenInputs {
   owner: string;
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
+  /** Fail instead of retaining the current token. Intended for the explicit refresh CLI. */
+  strict?: boolean;
 }
 
 interface RefreshRunnerGithubCredentialsInputs extends RefreshRunnerGithubTokenInputs {
@@ -43,23 +45,46 @@ export async function refreshRunnerGithubToken(
     });
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
+    if (inputs.strict) {
+      throw new Error(`[runner-token] Token refresh unavailable (${reason})`);
+    }
     console.warn(`[runner-token] Token refresh unavailable (${reason}); using the previous token.`);
     return inputs.currentToken;
   }
 
   if (!response.ok) {
-    if (response.status >= 500) {
-      console.warn(
-        `[runner-token] Token refresh failed with HTTP ${response.status}; using the previous token.`,
-      );
+    const message = `[runner-token] Token refresh rejected with HTTP ${response.status}`;
+    if (inputs.strict) {
+      throw new Error(message);
+    }
+    const canRetainBootToken = response.status === 403
+      || response.status === 404
+      || response.status === 429
+      || response.status >= 500;
+    if (canRetainBootToken) {
+      console.warn(`${message}; using the previous token.`);
       return inputs.currentToken;
     }
-    throw new Error(`[runner-token] Token refresh rejected with HTTP ${response.status}`);
+    throw new Error(message);
   }
 
-  const body = (await response.json()) as { token?: unknown };
+  let body: { token?: unknown };
+  try {
+    body = (await response.json()) as { token?: unknown };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    if (inputs.strict) {
+      throw new Error(`[runner-token] Token refresh returned invalid JSON (${reason})`);
+    }
+    console.warn(`[runner-token] Token refresh returned invalid JSON (${reason}); using the previous token.`);
+    return inputs.currentToken;
+  }
   if (typeof body.token !== "string" || body.token.length === 0) {
-    throw new Error("[runner-token] Token refresh returned no token");
+    if (inputs.strict) {
+      throw new Error("[runner-token] Token refresh returned no token");
+    }
+    console.warn("[runner-token] Token refresh returned no token; using the previous token.");
+    return inputs.currentToken;
   }
 
   console.log("[runner-token] Obtained a current GitHub token from the orchestrator.");


### PR DESCRIPTION
## Summary
- contain malformed-cookie and unexpected request-handler failures to one request
- preserve active runner nonce rows, clear terminal nonces, and make pipeline token refresh best-effort while keeping the explicit CLI strict
- gate MCP OAuth on the sidecar, bound dynamic registration, restrict redirect origins, support provider selection, normalize query routing, and strip cookies before proxying
- harden PR_NUMBER decoding and require an explicit Fly deploy target

## Security and lifecycle details
- arbitrary HTTPS MCP callbacks are denied unless their origin is listed in MCP_ALLOWED_REDIRECT_ORIGINS; loopback HTTP remains supported
- abandoned MCP client registrations expire after 24 hours, successful clients remain persistent, registration is limited to 100 per hour, and request bodies are capped at 64 KiB
- terminal status transitions clear machine nonces; active nonce rows survive the dispatch-log retention window
- no process-wide uncaughtException continuation handler was added

## Validation
- rebased onto current testing at 10eeb3e, preserving AII-346 refresh-token support
- npm test: 137 files, 2342 tests passed
- npm run typecheck
- npm run build
- shellcheck and bash -n for all deploy-critical entrypoints
- git diff --check
- independent architecture review: APPROVE
- independent code review: APPROVE

## Scope note
The supplied AWS deploy, Terraform SSM naming, image-prune retention, external-owner image allowlist, and fork runner-image fallback notes reference downstream-only files or deployment configuration and are intentionally not included here.