### PR TITLE
fix: honest token expiry for dependency-token vending

### DIFF
--- a/session/git-credential-helper.sh
+++ b/session/git-credential-helper.sh
@@ -41,13 +41,10 @@ EXPIRES_AT=$(jq -r '.expires_at // empty' "$TOKEN_FILE" 2>/dev/null) || true
 
 # Refresh when fewer than 10 minutes remain on the cached token.
 #
-# NOTE: expires_at is a synthetic 55-minute estimate produced by the vending
-# endpoint (getScopedInstallationToken discards GitHub's real expiry).  A
-# 10-minute safety margin is conservative — we refresh at ~45 min elapsed,
-# well before the estimate lapses.  This is safe today because installation
-# tokens last ~60 minutes, but if GitHub ever issues shorter tokens the
-# estimate could lie; see AII-294 notes on widening getScopedInstallationToken
-# to surface the real expiry.
+# expires_at is GitHub's real token expiry, passed through verbatim by the
+# vending endpoint, which also force-mints on every vend — so a fresh token
+# always arrives with its full (~60-minute) lifetime and the 10-minute margin
+# holds even if GitHub ever shortens token lifetimes.
 CALLBACK_URL="${GIT_DEPENDENCY_CALLBACK_URL:-}"
 # Treat this environment value as untrusted input. Normalize all trailing
 # slashes so appending the exact route can never produce a double-slash path.
@@ -72,9 +69,21 @@ if [ -n "$EXPIRES_AT" ] && [ -n "$CALLBACK_URL" ] && [ -n "$PROGRESS_TOKEN" ]; t
             NEW_EXPIRES=$(echo "$RESPONSE" | jq -r '.expires_at // empty' 2>/dev/null) || true
 
             if [ -n "$NEW_TOKEN" ] && [ -n "$NEW_EXPIRES" ]; then
-                # Overwrite cache atomically enough for a single-container runner.
-                printf '{"token":"%s","expires_at":"%s"}' "$NEW_TOKEN" "$NEW_EXPIRES" > "$TOKEN_FILE"
-                TOKEN="$NEW_TOKEN"
+                # git spawns one helper process per credential request, so parallel
+                # fetches can read this file while we replace it — write to a temp
+                # file in the same directory and rename so a reader never sees a
+                # truncated cache.  jq builds the JSON so a value containing quotes
+                # or backslashes cannot wedge the cache with unparseable content.
+                TMP_FILE=$(mktemp "${TOKEN_FILE}.XXXXXX" 2>/dev/null) || TMP_FILE=""
+                if [ -n "$TMP_FILE" ]; then
+                    if jq -n --arg token "$NEW_TOKEN" --arg expires_at "$NEW_EXPIRES" \
+                        '{token: $token, expires_at: $expires_at}' > "$TMP_FILE" 2>/dev/null; then
+                        mv -f "$TMP_FILE" "$TOKEN_FILE"
+                        TOKEN="$NEW_TOKEN"
+                    else
+                        rm -f "$TMP_FILE"
+                    fi
+                fi
             fi
         fi
     fi

