### PR TITLE
docs: refresh AI-Implement's grounding files (AII-204)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,12 +77,15 @@ ANTHROPIC_API_KEY=
 CLAUDE_CODE_OAUTH_TOKEN=
 
 # =============================================================================
-# Runner → orchestrator callback (Fly Machines mode)
+# Runner → orchestrator callback (all execution modes)
 # =============================================================================
 
-# Public base URL the session machine uses to POST status updates back to the
-# orchestrator (e.g. https://your-orchestrator.fly.dev). Without this and
-# RUNNER_TOKEN_SECRET, runner-callback features are disabled.
+# Public base URL runners use to POST progress and results back to the
+# orchestrator (e.g. https://your-orchestrator.fly.dev). This is not Fly-specific:
+# Fly Machines, GitHub Actions, and local Docker all report through it, and the
+# GHA path receives it as a workflow input rather than an environment variable.
+# Without this and RUNNER_TOKEN_SECRET, runner-callback features are disabled —
+# most visibly, a planning run never reports completion and the issue stalls.
 # Local dev (`npm run dev:local`, RUNNER_MODE=local) defaults this to
 # http://host.docker.internal:$PORT automatically — leave it blank there.
 RUNNER_CALLBACK_BASE_URL=
@@ -149,6 +152,9 @@ KG_SIDECAR_URL=
 # Dynamic clients may use loopback IP-literal HTTP callbacks. Comma-separate any HTTPS
 # origins that should also be accepted; arbitrary HTTPS callbacks are denied.
 MCP_ALLOWED_REDIRECT_ORIGINS=
+# Access-token lifetime in seconds (default 3600). Refresh tokens last 30 days and
+# rotate on use, so clients re-authenticate in a browser monthly, not hourly.
+MCP_ACCESS_TOKEN_TTL=
 # MCP OIDC redirect URIs to register in Google/Microsoft consoles:
 #   ${OAUTH_REDIRECT_BASE_URL}/mcp/callback/google
 #   ${OAUTH_REDIRECT_BASE_URL}/mcp/callback/microsoft

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,36 @@
+<!--
+  MAINTAINER NOTE — why this file is short, and how to keep it that way.
+
+  CLAUDE.md is loaded into EVERY Claude invocation: implement and review on each
+  feedback-loop iteration, plus every post-push-review fix pass. Length is a
+  correctness lever, not tidiness — Claude Code's own guidance is to target under
+  200 lines, because a longer file reduces adherence to what it says.
+
+  So the rule for what belongs here: keep what an agent CANNOT derive by reading
+  the repo — pitfalls, rationale, why-nots, and conventions that differ from tool
+  defaults. Anything derivable (directory trees, exhaustive field tables,
+  architecture narration) belongs in docs/ behind a "Full reference:" link, or
+  nowhere.
+
+  These HTML comments are stripped before the file reaches the model, verified
+  empirically — so maintainer notes here are free to the agent, and visible to
+  whoever reads the file to edit it. Use them rather than prose for guidance
+  aimed at humans.
+
+  Before adding a section, ask whether `ls` or one file-read would answer it. If
+  so, don't.
+-->
+
 # AI-Implement — Codebase Guide
 
-## What this is
+A Node.js service that polls Linear or Jira for issues labeled `AI-Implement` and dispatches containerized runs of Claude Code to implement them. It also serves an admin UI and manages the workflow templates synced to target repos.
 
-A Node.js service that polls Linear for issues labeled "AI-Implement" and dispatches GitHub Actions workflows that run Claude Code to implement them. It also provides an admin UI and manages workflow templates synced to target repos.
+## Issue tracker bindings
 
-## Issue tracker — Linear (BuildDown skills)
-
-Bindings for the BuildDown skills (bd-build-up, bd-build-down, bd-summit-push, etc.):
+Bindings for the BuildDown skills (bd-build-up, bd-build-down, bd-summit-push, etc.). These are read by name — keep the keys intact when editing.
 
 - tracker.kind: linear
-- MCP server: `linear-eudoxus` (project `.mcp.json`; pre-approved in `.claude/settings.json`)
+- MCP server: `linear-eudoxus` (declared in the project `.mcp.json`; **not** pre-approved — `.claude/` is gitignored and absent here, so each machine approves the server on first use)
 - Workspace: `eudoxus` (bound at OAuth time)
 - Team: `AII`  ← issues filed/listed/searched against this team
 - Team URL: https://linear.app/eudoxus/team/AII/overview
