### PR TITLE
CLAUDE.md: dual-target KG binding — record the local transition server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ Bindings for the KG skills (bd-kg-search, kg recon — format: skills `docs/kg-b
 - kg.mcp_server:   orch-ai-implement-testing
 - kg.search_tool:  mcp__orch-ai-implement-testing__kg_hybrid_search
 - kg.source_repo:  BuildDownAI/knowledge-graph-ai-implement
+- kg.local_mcp_server:  ai-implement-kg
+- kg.local_search_tool: mcp__ai-implement-kg__kg_hybrid_search
+- kg.prefer:       orchestrator
 
 ## Architecture
 


### PR DESCRIPTION
Companion to [BuildDownAI/skills#47](https://github.com/BuildDownAI/skills/pull/47) (merged): records this project's **local transition KG binding** in the canonical block so the new dual-target resolution rule can use it on any machine.

**Diff: three lines added to the `## Knowledge graph` block**
- `kg.local_mcp_server: ai-implement-kg` — the local stdio server (user-level config on dev machines)
- `kg.local_search_tool: mcp__ai-implement-kg__kg_hybrid_search`
- `kg.prefer: orchestrator` — skills try the orchestrator first; local is the announced fallback (or explicit choice by flipping this to `local` during development)

**Why this deliberately lands AFTER skills#47:** the block is the contract surface the skills *read* — these fields only mean something once the resolution rule that consumes them exists in skills `testing`. Committing them first would have had every other machine's plugin reading fields with no defined semantics, and if #47's review had changed the field names, this block would reference a contract that never shipped. Definition first (skills repo), then consumers' config (project repos) — same ordering discipline as every other binding-format change.

No behavior change for machines without the local server configured: the fields are optional, `kg.prefer: orchestrator` keeps the source-of-truth default, and skills without a bound local target simply never fall back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)