--- a/src/__tests__/dependency-token-vending.test.ts
+++ b/src/__tests__/dependency-token-vending.test.ts
@@ -100,21 +100,21 @@ async function callHandler(opts: {
 }
 
 describe("handleDependencyTokenRequest", () => {
-  it("returns 200 with token and expires_at for valid progress token + enabled scope", async () => {
+  it("returns 200 with token and GitHub's real expires_at for valid progress token + enabled scope", async () => {
     const token = mintProgressToken();
-    mockGetScopedToken.mockResolvedValueOnce("ghs_installation_token");
+    const realExpiry = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    mockGetScopedToken.mockResolvedValueOnce({ token: "ghs_installation_token", expiresAt: realExpiry });
 
     const result = await callHandler({ authorization: `Bearer ${token}` });
 
     expect(result.status).toBe(200);
     expect(result.body.token).toBe("ghs_installation_token");
-    expect(typeof result.body.expires_at).toBe("string");
-    expect(new Date(result.body.expires_at as string).getTime()).toBeGreaterThan(Date.now());
+    expect(result.body.expires_at).toBe(realExpiry);
   });
 
-  it("mints token with { contents: 'read' } permissions and no repositories field", async () => {
+  it("force-mints with { contents: 'read' } permissions and no repositories field", async () => {
     const token = mintProgressToken();
-    mockGetScopedToken.mockResolvedValueOnce("ghs_token");
+    mockGetScopedToken.mockResolvedValueOnce({ token: "ghs_token", expiresAt: "2030-01-01T00:00:00Z" });
 
     await callHandler({ authorization: `Bearer ${token}` });
 
@@ -122,7 +122,7 @@ describe("handleDependencyTokenRequest", () => {
       "app-id",
       "fake-key",
       "acme",
-      { permissions: { contents: "read" } },
+      { permissions: { contents: "read" }, forceRefresh: true },
     );
     const opts = mockGetScopedToken.mock.calls[0][3] as Record<string, unknown>;
     expect(opts).not.toHaveProperty("repositories");
@@ -130,7 +130,7 @@ describe("handleDependencyTokenRequest", () => {
 
   it("uses owner from the mapping, not anything from the request", async () => {
     const token = mintProgressToken();
-    mockGetScopedToken.mockResolvedValueOnce("ghs_token");
+    mockGetScopedToken.mockResolvedValueOnce({ token: "ghs_token", expiresAt: "2030-01-01T00:00:00Z" });
 
     await callHandler({
       authorization: `Bearer ${token}`,
@@ -144,7 +144,7 @@ describe("handleDependencyTokenRequest", () => {
 
   it("progress token can be used more than once (multi-use)", async () => {
     const token = mintProgressToken();
-    mockGetScopedToken.mockResolvedValue("ghs_token");
+    mockGetScopedToken.mockResolvedValue({ token: "ghs_token", expiresAt: "2030-01-01T00:00:00Z" });
 
     const first = await callHandler({ authorization: `Bearer ${token}` });
     const second = await callHandler({ authorization: `Bearer ${token}` });

--- a/src/__tests__/github-app-auth.test.ts
+++ b/src/__tests__/github-app-auth.test.ts
@@ -322,10 +322,10 @@ describe("getScopedInstallationToken", () => {
       { ok: true, json: { token: "ghs_perms", expires_at: futureExpiresAt() } },
     ]));
 
-    const token = await getScopedInstallationToken(APP_ID, privateKey, "my-org", {
+    const result = await getScopedInstallationToken(APP_ID, privateKey, "my-org", {
       permissions: { contents: "read" },
     });
-    expect(token).toBe("ghs_perms");
+    expect(result.token).toBe("ghs_perms");
 
     const [, opts] = vi.mocked(fetch).mock.calls[1];
     const body = JSON.parse((opts as RequestInit).body as string);
@@ -424,8 +424,9 @@ describe("getScopedInstallationToken", () => {
 
     const t1 = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
     const t2 = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
-    expect(t1).toBe("ghs_hit");
-    expect(t2).toBe("ghs_hit");
+    expect(t1.token).toBe("ghs_hit");
+    expect(t2.token).toBe("ghs_hit");
+    expect(t2.expiresAt).toBe(t1.expiresAt); // cache hit carries the real expiry through
     expect(fetch).toHaveBeenCalledTimes(2); // install + token, then served from cache
   });
 
@@ -440,9 +441,9 @@ describe("getScopedInstallationToken", () => {
     const t1 = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { repositories: ["repo-a"] });
     const t2 = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { repositories: ["repo-a"], forceRefresh: true });
     const t3 = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { repositories: ["repo-a"] });
-    expect(t1).toBe("ghs_first");
-    expect(t2).toBe("ghs_fresh");
-    expect(t3).toBe("ghs_fresh"); // the forced mint replaced the cached entry
+    expect(t1.token).toBe("ghs_first");
+    expect(t2.token).toBe("ghs_fresh");
+    expect(t3.token).toBe("ghs_fresh"); // the forced mint replaced the cached entry
     expect(fetch).toHaveBeenCalledTimes(4);
   });
 
@@ -456,8 +457,8 @@ describe("getScopedInstallationToken", () => {
 
     const t1 = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
     const t2 = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "write" } });
-    expect(t1).toBe("ghs_read");
-    expect(t2).toBe("ghs_write");
+    expect(t1.token).toBe("ghs_read");
+    expect(t2.token).toBe("ghs_write");
     expect(fetch).toHaveBeenCalledTimes(4);
   });
 
@@ -465,21 +466,24 @@ describe("getScopedInstallationToken", () => {
     const baseMs = 1_700_000_000_000;
     const oneHourMs = 60 * 60 * 1000;
     const fiveMinMs = 5 * 60 * 1000;
+    const realExpiry = new Date(baseMs + oneHourMs).toISOString();
 
     vi.spyOn(Date, "now").mockReturnValue(baseMs);
 
     vi.mocked(fetch).mockImplementation(mockFetch([
       { ok: true, json: { id: 1 } },
-      { ok: true, json: { token: "ghs_ttl", expires_at: new Date(baseMs + oneHourMs).toISOString() } },
+      { ok: true, json: { token: "ghs_ttl", expires_at: realExpiry } },
     ]));
 
-    await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
+    const minted = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
+    expect(minted.expiresAt).toBe(realExpiry); // GitHub's expiry surfaces verbatim, no synthetic estimate
 
     // Just before TTL boundary: cache still valid
     vi.spyOn(Date, "now").mockReturnValue(baseMs + oneHourMs - fiveMinMs - 1);
     vi.mocked(fetch).mockClear();
     const cached = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
-    expect(cached).toBe("ghs_ttl");
+    expect(cached.token).toBe("ghs_ttl");
+    expect(cached.expiresAt).toBe(realExpiry);
     expect(fetch).not.toHaveBeenCalled();
 
     // Just past TTL boundary: cache expired → re-fetch
@@ -490,7 +494,7 @@ describe("getScopedInstallationToken", () => {
     ]));
 
     const fresh = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
-    expect(fresh).toBe("ghs_ttl2");
+    expect(fresh.token).toBe("ghs_ttl2");
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
@@ -510,8 +514,8 @@ describe("getScopedInstallationToken", () => {
       { ok: true, json: { token: "ghs_after", expires_at: futureExpiresAt() } },
     ]));
 
-    const token = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
-    expect(token).toBe("ghs_after");
+    const result = await getScopedInstallationToken(APP_ID, privateKey, "my-org", { permissions: { contents: "read" } });
+    expect(result.token).toBe("ghs_after");
     expect(fetch).toHaveBeenCalledTimes(2); // re-fetched after cache was cleared
   });
 
@@ -547,10 +551,10 @@ describe("getScopedInstallationToken", () => {
       { ok: true, json: { token: "ghs_user_scoped", expires_at: futureExpiresAt() } },
     ]));
 
-    const token = await getScopedInstallationToken(APP_ID, privateKey, "my-user", {
+    const result = await getScopedInstallationToken(APP_ID, privateKey, "my-user", {
       repositories: ["my-repo"],
     });
-    expect(token).toBe("ghs_user_scoped");
+    expect(result.token).toBe("ghs_user_scoped");
 
     const [userInstallUrl] = vi.mocked(fetch).mock.calls[1];
     expect(userInstallUrl).toBe("https://api.github.com/users/my-user/installation");

--- a/src/__tests__/token-vending.test.ts
+++ b/src/__tests__/token-vending.test.ts
@@ -89,13 +89,13 @@ describe("token-vending", () => {
       repo: "acme/my-repo",
       machineNonce: "valid-nonce-123",
     });
-    mockGetScopedInstallationToken.mockResolvedValueOnce("ghs_test_token");
+    mockGetScopedInstallationToken.mockResolvedValueOnce({ token: "ghs_test_token", expiresAt: "2030-01-01T00:00:00Z" });
 
     const res = await callTokenEndpoint({ nonce: "valid-nonce-123", owner: "acme" });
     expect(res.statusCode).toBe(200);
     const data = JSON.parse(res.body);
     expect(data.token).toBe("ghs_test_token");
-    expect(data.expires_at).toBeTruthy();
+    expect(data.expires_at).toBe("2030-01-01T00:00:00Z");
     expect(mockGetScopedInstallationToken).toHaveBeenCalledWith(
       "app-id", "fake-private-key", "acme", { repositories: ["my-repo"], forceRefresh: true }
     );

--- a/src/dependency-token-vending.ts
+++ b/src/dependency-token-vending.ts
@@ -57,14 +57,16 @@ export async function handleDependencyTokenRequest(
   }
 
   try {
-    const token = await getScopedInstallationToken(
+    // forceRefresh: the credential helper refreshes purely on expires_at — never on 401 —
+    // so a vend must return a full-lifetime token. A cache hit could be minutes from
+    // expiry, and once it lapses every sibling clone fails for the rest of the run.
+    const { token, expiresAt } = await getScopedInstallationToken(
       input.githubAppId,
       input.githubAppPrivateKey,
       mapping.owner,
-      { permissions: { contents: "read" } },
+      { permissions: { contents: "read" }, forceRefresh: true },
     );
-    const expires_at = new Date(Date.now() + 55 * 60 * 1000).toISOString();
-    return { status: 200, body: { token, expires_at } };
+    return { status: 200, body: { token, expires_at: expiresAt } };
   } catch (err) {
     console.error("[dependency-token] Failed to mint installation token:", err);
     return { status: 500, body: { error: "Failed to mint token" } };

--- a/src/github-app-auth.ts
+++ b/src/github-app-auth.ts
@@ -9,8 +9,8 @@ export interface InstallationDetails {
 
 // Cache: owner → { token, expiresAt }
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
-// Cache: scopedCacheKey(owner, options) → { token, expiresAt }
-const scopedTokenCache = new Map<string, { token: string; expiresAt: number }>();
+// Cache: scopedCacheKey(owner, options) → { token, real expiresAt (ISO), staleAt (cache cutoff, ms) }
+const scopedTokenCache = new Map<string, { token: string; expiresAt: string; staleAt: number }>();
 let cachedAppSlug: string | null = null;
 const TOKEN_CACHE_TTL_MS = 50 * 60 * 1000;
 
@@ -178,6 +178,12 @@ export interface ScopedTokenOptions {
   forceRefresh?: boolean;
 }
 
+export interface ScopedInstallationToken {
+  token: string;
+  /** GitHub's actual expiry for this token (ISO 8601), passed through verbatim. */
+  expiresAt: string;
+}
+
 function scopedCacheKey(owner: string, options?: ScopedTokenOptions): string {
   const perms = options?.permissions
     ? Object.entries(options.permissions)
@@ -194,7 +200,10 @@ function scopedCacheKey(owner: string, options?: ScopedTokenOptions): string {
  * Passes `permissions` and/or `repositories` in the request body when supplied; sends no body
  * when neither is given (GitHub then grants the App's full installation permissions).
  *
- * TTL is derived from the response `expires_at` minus a 5-minute safety margin, so the
+ * Returns the token together with GitHub's real `expires_at`, so callers that advertise an
+ * expiry downstream never have to synthesize one.
+ *
+ * Cache TTL is derived from `expires_at` minus a 5-minute safety margin, so the
  * cache stays accurate regardless of the actual token lifetime.
  * Cached per (owner, permissions, repositories) tuple — distinct option sets never collide.
  */
@@ -203,11 +212,11 @@ export async function getScopedInstallationToken(
   privateKey: string,
   owner: string,
   options?: ScopedTokenOptions,
-): Promise<string> {
+): Promise<ScopedInstallationToken> {
   const cacheKey = scopedCacheKey(owner, options);
   const cached = scopedTokenCache.get(cacheKey);
-  if (!options?.forceRefresh && cached && Date.now() < cached.expiresAt) {
-    return cached.token;
+  if (!options?.forceRefresh && cached && Date.now() < cached.staleAt) {
+    return { token: cached.token, expiresAt: cached.expiresAt };
   }
 
   const normalizedKey = privateKey.replace(/\\n/g, "\n");
@@ -240,11 +249,14 @@ export async function getScopedInstallationToken(
 
   const tokenData = (await tokenRes.json()) as { token: string; expires_at: string };
   const expMs = new Date(tokenData.expires_at).getTime();
+  // Fallbacks cover GitHub omitting or sending an unparseable expires_at: assume the
+  // standard ~60-minute lifetime, advertised conservatively at 55.
   const expiresAt = Number.isFinite(expMs)
-    ? expMs - 5 * 60 * 1000
-    : Date.now() + 50 * 60 * 1000; // fallback when GitHub omits or sends an unparseable expires_at
-  scopedTokenCache.set(cacheKey, { token: tokenData.token, expiresAt });
-  return tokenData.token;
+    ? tokenData.expires_at
+    : new Date(Date.now() + 55 * 60 * 1000).toISOString();
+  const staleAt = Number.isFinite(expMs) ? expMs - 5 * 60 * 1000 : Date.now() + 50 * 60 * 1000;
+  scopedTokenCache.set(cacheKey, { token: tokenData.token, expiresAt, staleAt });
+  return { token: tokenData.token, expiresAt };
 }
 
 /**

--- a/src/pipeline/steps/dependency-auth.ts
+++ b/src/pipeline/steps/dependency-auth.ts
@@ -136,8 +136,8 @@ export const dependencyAuthStep: StepModule<DependencyAuthInputs, DependencyAuth
       }
 
       // Export COMPOSER_AUTH for composer's API-based (dist) downloads.
-      // This is a snapshot of the token at fetch time; valid for approximately
-      // one hour (matching the 55-min synthetic expires_at from the endpoint).
+      // This is a snapshot of the token at fetch time; valid until the endpoint's
+      // expires_at (GitHub's real token expiry, ~1 hour on a fresh mint).
       // Dependency installs run early in the pipeline, so this is acceptable
       // in practice — adding refresh machinery for COMPOSER_AUTH is not needed.
       process.env.COMPOSER_AUTH = JSON.stringify({ "github-oauth": { "github.com": result.token } });

--- a/src/token-vending.ts
+++ b/src/token-vending.ts
@@ -47,11 +47,10 @@ export async function handleTokenRequest(
     }
 
     // forceRefresh mirrors the refreshInstallationToken semantics this endpoint had on
-    // testing: the advertised 55-minute expiry is only honest on a freshly minted token,
-    // never a cache hit.
+    // testing: a vend must return a full-lifetime token, never a cache hit that may be
+    // minutes from expiry.
     const repoName = job.repo!.split("/")[1];
-    const token = await getScopedInstallationToken(githubAppId, githubAppPrivateKey, body.owner, { repositories: [repoName], forceRefresh: true });
-    const expiresAt = new Date(Date.now() + 55 * 60 * 1000).toISOString();
+    const { token, expiresAt } = await getScopedInstallationToken(githubAppId, githubAppPrivateKey, body.owner, { repositories: [repoName], forceRefresh: true });
 
     json(res, 200, { token, expires_at: expiresAt });
   } catch (err) {


### PR DESCRIPTION
## Summary

Addresses review feedback on the multi-repo runner token minting ([AII-287](https://linear.app/eudoxus/issue/AII-287) tree). All three findings validated as real:

1. **`handleDependencyTokenRequest` was missing `forceRefresh: true`** — a cache hit up to ~55 minutes old could be vended while advertising `now + 55min`. Since `git-credential-helper.sh` refreshes purely on the advertised `expires_at` (never on 401), a near-expiry cache hit meant every sibling clone 401ing unrecoverably for the rest of the run. Cross-run cache hits are the normal case when projects share one owner.
2. **Credential-helper cache write was not atomic** — git spawns one helper process per credential request, so parallel fetches / composer workers could read the token file mid-truncation, and every failed parse exits 0 silently.
3. **`getScopedInstallationToken` discarded GitHub's real `expires_at`** — both vending endpoints synthesized `now + 55min` (the latent assumption flagged in the helper's AII-294 note).

## Changes

- `getScopedInstallationToken` now returns `{ token, expiresAt }` with GitHub's real expiry passed through verbatim; cache entries carry it too, so even cache hits advertise an honest expiry. This makes finding #1's bug class unrepresentable rather than a per-call-site convention (it had exactly two callers, both vending endpoints).
- `POST /api/runner/dependency-token` now passes `forceRefresh: true`, matching `/api/token`, so every vend returns a full-lifetime token.
- `/api/token` drops its synthesized expiry in favor of the real one (`forceRefresh` unchanged).
- `session/git-credential-helper.sh` refresh now writes via `mktemp` in the same directory + `mv` (atomic rename; mktemp's 0600 mode preserves the file's permissions) and builds the JSON with `jq -n --arg`, so a truncated read or a value containing quotes/backslashes can no longer wedge the cache. A failed temp write cleans up and falls back to the old token.
- Updated the now-stale AII-294 comment in the helper and the COMPOSER_AUTH comment in `dependency-auth.ts`.

## Testing

- `npm test` — 2,436 tests across 139 files pass, including the helper's refresh-path integration tests (mocked vending server, cache-file re-parse) and updated assertions that `forceRefresh: true` is sent and GitHub's expiry surfaces verbatim through both endpoints and cache hits
- `npm run typecheck` clean, plus a strict-mode throwaway `tsc` pass over the edited test files (vitest does not type-check)
- `shellcheck session/git-credential-helper.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)