@@ -17,651 +38,224 @@ Bindings for the BuildDown skills (bd-build-up, bd-build-down, bd-summit-push, e
 - Implement label: `AI-Implement` (orchestrator pickup trigger)
 - Agent mention (PR comment re-trigger): `/ai-implement`
 
-> Note: a separate global `claude.ai Linear` connector is authenticated to the **oolidata** workspace.
-> `linear-eudoxus` is a distinctly-named project server with its own token on **eudoxus**, so the two
-> never collide.
 
 ## Architecture
 
 ```
-Linear (AI-Implement label)
-    ↓ poll every 60s (src/index.ts)
-Node.js service on Fly.io
-    ↓ workflow_dispatch (src/github.ts)
-GitHub Actions in target repos (.github/workflows/claude-implement.yml)
-    ↓ anthropics/claude-code-action
-PR created → gap analysis posted → Linear updated
-    ↓ /ai-implement comment → orchestrator webhook (POST /api/github/webhook)
-Gap-fill run dispatched via orchestrator poll loop
+Linear / Jira  ──poll every 60s──▶  orchestrator (src/index.ts)
+                                          │
+                                          ▼  dispatch
+                     GitHub Actions │ Fly Machines │ local Docker
+                                          │
+                                          ▼  all three enter session/entrypoint.sh
+                                    runner container
+                                          │
+                              pipeline (src/pipeline/) runs the steps
+                                          │
+                                          ▼
+                        PR opened → review → callbacks → tracker updated
 ```
 
-## Project structure
+The runner never holds a ticketing credential. It reports through authenticated callbacks and the orchestrator performs every tracker write with its own.
 
-```
-src/
-  index.ts          — main entry: polling loop + HTTP server
-  linear.ts         — Linear GraphQL client
-  github.ts         — GitHub workflow_dispatch
-  notify.ts         — notification adapter (slack | teams)
-  config.ts         — SQLite-backed team→repo mappings
-  dedup.ts          — SQLite deduplication + DB singleton
-  poll-selection.ts — per-team capacity selection logic
-  log.ts            — dispatch audit log (SQLite)
-  admin.ts          — admin HTTP API (auth + CRUD)
-  admin-html.ts     — re-exports the assembled admin HTML from admin-ui/index.ts
-  admin-ui/         — string-composed admin SPA (see "admin-ui" section below)
-  mcp.ts            — OAuth-authenticated MCP proxy to KG sidecar
-  mcp-oauth.ts      — RFC 6749 authorization server for /mcp (client reg, PKCE, token exchange)
-  oauth/            — OIDC engine + shared admin-UI and MCP login routes
-  __tests__/        — Vitest unit tests
+## Subsystem index
 
-workflows/          — templates synced to target repos
-  claude-implement.yml
-  comment-trigger.yml    — legacy comment trigger (kept for legacy-generation repos; removed from envelope repos by sync)
-  claude-plan.yml   — planning workflow template (always synced)
-  WORKFLOW.md       — Claude implementation prompt template (seeded once)
-  PLANNING.md       — Claude planning prompt template (seeded once)
-  custom/           — repo-local override scaffold seeded once (README + .gitkeep placeholders)
+Entry points for areas that are easy to miss. Each names the module to start from; the ones with references have depth behind them.
 
-clients/            — one .toml per deployed client
-  example-client.toml  — copy this to onboard a new client
-
-scripts/
-  provision-client.sh  — interactive client onboarding helper
-
-.github/workflows/
-  deploy-clients.yml — matrix deploy to all clients on push to main
-  sync-workflow.yml  — sync workflow templates to target repos
-  claude-review.yml  — Claude reviews PRs (auto for same-repo, /claude-review for forks)
-  build-runner.yml   — build and push the session runner image to GHCR
-
-docs/
-  plans/      — implementation plans (decision artifacts; progress derived from git)
-  solutions/  — documented solutions to past problems (bugs, best practices, workflow
-                patterns), by category with YAML frontmatter (module, tags, problem_type);
-                relevant when implementing or debugging in documented areas
-
-docker-entrypoint.sh  — container entrypoint: starts KG sidecar on loopback before Node
-kg/                   — KG sidecar artifacts (manually populated pre-build; see "KG sidecar")
-  .gitkeep            — placeholder; replaced with actual server code + snapshot artifacts
-```
+| Subsystem | Start at | Reference |
+|---|---|---|
+| Pipeline, steps, custom overrides | `src/pipeline/` | [docs/pipeline-architecture.md](docs/pipeline-architecture.md) |
+| Review findings → fix dispatches | `src/review-fix-queue.ts` | [docs/review-fix-rail.md](docs/review-fix-rail.md) |
+| Parent/child grouping and roll-up | `src/feature-branch.ts`, `src/merge-up.ts` | [docs/feature-branch-grouping.md](docs/feature-branch-grouping.md) |
+| Dispatch envelope (`RunConfigV1`) | `src/run-config.ts` | [docs/workflow-envelope.md](docs/workflow-envelope.md) |
+| Runner image selection | `src/repo-image.ts` | [docs/runner-images.md](docs/runner-images.md) |
+| KG sidecar and `/mcp` | `src/mcp.ts`, `src/mcp-oauth.ts` | [docs/kg-sidecar.md](docs/kg-sidecar.md) |
+| Deploying, clients, Bedrock | `scripts/deploy-orchestrator.sh` | [docs/deployment.md](docs/deployment.md) |
+| Ticketing provider abstraction | `src/providers/` — `linear.ts`, `jira.ts`, `registry.ts` | |
+| Execution backends | `src/fly-machines.ts`, `src/local-docker.ts`, `src/github.ts` | |
+| Runner callbacks and tokens | `src/runner-callback.ts`, `src/runner-token.ts`, `src/token-vending.ts` | |
+| Merge reconciliation | `src/reconciliation.ts`, `src/reconcile-merged.ts`, `src/poll-merged-prs.ts` | |
+| Workflow sync to target repos | `src/workflow-sync.ts`, `src/workflow-sync-queue.ts` | |
+| `/ai-implement` comment rail | `src/webhook.ts`, `src/comment-gapfill-drain.ts` | |
+| Stuck-run recovery | `src/reaper.ts`, `src/stuck-watchdog.ts` | |
+| Per-team dispatch capacity | `src/poll-selection.ts` | |
+| Run classification and autopsy | `src/completion-classification.ts`, `src/run-autopsy.ts` | |
+| Admin SSO / OIDC | `src/oauth/`, `src/admin-session.ts` | |
+| Admin SPA | `src/admin-ui/` | |
 
 ## Running locally
 
 ```bash
-cp .env.example .env   # fill in LINEAR_CLIENT_ID + LINEAR_CLIENT_SECRET, GITHUB_PAT
+cp .env.example .env   # GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY are the only required pair
 npm install
-npm run dev            # runs src/index.ts via tsx
-npm run dev:local      # rebuilds local session image, then runs local Docker jobs
+npm run dev            # checks the Node major, loads .env when present, runs src/index.ts via tsx
+npm run dev:local      # rebuilds the local runner image, then runs dispatches in local Docker
 ```
 
-Health check: `curl http://localhost:8080/`
-Admin UI: `http://localhost:8080/admin` (requires an OAuth provider configured **or** ADMIN_ACCESS_CODE set)
+Only the GitHub App pair is hard-required — `loadConfig` throws without it. Ticketing credentials are not: an absent Linear or Jira configuration logs a warning and skips that provider's mappings, so the orchestrator still boots and serves.
+
+Health check `curl http://localhost:8080/` · Admin UI `http://localhost:8080/admin` (needs an OAuth provider **or** `ADMIN_ACCESS_CODE`).
+
+Node is pinned to 24 (`engines`, `.tool-versions`). On a Node-major switch, `npm test` fails wholesale inside `getDb()` with a `NODE_MODULE_VERSION` mismatch — check which Node you are on before reaching for `npm rebuild better-sqlite3`, since the native modules are usually right and the shell is wrong.
 
 ## Local dev harness
 
-`npm run dev:run` launches a single runner container directly against a local target-repo checkout — no orchestrator, no poll loop, no tracker. Ideal for iterating on `WORKFLOW.md` and `setup:` hook scripts.
+`npm run dev:run` launches a single runner container against a local target-repo checkout — no orchestrator, no poll loop, no tracker. It is the only local path that can iterate on `WORKFLOW.md` and hook scripts, because it bind-mounts your working tree instead of cloning.
 
 ```bash
 npm run dev:run -- --workspace ../target-repo --task task.md
-npm run dev:run -- --workspace ../target-repo --task task.md --until setup
 npm run dev:run -- --workspace ../target-repo --task task.md --until setup --shell
 ```
 
-**Task file format** (`task.md`):
-```markdown
----
-identifier: PROJ-123   # optional; defaults to DEV-<timestamp>
-title: Add login        # required
-maxTurns: 30            # optional
-maxIterations: 2        # optional
-repo: owner/repo        # optional; auto-detected from git remote
-branch: main            # optional; auto-detected from current HEAD
----
+The task file is Markdown with front matter: `title` required; `identifier`, `maxTurns`, `maxIterations`, `repo`, `branch` optional.
 
-Issue description / implementation instructions go here.
-```
+- `--until <step>` stops after that pipeline step, **including when the step is skipped**; an unknown step name fails before execution rather than falling through to a full run. Since `setup` precedes `feedback-loop`, `--until setup` is a token-free hook loop.
+- `--shell` holds the container open at that boundary and attaches a shell in `/workspace`, with setup-hook `$GITHUB_ENV` exports loaded. Exiting collects artifacts, then removes the container.
+- **Mounted mode never pushes** — the mount is your live checkout, dirty by design, so a push would sweep in-progress work into the commit. The mutated tree is left for `git diff`.
+- The clone and install steps both detect mounted mode and no-op, so uncommitted edits take effect immediately and your `node_modules` is left alone.
 
-**How it works:**
-- `--workspace <dir>` bind-mounts the local checkout at `/workspace` inside the container.
-- `--until <step>` stops after that pipeline step, including when the step is skipped. Unknown step names fail before execution instead of falling through to a full implementation run. `--until setup` is the token-free setup-hook loop.
-- `--shell` keeps the local container alive after the selected boundary and attaches an interactive shell in `/workspace`; setup-hook `$GITHUB_ENV` exports are loaded into that shell. Exiting collects artifacts and then removes the container.
-- The clone step detects `AI_IMPLEMENT_WORKSPACE_MODE=mounted` and skips `git fetch/reset` entirely, so uncommitted edits to `WORKFLOW.md` and hook scripts take effect immediately.
-- Mounted mode **never pushes** — the push step is a no-op whenever `AI_IMPLEMENT_WORKSPACE_MODE=mounted`. The mount is your live checkout, dirty by design (the uncommitted `WORKFLOW.md`/hook edits under test), so a push would sweep in-progress work into the commit. The mutated working tree is left in the mount for inspection with `git diff`; commit/push the parts you want to keep yourself.
-- Logs are streamed to the terminal in real time. Per-run artifacts (log, diff, telemetry) are saved to `.dev-runs/<timestamp>/` (gitignored).
-
-**Library API** (for programmatic use or a future MCP wrapper — `src/dev-harness/`):
-```typescript
-import { startDevRun, streamLogs, getRunResult, collectRunArtifacts } from "./src/dev-harness/index.js";
-const handle = await startDevRun({ workspace, task });
-await streamLogs(handle, console.log);
-const result = await getRunResult(handle);
-await collectRunArtifacts(handle, result.exitCode);
-```
-
-**Artifacts per run** (`.dev-runs/<timestamp>/`):
-- `run.log` — full container output
-- `changes.diff` — `git diff` of the mounted workspace after the run
-- `diffstat.txt` — `git diff --stat` summary
-- `telemetry.json` — exit code, timing, issue metadata
+Per-run artifacts land in `.dev-runs/<timestamp>/` (gitignored): `run.log`, `changes.diff`, `diffstat.txt`, `telemetry.json`.
 
 ## Running tests
 
 ```bash
-npm test              # vitest run (all tests)
-npm run test:watch    # watch mode
-npm run typecheck     # tsc --noEmit
+npm test          # vitest run
+npm run typecheck # tsc --noEmit
 ```
 
-## SQLite databases
+**`typecheck` excludes `src/__tests__`, and vitest strips types without checking them** — so type errors in a test file are caught by nothing. Type-check a new test file explicitly with a throwaway tsconfig. `src/admin-ui/__tests__/` *is* covered and can break the build.
 
-All tables live in a single SQLite file at `DEDUP_DB_PATH` (default `/data/dedup.sqlite` in production, `./dedup.sqlite` locally).
+## Data layer
 
-| Table | Purpose |
-|-------|---------|
-| `dispatched` | Dedup — issue IDs dispatched in the last 24h |
-| `mappings` | Team key → GitHub repo config |
-| `dispatch_log` | Audit log, last 500 dispatches |
-| `settings` | Key-value store — runner mode, Fly session config, deploy-notification state |
-| `mcp_clients` | MCP OAuth — registered clients (RFC 7591 dynamic registration) |
-| `mcp_oauth_states` | MCP OAuth — in-flight OIDC transactions (10-minute TTL) |
-| `mcp_auth_codes` | MCP OAuth — short-lived authorization codes (5-minute TTL) |
-| `mcp_tokens` | MCP OAuth — issued Bearer access tokens (1-hour TTL) |
+One SQLite file at `DEDUP_DB_PATH` (default `/data/dedup.sqlite`; `./dedup.sqlite` locally) holding 22 tables. `dedup.ts` owns the singleton — every other module imports `getDb` from it rather than opening its own handle.
 
-`dedup.ts` owns the DB singleton (`getDb()`). All other modules import `getDb` from `dedup.ts`.
+**Dedup has no TTL.** The `dispatched` table is a bare existence check with no retention logic: an entry clears only when something explicitly removes it — a failed or timed-out run, the reconcile loop reaching a terminal issue, or a manual delete. There is no time-based auto-retry. This is a recurring source of documentation errors claiming a 24-hour window; the only genuine 24-hour figure belongs to the reaper's summary statistic.
 
-## Key environment variables
+## Environment variables
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `LINEAR_CLIENT_ID` | Yes | Linear OAuth app client ID (client-credentials grant) |
-| `LINEAR_CLIENT_SECRET` | Yes | Linear OAuth app client secret |
-| `GITHUB_APP_ID` | Yes | GitHub App numeric ID |
-| `GITHUB_APP_PRIVATE_KEY` | Yes | GitHub App RSA private key (PEM, `\n`-escaped) |
-| `NOTIFY_TYPE` | No | `slack` (default) or `teams` |
-| `NOTIFY_WEBHOOK_URL` | No | Webhook URL; notifications skipped if unset |
-| `ADMIN_ACCESS_CODE` | No | **Deprecated** admin-UI password fallback (prefer SSO below). UI is enabled if this **or** any OAuth provider is set. |
-| `OAUTH_REDIRECT_BASE_URL` | No | Base URL for OAuth redirect URIs (`https://<app>.fly.dev`; `http://localhost:8080` locally) |
-| `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` | No | Google OIDC credentials — enables the Google SSO button |
-| `MICROSOFT_OAUTH_CLIENT_ID` / `MICROSOFT_OAUTH_CLIENT_SECRET` / `MICROSOFT_OAUTH_TENANT` | No | Microsoft (Entra) OIDC credentials; `_TENANT` is the directory (tenant) ID |
-| `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` | No | Comma-separated allowlist; a verified identity must match a domain or email (fail-closed) |
-| `KG_SIDECAR_URL` | No | URL of the private KG sidecar (streamable-HTTP MCP transport), e.g. `http://127.0.0.1:8765/mcp`. Unset → 503 on `/mcp`. The sidecar should be reachable only from loopback; the orchestrator proxies auth-verified requests verbatim and strips the `Authorization` header before forwarding. |
-| `DEDUP_DB_PATH` | No | SQLite path (default `/data/dedup.sqlite`) |
-| `POLL_INTERVAL_MS` | No | Poll interval ms (default `60000`) |
-| `PORT` | No | HTTP port (default `8080`) |
-| `AI_IMPLEMENT_LOG_LEVEL` | No | Runner log verbosity: `summary` (default) or `stream`. `stream` tees per-turn tool activity to the log. Telemetry (turns/cost/tokens/outcome) is captured at both levels. |
+**`.env.example` is canonical** — it carries every orchestrator variable with grouped comments, and is kept in lockstep with the code. Consult it rather than a second list here.
 
-## KG sidecar and MCP endpoint
+Only the non-obvious ones are worth restating:
 
-The orchestrator bundles a Python-based KG (knowledge-graph) sidecar that serves `kg_*` tools. MCP clients (e.g. Claude Code) reach those tools via the orchestrator's `/mcp` endpoint — an OAuth-authenticated proxy implemented in `src/mcp.ts`. The sidecar is started by `docker-entrypoint.sh` on `127.0.0.1:8765` before Node, then `KG_SIDECAR_URL` is exported so `src/index.ts` picks it up automatically. Sidecar failure (crash, timeout, absent artifacts) is **non-fatal**: the orchestrator boots normally and `/mcp` returns 503; all other routes are unaffected.
+- `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` — the only pair that throws at boot when absent. Everything else warns and degrades a feature.
+- `RUNNER_CALLBACK_BASE_URL` + `RUNNER_TOKEN_SECRET` — **not Fly-specific.** All three execution modes report through them; the GHA path receives the URL as a workflow input rather than an env var. Without them a planning run never reports completion and the issue stalls.
+- `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` — fail-closed. Empty means deny everyone.
+- `KG_SIDECAR_URL` — unset gives `/mcp` a 503, **and so does an unset `OAUTH_REDIRECT_BASE_URL`**. The two failures look identical from outside.
+- `AI_IMPLEMENT_LOG_LEVEL`, `AI_IMPLEMENT_RUNNER_LABEL`, `AI_IMPLEMENT_PROVIDER` — repo/org **Actions variables**, not orchestrator env, and effective only after the target repo re-syncs `claude-implement.yml`. `LOG_LEVEL` is `summary` (one result line per invocation — outcome, turns, duration, cost, tokens) or `stream` (additionally tees each tool call, not its output); telemetry is captured at both. `RUNNER_LABEL` overrides `runs-on`, default `ubuntu-latest` — pointing it at a larger runner roughly halves the CPU-bound implement job, but **write access to that variable lets the holder retarget the job to an arbitrary self-hosted runner that would then see the job's secrets.**
 
-### Single-machine deploy shape
-
-The sidecar runs **inside** the orchestrator container on loopback — no separate service, no public port. `docker-entrypoint.sh` starts the sidecar, polls `http://127.0.0.1:8765/mcp` for up to 30 s, and exports `KG_SIDECAR_URL=http://127.0.0.1:8765/mcp` if it becomes ready. Node then starts with that variable already set. For local dev (`npm run dev`), start the sidecar manually and set `KG_SIDECAR_URL` in `.env`; or leave it blank (no `/mcp`).
-
-### MCP OAuth flow
-
-The `/mcp` endpoint returns 401 with `WWW-Authenticate` pointing to `/.well-known/oauth-protected-resource`. A compliant MCP client discovers the authorization server from there and completes the RFC 6749 authorization code + PKCE flow implemented in `src/mcp-oauth.ts`:
-
-| Endpoint | Purpose |
-|----------|---------|
-| `POST /mcp/register` | RFC 7591 dynamic client registration — returns `client_id` |
-| `GET /mcp/authorize` | Start PKCE auth flow → delegates to configured OIDC provider |
-| `GET /mcp/callback/{provider}` | OIDC callback — applies allowlist, mints 5-min auth code |
-| `POST /mcp/token` | Exchange auth code + PKCE verifier for a 1-hour Bearer token |
-| `GET /.well-known/oauth-protected-resource` | RFC resource metadata — points clients to the AS |
-| `GET /.well-known/oauth-authorization-server` | RFC 8414 AS metadata |
-
-Authorization is **fail-closed**: a verified identity must pass the same `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` allowlist as the admin UI. Tokens live 1 hour; the client re-authenticates after expiry.
-
-**Configuring MCP OAuth** — register two additional redirect URIs in the OIDC provider consoles (alongside the admin-UI redirect URIs):
-- `${OAUTH_REDIRECT_BASE_URL}/mcp/callback/google`
-- `${OAUTH_REDIRECT_BASE_URL}/mcp/callback/microsoft`
-
-`OAUTH_REDIRECT_BASE_URL` and at least one OIDC provider must be configured; `/mcp/authorize` returns 503 when neither is set.
-
-### Decision (a) — base image
-
-`Dockerfile` uses `node:24-slim` (Debian bookworm) instead of `node:24-alpine`. fastembed and onnxruntime ship pre-built glibc wheels; Alpine's musl libc makes those wheels fail to install without a full from-source build. Slim costs ~30 MB more but makes the sidecar viable without cross-compilation.
-
-### Decision (b) — KG artifact acquisition via BuildKit build secret (fail-soft)
-
-The KG repository is private. A **BuildKit `--build-secret` mount** clones it at build time. The token is only readable inside the mounted `RUN` layer and is never written to `ARG`, `ENV`, or image history.
-
-**Build with the KG sidecar enabled** (requires a GitHub token with read access to `BuildDownAI/knowledge-graph-ai-implement`):
-
-```bash
-# Local Docker build:
-docker build --secret id=kg_token,env=GH_TOKEN .
-
-# Fly deploy — ALWAYS use the wrapper script (it encodes the required flags and
-# verifies the deployed sidecar actually serves):
-./scripts/deploy-orchestrator.sh ai-implement-testing-orchestrator  # testing orchestrator
-./scripts/deploy-orchestrator.sh <other-app-name>                    # any other orchestrator app
-```
-
-> **Never deploy with a plain `fly deploy`** — it silently produces a sidecar-less
-> image (`/mcp` → 503). The script exists because this has happened three times:
-> the KG clone needs the build secret, `--no-cache` is required (a build secret is
-> not part of the layer cache key, so repeat deploys silently reuse stale layers),
-> and `GH_TOKEN` must be exported (an inline prefix passes an empty secret). The
-> script ends by asserting `/mcp` answers 401 — a deploy that ships without a
-> working sidecar fails loudly instead of being discovered days later.
-
-The sidecar clone copies the KG's `sources.yml` (which pins the IRI `namespace:`)
-alongside the code — without it the server falls back to the placeholder
-namespace and every type-filtered `kg_*` tool silently returns empty (the graph
-loads, but queries match nothing). Verify a deploy with a real query
-(`kg_search` returns non-empty), not just that `/mcp` answers.
-
-**Build without the KG sidecar** (sidecar-less / degraded — `/mcp` returns 503, all other routes remain healthy):
-
-```bash
-docker build .
-fly deploy --remote-only
-```
-
-When the `kg_token` secret is absent or empty the build succeeds and logs `[kg] sidecar-less build`. The entrypoint skips sidecar startup and the orchestrator boots normally.
-
-**When testing moves to Fly native auto-deploy (AII-256):** the build secret must be configured in that deploy path (e.g. as a Fly build secret or CI secret) so automated deployments continue to produce sidecar-enabled images.
-
-`kg/` is excluded from workflow sync and never copied to target repos. The `kg/.gitkeep` placeholder remains in git; the actual KG code and snapshot are cloned at build time and never committed. After the venv install, the Dockerfile performs three distinct build steps:
-
-1. **Model bake** — warms the fastembed model (`BAAI/bge-small-en-v1.5`) into a baked cache at `FASTEMBED_CACHE_PATH=/app/kg/.fastembed-cache`. This eliminates network fetches at runtime: the query-embedding path reads the baked cache from the image. If this step fails, the build prints `[kg] WARNING: EMBEDDINGS BUILD FAILED` and continues graph-only; the sidecar starts in lexical-only mode.
-2. **Graph materialize** — runs `kg_ingest.materialize --no-embed` to produce `out/graph.trig`. This step is a hard failure: a broken graph is not usable.
-3. **Embed** — runs `kg_ingest.materialize` (full) using the same `FASTEMBED_CACHE_PATH`. If this step fails, the build prints `[kg] WARNING: EMBEDDINGS BUILD FAILED` and continues graph-only. A successful embed step produces `out/graph.trig` with semantic vectors; lexical-only search is the fallback if the embed step fails.
-
-The `start.sh` script generated at build time exports `FASTEMBED_CACHE_PATH=/app/kg/.fastembed-cache` so the running sidecar also reads the baked cache rather than downloading the model on first query. `kg_hybrid_search` returns results immediately on boot without a separate data-load step. Verify a sidecar-enabled deploy by asserting `degraded:false` in a `kg_hybrid_search` response (not just that `/mcp` answers).
-
-### Memory sizing
-
-Fastembed embedding models load into process memory at startup. A typical small model (e.g. BAAI/bge-small-en-v1.5, ~130 MB on disk) expands to ~300–400 MB resident once loaded. Combined with the orchestrator's Node.js footprint (~100–150 MB), **256 MB Fly machines are too small** and will OOM-kill the sidecar or the orchestrator.
-
-**Recommended minimum: 512 MB.** For comfortable headroom (larger models, concurrent requests): **1 GB.**
-
-Update `fly.toml` before deploying a sidecar-enabled image:
-
-```toml
-[[vm]]
-  size = "shared-cpu-1x"
-  memory = "512mb"   # minimum with KG sidecar; 1024mb recommended
-```
-
-The `fly.toml` in this repository shows `512mb` as the base default (sufficient for sidecar-enabled deployments; sidecar-less deployments could use 256mb but 512mb is harmless). Adjust per-client in `clients/<slug>.toml`.
+Adding or renaming a variable means updating `.env.example` in the same change; it is the operator's only discovery surface.
 
 ## Adding a new target repo
 
-1. Add the project mapping in the admin UI at `/admin` — the **New project** stepper (or **Edit** on an existing row). On the **Source** step, enter the owner/repo and click **Check installation**: the stepper probes whether the GitHub App is installed and can see the repo, and links straight to the fix when it can't —
-   - **App not installed** → "Install the App" (GitHub's install flow; org members who aren't owners get GitHub's "request the owner to install" path),
-   - **Repo not selected** → "Add this repo" (same install flow — adjusts the install's selected-repositories set),
-   - **Ready** → green confirmation.
+1. Add the mapping at `/admin` via the **New project** stepper. On the Source step, **Check installation** probes whether the App is installed and can see the repo, linking straight to the fix — install the App, or add the repo to an existing install. The check is advisory; you can save regardless.
+2. **Save.** The mapping persists immediately and sync runs in the background, polling to a terminal state. The mapping is saved however the sync resolves.
+3. Merge the sync PR in the target repo.
 
-   Use **Re-check** after installing/adding in the opened tab. The check is advisory — you can still save without it.
-2. **Save.** The mapping persists immediately, and the workflow sync runs in the background. The project row's Sync button shows **"Syncing…"**, then polls a status endpoint to a terminal state: **"Workflows synced — PR opened ↗"** (or a transient "Up to date"), or it reverts with an alert naming the failure (App not installed, permission denied, clock skew, …). The mapping is saved regardless of how the sync resolves.
-3. Merge the sync PR in the target repo
-4. Enable "Allow GitHub Actions to create and approve pull requests" in the target repo settings
+The GitHub App needs **Workflows** permission alongside **Contents** — GitHub rejects writes under `.github/workflows/` without it, and the sync fails with "permission denied" before opening its PR. If the orchestrator restarts mid-sync, the poll loop reclaims the orphaned job after a stale window.
 
-The **Sync workflows** button on each project row re-runs the sync manually at any time, and `.github/workflows/sync-workflow.yml` remains as a manual/bulk fallback. If the orchestrator restarts mid-sync, the poll loop reclaims the orphaned job after a short stale window and finishes it.
+The target repo's "Allow GitHub Actions to create and approve pull requests" toggle is **not** a prerequisite, despite older instructions saying so. Every synced workflow opens PRs with a **GitHub App token**, while that toggle governs the default `github-actions[bot]` actor — a different identity. Leaving it on is harmless; the real prerequisite is the App installed with contents, pull-requests, and workflows permissions.
 
-The GitHub App must have **Workflows** permission in addition to **Contents** permission. GitHub rejects writes under `.github/workflows/` without it, so the sync will fail (surfaced as a "permission denied" message) before opening or updating the target-repo PR.
-
-## Admin authentication
-
-The admin UI supports **SSO via OIDC** (Google + Microsoft) with a **deprecated shared access-code** fallback. The UI is enabled when at least one is configured, and returns 503 when neither is.
-
-- **SSO (preferred):** configure one or more providers (`GOOGLE_OAUTH_*` / `MICROSOFT_OAUTH_*`) plus `OAUTH_REDIRECT_BASE_URL`, and an allowlist (`OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS`). Sign-in yields an httpOnly session cookie; authorization is **fail-closed** against the email/domain allowlist — a verified `email` must match `OAUTH_ALLOWED_EMAILS`, or its domain must match `OAUTH_ALLOWED_DOMAINS`. The session stores the provider's stable `sub` as its identity reference (email is mutable). Claims are normalized across providers in `src/oauth/oidc.ts`.
-- **Access code (deprecated):** `ADMIN_ACCESS_CODE` remains for local dev/bootstrapping. It uses a timing-safe compare and logs a deprecation warning on each use.
-
-## admin-ui
-
-The admin SPA at `/admin` is composed from string-exporting modules under `src/admin-ui/`. `src/admin-html.ts` is a thin re-export of `src/admin-ui/index.ts`. There is **no client-side build step** — all client JS is concatenated into a single inline `<script>` block at module load time.
-
-| Module | Owns |
-|---|---|
-| `tokens.ts` | CSS custom properties (light + dark + accent + spacing + type + radius + shadow) |
-| `components.ts` | All component classes (`.card`, `.tbl`, `.btn`, `.badge`, `.kpi`, `.alert`, `.drawer`, `.modal-card`, etc.) |
-| `icons.ts` | SVG icon registry + `icon(name, size)` helper |
-| `sidebar.ts` | Sidebar render + `SIDEBAR_ROUTES` |
-| `router.ts` | Hash-based router; `window.registerPage(key, init)` runs an init once on first show |
-| `theme.ts` | Reads/writes `data-theme` from localStorage; default `dark` |
-| `auth.ts` | Shared auth: `window.api()`, `window.esc()`, `window.login()`, `window.logout()`, token storage |
-| `pages/<name>.ts` | One per sidebar item — exports `<name>Html` and `<name>Script` strings |
-
-Page conventions: each `<name>.ts` exports two strings. The HTML uses `data-page="<route>"` matching the sidebar's `data-route`. The script is an IIFE that defines page-specific functions, exposes any `onclick=`-referenced ones on `window`, and ends with `window.registerPage('<route>', () => { /* init */ });`. Page scripts call `window.api()` and `window.esc()` rather than referencing them as bare globals.
-
-When adding a new page: create the page module, append both strings to the lists in `src/admin-ui/index.ts`, and add the route to `sidebar.ts`. When adding a new design token: extend `tokens.ts` and the `tokens.test.ts` spot-check. When adding a new icon: drop the SVG inner markup into `iconRegistry`.
-
-Six routes (`channels`, `policies`, `secrets`, `mcp`, `webhooks`, `updates`) are still stubbed in `src/admin-ui/pages/stubs.ts` with "Coming soon" placeholders (badged "Not implemented yet" or "Partially implemented") that explain what exists today and link to the related built pages.
-
-## Backend outage playbook (runner-mode failover)
-
-When GitHub Actions (or Fly) is degraded, the global **runner mode** is the failover lever: `/admin#runners` (or `POST /api/runner-mode`) with `fly` forces every new dispatch onto Fly Machines; `gha` forces GitHub Actions; `default` restores per-project modes. In-flight runs keep their monitors — only new dispatches reroute.
-
-- **Prerequisite for `fly`:** the orchestrator must have a Fly session backend (`FLY_SESSIONS_APP` + Fly API token) and the mapping must be Fly-capable. **Ineligible mappings are skipped at dispatch** (provider=`bedrock` is GHA-only; no sessions app configured) — they stay queued, dedup untouched, with one log line per poll, and are listed in the Runners-page override banner and the `GET /api/runner-mode` response (`ineligible`).
-- Every mode change is logged (`old → new`) and fires a plain-text notification when `NOTIFY_WEBHOOK_URL` is set.
-- Flip back to `default` after the outage; skipped issues dispatch normally on the next poll.
-
-## Notification adapter
-
-`src/notify.ts` exports a single `notify(type, webhookUrl, notification)` function. Set `NOTIFY_TYPE=slack` or `NOTIFY_TYPE=teams` to switch providers. Adding a new provider means adding a private function in `notify.ts` and a new case in the switch.
-
-The orchestrator also announces its own deploys. On shutdown it posts an `@channel` heads-up that dispatches are pausing; on the next boot it compares `FLY_IMAGE_REF` against the value it stored in the `settings` table and posts either "redeployed" (the image changed) or "restarted" (it did not), with how long it was down. A first boot on a fresh volume records the reference silently.
-
-Both notices are gated on `FLY_IMAGE_REF`, which only exists inside a Fly Machine — local runs never post. Failures are logged and swallowed, and the shutdown notice is bounded to a fraction of the shutdown budget so it cannot outlive `kill_timeout`.
+`.github/workflows/sync-workflow.yml` remains a manual bulk fallback, but normal distribution happens from the orchestrator.
 
 ## Workflow templates
 
-`workflows/claude-implement.yml` is the main implementation workflow synced to target repos. It supports:
-- **WORKFLOW.md** — per-repo Claude prompt template; front matter carries `model:` (required for bedrock, defaults to `claude-sonnet-4-6` for anthropic) and optional `gap_analysis_model:`
-- **Gap analysis** — secondary Claude invocation after each PR
-- **Unapproved runs → draft PR** — when the implement/review feedback loop exhausts its iterations (or a pass hits the hard `max_turns` cap) without reviewer approval, the pipeline still pushes the working tree and opens a **draft PR** whose body carries the reviewer's final feedback, per-pass turn/cost stats, and (on `max_turns`) a read-only post-mortem. The runner reports the run as a coded failure (`REVIEW_UNAPPROVED` or `MAX_TURNS_EXHAUSTED`, with the draft-PR URL) so the ticket is updated and notifications fire; a run-autopsy comment is posted to the ticket; the GHA job stays green with a `::warning::` annotation. If the repo plan rejects draft PRs (422), the PR is opened normally with the title prefix `[NEEDS REVIEW — unapproved]`.
-- **Comment trigger** — a PR comment that **starts with** `/ai-implement` on an envelope-generation repo is handled by the orchestrator webhook (`POST /api/github/webhook`). The orchestrator verifies the commenter has write/maintain/admin permission on the repo, posts a 👀 reaction as acknowledgement, and enqueues a gap-fill dispatch that runs through the same unified dispatch path as orchestrator-initiated runs. Any text after the `/ai-implement` token is forwarded as an operator instruction (rides `run_config.commentInstruction`). `/ai-implementfoo` and comments that merely contain the token mid-text do not fire. Legacy repos (whose `claude-implement.yml` does not have a `run_config:` input) are silently ignored by the webhook; they continue to use `comment-trigger.yml` if it is still present in the target repo.
-- **Triple auth** — bedrock (when orchestrator sets `provider=bedrock`), OAuth (`CLAUDE_CODE_OAUTH_TOKEN`), or API key (`ANTHROPIC_API_KEY`)
-- **setup / verify / teardown hooks** — `WORKFLOW.md` front-matter keys `setup:` / `verify:` / `teardown:` are paths (relative to repo root) to shell scripts that the runner now executes: `setup` before the implement loop (its failure aborts the run early), `verify` after a successful push, and `teardown` always (even on failure, via a `finally` in the runner). Scripts run with `set -euo pipefail`; env vars a setup script appends via `echo "VAR=value" >> "$GITHUB_ENV"` are visible to Claude and to the verify/teardown scripts (the runner manages `$GITHUB_ENV` across all execution modes). Repos with no hooks behave exactly as before.
+`workflows/claude-implement.yml` and `claude-plan.yml` are synced to target repos; `WORKFLOW.md` and `PLANNING.md` are **seeded once and never overwritten**, so every repo keeps whatever template it was created with. Sync also *removes* `comment-trigger.yml`, since the orchestrator webhook now handles `/ai-implement` for envelope repos.
 
-### Operational prerequisites (webhook-based /ai-implement)
+That seed-once rule has a consequence worth internalising: **a template correction never reaches an existing repo.** Fixing a bug in `workflows/WORKFLOW.md` fixes it for repos onboarded afterward and for nobody else.
 
-The orchestrator handles `/ai-implement` PR comments directly via `POST /api/github/webhook`. Three prerequisites must be met before comment-triggered gap-fill runs work for a repo:
+Non-obvious behaviour:
 
-- **GitHub App subscribed to `issue_comment`** — add `issue_comment` to the App's webhook event subscriptions (GitHub App settings). Without this, comment events are never delivered.
-- **`GITHUB_WEBHOOK_SECRET` set** — the orchestrator verifies HMAC-SHA256 signatures on every delivery; set the same secret value in both the App webhook configuration and the orchestrator's environment. Deliveries with an invalid or missing signature are rejected 401.
-- **Orchestrator publicly reachable** — Fly deployments expose a public HTTPS endpoint by default. For local development, a tunnel is required (see [AII-115](https://linear.app/eudoxus/issue/AII-115)); the orchestrator must be reachable from GitHub's webhook IPs.
-- **Envelope-generation target repo** — only repos whose `claude-implement.yml` has a `run_config:` input receive orchestrator-dispatched gap-fill runs. Legacy repos are silently ignored; they still use `comment-trigger.yml` if present.
+- **Model IDs pass through verbatim**, and nothing validates them against the provider. A Bedrock mapping with an Anthropic-style `model:` fails at Claude invocation time rather than at dispatch. Per-phase model selection lives in `.ai-implement/config.yml`, not front matter.
+- **Prompt assembly** — the runner uses `WORKFLOW.md`'s body with front matter and HTML comments stripped and `${UPPER_SNAKE}` substituted, then appends its own blocks. Any *unrecognised* `${TOKEN}` becomes an empty string, so a shell example containing one is silently blanked. Never put `${PLANNING_CONTEXT}` in the body: it is substituted *and* appended, emitting the block twice.
+- **The pipeline owns git on initial runs** — branch, commit, push, PR. On gap-fill runs the push step is skipped and the agent commits and pushes itself. A template must handle both, keyed on `${PR_NUMBER}`.
+- **Unapproved runs still ship** as a draft PR carrying the reviewer's final feedback and per-pass stats, reported as a coded failure (`REVIEW_UNAPPROVED` / `MAX_TURNS_EXHAUSTED`) so the ticket updates and notifications fire, while the GHA job stays green with a `::warning::`. If the repo plan rejects draft PRs (422), it opens normally prefixed `[NEEDS REVIEW — unapproved]`.
+- **Hooks work in every execution mode.** `setup` / `verify` / `teardown` front-matter paths run around the implement loop — setup failure aborts early, teardown always runs. All three modes enter through `session/entrypoint.sh`, which populates the workspace before the runner starts.
+- **Planning writes files, it does not post.** A planning run writes `ai-output/comments/NN-*.md`; the orchestrator posts them to the ticket. Runner-written files are collected in lexicographic order — avoid the `90-` prefix, which the run autopsy uses.
 
-### Workflow envelope (run_config)
+`/ai-implement` comment handling requires the App subscribed to `issue_comment`, `GITHUB_WEBHOOK_SECRET` set on both sides, a publicly reachable orchestrator, and an envelope-generation target repo. Legacy repos are silently ignored.
 
-`claude-implement.yml` exposes 7 top-level `workflow_dispatch` inputs. All issue fields, caps, branchPrefix, skillsRepo, sensitiveFiles, profiles, and planningContext ride inside the single `run_config` JSON blob (base64-encoded `RunConfigV1`); the remaining six inputs stay top-level because the workflow must `::add-mask::` or evaluate them before unpacking the envelope.
+## Per-project settings (admin UI)
 
-| Input | Required | Notes |
-|-------|----------|-------|
-| `run_config` | Yes | Base64-encoded `RunConfigV1` JSON envelope |
-| `runner_image` | No | Container image override (allowlist-validated) |
-| `job_timeout_minutes` | No | GHA job timeout in minutes (empty = 90) |
-| `provider` | No | `anthropic` (default) or `bedrock` |
-| `aws_region` | No | Required when `provider=bedrock` |
-| `run_token` | No | HMAC bearer token for result callback; empty skips callback |
-| `run_progress_token` | No | HMAC bearer token for progress callbacks |
+Editable per mapping; blank means the default.
 
-**`RunConfigV1` schema** — fields carried inside the envelope:
+| Field | Default | Notes |
+|---|---|---|
+| Max Turns | `50` | Claude turns per implement pass |
+| Max Iterations | bedrock `2`, anthropic `3` | implement/review cycles |
+| Job Timeout (min) | `90` | GHA only |
+| Branch Prefix | none | Path segment prepended to the implementation branch |
+| Sensitive Add / Allow Globs | none | Extends or un-blocks the push step's blocklist; **allow always wins** |
+| Dependency Token Scope | off | `installation` lets the run read private sibling repos during dependency install |
 
-| Field | Type | Notes |
-|-------|------|-------|
-| `v` | `1` | Version discriminant (must be 1) |
-| `issue` | `{ id, identifier, title, description }` | Required; description capped at 40,000 chars |
-| `prNumber` | string? | PR number for gap-fill or review passes |
-| `baseBranch` | string? | Feature-branch parent or repo default |
-| `runnerPhase` | `"implementation" \| "gap-analysis" \| "planning"` | Dispatch phase |
-| `branchPrefix` | string? | Optional path-segment prefix for the implementation branch |
-| `skillsRepo` | string? | Owner/repo or git URL for per-project skills |
-| `runnerCallbackUrl` | string? | Orchestrator callback URL for result posts |
-| `maxTurns` | number? | Claude turn cap |
-| `maxIterations` | number? | Implement/review cycle cap |
-| `commentInstruction` | string? | Operator instruction from `/ai-implement` comment |
-| `sensitiveFiles` | `{ add?: string[], allow?: string[] }` | Envelope-only guardrail config |
-| `profiles` | string[]? | Jira AI-Implement Profiles values |
-| `planningContext` | `{ parent?, siblings?, dependencies? }` | Planning context for child issues |
+Caps apply to re-dispatches, not just initial runs. Branch prefix affects only the initial run — gap-fill commits to the existing PR branch. Sensitive-file globs travel **exclusively** in the envelope, so a repo must be on envelope generation before setting them.
 
-**Dual-mode probe** — before every dispatch the orchestrator fetches the target repo's `claude-implement.yml` from the default branch and checks for a `run_config:` input declaration. If found, it uses the 7-input envelope contract; if not (or on any fetch error), it falls back to legacy per-field inputs. The probe result is cached per repo/workflow for 5 minutes (`CACHE_TTL_MS = 300_000`).
+On **legacy** repos only — those still carrying `comment-trigger.yml` — the repo variables `AI_IMPLEMENT_MAX_TURNS`, `AI_IMPLEMENT_MAX_ITERATIONS`, `AI_IMPLEMENT_MAX_JOB_MINUTES`, and `AI_IMPLEMENT_SKILLS_REPO` still cap comment-triggered gap-fill runs. They are deprecated and unnecessary once a repo is on envelope generation, where the mapping's own values ride the envelope instead.
 
-**Migration (re-sync once, then never again)** — a target repo migrates from the legacy contract to the envelope by running **Sync workflows** once. After the sync PR merges, all subsequent dispatches use the 7-input envelope automatically. No orchestrator restart or config change is needed.
+**Jira profiles** ride `run_config.profiles`, read from a multi-select custom field that must be named exactly `AI-Implement Profiles` unless `profilesFieldOverride` pins its ID. Option names must not contain commas — the contract is a comma-joined list. **No built-in step consumes profiles**; they exist as the contract surface for image-baked `custom/` steps.
 
-For the existing per-feature "must re-sync first" caveats: **legacy repos** continue to receive caps, branchPrefix, skillsRepo, and profiles as individual dispatch inputs (unchanged behavior); **envelope repos** carry all of these inside `run_config` and never see them as separate inputs.
+**Dependency Token Scope** runs on a deliberate two-token split. The **primary** token carries the App's full grants but is scoped to the target repository alone; the **dependency** token is installation-wide but strictly `contents: read`. The `dependency-auth` step fetches the second from `POST /api/runner/dependency-token`, installs it as a git credential helper for `github.com` and as `COMPOSER_AUTH`, and the helper re-mints it when under ten minutes remain. So the implementer can read sibling repos it needs and can never push to them.
 
-### Per-project run caps (admin UI)
+Two things to know before enabling it. The scope is **all-or-nothing** — the token reads every repository the App installation covers, not a chosen subset (a per-project list is a planned v2; the field is stored as text so a JSON array slots in without a migration). And it needs a **publicly reachable orchestrator**, since the token is fetched over the runner callback; runs dispatched without a progress token skip the fetch and proceed without private-dependency access rather than failing.
 
-Each project's mapping carries three optional caps, editable in the `/admin` Projects edit dialog (blank = use the default):
+> **Behaviour change for existing Fly deployments.** The Fly-mode `/api/token` endpoint used to mint a full-installation token. It now narrows the primary token to the target repository, matching the GHA path. A deployment that incidentally relied on org-wide primary-token access to read private sibling repos must set this field to restore it.
 
-| Field | Default when blank | Applies to |
-|-------|--------------------|------------|
-| **Max Turns** | `50` | Claude turns per implement pass (both providers) |
-| **Max Iterations** | bedrock `2`, anthropic `3` | implement/review cycles in the feedback loop |
-| **Job Timeout (min)** | `90` | GitHub Actions job `timeout-minutes` (GHA mode only) |
+## Per-repo configuration (`.ai-implement/config.yml`)
 
-`maxTurns`/`maxIterations` ride in `run_config` for envelope repos, or reach the runner as individual `workflow_dispatch` inputs for legacy repos (GHA) / runner env (Fly/local). `maxJobMinutes` is always a separate GHA `job_timeout_minutes` dispatch input. Caps apply to gap-fill and review-feedback re-dispatches, not just the initial run. For envelope repos, `/ai-implement` webhook-triggered gap-fill runs go through the orchestrator and inherit the same mapping caps automatically.
+Optional, in the target repo. Parsed with a real YAML parser; a missing file, malformed YAML, or an unexpected shape all resolve silently to "no config", so a typo disables a key rather than failing the run.
 
-> **Deprecated (legacy repos only):** `AI_IMPLEMENT_MAX_TURNS`, `AI_IMPLEMENT_MAX_ITERATIONS`, `AI_IMPLEMENT_MAX_JOB_MINUTES` — repo variables read by `comment-trigger.yml` to cap comment-triggered gap-fill runs on legacy-generation repos. Still honored where `comment-trigger.yml` is present. Not needed for envelope repos.
->
-> **Deprecated (legacy repos only):** `AI_IMPLEMENT_SKILLS_REPO` — repo variable that mirrored the per-project skills field for legacy `comment-trigger.yml` runs. Skills repo rides `run_config.skillsRepo` for envelope repos.
+| Key | Effect |
+|---|---|
+| `packageManager` | Overrides the install step's lockfile detection |
+| `models.implement` / `models.review` | Per-phase models |
+| `reviewProviders` | External review sources; `github-claude-code-review` is the only recognised value |
 
-### Per-project branch prefix (admin UI)
+**This is where per-phase model selection lives.** Both keys take precedence over `WORKFLOW.md`'s `model:` — the chain is `config.yml` → front matter → built-in default. Pairing a strong implement model with a cheap review model is the supported way to hold down review cost.
 
-Each project's mapping carries an optional **Branch Prefix** (blank = none, the default). When set, it is prepended as a path segment to the implementation branch name: with prefix `pr`, a branch that would be `ai-implement/PROJ-123-add-login` becomes `pr/ai-implement/PROJ-123-add-login`. Each `/`-separated segment of the prefix must start with a letter or digit and may otherwise contain only letters, digits, `.`, `_`, `-` (no `..` or `//`, ≤ 64 chars); the admin API rejects anything else.
+`reviewProviders` is **enabled when absent**. Two shapes disable collection quietly: an explicit empty list, and a list whose entries are all unrecognised (unknown names are filtered out, leaving empty).
 
-The prefix only affects the **initial orchestrator-driven run** — `/ai-implement` webhook-triggered gap-fill runs commit to the existing PR branch and are unaffected. For envelope repos, the prefix rides `run_config.branchPrefix`; for legacy repos, it is sent as a separate `branch_prefix` dispatch input (only when set — a legacy repo must have re-synced `claude-implement.yml` before setting a prefix, or GitHub rejects the dispatch with "unexpected inputs").
-
-### Jira: AI-Implement Profiles field (multi-select)
-
-When using the Jira provider, the orchestrator reads a multi-select custom field to populate `TicketIssue.profiles` on each dispatched issue. The field is discovered by name at runtime — **it must be named exactly `AI-Implement Profiles`** in your Jira instance for auto-discovery to work. If the field is absent the orchestrator logs a warning and continues without populating profiles (it does not fail).
-
-If the field exists under a different name, or if multiple fields share the same name, set `profilesFieldOverride` to the explicit `customfield_NNNNN` ID — via the **Profiles Field** dropdown in the `/admin` Projects edit dialog or the add-project wizard's Jira step, or directly on the mapping's `ticketingConfig` through the API. When all three overrides (`statusFieldOverride`, `repoFieldOverride`, `profilesFieldOverride`) are set, the orchestrator skips the `listFields` call entirely.
-
-At implementation-dispatch time the orchestrator embeds the issue's profiles (comma-joined) in `run_config.profiles` for envelope repos, or as a `profiles` workflow_dispatch input for legacy repos (only sent when non-empty; a legacy repo must have re-synced before setting profiles, or GitHub rejects the dispatch). Profile option names must not contain commas — the forwarding contract is a comma-joined list. The runner parses the value into `ctx.data.profiles`; **no built-in pipeline step consumes it** — it is the contract surface for image-baked `custom/` steps which branch their setup on the selected profiles. Profiles are per-issue: `/ai-implement` webhook-triggered gap-fill runs and review-feedback re-dispatches run without profiles (the initial profile-aware run already produced the PR they amend).
-
-### Runner log verbosity
-
-`AI_IMPLEMENT_LOG_LEVEL` controls how much the runner logs during an implement pass:
-- `summary` (default): logs a single result line per Claude invocation — outcome (incl. `max_turns`), turns, duration, cost (when reported), tokens.
-- `stream`: additionally tees each per-turn tool call (name + truncated input; not tool output) to the log.
-
-Set it as a repository or organization **variable** (Settings → Secrets and variables → Actions → Variables), mirroring `AI_IMPLEMENT_PROVIDER`. It is read inside the runner container, so it applies to both orchestrator-initiated and `/ai-implement` comment-triggered runs **after the target repo has re-synced `claude-implement.yml`**. It is not a per-project admin field and not a dispatch input.
-
-### Runner label (GHA mode)
-
-`AI_IMPLEMENT_RUNNER_LABEL` overrides the `runs-on` label for the `implement` job, defaulting to `ubuntu-latest`. Default GitHub-hosted runners are 2 vCPU; the test suites Claude runs during implement (and the verify-hook gauntlet) are CPU-bound and scale ~linearly with cores, so pointing this at a larger-runner label (e.g. `ubuntu-latest-4-cores`) roughly halves the implement job's wall-clock.
-
-Set it as a repository or organization **variable** (Settings → Secrets and variables → Actions → Variables), like `AI_IMPLEMENT_LOG_LEVEL`. It only affects the GitHub Actions execution mode and only after the target repo has re-synced `claude-implement.yml`. It takes a single label string, not a label array. Granting write access to this variable lets the holder retarget the job to an arbitrary (e.g. self-hosted) runner that would see the job's secrets — the same threat model as any org-variable-controlled `runs-on`.
-
-### Sensitive files (admin UI)
-
-Each project's mapping carries two optional glob-list fields, editable in the `/admin` Projects edit dialog:
-
-| Field | Effect |
-|-------|--------|
-| **Sensitive Add Globs** | Extends the built-in sensitive-file blocklist with additional picomatch glob patterns. Files matching these patterns cause the push step to abort with a `SENSITIVE_FILES_BLOCKED` error. |
-| **Sensitive Allow Globs** | Explicitly un-blocks files that would otherwise match. Allow wins over both the built-in list and any Add glob — if a file matches an allow glob, the push step never blocks it regardless of other patterns. |
-
-These globs are delivered **exclusively via the `run_config` envelope** (`sensitiveFiles.add` / `sensitiveFiles.allow`). They are not sent as legacy dispatch inputs. A project using sensitive file globs must therefore have re-synced `claude-implement.yml` to envelope generation before setting these fields.
-
-### Dependency repo access (admin UI)
-
-Each project's mapping carries an optional **Dependency Token Scope** field, editable in the `/admin` Projects edit dialog. When set to **All repos the App can access**, the runner fetches a second, read-only token before the dependency-install phase — allowing it to clone or install from private sibling repositories that the GitHub App installation covers (e.g. private Composer packages, npm packages from a private org, core-service checkouts).
-
-#### Two-token model
-
-| Token | Scope | Permissions | Source |
-|-------|-------|-------------|--------|
-| **Primary** | Target repo only | Full App grants (contents write, PRs, …) | GHA `create-github-app-token` / Fly-mode `/api/token` endpoint |
-| **Dependency** | All repos the App installation can see | `contents: read` | Runner step via `POST /api/runner/dependency-token` |
-
-The runner never broadens the primary token — the implementer's write access stays scoped to the target repo at all times. The dependency token is injected as:
-- A git HTTPS credential helper (`git config credential.https://github.com.helper …`) covering all `github.com` HTTPS clones.
-- `COMPOSER_AUTH` environment variable for PHP Composer installs.
-
-The credential helper auto-refreshes the token when fewer than 10 minutes remain on its expiry, so long dependency installs do not fail mid-build.
-
-#### Prerequisites
-
-- A **publicly reachable orchestrator** (`RUNNER_CALLBACK_BASE_URL` + `RUNNER_TOKEN_SECRET`). This is the same requirement as planning auto-advance and the feature-branch cascade. Runs dispatched without progress tokens skip the dependency token fetch gracefully and proceed without private-dependency access.
-- An **App installation** that already covers the sibling repos. The dependency token grants access to exactly the repositories the App installation can already see — no additional GitHub permissions are required.
-
-#### Security trade-off
-
-`installation` scope is all-or-nothing: the token can read every repository the GitHub App installation covers, not just an explicit subset. This is the v1 behavior; per-project explicit repo lists are a planned v2 addition (`dependencyTokenScope` is stored as text so a JSON array slots in with no schema migration). The token is strictly read-only (`contents: read`) and separate from the write-capable primary token, so the implementer can never push to sibling repos.
-
-#### Fly/local primary-token narrowing (behaviour change)
-
-Previously, the Fly-mode `/api/token` endpoint minted a full-installation token (every repository the App can see, with all App permissions). It now narrows the primary token to the **target repository only** — consistent with the GHA primary token minted by `create-github-app-token`. **Existing Fly deployments that incidentally relied on org-wide primary-token access to read private sibling repos must enable "All repos the App can access" in the project's Dependency Token Scope field to restore that access.**
-
-`workflows/claude-plan.yml` is the planning workflow synced to target repos. It runs read-only codebase analysis and posts structured planning comments to Linear when dispatched. It supports:
-- **PLANNING.md** — per-repo Claude prompt template; front matter carries `model:` (same rules as WORKFLOW.md)
-
-The Projects page **Sync workflows** action syncs `claude-implement.yml` (envelope generation) and `claude-plan.yml` into the target repo, and **removes** `comment-trigger.yml` from the target repo (the orchestrator webhook now handles `/ai-implement` comments for envelope repos). It seeds `WORKFLOW.md` and `PLANNING.md` once and never overwrites them. The `custom/` directory is an AI-Implement fork-local extension point; workflow sync never creates or modifies it in a target repository. `.github/workflows/sync-workflow.yml` remains as a manual fallback, but normal distribution should happen from the orchestrator.
-
-### Model IDs are passed through verbatim
-
-Neither workflow validates model IDs — whatever `model:` says in front matter goes directly to `claude-code --model`. This lets new Anthropic releases and Bedrock IDs (`anthropic.<name>-<date>-v1:0` or inference-profile ARNs) flow without a workflow template edit. Typos fail fast at Claude invocation time with a clear error. The seed `WORKFLOW.md` / `PLANNING.md` ship with `model: claude-sonnet-4-6`, so fresh target repos work out of the box on the Anthropic provider.
-
-### Using AWS Bedrock
-
-To run a target repo against AWS Bedrock instead of the Anthropic API, use the GitHub Actions execution mode. Bedrock is not supported on Fly Machines or local Docker because those backends do not have a role-assumption mechanism equivalent to GitHub OIDC.
-
-1. **In the orchestrator admin UI (`/admin`)**, edit the repo's mapping:
-   - Set **Provider** to `bedrock`
-   - Set **AWS Region** to the region that hosts your Bedrock inference profile (e.g. `us-west-2`)
-2. **In the target repo**, add a repository secret:
-   - `AWS_BEDROCK_ROLE_ARN` — an IAM role ARN that trusts the GitHub OIDC provider for this repo and grants `bedrock:InvokeModel` on the inference profiles you need
-3. **In the target repo**, add two repository *variables* (Settings → Secrets and variables → Actions → Variables) so `/ai-implement` comment-triggered gap-fill runs route to the same provider as the orchestrator-initiated runs:
-   - `AI_IMPLEMENT_PROVIDER` = `bedrock`
-   - `AI_IMPLEMENT_AWS_REGION` = the same region used in the admin UI mapping
-4. **In the target repo's `WORKFLOW.md` (and `PLANNING.md` if planning is enabled)**, change `model:` from the Anthropic default (`claude-sonnet-4-6`) to a Bedrock model ID or inference-profile ARN. There is no safe default for Bedrock — the workflow will hard-fail if `model:` isn't set when `provider=bedrock`.
-
-IAM trust policy shape (use the `sub` condition to restrict to this specific repo):
-
-```json
-{
-  "Effect": "Allow",
-  "Principal": { "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com" },
-  "Action": "sts:AssumeRoleWithWebIdentity",
-  "Condition": {
-    "StringEquals": { "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" },
-    "StringLike":   { "token.actions.githubusercontent.com:sub": "repo:<owner>/<repo>:*" }
-  }
-}
-```
-
-The workflow runs `aws-actions/configure-aws-credentials` once before the containerized runner step with a 4-hour session duration, covering implementation and gap-analysis runs. Only GitHub OIDC is supported — there is no static-key path.
-
-## Feature-branch grouping (parent/child issues)
-
-A Linear **parent issue** tagged `AI-Implement` that has `AI-Implement` children becomes a **feature node**: it owns a long-running branch `ai-implement/feature/<issue-key>` (or `ai-implement/multi-issue/<issue-key>` — selectable via an `ai-implement.yml` block in the parent's description), its labelled children PR **into that branch** (not the repo base), and the tree cascades recursively. A parent's own work is deferred until its children finish, then runs onto its own branch; completed feature branches **roll up** into their parent automatically (internal levels via a direct merge, the top of the tree as a human-reviewed `feature → base` PR).
-
-Key labels: `AI-Implement` (trigger) → `AI-Planning` (planning in flight) → `Plan-Complete` (ready to implement) → `AI-Working` (implementing) → `Ready for Review` (PR open); the orchestrator moves the issue to Done when the PR merges (via poll detector and optional webhook; this complements any native Linear/Jira GitHub integration). A parent labelled before its children is left alone until a child is labelled (race guard).
-
-Parts: classification + roll-up discovery in `src/providers/linear.ts`; `TicketIssue.featureBranchChain` / `FeatureNodeRollUp` in `src/providers/types.ts`; per-issue config (`ai-implement.yml` mode selector) in `src/issue-config.ts`; cascade branch creation in `src/feature-branch.ts` (`resolveBaseBranch`); roll-up in `src/merge-up.ts`; GitHub helpers in `src/github.ts`; `Plan-Complete` via `src/runner-callback.ts`; wired into the poll loop in `src/index.ts`. Jira support lives in `src/providers/jira.ts` + `src/providers/jira-hierarchy.ts` (native parent with classic Epic Link fallback; roll-up completion = native Done **or** AI-Implement Status `Merged`). **Full reference: [docs/feature-branch-grouping.md](docs/feature-branch-grouping.md).**
-
-Operational requirements: re-sync `claude-implement.yml` to the target repo (for the `base_branch` input); a **publicly reachable** runner callback (`RUNNER_CALLBACK_BASE_URL` + `RUNNER_TOKEN_SECRET`) so planning auto-advances and the cascade self-drives; and pair the runner image with the orchestrator channel (testing → `SESSION_IMAGE=…:next`).
-
-**Conflict recovery:** When a child PR lands dirty (merge conflicts) on its grouping branch, the cascade self-heals automatically. The orchestrator re-queues the issue through the comment-gapfill rail (a synthetic negative-`comment_id` entry, capped at 2 attempts per issue via queue accounting). On exhaustion it logs, fires the `notify` hook, and leaves the PR for a human. The conflict-classification seam is `classifyStalledChild` — it already classifies `conflict`/`blocked` merge results as recoverable conflicts; AII-263 will later extend the seam with additional stall kinds (max_turns / draft-PR stalls).
-
-**Roll-up hold:** A grouping parent whose top-of-tree roll-up PR is open is held from dispatch (dedup untouched) until that PR merges or closes — re-dispatching such parents produced junk closing PRs / pr_not_found churn loops. Upstream of the hold, a grouping parent's closing run that exits cleanly with **no changes** is finalized (`markMerged` → merge-up opens the roll-up PR) rather than classified `pr_not_found` — the monitors mirror the runner-callback `noWork` path via the job's `grouping_parent` flag. Non-parent jobs that exit cleanly without a visible PR get a bounded grace re-check before `pr_not_found` is declared.
-
-**Dispatch guard:** Before dispatching a same-feature-node sibling, the orchestrator checks whether its declared `Files:` paths (from the issue description) overlap with a currently in-flight sibling's paths; if they do, dispatch is deferred until the in-flight sibling completes. The check fails open — if path data is unavailable or the check errors, the sibling dispatches normally.
-
-### Issue completion on PR merge
-
-When an AI-Implement PR merges, the orchestrator moves the tracker issue to a completed state (Linear: the team's `Done` state, else the first completed-type state; Jira: the AI-Implement status field value `Merged`) and clears the `Ready for Review` label. This runs even for paused projects.
-
-Two paths feed the same `reconciliation_queue` → `markMerged` worker:
-
-- **Poll detector (guaranteed):** every tick the orchestrator checks recent dispatches whose PR is not yet reconciled and asks GitHub whether the PR merged. This requires no webhook configuration.
-- **Webhook (optimization):** a `pull_request` `closed`+`merged` delivery to `POST /api/github/webhook` enqueues the same reconciliation immediately, reducing merge→Done latency. If the webhook is unconfigured or a delivery is dropped, the poll detector still completes the issue within one tick.
-
-Jira target repos must add a `Merged` option to their AI-Implement status field.
+The two `.ai-implement/` files read from different refs: `image.yml` from the **default branch**, so a PR cannot pick its own runner image; `config.yml` from the **checked-out workspace**, which on a gap-fill run is the PR head.
 
 ## Custom extensions
 
-Client forks can override built-in behaviour without touching upstream code by placing files under `custom/`. A file at `custom/<path>` takes precedence over the corresponding built-in.
+A file at `custom/<path>` overrides the corresponding built-in. Resolution searches the workspace root, then `AI_IMPLEMENT_CUSTOM_ROOT`, then the package root — see [docs/pipeline-architecture.md](docs/pipeline-architecture.md) for the mechanics and the step contract.
 
-Resolution is handled by two functions in `src/pipeline/resolve-module.ts`:
+Built-in step keys, in pipeline order: `clone`, `install-skills`, `dependency-auth`, `install`, `setup`, `feedback-loop`, `preflight`, `push`, `verify`, `post-push-review`.
 
-| Function | Use case | Return value |
-|----------|----------|--------------|
-| `resolveModule(path)` | YAML and template files | Absolute filesystem path |
-| `resolveModuleImport<T>(path)` | TypeScript/JavaScript modules | `default` export, or `null` if no override |
+- `custom/` belongs to an AI-Implement **fork**, not a target repo; sync never creates it there.
+- **Place client-specific behaviour in `custom/`** rather than editing built-in modules — that is what keeps a fork rebasing cleanly.
+- A `custom/` file with no `default` export warns and falls back to the built-in rather than misbehaving silently.
+- `protect-custom.yml` flags upstream PRs touching `custom/`, but is **advisory only** — it emits a `::warning::`, never fails, and only runs on PRs targeting `main`, so PRs into `testing` never trigger it.
 
-Both functions search two custom roots in order, then fall back to the built-in package root. There is no per-type discovery logic — the same two functions cover all extension points.
+## Feature-branch grouping
 
-1. **Workspace root** — `custom/<path>` relative to `process.cwd()`. This is how orchestrator-side loading picks up a fork's `custom/` (the orchestrator runs with cwd = app root).
-2. **Baked root** — `<AI_IMPLEMENT_CUSTOM_ROOT>/custom/<path>`, where the `AI_IMPLEMENT_CUSTOM_ROOT` env var names a directory that *contains* a `custom/` subdirectory. This is how the session runner picks up overrides: its cwd is `/workspace` (the target-repo clone dir, empty at process start), so the workspace root never matches there. `Dockerfile.session` copies the repo's `custom/` to `/app/custom/` and sets `AI_IMPLEMENT_CUSTOM_ROOT=/app`, so a client fork that builds its own runner image gets its `custom/pipelines/` and `custom/steps/` honored inside the runner — including the import-time load of `pipelines/autonomous.yml` and the eager step resolution in `createDefaultRunner()`, both of which happen before the clone step runs. With the env var unset (local dev, tests) resolution behaves exactly as before.
+A parent issue labelled `AI-Implement` with labelled children becomes a **feature node**: it owns `ai-implement/feature/<key>`, its children PR into that branch rather than the repo base, and the tree cascades recursively. Internal roll-ups merge directly; only the top-of-tree `feature → base` is a human-reviewed PR. A parent labelled before its children is left alone until a child is labelled.
 
-### Extension points
+Labels: `AI-Implement` → `AI-Planning` → `Plan-Complete` → `AI-Working` → `Ready for Review`, then Done on merge.
 
-**`custom/pipelines/`** — Override a pipeline YAML definition. Example: place `custom/pipelines/autonomous.yml` to replace the built-in autonomous loop.
+The cascade **self-advances** and self-heals: a child PR landing dirty is re-queued through the comment-gapfill rail (capped at 2 attempts), a parent with an open roll-up PR is held from dispatch, and siblings whose declared `Files:` overlap an in-flight sibling are deferred (failing open). Requires a publicly reachable runner callback, and the runner image channel paired to the orchestrator's.
 
-**`custom/steps/`** — Override a built-in step module. A file `custom/steps/<id>.ts` replaces the step registered under that key. It must export a `StepModule` as its default export. Built-in step keys: `clone`, `install`, `feedback-loop`, `preflight`, `push`.
+**Full reference: [docs/feature-branch-grouping.md](docs/feature-branch-grouping.md).**
 
-**`custom/providers/`** — Reserved for provider overrides (TicketingProvider interface). Provider loading will call `resolveModuleImport("providers/<id>")`.
+## Issue completion on PR merge
 
-### Rules
+Two paths feed one `reconciliation_queue` → `markMerged` worker: a **poll detector** that needs no configuration and catches everything within a tick, and a **webhook** that merely reduces latency. Completion runs even for paused projects. Jira target repos need a `Merged` option on their AI-Implement status field.
 
-- `custom/` belongs to an AI-Implement fork, not a target repository: workflow sync never creates or overwrites it in target repos.
-- Upstream changes preserve fork-owned files under `custom/`; only `custom/README.md` may be maintained upstream.
-- A CI check (`protect-custom.yml`) rejects upstream PRs that touch other `custom/` files.
-- When implementing client-specific behaviour, **always place new files in `custom/`** rather than modifying built-in modules — this keeps the fork rebasing cleanly on upstream changes.
-- A `custom/` file that exists but has no `default` export produces a warning and falls back to the built-in rather than silently misbehaving.
+## Admin UI and auth
 
-## Runner image resolution
+SSO via OIDC (Google, Microsoft) with a deprecated `ADMIN_ACCESS_CODE` fallback; the UI 503s when neither is configured. **Authorization and session identity key on different claims, and it is easy to state this backwards:** authorization is a fail-closed allowlist matched against the verified *email*, while the session stores the provider's stable `sub`, because email is mutable.
 
-Both execution modes resolve the runner image with the same ladder, highest priority first:
+The SPA at `/admin` is composed from string-exporting modules under `src/admin-ui/` with **no client-side build step** — all client JS is concatenated into one inline `<script>` at module load. Each `pages/<name>.ts` exports `<name>Html` and `<name>Script`; the script is an IIFE ending in `window.registerPage('<route>', …)`, and page scripts call `window.api()` / `window.esc()` rather than bare globals. Adding a page means the module, both strings in `index.ts`, and a route in `sidebar.ts`.
 
-1. **`.ai-implement/image.yml`** at the target repo's default branch — per-repo override:
+Six routes (`channels`, `policies`, `secrets`, `mcp`, `webhooks`, `updates`) are still "Coming soon" stubs in `pages/stubs.ts`.
 
-   ```yaml
-   image: ghcr.io/your-org/your-runner:v1
-   ```
+## Backend outage playbook
 
-   In `fly-machines` mode the orchestrator reads it via the GitHub contents API (`src/repo-image.ts`); in `github-actions` mode `claude-implement.yml` reads it with `gh api` from the **default branch only** (never a PR head, so a PR can't choose its own privileged image).
+The global **runner mode** is the failover lever: `/admin#runners` or `POST /api/runner-mode` with `fly` forces Fly Machines, `gha` forces GitHub Actions, `default` restores per-project modes. In-flight runs keep their monitors; only new dispatches reroute.
 
-2. **`AI_IMPLEMENT_RUNNER_IMAGE`** — the operator/org default. A GitHub repo/org **variable** in `github-actions` mode (org-level applies to every repo); an orchestrator **env var** in `fly-machines` mode. `SESSION_IMAGE` is the deprecated former name of the env var — still honored, but the orchestrator logs a deprecation warning at startup.
+Ineligible mappings are **skipped at dispatch** — `provider=bedrock` is GHA-only, and Fly needs a sessions app — staying queued with dedup untouched and appearing in the Runners banner and `GET /api/runner-mode`. Flip back to `default` afterward; skipped issues dispatch on the next poll.
 
-3. **Upstream fallback** — `ghcr.io/builddownai/ai-implement-runner:latest` (orchestrator / comment-trigger) or `:next` (claude-implement). In `github-actions` mode a manual `runner_image` dispatch input overrides everything for that one run.
+## Notifications
 
-The `github-actions` allowlist auto-trusts `ghcr.io/builddownai/` and the repo owner's own `ghcr.io/<owner>/` namespace, so a fork using its own published image needs no extra config; `AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES` is only for third-party registries. The `fly-machines` path validates image-reference format but has no allowlist.
+`src/notify.ts` exports one function per notification shape — `notify`, `notifyCompletion`, `notifyDeploy`, `notifyStuckGiveUp`, `notifyReaperBurst` — each taking `(type, webhookUrl, payload)` and switching on `NOTIFY_TYPE` to a private per-provider implementation; any unrecognised value falls through to Slack. A sixth export, `notifyText`, deliberately skips the switch for cases with no issue context. Adding a provider means a private function per shape plus a case in each switch.
 
-The image should be publicly pullable for the broadest compatibility (a private image restricts you to the GitHub Actions execution mode — see "Private runner images" below). The customer owns building and publishing it. If `.ai-implement/image.yml` is absent, malformed, or points at an unreachable reference, resolution falls through to the next ladder rung.
-
-This resolution applies to **both** execution modes. On the Fly Machines path the orchestrator boots the session machine on the resolved image directly. On the GitHub Actions path the orchestrator forwards the resolved image as the `runner_image` workflow_dispatch input to `claude-implement.yml` (which runs it as the job's `container.image`) — but only when the choice is explicit: a per-repo `.ai-implement/image.yml` override, or an explicitly-set `SESSION_IMAGE`. When neither is set the orchestrator sends no `runner_image`, so the workflow keeps its own resolution order (the `AI_IMPLEMENT_RUNNER_IMAGE` repo/org variable, then its built-in `:latest` default) and repos that pin via that variable are not overridden.
-
-Planning runs (`claude-plan.yml`) now run on the same runner container and honor the **same** resolution: the orchestrator forwards the resolved image as the `runner_image` workflow_dispatch input to `claude-plan.yml` under the identical "only when explicit" rule, so a testing orchestrator pinned to `:next` steers planning to `:next` and a per-repo `.ai-implement/image.yml` pin is honored for planning too. (Unlike `claude-implement.yml`, `claude-plan.yml`'s own validate step does not read `image.yml`, so orchestrator-forwarding is the only path by which GHA planning picks up either — and a target repo must have **re-synced `claude-plan.yml`** before the orchestrator will forward `runner_image` to it, otherwise GitHub rejects the dispatch with "unexpected inputs", the same caveat as the run-caps and branch-prefix inputs.)
-
-The default runner image itself must also be public on GHCR — Fly pulls anonymously, so a private package surfaces as `failed to get manifest ... unauthorized` at machine-create time. New GHCR packages default to Private and the org must allow public container packages first (Org Settings → Packages). See the comment at the top of `.github/workflows/build-runner.yml`.
-
-### Private runner images
-
-A private GHCR runner image is only usable in the **GitHub Actions execution mode**. The Fly Machines and local Docker backends pull the image anonymously (no credential mechanism), so a private image fails at machine-create time with `failed to get manifest ... unauthorized`. There is no workaround on those backends — choosing a private image is effectively choosing GHA mode.
-
-On the GitHub Actions path, `claude-implement.yml` and `claude-plan.yml` authenticate the container pull with the job's `GITHUB_TOKEN`: each requests `packages: read` and passes the token through the container `credentials:` block. A bare `packages: read` is **not** enough on its own — GitHub Actions does not auto-authenticate a job-container image pull, so the `credentials:` block is what actually performs the authenticated pull.
-
-`GITHUB_TOKEN` can only read private packages owned by the **same org/account as the target repo**. So a private runner image must live in the target repo's own org — the realistic case is a customer pinning their own private image via `.ai-implement/image.yml` (the GHA allowlist auto-trusts the owner's `ghcr.io/<owner>/` namespace, so no extra prefix variable is needed) and linking that GHCR package to the repo. The default `ghcr.io/builddownai/ai-implement-runner` image stays public precisely because a cross-org `GITHUB_TOKEN` cannot pull it; making it private would break every customer repo. A private image hosted in a *different* org requires swapping a PAT (with `read:packages` on that org) into the workflow's `credentials.password` in place of `GITHUB_TOKEN`.
-
-Runner image channels:
-
-- `.github/workflows/build-runner.yml` publishes the runner image to `ghcr.io/<owner>/ai-implement-runner` (the lowercased owner of the repo it runs in), so a fork's builds land in its own namespace automatically — a namespace the `github-actions` allowlist already trusts. The built-in fallback in the code and synced workflows stays `ghcr.io/builddownai/ai-implement-runner` regardless; a fork that wants its own image used must pin it via `AI_IMPLEMENT_RUNNER_IMAGE` or `.ai-implement/image.yml` rather than editing the fallback.
-- The `:latest` channel is published from `main` and is the stable default for production orchestrators and synced target-repo workflows.
-- The `:next` channel is published from `testing` and is intended for staging/testing orchestrators. Set the orchestrator's runner-image env var to your namespace's `:next` tag (e.g. `AI_IMPLEMENT_RUNNER_IMAGE=ghcr.io/builddownai/ai-implement-runner:next`) to keep that environment paired with the testing runner.
-- Commit SHA tags are pushed first, then the build digest is smoke-tested before any mutable channel is promoted. Use the immutable digest for the strongest rollback pin; the SHA tag is a convenient lookup tag for the same build.
-- Channel-scoped date/debug tags are promoted only after the digest image passes smoke testing. They use `base-<channel>-vYYYYMMDD-<12-char-sha>` (for example, `base-next-v20260526-abc123def456`) so `latest` and `next` builds do not collide and same-day builds do not overwrite each other.
-- Cancelled or failed runs can leave SHA-only images with no channel pointer. That is intentional fail-closed behavior; clean old SHA-only images through GHCR retention/cleanup rather than relying on mutable channel tags for retention.
-
-Typical custom-image use: your repo needs a language runtime or tool that isn't in the base image (e.g. terraform, ruby, go). Build an image `FROM` the channel that matches your orchestrator (`latest` for production, `next` for testing), add your tools, push, and point `image.yml` at it.
-
-## Multi-client deploy
-
-Each client is a separate Fly.io app, defined by a file in `clients/<slug>.toml`. The `deploy-clients.yml` workflow reads these files and deploys each app in a matrix on every push to `main`.
-
-### Onboarding a new client
-
-```bash
-# Guided interactive setup:
-./scripts/provision-client.sh <client-slug>
-
-# Or manually:
-cp clients/example-client.toml clients/<slug>.toml
-# Edit the file, then:
-fly apps create <app_name> --org <org>
-fly volumes create dedup_data --size 1 --region iad --app <app_name>
-fly secrets set LINEAR_CLIENT_ID=... LINEAR_CLIENT_SECRET=... GITHUB_APP_ID=... GITHUB_APP_PRIVATE_KEY=... --app <app_name>
-```
-
-Then commit `clients/<slug>.toml` and push — the workflow deploys all clients automatically using the single `FLY_API_TOKEN` org secret.
-
-### Fly.io commands
-
-```bash
-fly deploy --remote-only --app <app_name>   # manual deploy
-fly secrets set KEY=value --app <app_name>  # set secrets
-fly logs --app <app_name>                   # tail logs
-fly ssh console --app <app_name>            # shell into machine
-```
-
-The Fly volume `dedup_data` is mounted at `/data` for persistent SQLite storage.
+The orchestrator also announces its own deploys, comparing `FLY_IMAGE_REF` against a value in `settings` to distinguish "redeployed" from "restarted". Both notices gate on `FLY_IMAGE_REF`, which exists only inside a Fly Machine, so local runs never post. **A failure classification always reaches the tracker comment** regardless of whether a webhook is configured — the ticket is the highest-visibility surface, and the webhook send is gated separately and best-effort.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,87 +1,49 @@
 ---
-# Claude model used for implementation. Passed through verbatim to
-# `claude-code --model`, so any ID your configured provider accepts is fine.
-# Examples:
-#   Anthropic API / OAuth: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5-20251001
-#   AWS Bedrock:           anthropic.claude-sonnet-4-6-20250805-v1:0
-#                          or an inference-profile ARN (arn:aws:bedrock:...)
-# The default below works for the Anthropic provider. If this repo's mapping
-# is switched to provider=bedrock in the orchestrator admin UI, replace this
-# with a Bedrock model ID — the workflow will hard-fail otherwise, since
-# Bedrock IDs are account- and region-specific and have no safe default.
+# Model for implementation and review passes. Passed to `claude --model`
+# verbatim, so any ID this repo's provider accepts works. This repo's mapping
+# runs on the Anthropic provider; replace with a Bedrock model ID if that changes.
 model: claude-sonnet-4-6
-
-# Optional: model used for the post-PR gap-analysis step. Pass through as above.
-# Default (if omitted): claude-haiku-4-5-20251001 for anthropic, same as `model`
-# above for bedrock (override if you want a cheaper model for gap analysis).
-# gap_analysis_model: claude-haiku-4-5-20251001
 ---
 
 <!--
-  WORKFLOW.md — Claude AI Implementation prompt template
-  =======================================================
-  This file is seeded into your repo by the ai-implement sync workflow.
-  It is YOURS to customise — future syncs will never overwrite it.
+  AI-Implement's OWN implementation prompt, used when the orchestrator dispatches a runner at this repository. The template distributed to target repos is a separate file — workflows/WORKFLOW.md — and edits here do not propagate to it.
 
-  When claude-implement.yml runs, it renders this file as the prompt sent to
-  Claude Code. The YAML front matter block (between the --- lines) is stripped
-  before Claude sees it. The rest of the file is passed through envsubst, which
-  substitutes the following variables:
-
-    ${ISSUE_IDENTIFIER}   Linear identifier, e.g. ENG-42
-    ${ISSUE_TITLE}        Issue title
-    ${ISSUE_DESCRIPTION}  Full issue description (Markdown)
-    ${ISSUE_ID}           Linear UUID (useful if you want Claude to call the Linear API)
-    ${PR_NUMBER}          Set on gap-fill re-runs; empty on first run
-
-  FRONT MATTER (the --- block at the top)
-  ----------------------------------------
-  Stripped before sending to Claude. Supported keys:
-
-    model                Model ID for implementation (see above).
-    gap_analysis_model   Model ID for the post-PR gap-analysis step (see above).
-
-  NEW IMPLEMENTATION vs GAP-FILL RUNS
-  -------------------------------------
-  When ${PR_NUMBER} is empty  → Claude creates a new branch and PR.
-  When ${PR_NUMBER} is set    → Claude pushes gap-fill commits to the existing PR.
-  Both scenarios use this same file. The conditional sections below handle both.
-
-  HOW TO CUSTOMISE THIS FILE
-  ---------------------------
-  1. Fill in the "Repo context" section with your stack, test commands, conventions.
-  2. Adjust the quality checklist to match your standards.
-  3. Add any repo-specific constraints (e.g. "never modify migration files directly").
-  4. Change the model in the front matter if this repo needs more (opus) or less (haiku).
-  5. Remove these HTML comments once you're done — Claude won't see them anyway.
+  The runner strips this front matter and these comments, substitutes ${ISSUE_ID}, ${ISSUE_IDENTIFIER}, ${ISSUE_TITLE}, ${ISSUE_DESCRIPTION} and ${PR_NUMBER}, then sends the rest as the prompt. Any other ${UPPER_SNAKE} token is replaced with an empty string, so don't write shell examples containing one. CLAUDE.md is also loaded automatically on every invocation, so the pointer below is deliberate redundancy: that behaviour is documented but implicit, and an instruction resting on it fails silently if it ever changes. Repo conventions belong in CLAUDE.md, not here.
 -->
 
-Read CLAUDE.md if it exists for repo-specific context and conventions.
+Read `CLAUDE.md` before you begin. It carries this repository's architecture, the conventions that differ from tool defaults, and the pitfalls worth knowing before you touch the pipeline.
 
----
-
-If `${PR_NUMBER}` is set (value: "${PR_NUMBER}"), skip to the **Gap-fill instructions**
-section below and ignore New implementation.
+This run is a **gap-fill** if a pull-request number appears between these quotes: "${PR_NUMBER}". If it is empty, this is a **new implementation**. Follow only the matching section below.
 
 ---
 
 ## New implementation
 
-Create a branch named `${ISSUE_IDENTIFIER}/short-description`, implement the
-feature described in the issue below, then open a pull request with:
+Implement the issue in the current checkout. Do not create or switch branches, and do not commit, push, or open a pull request — leave your changes unstaged and uncommitted. The pipeline makes the commit, pushes an issue-scoped branch, and opens the pull request once the review pass approves the work.
 
-- **Title:** `${ISSUE_IDENTIFIER}: ${ISSUE_TITLE}`
-- **Body:** must include `Fixes ${ISSUE_IDENTIFIER}` so Linear automatically
-  closes the issue when the PR is merged.
+Then write an implementation summary to `ai-output/comments/01-summary.md`. The orchestrator posts that file to the ticket verbatim, and it is the only account of your reasoning the issue ever receives — without it the ticket gets a bare pull-request link and nothing else. Cover what you changed and why, the judgement calls you made and what you rejected, and how you satisfied each acceptance criterion. Do not post to Linear yourself; the orchestrator owns every ticket write.
+
+Anything under `ai-output/` is excluded from commits, so writing there never affects the pull request.
 
 ---
 
-## Gap-fill instructions _(only when PR_NUMBER is set)_
+## Gap-fill instructions
 
-You are adding missing work to existing PR #${PR_NUMBER}.
-**Do NOT create a new branch or PR.** Commit your changes to the current
-branch and push. Review the gap analysis comment on the PR to understand
-what is still missing.
+You are adding missing work to existing pull request #${PR_NUMBER}. Do not create a new branch or pull request. Commit to the branch already checked out and push it yourself — this is the one path where the pipeline does not handle git for you. Read the review feedback on the pull request to see what is outstanding.
+
+Write what you addressed to `ai-output/comments/01-gap-fill-summary.md`.
+
+---
+
+## Working efficiently
+
+Each pass has a turn cap, and exploration is where caps are usually spent.
+
+**Batch independent tool calls into a single message.** Reading three files and grepping for a symbol do not depend on each other — issue them together rather than one per turn. Surveying a change here typically means reading two to four source files plus their tests: one turn batched, five or more sequentially. Only sequence when one call's input genuinely depends on another's output.
+
+**Prefer `Read`, `Grep`, and `Glob` over their shell equivalents.** A `Bash` pipeline ending in `head` or `tail` silently truncates its own output, and absence of a match in truncated output is not evidence of absence — that is how a confident wrong conclusion gets reached. Use `Grep` to locate and `Read` to read the surrounding context.
+
+If you approach the cap before finishing, say what remains rather than quietly narrowing scope.
 
 ---
 
@@ -89,28 +51,36 @@ what is still missing.
 
 **Identifier:** ${ISSUE_IDENTIFIER}
 **Title:** ${ISSUE_TITLE}
-**Description:**
+
 ${ISSUE_DESCRIPTION}
 
 ---
 
-## Repo context
+## Verifying your work
 
-<!-- Customise this section for your repo -->
+Run both before you consider the work finished:
 
-- **Stack:** _e.g. Node.js 20, TypeScript, PostgreSQL, Vitest_
-- **Run tests:** _e.g. `npm test`_
-- **Run linting / formatting:** _e.g. `npm run lint`_
-- **Key conventions:** _e.g. follow patterns in existing files; no new dependencies without good reason_
+```bash
+npm run typecheck   # tsc --noEmit
+npm test            # vitest run
+```
+
+The pipeline runs these again after the review pass, but **only records the result — it does not block the pull request on it.** A failure you don't catch ships anyway, so treat these as yours to pass, not as a safety net.
+
+There is no lint script in this repository. Do not invent one or add a linter.
+
+Two things make a green pair misleading:
+
+- `tsconfig.json` excludes `src/__tests__`, so type errors in a test file are caught by neither command. Type-check any new test file explicitly.
+- `noUnusedLocals` and `noUnusedParameters` are enabled, so a leftover import or an unused parameter fails `typecheck` even when the logic is correct.
 
 ---
 
-## Quality checklist
+## Before you finish
 
-Before opening or updating the PR, verify:
-
-- [ ] Tests pass
-- [ ] No lint errors. Build completes successfully
-- [ ] No debug output, `console.log`, or commented-out code left in
-- [ ] PR description explains the approach, not just the what
+- [ ] `npm run typecheck` and `npm test` both pass
+- [ ] Any new test file type-checks despite being outside `typecheck`'s scope
+- [ ] Every acceptance criterion is met, or the summary says why it is not
+- [ ] No debug output, `console.log`, or commented-out code left behind
 - [ ] No unrelated files changed
+- [ ] `ai-output/comments/01-summary.md` written (or the gap-fill equivalent)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# docs/
+
+Two tiers, distinguished by what a file *is* rather than what it covers.
+
+**Top-level `docs/*.md` are subsystem references.** Each one is the authority on its subject, and `CLAUDE.md` links to them rather than restating their contents. `CLAUDE.md` is loaded into every Claude invocation, so it stays a lean index of pitfalls and conventions; depth lives here, where it is read on demand. A reference doc is expected to be accurate — it is cited as source of truth, so treat a correction here with the same care as a code change.
+
+**Subdirectories are typed artifacts** — records of decisions and work, not maintained references. They are historical: accurate as of writing, not updated as the code moves.
+
+## Subsystem references
+
+| Document | Covers |
+|----------|--------|
+| [pipeline-architecture.md](pipeline-architecture.md) | The step contract, the nine built-in steps, how `applyWiring` supplies inputs, and how a fork overrides steps or the pipeline |
+| [review-fix-rail.md](review-fix-rail.md) | The finding ledger, the four `review_*` tables, the webhook events that feed the fix queue, and the drain loop |
+| [feature-branch-grouping.md](feature-branch-grouping.md) | Parent/child issue grouping, cascade branch creation, and automatic roll-up |
+| [workflow-envelope.md](workflow-envelope.md) | The `RunConfigV1` dispatch envelope and the legacy per-field contract |
+| [runner-images.md](runner-images.md) | The image resolution ladder, publishing channels, and why a private image constrains the execution mode |
+| [kg-sidecar.md](kg-sidecar.md) | The knowledge-graph sidecar, the `/mcp` proxy and its OAuth flow, and the image build |
+| [deployment.md](deployment.md) | Deploy paths, client instances, and the AWS Bedrock setup |
+
+Two references live outside this directory because they are consumed directly rather than read: `.env.example` is the canonical list of orchestrator environment variables, and `CLAUDE.md` is the index that points at everything here.
+
+## Typed artifacts
+
+| Directory | Contents |
+|-----------|----------|
+| `adr/` | Architecture decision records — a decision, its context, and what was rejected |
+| `plans/` | Dated implementation plans and design notes for specific pieces of work |
+| `solutions/` | Documented fixes to past problems, filed by category with YAML front matter (module, tags, problem_type) |
+| `superpowers/` | Per-issue design specs, plans, and notes, dated and linked to their tracker issue |
+
+## Adding a reference
+
+Add the file at the top level, add a row above, and link it from the relevant section of `CLAUDE.md` with a one-paragraph summary plus **Full reference:**. Follow the pattern the existing entries use: `CLAUDE.md` says what the subsystem is and what its non-obvious pitfalls are; the reference says how it works.
+
+Verify claims against the code as you write, not afterward. These documents are cited as authoritative, and an inaccurate reference is worse than a missing one — the whole point of moving depth out of `CLAUDE.md` was to make it accurate enough to trust.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,102 @@
+# Deploying the orchestrator
+
+How an orchestrator instance gets deployed, how a new client instance is stood up, and how to point a target repo at AWS Bedrock.
+
+Reference for `scripts/deploy-orchestrator.sh`, `scripts/provision-client.sh`, `clients/`, `.github/workflows/deploy-clients.yml`, and the Bedrock path in the synced workflows. `CLAUDE.md` carries the summary and points here.
+
+## Deploy paths
+
+Three ways an orchestrator gets deployed, in descending order of how often they are actually used.
+
+### The wrapper script — the standard command
+
+```bash
+./scripts/deploy-orchestrator.sh ai-implement-testing-orchestrator
+./scripts/deploy-orchestrator.sh <other-app-name>
+```
+
+This is the correct command for any orchestrator carrying the KG sidecar, which is all of them. It encodes the build secret, `--no-cache`, and an exported `GH_TOKEN`, then asserts the deployed `/mcp` answers 401 before exiting.
+
+**The app name is required** — the script exits 64 with a usage message when it is missing, rather than falling back to a default. That is deliberate: a default would let a fork deploy itself over the upstream app. **A plain `fly deploy` silently ships a sidecar-less image** — see [kg-sidecar.md](kg-sidecar.md) for why each flag is load-bearing.
+
+### Fly's native GitHub integration
+
+A Fly app can watch a branch and deploy on push, with no workflow involved. Fly documents little of this, so the behaviour worth knowing:
+
+- **The attached app wins over `fly.toml`'s `app` key.** Deploys reach the attached app despite a different name in the root toml, and no stray app is created — so one repo can serve several apps without per-app toml edits.
+- **Auto-deploy is off by default, and the toggle only appears *after* attaching the repo.** Every new connection must enable it explicitly, or pushes deploy nothing.
+- **Attaching does not itself deploy.** The first deploy happens on the next push to the watched branch.
+- **The release `USER` field shows the connecting account even for integration deploys**, so it cannot distinguish an automated deploy from a manual one. Correlate by timestamp instead.
+
+Note the interaction with the sidecar: an integration deploy does not pass the KG build secret, so it produces a sidecar-less image unless the secret is configured in that build path.
+
+### Manual fallback
+
+```bash
+flyctl deploy --remote-only --app <app-name>
+```
+
+Works from any logged-in checkout. Same sidecar caveat as above.
+
+## Client instances
+
+Each client is a separate Fly app described by a file in `clients/<slug>.toml`. Copy `clients/example-client.toml` to start, or use the guided helper:
+
+```bash
+./scripts/provision-client.sh <client-slug>
+```
+
+Manual equivalent:
+
+```bash
+cp clients/example-client.toml clients/<slug>.toml
+# edit the file, then:
+fly apps create <app_name> --org <org>
+fly volumes create dedup_data --size 1 --region iad --app <app_name>
+fly secrets set GITHUB_APP_ID=... GITHUB_APP_PRIVATE_KEY=... --app <app_name>
+```
+
+The Fly volume `dedup_data` mounts at `/data` and holds the SQLite database. Only the GitHub App pair is required for the orchestrator to boot; ticketing credentials are needed for it to poll anything. See `.env.example` for the full set.
+
+### The matrix workflow does not currently deploy clients
+
+`.github/workflows/deploy-clients.yml` exists and triggers on pushes to `main`, building a deploy matrix by globbing `clients/*.toml`. **In practice it always deploys nothing**, because `.gitignore` excludes `clients/*.toml` and un-ignores only the example — which the workflow explicitly skips. Every run finds zero clients, emits an empty matrix, and skips the deploy job via its own guard, reporting success.
+
+So a client toml is local-only unless force-added, and client instances are deployed through the wrapper script or the Fly integration rather than by this workflow. Treat the workflow as inert until that is deliberately resolved one way or the other.
+
+### Per-instance Fly commands
+
+```bash
+fly secrets set KEY=value --app <app_name>   # set secrets
+fly logs --app <app_name>                    # tail logs
+fly ssh console --app <app_name>             # shell into the machine
+```
+
+## Using AWS Bedrock
+
+To run a target repo against Bedrock instead of the Anthropic API, use the **GitHub Actions execution mode**. Bedrock is not supported on Fly Machines or local Docker: those backends have no equivalent of GitHub's OIDC role assumption, and the runner entrypoint rejects `provider=bedrock` outside GHA mode outright.
+
+1. **In the admin UI (`/admin`)**, edit the repo's mapping: set **Provider** to `bedrock` and **AWS Region** to the region hosting your inference profile (e.g. `us-west-2`).
+2. **In the target repo**, add a repository secret `AWS_BEDROCK_ROLE_ARN` — an IAM role trusting the GitHub OIDC provider for that repo, with `bedrock:InvokeModel` on the profiles you need.
+3. **In the target repo**, add two repository *variables* so `/ai-implement` comment-triggered runs route to the same provider:
+   - `AI_IMPLEMENT_PROVIDER` = `bedrock`
+   - `AI_IMPLEMENT_AWS_REGION` = the same region
+4. **In the target repo's `WORKFLOW.md`** (and `PLANNING.md` if planning is enabled), change `model:` to a Bedrock model ID or inference-profile ARN.
+
+**Step 4 is not optional and nothing enforces it.** The workflows validate that `aws_region` and `AWS_BEDROCK_ROLE_ARN` are present, and fail clearly when they are not — but **nothing validates the model against the provider**. An Anthropic-style ID left in front matter is passed to Bedrock verbatim and fails at Claude invocation time with a provider error rather than a configuration error.
+
+IAM trust policy shape, scoped to one repo:
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": { "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com" },
+  "Action": "sts:AssumeRoleWithWebIdentity",
+  "Condition": {
+    "StringEquals": { "token.actions.githubusercontent.com:aud": "sts.amazonaws.com" },
+    "StringLike":   { "token.actions.githubusercontent.com:sub": "repo:<owner>/<repo>:*" }
+  }
+}
+```
+
+Credentials are configured once before the containerized runner step with a **4-hour session duration**, covering the implementation and gap-analysis runs in a single job. Only GitHub OIDC is supported — there is no static-key path.

--- a/docs/kg-sidecar.md
+++ b/docs/kg-sidecar.md
@@ -1,0 +1,132 @@
+# KG sidecar and the `/mcp` endpoint
+
+The orchestrator bundles a Python knowledge-graph sidecar that serves `kg_*` tools, and exposes them to MCP clients through an OAuth-authenticated proxy at `/mcp`. This covers the deploy shape, how the image is built, the OAuth flow, and the ways a deploy can ship without a working sidecar.
+
+Reference for `docker-entrypoint.sh`, the KG stages of `Dockerfile`, `src/mcp.ts`, `src/mcp-oauth.ts`, and `scripts/deploy-orchestrator.sh`. `CLAUDE.md` carries the summary and points here.
+
+## Deploy shape
+
+The sidecar runs **inside the orchestrator container on loopback** — no separate service, no public port, no second Fly app. `docker-entrypoint.sh` starts it on `127.0.0.1:8765`, waits for it, exports `KG_SIDECAR_URL`, and only then executes Node.
+
+Startup has two entry points, tried in order: `kg/start.sh` (preferred — the vendor script knows its own arguments, and is generated at build time) or a bare `kg/server.py` with a pre-built `.venv`. Neither present means no sidecar.
+
+Readiness is polled for up to 30 seconds. **Any HTTP response counts as ready**, including 4xx and 5xx — the check is whether the server accepts connections, not whether it answers correctly. The poll also bails early if the sidecar process has already exited, rather than waiting out the full timeout.
+
+**Sidecar failure is non-fatal at every stage.** A missing entry point, a crash, or a readiness timeout all leave `KG_SIDECAR_URL` unset and let the orchestrator boot normally; `/mcp` returns 503 and every other route is unaffected.
+
+For local development, start the sidecar yourself and set `KG_SIDECAR_URL` in `.env`, or leave it blank to run without `/mcp`.
+
+## `/mcp` returns 503 for two different reasons
+
+The endpoint requires **both** `KG_SIDECAR_URL` and `OAUTH_REDIRECT_BASE_URL`. Missing either produces the same 503. A sidecar-enabled image deployed without an OAuth base URL therefore looks exactly like a sidecar-less build from the outside — worth checking both before concluding the sidecar failed to start.
+
+## Building the image
+
+### Base image
+
+`node:24-slim` (Debian bookworm), not Alpine. fastembed and onnxruntime ship pre-built glibc wheels, and Alpine's musl libc makes those fail to install without a full from-source build. Slim costs roughly 30 MB and makes the sidecar viable without cross-compilation.
+
+### Acquiring the KG source
+
+The knowledge-graph repository is private. A **BuildKit build secret** mounts a GitHub token for exactly one `RUN` layer to clone it; the token is never written to `ARG`, `ENV`, or image history.
+
+The mount is declared `required=false`, so a build with no secret still succeeds — it logs `[kg] sidecar-less build` and produces a working orchestrator without `/mcp`. That fail-soft behaviour is deliberate, and it is also the trap described below.
+
+### The four build stages
+
+1. **Clone** — copies `kg_query`, `kg_ingest`, and `snapshot` plus the top-level files, then generates `start.sh` with the runtime environment baked in.
+2. **Dependency install** — creates `/app/kg/.venv` from `requirements.txt`. Absent requirements means no venv, and everything downstream skips.
+3. **Model bake** — warms the fastembed model `BAAI/bge-small-en-v1.5` into `FASTEMBED_CACHE_PATH=/app/kg/.fastembed-cache` so the running sidecar never fetches it at query time. **Soft failure** — logs `[kg] WARNING: EMBEDDINGS BUILD FAILED` and continues lexical-only.
+4. **Materialize and embed** — `kg_ingest.materialize --no-embed` produces `out/graph.trig`, then a second full pass adds semantic vectors. The graph pass is a **hard failure**: it is the one step not wrapped in a fallback, so a broken graph fails the build. The embed pass is **soft**, falling back to lexical-only search.
+
+`start.sh` exports the same `FASTEMBED_CACHE_PATH`, so the running sidecar reads the baked cache rather than downloading on first query. `kg_hybrid_search` therefore returns results immediately on boot with no separate data-load step.
+
+### The graph is built from committed data, at build time
+
+The clone brings three directories — `kg_query` (the server), `kg_ingest` (the transformer), and `snapshot` (the source data) — plus `requirements.txt` and `sources.yml`. The KG repository owns both the mechanism and the data.
+
+**There is no runtime ingestion.** Nothing crawls, refreshes, or re-materializes while the orchestrator runs. The graph's freshness is a product of two separate things: when the snapshot was last committed to the KG repository, and when this image was last built. A perfectly healthy sidecar can serve a months-old view of the world, and nothing in its responses indicates the age of what it is serving. The clone is `--depth 1`, so the image does not carry the history that would let you check.
+
+Updating the graph therefore means updating the snapshot upstream **and** rebuilding the orchestrator image. A redeploy alone changes nothing about graph content.
+
+The container runs as the unprivileged `node` user.
+
+## Deploying
+
+**Always use the wrapper script.** A plain `fly deploy` silently produces a sidecar-less image:
+
+```bash
+./scripts/deploy-orchestrator.sh ai-implement-testing-orchestrator
+./scripts/deploy-orchestrator.sh <other-app-name>
+```
+
+The script exists because three separate mistakes each produce a silently degraded deploy, and this has happened repeatedly:
+
+- **The build secret is required for the clone.** Without it the build fail-softs to a sidecar-less image rather than failing.
+- **`--no-cache` is required.** A build secret is not part of the layer cache key, so a repeat deploy otherwise reuses a stale — possibly sidecar-less — clone layer even when the secret is present.
+- **`GH_TOKEN` must be exported.** An inline `GH_TOKEN=... fly deploy ... "$GH_TOKEN"` prefix does not affect same-line expansion and passes an empty secret.
+
+The script ends by polling `/mcp` until it answers **401**, and exits non-zero otherwise. A deploy that ships without a working sidecar fails loudly instead of being discovered days later.
+
+### Verifying more than "it answers"
+
+A 401 proves the endpoint is alive and OAuth-gated. It does not prove the graph is queryable.
+
+The clone copies the KG's `sources.yml`, which pins the IRI namespace. Without it the server falls back to a placeholder namespace and every type-filtered `kg_*` tool returns empty — the graph loads, queries match nothing, and nothing errors. Verify a deploy with a real query (`kg_search` returning non-empty, or `degraded:false` in a `kg_hybrid_search` response), not just the 401.
+
+### Building without the sidecar
+
+```bash
+docker build .                 # local, no secret
+fly deploy --remote-only       # degraded: /mcp returns 503, all other routes healthy
+```
+
+## MCP OAuth
+
+`/mcp` returns 401 with a `WWW-Authenticate` header pointing at `/.well-known/oauth-protected-resource`. A compliant client discovers the authorization server from there and completes an RFC 6749 authorization-code flow with PKCE.
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /mcp/register` | RFC 7591 dynamic client registration — returns `client_id` |
+| `GET /mcp/authorize` | Starts the PKCE flow; delegates to the configured OIDC provider |
+| `GET /mcp/callback/{provider}` | OIDC callback; applies the allowlist, mints a 5-minute auth code |
+| `POST /mcp/token` | `authorization_code` exchanges code + PKCE verifier for an access token and a refresh token; `refresh_token` rotates both |
+| `GET /.well-known/oauth-protected-resource` | Resource metadata pointing at the authorization server |
+| `GET /.well-known/oauth-authorization-server` | RFC 8414 authorization-server metadata |
+
+Authorization is **fail-closed**: a verified identity must pass the same `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` allowlist as the admin UI.
+
+### Token lifetimes and rotation
+
+Access tokens default to one hour and are configurable through `MCP_ACCESS_TOKEN_TTL` (seconds). Refresh tokens live **30 days**, so a client re-authenticates in a browser roughly monthly rather than hourly.
+
+Refresh is **rotating with reuse detection**. Each refresh mints a replacement in the same rotation chain, tracked by a `family_id` on the `mcp_refresh_tokens` table. Presenting an already-rotated token is treated as a replay: the entire family is deleted and a warning is logged, so a stolen token cannot be used alongside the legitimate client — both are forced back through a full sign-in.
+
+Registration is bounded in the same spirit: a dynamically registered client that never completes its first authorization is pruned after 24 hours, and expired refresh tokens are swept on the same pass.
+
+`MCP_ALLOWED_REDIRECT_ORIGINS` controls which callback origins dynamic clients may use. Loopback IP-literal HTTP callbacks are allowed by default; any other HTTPS origin must be listed explicitly, and arbitrary HTTPS callbacks are denied.
+
+The orchestrator proxies auth-verified requests to the sidecar verbatim and **strips the `Authorization` header before forwarding**, so the sidecar never sees the caller's token. It should be reachable only from loopback.
+
+Register two additional redirect URIs in the provider consoles, alongside the admin-UI ones:
+
+- `${OAUTH_REDIRECT_BASE_URL}/mcp/callback/google`
+- `${OAUTH_REDIRECT_BASE_URL}/mcp/callback/microsoft`
+
+## Memory sizing
+
+Fastembed models load into process memory at startup. A small model such as `BAAI/bge-small-en-v1.5` is ~130 MB on disk but expands to roughly 300–400 MB resident. With the orchestrator's own Node footprint of 100–150 MB, **256 MB Fly machines are too small** and will OOM-kill one process or the other.
+
+Minimum with the sidecar is **512 MB**; **1 GB** gives comfortable headroom for larger models or concurrent requests.
+
+```toml
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+```
+
+`fly.toml` ships 512 MB as the base default. Adjust per client in `clients/<slug>.toml`.
+
+## Repository layout
+
+`kg/` holds only a `.gitkeep` placeholder in git — the actual server code and snapshot are cloned at build time and never committed. The directory is excluded from workflow sync and never copied to target repos.

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -1,0 +1,121 @@
+# Pipeline architecture
+
+How the containerized runner executes an issue: the step contract, the built-in pipeline, how steps are wired, and how a fork overrides any of it.
+
+This is the reference for `src/pipeline/`. `CLAUDE.md` carries the one-paragraph summary and points here.
+
+## Where the pipeline runs
+
+Every execution mode — GitHub Actions, Fly Machines, and local Docker — runs the same runner image and enters through `session/entrypoint.sh`. That script validates the environment, prepares `/workspace` (a clone, or a bind mount under the local dev harness), drops to a non-root user, and only then executes the phase-appropriate TypeScript entry point: `run-planning.js` for planning runs, `run-autonomous.js` for everything else.
+
+The practical consequence: by the time any pipeline code runs, the target repo is already on disk. `WORKFLOW.md`, its hook scripts, and any `custom/` overrides the repo ships are all readable from the first step onward, in every mode.
+
+## The step contract
+
+A step is any module with a `run` method, defined in `src/pipeline/types.ts`:
+
+```typescript
+export interface StepModule<
+  I extends Record<string, unknown> = Record<string, unknown>,
+  O extends Record<string, unknown> = Record<string, unknown>,
+> {
+  run(context: PipelineContext, inputs: I, reporter: StepReporter): Promise<O>;
+}
+```
+
+Both type parameters must extend `Record<string, unknown>`. This is a real constraint, not a formality: outputs are stored in an untyped map keyed by step id and read back by other steps, so an interface that does not satisfy the index signature will not compile as a `StepModule`.
+
+The `context` argument carries `PipelineContextData` — the issue fields, workspace path, resolved model, caps, and the parsed `hooks` paths — plus `getOutputs`/`setOutputs` and the `llmExecutor`. The `reporter` receives a `Step` record as each step starts and finishes; that is what surfaces progress to the orchestrator.
+
+## The built-in pipeline
+
+`pipelines/autonomous.yml` declares ten steps. They run in file order, and each is registered under a key in `BUILTIN_STEPS` (`src/pipeline/default-pipeline.ts`).
+
+| # | Step id | Skipped when |
+|---|---------|--------------|
+| 1 | `clone` | never |
+| 2 | `install-skills` | no `skillsRepo` configured |
+| 3 | `dependency-auth` | the mapping has no Dependency Token Scope set |
+| 4 | `install` | never (internally no-ops for a mounted workspace or a repo with no `package.json`) |
+| 5 | `setup` | no `setup:` hook in `WORKFLOW.md` front matter |
+| 6 | `feedback-loop` | never |
+| 7 | `preflight` | the feedback loop did not approve |
+| 8 | `push` | the run is a gap-fill (`prNumber` set) |
+| 9 | `verify` | no `verify:` hook, or the feedback loop did not approve |
+| 10 | `post-push-review` | not approved, or nothing was pushed, or no PR number |
+
+`dependency-auth` sits deliberately before `install`: it fetches a read-only, installation-wide token and installs it as a git credential helper plus `COMPOSER_AUTH`, so the dependency install that follows can resolve private sibling repositories. Its inputs are also a worked example of a real constraint — the run's progress token is **not** passed through `inputs`, because inputs are persisted to the step log and surfaced through the admin API. The step reads that secret from `process.env` directly. Anything secret belongs in the environment, not in a step's inputs.
+
+`feedback-loop` is where Claude actually runs — it drives the implement/review cycle up to `maxIterations`. Everything before it prepares the workspace; everything after it reacts to the result.
+
+Two consequences worth internalising:
+
+**`preflight` does not gate the push.** It is skipped unless the review already approved, and `push` runs regardless of what it found. It records `typecheck`/`lint`/`test` results; it does not block a pull request on them. Work that fails preflight still ships.
+
+**A gap-fill run never pushes from the pipeline.** `push` is skipped whenever `prNumber` is set, because the agent commits and pushes to the existing PR branch itself. This is why gap-fill and initial runs need different instructions in `WORKFLOW.md`.
+
+## How steps get their inputs
+
+This is the least obvious part of the design, and the easiest thing to get wrong when extending it.
+
+The YAML declares only three things per step: `id`, `type`, and an optional `moduleId`. It declares **no inputs and no skip conditions**. Those live in `applyWiring()` — a `switch` on **step id** in `src/pipeline/pipeline-loader.ts` — which attaches an `inputs` function and an optional `skip` predicate to each known id as the YAML is loaded.
+
+```yaml
+  - id: preflight
+    type: preflight
+```
+
+```typescript
+    case "preflight":
+      return {
+        ...step,
+        inputs: (ctx) => ({
+          workspaceDir: ctx.getOutputs("clone").workspaceDir,
+          packageManager: ctx.getOutputs("install").packageManager,
+        }),
+        skip: (ctx) => ctx.getOutputs("feedback-loop").approved !== true,
+      };
+```
+
+**The footgun:** `applyWiring`'s `default` branch returns the step unchanged, with no `inputs` function. `resolveInputs` returns `{}` for an undefined definition. So **a step added to the YAML without a matching `case` receives an empty inputs object** — no error, no warning, just a step that runs with nothing. If a new step behaves as though it were handed no configuration, this is why.
+
+Adding a step therefore means two edits, not one: the YAML entry and the `applyWiring` case.
+
+## Steps are coupled by step id
+
+Steps communicate through `context.getOutputs("<step id>")`. The ids in that call are string literals scattered across `applyWiring` and the step modules — `clone` supplies `workspaceDir` and `githubToken` to nearly everything, `install` supplies `packageManager` and `repoModels`, `feedback-loop` supplies `approved` and the termination reason, `push` supplies `prNumber` and `branchPushed`.
+
+**Renaming a step id in the YAML breaks every reader of its outputs**, and does so silently: `getOutputs` on an unknown id returns an empty object rather than throwing. Treat step ids as a published interface.
+
+## Overriding the pipeline in a fork
+
+Resolution is handled by two functions in `src/pipeline/resolve-module.ts`, which search two custom roots in order before falling back to the built-in package root:
+
+1. **Workspace root** — `custom/<path>` relative to `process.cwd()`. This is how orchestrator-side loading picks up a fork's `custom/`.
+2. **Baked root** — `<AI_IMPLEMENT_CUSTOM_ROOT>/custom/<path>`. `Dockerfile.session` copies the repo's `custom/` to `/app/custom/` and sets `AI_IMPLEMENT_CUSTOM_ROOT=/app`, which is how the runner picks up overrides — its cwd is `/workspace`, so the workspace root never matches there.
+
+### Replacing a step
+
+Place `custom/steps/<id>.ts` exporting a `StepModule` as its **default export**. It replaces the built-in registered under that key. A file that exists but has no default export logs a warning and falls back to the built-in, rather than failing the run or silently misbehaving.
+
+The lookup tries `.ts`, then `.js`, then `.mjs`, so the same override works under `tsx` in development and in a compiled image.
+
+Two resolvers exist and their extension orders differ, which matters only if you are reading the code. Overrides of a **registered** step — every built-in — go through `resolveModuleImport` in `src/pipeline/resolve-module.ts`, the `.ts`-first order above. `PipelineRunner.loadModule` uses `.js` first and has no `.mjs`, but it is only reached for a step id absent from the registry, so it never handles a built-in override.
+
+### Replacing the pipeline
+
+Place `custom/pipelines/autonomous.yml`. It replaces the built-in definition wholesale. `applyWiring` still runs against it, so step ids that match built-in ids keep their standard wiring — and ids that do not match get nothing, per the footgun above.
+
+Only these `type` values are accepted: `clone`, `install`, `implement`, `review`, `preflight`, `push`, `await_ci`, `custom`. Any other value fails at load time with the offending step id named. Note that several built-in steps use `type: custom` with an explicit `moduleId` — the type is a coarse category, and `moduleId` (falling back to `type`) is what actually selects the module.
+
+### Timing
+
+Both the pipeline definition and the step modules resolve **before the clone step runs** — the definition at module import time, the modules eagerly in `createDefaultRunner()`. Overrides therefore have to be baked into the runner image; a `custom/` directory that only exists in the target repo's checkout arrives too late to be honored for these two extension points.
+
+## Execution semantics
+
+`PipelineRunner.run` iterates steps in order. A step that throws is reported as `failed`, has its error stored in its outputs, and the exception propagates — the pipeline stops there. A skipped step is reported as `skipped` and its outputs are set to `{}`, so downstream `getOutputs` calls return an empty object rather than undefined.
+
+The runner accepts a `stopAfterStep` option, used by the local dev harness's `--until` flag. An unknown step name throws **before any step executes**, rather than running the whole pipeline and then failing to find the boundary. The stop applies to skipped steps too — `--until setup` halts after `setup` whether the hook ran or was skipped for want of a `setup:` entry.
+
+Because `feedback-loop` is step 5, `--until` with any earlier step is a token-free run: no Claude invocation happens.

--- a/docs/review-fix-rail.md
+++ b/docs/review-fix-rail.md
@@ -1,0 +1,117 @@
+# Review-fix rail
+
+How review feedback on an AI-Implement pull request becomes another run. Covers the finding ledger, the four `review_*` tables, the webhook events that feed the queue, the drain loop, and how findings get resolved.
+
+This is the reference for `src/review-ledger-store.ts`, `src/review-fix-queue.ts`, `src/pipeline/review-ledger.ts`, `src/pipeline/steps/post-push-review.ts`, and the review-handling half of `src/webhook.ts`. `CLAUDE.md` carries the summary and points here.
+
+## What it does
+
+An AI-Implement PR attracts review feedback from several places: the pipeline's own post-push review, a GitHub Code Review bot, and human reviewers leaving formal reviews or inline comments. The rail turns all of that into a single deduplicated ledger of findings per PR, and dispatches gap-fill runs to address them.
+
+It has two halves that share the ledger:
+
+- **In-run** — the `post-push-review` step, which reviews and fixes within the original run, before it ends.
+- **Post-run** — webhook events arriving after the run finished, which enqueue a fresh dispatch.
+
+The second half is the reason the rail exists. Without it, any review posted after the run completed lands on a PR nobody is watching.
+
+## Prerequisites
+
+The post-run half is **entirely webhook-driven**. Three GitHub event subscriptions feed it, and a repo subscribed to none of them silently gets no rail at all — no error, no log line, just a PR that never receives a fix run:
+
+| Event | Gate | Recorded as |
+|-------|------|-------------|
+| `pull_request_review` | `action=submitted` **and** `state=CHANGES_REQUESTED` | `github-review`, severity `blocking` |
+| `pull_request_review_comment` | `action=created` | `github-review-thread`, severity `medium` |
+| `issue_comment` | author is a trusted reviewer bot **and** the body has extractable blocking findings | `claude-review-summary`, severity `blocking` |
+
+`GITHUB_WEBHOOK_SECRET` must be set, and deliveries are rejected 401 on an invalid signature. Note that `pull_request` and `issue_comment` are already needed for merge reconciliation and `/ai-implement` handling respectively — the two review events are the ones easily missed.
+
+Every path additionally requires a **matching dispatch record**: the orchestrator looks up the PR against its own dispatch log, and ignores anything it did not create. Reviews on unrelated PRs in the same repo are not picked up.
+
+## Finding identity
+
+A finding's identity is a SHA-256 over its source, path, line, and **normalized** body — whitespace collapsed and lowercased (`stableReviewFindingKey`). The table is unique on `(repo, pr_number, finding_key)`.
+
+Two consequences worth knowing:
+
+- The same finding reported repeatedly collapses to one row, with `last_seen_at` advancing. Re-reporting a **resolved** finding reopens it — the upsert sets `status = 'open'` and clears `resolved_at`.
+- A **reworded** finding is a new finding. A reviewer who rephrases the same objection produces a second row, because the hash covers the body.
+
+Collection additionally dedupes in memory by normalized body before anything is stored, keeping the variant that carries a file and line over one that does not.
+
+## The four tables
+
+| Table | Grain | Purpose |
+|-------|-------|---------|
+| `review_findings` | one row per distinct finding per PR | The ledger. `status` is `open` or `resolved` |
+| `review_fix_queue` | **one row per PR** (unique on `repo, pr_number`) | Work queue; `pending` → `dispatched` / `skipped` / `failed` |
+| `review_fix_events` | append-only, one per enqueue | Audit trail of what triggered each enqueue, with actor and source URL |
+| `review_fix_dispatches` | one per dispatch id | Snapshot of which finding ids a given dispatch is allowed to resolve |
+
+The queue's one-row-per-PR grain is deliberate. Enqueuing coalesces: a second event for a PR already queued updates the existing row rather than adding another, and if the new reason differs from the stored one the reason becomes `multiple`. Three reviewers commenting in quick succession produce one fix run, not three. The `review_fix_events` table is what preserves the individual triggers, since the queue row itself is overwritten.
+
+## Severity, and why an inline comment does not block
+
+Severity is `blocking`, `medium`, or `minor`, and the rule for deciding it is the subtlest part of the rail.
+
+**A reviewer's latest formal verdict is authoritative.** Only reviewers whose most recent actionable review is `CHANGES_REQUESTED` contribute blocking findings. Unresolved inline threads authored by someone who has since approved are recorded as `medium` — non-blocking context. Without that rule, a stale nit thread from an approving reviewer would keep the PR blocked forever.
+
+The `pull_request_review_comment` webhook records `medium` for the same reason from the other direction: that event carries no parent review state, so an inline comment alone cannot be assumed to block. A genuine changes-requested verdict arrives separately via `pull_request_review` and records the blocking finding itself.
+
+Unresolved threads are collected via GraphQL with pagination, and a thread is only collected when it is both **unresolved and not outdated**.
+
+## The rail does not ingest its own output
+
+Findings are collected from bot comments, and the rail itself posts bot comments — so it excludes its own. Two guards:
+
+- Any comment body containing `<!-- ai-implement` is skipped during collection.
+- A review whose body carries the native-review marker, or begins with `AI-Implement post-push review`, is ignored at the webhook.
+
+Trusted comment authors are an explicit allowlist (`ai-implement`, `claude`, and their `[bot]` forms), so an arbitrary bot commenting on a PR cannot inject findings.
+
+## In-run: the post-push-review step
+
+The last step of the pipeline. It runs only when the feedback loop approved, something was actually pushed, and a PR number exists.
+
+It runs its own LLM review, then **waits for the external review check** on the PR's current head SHA to reach a terminal state — polling every 5 seconds up to a 5-minute budget — before deciding merge readiness. The wait exists because the external review starts at roughly the same moment; reading findings immediately would read an empty snapshot.
+
+**It fails closed.** If the internal review is clean but the external check has not finished within the budget, the step does *not* auto-approve. It posts a comment saying manual review is required and stops. The same applies when the reviewer returns structurally invalid output.
+
+Internal issues are deduplicated against external findings so the same problem is not reported twice, and fix passes iterate up to the configured maximum. PR comments carry `<!-- ai-implement post-push iter=N ... -->` markers so repeated passes update rather than duplicate.
+
+External collection can be disabled per repo via `reviewProviders` in `.ai-implement/config.yml`; when it is, the step skips the wait entirely.
+
+## Post-run: the drain loop
+
+`processReviewFixQueue` runs once per poll tick. For each pending item, in FIFO order:
+
+1. Find the mapping whose `owner/repo` matches. **No mapping → `skipped`.**
+2. **Paused project → `skipped`.**
+3. Mint result and progress tokens (only when a runner callback is configured).
+4. **Snapshot the currently-open finding ids.** This is what the dispatch is permitted to resolve.
+5. Dispatch a `gap-analysis` phase run against the existing PR.
+6. Record the dispatch with its snapshot, then mark the queue row `dispatched`.
+
+A dispatch failure marks the row `failed` and surfaces a notification; the loop continues to the next item rather than aborting.
+
+**The drain loop dispatches through GitHub Actions specifically** — it calls `dispatchWorkflow` directly rather than going through runner-mode resolution. A project running on Fly Machines still gets its review-fix runs on GitHub Actions.
+
+The synthesized issue title is `Review feedback fix for PR #<n>`, and the phase is reported as `gap-analysis` so the ticket's status does not regress to in-progress for what is a follow-up pass.
+
+## Resolution
+
+When a `gap-analysis` run reports success, the callback resolves findings — and *which* findings depends on whether a dispatch snapshot exists:
+
+- **With a snapshot** — exactly the finding ids captured at dispatch time are resolved.
+- **Without one** — everything for that PR last seen at or before the job's dispatch timestamp.
+
+The snapshot is the important case. A finding that arrives *while* a fix run is in flight was never seen by that run, and resolving it would silently drop real feedback. Scoping resolution to the snapshot leaves it open for the next queue event instead.
+
+## Gotchas
+
+- **No webhook subscription means no rail, silently.** This is the single most common way for the post-run half to appear broken.
+- **A reworded finding is a new finding.** Expect duplicates when a reviewer restates an objection differently.
+- **The queue holds one row per PR**, so a burst of feedback produces one run. Read `review_fix_events` to see everything that contributed.
+- **Findings from a review on a PR the orchestrator did not dispatch are ignored**, since every path requires a matching dispatch record.
+- **`review_findings` has no retention policy.** Rows persist for merged and closed PRs alike.

--- a/docs/runner-images.md
+++ b/docs/runner-images.md
@@ -1,0 +1,70 @@
+# Runner image resolution
+
+Which container image a run executes in, how a target repo overrides it, the publishing channels, and why a private image constrains the execution mode.
+
+Reference for `src/repo-image.ts`, the `runner_image` handling in the synced workflows, and `.github/workflows/build-runner.yml`. `CLAUDE.md` carries the summary and points here.
+
+## The resolution ladder
+
+Both execution modes resolve the image the same way, highest priority first.
+
+**1. `.ai-implement/image.yml` at the target repo's default branch** — the per-repo override:
+
+```yaml
+image: ghcr.io/your-org/your-runner:v1
+```
+
+In `fly-machines` mode the orchestrator reads it through the GitHub contents API (`src/repo-image.ts`). In `github-actions` mode `claude-implement.yml` reads it with `gh api` from the **default branch only** — never a PR head, so a pull request cannot select its own privileged image.
+
+**2. `AI_IMPLEMENT_RUNNER_IMAGE`** — the operator or organization default. A GitHub repo/org **variable** in `github-actions` mode (org-level applies to every repo); an orchestrator **environment variable** in `fly-machines` mode. `SESSION_IMAGE` is the deprecated former name of the env var — still honored, with a deprecation warning logged at startup.
+
+**3. Upstream fallback** — `ghcr.io/builddownai/ai-implement-runner:latest`. Every fallback site resolves to `:latest`: `src/repo-image.ts` for the orchestrator, and the `runner_image` resolution inside `claude-implement.yml`, `claude-plan.yml`, and `comment-trigger.yml`.
+
+In `github-actions` mode a manual `runner_image` dispatch input overrides everything for that one run.
+
+If `image.yml` is absent, malformed, or names an unreachable reference, resolution falls through to the next rung rather than failing.
+
+## Forwarding, and why it is conditional
+
+On the Fly Machines path the orchestrator boots the session machine on the resolved image directly.
+
+On the GitHub Actions path it forwards the resolved image as the `runner_image` dispatch input — **but only when the choice is explicit**: a per-repo `image.yml` override, or an explicitly set orchestrator image variable. When neither is set the orchestrator sends nothing, leaving the workflow to run its own resolution order (the repo/org variable, then its built-in `:latest`). That is what stops the orchestrator from silently overriding a repo that pins its image through the variable.
+
+Planning runs honor the identical rule, so a testing orchestrator pinned to `:next` steers planning to `:next` as well. One asymmetry: unlike `claude-implement.yml`, `claude-plan.yml`'s own validate step does **not** read `image.yml`, so orchestrator forwarding is the only path by which a GHA planning run picks up either source — and the target repo must have re-synced `claude-plan.yml` first, or GitHub rejects the dispatch with "unexpected inputs".
+
+## Allowlisting
+
+The `github-actions` path auto-trusts `ghcr.io/builddownai/` and the repo owner's own `ghcr.io/<owner>/` namespace, so a fork publishing its own image needs no extra configuration. `AI_IMPLEMENT_ALLOWED_RUNNER_IMAGE_PREFIXES` exists only for third-party registries.
+
+The `fly-machines` path validates the image-reference format but applies no allowlist.
+
+## Private images constrain the execution mode
+
+A private GHCR image is usable **only in GitHub Actions mode**. Fly Machines and local Docker pull anonymously with no credential mechanism, so a private image fails at machine-create time with `failed to get manifest ... unauthorized`. There is no workaround on those backends — choosing a private image is choosing GHA mode.
+
+On the GHA path, `claude-implement.yml` and `claude-plan.yml` authenticate the pull with the job's `GITHUB_TOKEN`: each requests `packages: read` **and** passes the token through the container `credentials:` block. A bare `packages: read` is not sufficient on its own, because GitHub Actions does not auto-authenticate a job-container image pull — the `credentials:` block is what performs the authenticated pull.
+
+`GITHUB_TOKEN` can only read private packages owned by the **same org or account as the target repo**. So a private runner image must live in the target repo's own org; the realistic case is a customer pinning their own image via `image.yml` and linking that GHCR package to the repo. A private image in a *different* org requires substituting a PAT with `read:packages` on that org for `GITHUB_TOKEN` in `credentials.password`.
+
+This is why the default image stays public: a cross-org `GITHUB_TOKEN` cannot pull it, so making it private would break every customer repo. The default must also be public for Fly, which pulls anonymously. New GHCR packages default to Private, and the organization must permit public container packages first (Org Settings → Packages).
+
+## Channels
+
+`.github/workflows/build-runner.yml` publishes to `ghcr.io/<owner>/ai-implement-runner`, lowercasing the owner of the repo it runs in — so a fork's builds land in its own namespace automatically, one the GHA allowlist already trusts. The built-in fallback in code and in the synced workflows stays `ghcr.io/builddownai/ai-implement-runner` regardless; a fork wanting its own image used must pin it rather than edit the fallback.
+
+| Channel | Published from | Intended for |
+|---------|----------------|--------------|
+| `:latest` | `main` | Production orchestrators and synced target-repo workflows |
+| `:next` | `testing` | Staging and testing orchestrators |
+
+Pair the runner channel with the orchestrator's channel — a testing orchestrator should set its image variable to `:next` so the two move together.
+
+**Promotion order.** Commit SHA tags are pushed first, then the build digest is smoke-tested, and only then is any mutable channel tag promoted. Channel-scoped date tags follow `base-<channel>-vYYYYMMDD-<12-char-sha>` (e.g. `base-next-v20260526-abc123def456`) so `latest` and `next` never collide and same-day builds do not overwrite one another.
+
+Use the immutable **digest** for the strongest rollback pin; the SHA tag is a convenient lookup for the same build.
+
+Cancelled or failed runs can leave SHA-only images with no channel pointer. That is intentional fail-closed behaviour — clean them through GHCR retention rather than treating mutable channel tags as a retention mechanism.
+
+## Building a custom image
+
+The typical reason is a language runtime or tool the base image lacks (terraform, ruby, go). Build `FROM` the channel matching your orchestrator, add your tools, publish, and point `image.yml` at it. The customer owns building and publishing; the image should be publicly pullable for the broadest compatibility.

--- a/src/__tests__/workflow-md.test.ts
+++ b/src/__tests__/workflow-md.test.ts
@@ -46,10 +46,13 @@ describe("parseWorkflowMd", () => {
     expect((out.frontMatter as Record<string, unknown>).unknown_key).toBeUndefined();
   });
 
-  it("parses gap_analysis_model and teardown", () => {
+  it("parses teardown and ignores the removed gap_analysis_model key", () => {
     const md = `---\ngap_analysis_model: claude-haiku-4-5\nteardown: scripts/teardown.sh\n---\nbody\n`;
     const out = parseWorkflowMd(md, {});
-    expect(out.frontMatter.gap_analysis_model).toBe("claude-haiku-4-5");
     expect(out.frontMatter.teardown).toBe("scripts/teardown.sh");
+    // gap_analysis_model was parsed but never consumed by any caller. Dropping it
+    // from KEYS is behaviour-neutral; this pins that a repo still setting it is
+    // ignored at parse time rather than silently accepted and discarded later.
+    expect((out.frontMatter as Record<string, unknown>).gap_analysis_model).toBeUndefined();
   });
 });

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -398,11 +398,10 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     prNumber,
   });
   // WORKFLOW.md (and therefore the hook paths, incl. teardown) is read once here,
-  // before the pipeline runs. In GHA mode the repo is already checked out into
-  // `workspaceDir`, so the hooks resolve and the captured teardown path stays valid
-  // through `finally`. In Fly/local modes the `clone` step runs later in the
-  // pipeline, so `workspaceDir` is empty at this point — WORKFLOW.md isn't found and
-  // all hooks resolve to undefined (hooks are effectively GHA-only; see WORKFLOW.md).
+  // before the pipeline runs. This holds in every execution mode: all three enter
+  // through session/entrypoint.sh, which populates `workspaceDir` — by clone, or by
+  // bind mount under the local dev harness — before this process starts. So the
+  // hooks resolve and the captured teardown path stays valid through `finally`.
   const wfPath = join(workspaceDir, "WORKFLOW.md");
   if (existsSync(wfPath)) {
     const parsed = parseWorkflowMd(readFileSync(wfPath, "utf-8"), {

--- a/src/workflow-md.ts
+++ b/src/workflow-md.ts
@@ -3,7 +3,6 @@ export interface WorkflowFrontMatter {
   setup?: string;
   verify?: string;
   teardown?: string;
-  gap_analysis_model?: string;
 }
 
 export interface ParsedWorkflowMd {
@@ -11,7 +10,7 @@ export interface ParsedWorkflowMd {
   body: string;
 }
 
-const KEYS: (keyof WorkflowFrontMatter)[] = ["model", "setup", "verify", "teardown", "gap_analysis_model"];
+const KEYS: (keyof WorkflowFrontMatter)[] = ["model", "setup", "verify", "teardown"];
 
 export function parseWorkflowMd(raw: string, envSubs: Record<string, string>): ParsedWorkflowMd {
   const lines = raw.split("\n");

--- a/workflows/PLANNING.md
+++ b/workflows/PLANNING.md
@@ -7,8 +7,8 @@
 #                          or an inference-profile ARN (arn:aws:bedrock:...)
 # The default below works for the Anthropic provider. If this repo's mapping
 # is switched to provider=bedrock in the orchestrator admin UI, replace this
-# with a Bedrock model ID — the workflow will hard-fail otherwise, since
-# Bedrock IDs are account- and region-specific and have no safe default.
+# with a Bedrock model ID: nothing validates the pairing, so an Anthropic-style
+# ID reaches Bedrock verbatim and fails at invocation time rather than early.
 model: claude-sonnet-4-6
 ---
 
@@ -18,28 +18,38 @@ model: claude-sonnet-4-6
   This file is seeded into your repo by the ai-implement sync workflow.
   It is YOURS to customise — future syncs will never overwrite it.
 
-  When claude-plan.yml runs, it renders this file as the prompt sent to Claude.
-  The YAML front matter block (between the --- lines) is stripped before Claude
-  sees it. The rest of the file is passed through envsubst, which substitutes:
+  When a planning run executes this repo, it renders this file as the prompt sent
+  to Claude. The YAML front matter block (between the --- lines) is stripped before
+  Claude sees it, as are these HTML comments. The runner then substitutes the
+  variables below using a regular expression — not envsubst. Any OTHER
+  ${UPPER_SNAKE} token is replaced with an empty string, so a shell example
+  containing one is silently blanked; a plain $VAR without braces survives.
 
-    ${ISSUE_IDENTIFIER}   Linear identifier, e.g. ENG-42
+    ${ISSUE_IDENTIFIER}   Ticket identifier, e.g. ENG-42
     ${ISSUE_TITLE}        Issue title
     ${ISSUE_DESCRIPTION}  Full issue description (Markdown)
-    ${ISSUE_ID}           Linear UUID (used in curl commands to post comments)
+    ${ISSUE_ID}           Ticket UUID; rarely useful, as the runner holds no ticketing credential
     ${PARENT}             Parent issue as "- IDENTIFIER: Title" (or "None")
     ${SIBLINGS}           Sibling stories (other children of the parent), newline-separated
     ${DEPENDENCIES}       Related issues as "- [type] IDENTIFIER: Title", newline-separated
+
+  This body REPLACES the runner's built-in planning prompt rather than adding to
+  it, so anything the built-in prompt would have said must be stated here.
 
   FRONT MATTER (the --- block at the top)
   ----------------------------------------
   Stripped before sending to Claude. Supported keys:
 
-    model      Model ID for planning (see above). Required; no default for bedrock.
+    model      Model ID for planning (see above). Optional; falls back to the
+               runner's built-in default. Nothing validates it against the
+               configured provider, so a Bedrock mapping with an Anthropic-style
+               ID fails at invocation time rather than at dispatch.
 
   COMMENT FORMAT
   ---------------
-  Claude posts up to 4 structured comments to Linear. Headers are parseable
-  so the implementation workflow can locate them later:
+  Claude writes up to 4 structured comment files, which the orchestrator posts to
+  the ticket after the run. Headers are parseable so the implementation workflow
+  can locate them later:
 
     ## 🏗️ AI Planning: Architecture Analysis
     ## 🧪 AI Planning: Test Plan
@@ -55,7 +65,7 @@ model: claude-sonnet-4-6
   5. Remove these HTML comments once you're done — Claude won't see them anyway.
 -->
 
-You are a senior software architect performing a read-only planning analysis. Do NOT create any branches, files, or pull requests. Do NOT write any code. Explore the codebase and post structured planning comments to Linear.
+You are a senior software architect performing a read-only planning analysis. Do NOT create branches or pull requests, and do NOT write or modify any source code. Explore the codebase and record your analysis as the comment files described under Instructions below.
 
 **Issue:** ${ISSUE_IDENTIFIER} — ${ISSUE_TITLE}
 

--- a/workflows/WORKFLOW.md
+++ b/workflows/WORKFLOW.md
@@ -7,14 +7,14 @@
 #                          or an inference-profile ARN (arn:aws:bedrock:...)
 # The default below works for the Anthropic provider. If this repo's mapping
 # is switched to provider=bedrock in the orchestrator admin UI, replace this
-# with a Bedrock model ID — the workflow will hard-fail otherwise, since
-# Bedrock IDs are account- and region-specific and have no safe default.
+# with a Bedrock model ID: nothing validates the pairing, so an Anthropic-style
+# ID reaches Bedrock verbatim and fails at invocation time rather than early.
 model: claude-sonnet-4-6
 
-# Optional: model used for the post-PR gap-analysis step. Pass through as above.
-# Default (if omitted): claude-haiku-4-5-20251001 for anthropic, same as `model`
-# above for bedrock (override if you want a cheaper model for gap analysis).
-# gap_analysis_model: claude-haiku-4-5-20251001
+# To run a cheaper model for the automated review pass than for implementation,
+# set models.implement / models.review in .ai-implement/config.yml. Those take
+# precedence over the model: above, and are the only supported way to split the
+# two — there is no per-phase model key in this front matter.
 ---
 
 <!--
@@ -23,24 +23,28 @@ model: claude-sonnet-4-6
   This file is seeded into your repo by the ai-implement sync workflow.
   It is YOURS to customise — future syncs will never overwrite it.
 
-  When claude-implement.yml runs, it renders this file as the prompt sent to
+  When the runner executes this repo, it renders this file as the prompt sent to
   Claude Code. The YAML front matter block (between the --- lines) is stripped
-  before Claude sees it. The rest of the file is passed through envsubst, which
-  substitutes the following variables:
+  before Claude sees it, as are these HTML comments. The runner then substitutes
+  the variables below using a regular expression — not envsubst. Any OTHER
+  ${UPPER_SNAKE} token is replaced with an empty string, so a shell example
+  containing one is silently blanked; a plain $VAR without braces survives.
 
-    ${ISSUE_IDENTIFIER}   Linear identifier, e.g. ENG-42
+    ${ISSUE_IDENTIFIER}   Ticket identifier, e.g. ENG-42
     ${ISSUE_TITLE}        Issue title
     ${ISSUE_DESCRIPTION}  Full issue description (Markdown)
-    ${ISSUE_ID}           Linear UUID (useful if you want Claude to call the Linear API)
+    ${ISSUE_ID}           Ticket UUID; rarely useful, as the runner holds no ticketing credential
     ${PR_NUMBER}          Set on gap-fill re-runs; empty on first run
-    ${PLANNING_CONTEXT}   Rendered planning comments (empty if none); expands to a full "## Planning Context" block or nothing
+
+  Planning context is appended automatically when a planning run produced it.
+  Do NOT put a ${PLANNING_CONTEXT} token in the body: the runner substitutes it
+  AND the pipeline appends the same block, so the token emits it twice.
 
   FRONT MATTER (the --- block at the top)
   ----------------------------------------
   Stripped before sending to Claude. Supported keys:
 
     model                Model ID for implementation (see above).
-    gap_analysis_model   Model ID for the post-PR gap-analysis step (see above).
     setup      Path (relative to repo root) to a shell script that runs BEFORE Claude.
                Use this to start services, install dependencies, and run migrations.
                Export env vars via `echo "VAR=value" >> "$GITHUB_ENV"` — they persist
@@ -52,9 +56,10 @@ model: claude-sonnet-4-6
     teardown   Path to a shell script that runs AFTER Claude, even on failure.
                Use this to stop containers or clean up resources.
 
-    NOTE: Hooks run only in GitHub Actions execution mode. On Fly/local modes the
-    workspace is empty when WORKFLOW.md is read (the repo is cloned later), so
-    setup/verify/teardown are silently skipped.
+    Hooks run in every execution mode — GitHub Actions, Fly Machines, and local
+    Docker. All three start from the same container entrypoint, which prepares
+    the workspace before the runner process starts, so WORKFLOW.md and the hook
+    scripts are already on disk when they are read.
 
   SETUP AND TEARDOWN HOOKS
   ------------------------
@@ -92,8 +97,9 @@ model: claude-sonnet-4-6
 
   NEW IMPLEMENTATION vs GAP-FILL RUNS
   -------------------------------------
-  When ${PR_NUMBER} is empty  → Claude creates a new branch and PR.
-  When ${PR_NUMBER} is set    → Claude pushes gap-fill commits to the existing PR.
+  When ${PR_NUMBER} is empty  → Claude edits the checkout and leaves the changes uncommitted; the pipeline commits, pushes the branch, and opens the PR.
+  When ${PR_NUMBER} is set    → Claude commits and pushes to the existing PR branch itself; the pipeline skips its push step.
+
   Both scenarios use this same file. The conditional sections below handle both.
 
   HOW TO CUSTOMISE THIS FILE
@@ -168,8 +174,6 @@ AI-Implement ingests GitHub review events and dispatches its own gap-fill run.
 **Description:**
 ${ISSUE_DESCRIPTION}
 
-${PLANNING_CONTEXT}
-
 ---
 
 ## Repo context
@@ -185,7 +189,7 @@ ${PLANNING_CONTEXT}
 
 ## Quality checklist
 
-Before opening or updating the PR, verify:
+Before you finish, verify:
 
 - [ ] Tests pass
 - [ ] No lint errors. Build completes successfully


### PR DESCRIPTION
## Summary

This repository is a mapped project on the testing orchestrator, so its own issues get implemented by the containerized runner — but nobody had ever customized the files that runner reads. This refreshes them.

The root `WORKFLOW.md` was the untouched seed template. It declared this repo's stack as "e.g. Node.js 20, TypeScript, PostgreSQL", told the agent to run `npm run lint` (no such script), and instructed it to create a branch and open a pull request — which the pipeline contradicts by appending its own "do not branch, commit, or push" block immediately after. **Every initial run received two mutually exclusive sets of orders.**

`CLAUDE.md` carried roughly thirty factual errors and had grown to 665 lines. Since it is auto-loaded into *every* Claude invocation — implement and review on each feedback-loop iteration, plus every post-push fix pass — its length is a correctness lever, not tidiness: Claude Code's own guidance is that a longer file reduces adherence.

## The contradiction, and the evidence it's fixed

Three end-to-end runs through the rewritten files, on two different subsystems, using the local dev harness against a mounted copy of this repo:

| Run | Surface | Branch | Commits | Staged | Outcome |
|---|---|---|---|---|---|
| AII-212 | execution backends, monitor logs | none | 0 | 0 | turn-capped |
| AII-203 | admin-ui router + pages | none | 0 | 0 | turn-capped |
| AII-203 (higher cap) | admin-ui router + pages | none | 0 | 0 | **success, review approved** |

No run branched, committed, or pushed. The third also produced the implementation summary the pipeline posts to the ticket — covering what changed per file, three judgement calls with reasoning, and the acceptance criteria checked off. Previously a run on this repo left a ticket carrying nothing but a bare pull-request link, because the root template omitted the instruction the distributed one has.

## What changed

**`WORKFLOW.md`** — rewritten. States pipeline git ownership in the direction the pipeline actually enforces, adds the `ai-output/comments/01-summary.md` instruction, keeps the `${PR_NUMBER}` dispatcher, and carries this repo's real verification commands with the note that there is no lint script. Drops the placeholder repo context and the seed scaffolding.

**`CLAUDE.md`** — 665 → ~250 lines, of which ~230 reach the model. Corrections include a dedup "24-hour window" that does not exist, a Linear client at a path that never existed, eight of twenty-one SQLite tables, a `GITHUB_PAT` that is not a thing, a `.claude/settings.json` that is absent, five of nine step keys, a `:next` fallback that is `:latest` everywhere, and `protect-custom.yml` described as rejecting when it only warns. Depth moved into `docs/` behind "Full reference:" links; a subsystem index replaces the project-structure tree.

**New `docs/` references** — `pipeline-architecture.md`, `review-fix-rail.md` (the largest previously-undocumented subsystem), `kg-sidecar.md`, `deployment.md`, `runner-images.md`, and a `README.md` explaining the two-tier convention: top-level files are references `CLAUDE.md` cites, subdirectories are typed artifacts.

**Templates and code** — both distributed templates corrected; `gap_analysis_model` removed from the parser, interface, and templates with its test reshaped to pin the removal; the stale hooks comment in `run-autonomous.ts` fixed to match `Dockerfile.session`, which already said the opposite; `.env.example`'s callback section relabelled.

## Acceptance criteria

| Criterion | How it's met | Key files |
|---|---|---|
| Runner prompt matches pipeline behaviour | Git-ownership section inverted; verified by three runs producing no branch or commit | `WORKFLOW.md` |
| Ticket receives real reasoning | Summary instruction added; verified by a run writing a 3 KB summary | `WORKFLOW.md` |
| Reference the agent loads is accurate | ~30 corrections, each re-verified against source | `CLAUDE.md` |
| Reference is cheap enough to follow | 665 → ~250 lines; depth relocated, nothing deleted | `CLAUDE.md`, `docs/` |
| Templates stop making false promises | Bedrock hard-fail claim corrected in both | `workflows/*.md` |
| Dead front-matter key gone | Removed from parser, interface, templates; test pins it | `src/workflow-md.ts` |

## Verification

`npm run typecheck` clean; `npm test` 2314 passing across 136 files. The reshaped test was additionally type-checked under a throwaway config, since `tsconfig.json` excludes `src/__tests__` and vitest strips types without checking them — so nothing else would have caught an error there.

Every relocated section was diffed against the original to confirm no substantive point was lost. That check found four genuine drops, all restored: the deprecated legacy-repo cap variables, the runner-label security note about self-hosted runners seeing job secrets, the log-verbosity level semantics, and the pull-request-approval toggle. The last came back **corrected** rather than restated — it is not a prerequisite, because every synced workflow opens PRs with a GitHub App token while that toggle governs the `github-actions[bot]` actor.

## Follow-ups

Filed separately rather than folded in here:

- Runner environment variables leak into the test process, so `npm test` inside a dev-run container fails 62 tests on an otherwise-green tree. An agent was observed dismissing them as pre-existing and proceeding.
- An approved mounted run is reported as `review did not approve … (approved)`, and its autopsy claims no code changes were produced while files sit modified — both because mounted mode's no-op push makes absence of a PR read as absence of work.
- `docs/feature-branch-grouping.md` and `docs/workflow-envelope.md` are now cited as authoritative and have never been audited.
- `README.md` has never been checked against the code.

Fixes AII-204
Fixes AII-216
Fixes AII-332
Fixes AII-333
