### PR TITLE
fix: accept localhost redirect URIs in MCP OAuth client registration

### DIFF
--- a/src/__tests__/mcp-oauth.test.ts
+++ b/src/__tests__/mcp-oauth.test.ts
@@ -245,8 +245,16 @@ describe("handleMcpClientRegistration", () => {
     expect(res.statusCode).toBe(201);
   });
 
-  it("rejects localhost hostname redirects in favor of loopback IP literals", async () => {
+  it("accepts localhost hostname redirects (what MCP clients actually register)", async () => {
     const body = JSON.stringify({ redirect_uris: ["http://localhost:8080/callback"] });
+    const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
+    const res = new MockResponse();
+    await mcpOauth.handleMcpClientRegistration(req, asRes(res));
+    expect(res.statusCode).toBe(201);
+  });
+
+  it("rejects non-loopback HTTP hostname redirects", async () => {
+    const body = JSON.stringify({ redirect_uris: ["http://evil.example:8080/callback"] });
     const req = mkReq("/mcp/register", "POST", { "content-type": "application/json" }, body);
     const res = new MockResponse();
     await mcpOauth.handleMcpClientRegistration(req, asRes(res));

--- a/src/mcp-oauth.ts
+++ b/src/mcp-oauth.ts
@@ -138,6 +138,11 @@ function isAllowedRedirectUri(redirectUri: string): boolean {
 
   const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (parsed.protocol === "http:") {
+    // RFC 8252 §7.3 prefers loopback IP literals, but real MCP clients
+    // (Claude Code included) register http://localhost:<port> — accept both.
+    if (host === "localhost") {
+      return true;
+    }
     const ipVersion = isIP(host);
     return ipVersion === 6 ? host === "::1" : ipVersion === 4 && host.startsWith("127.");
   }
@@ -243,7 +248,7 @@ export async function handleMcpClientRegistration(
   ) {
     return json(res, 400, {
       error: "invalid_redirect_uri",
-      error_description: "redirect_uris must use a loopback IP literal over HTTP or an explicitly allowed HTTPS origin",
+      error_description: "redirect_uris must use localhost or a loopback IP over HTTP, or an explicitly allowed HTTPS origin",
     });
   }
 


### PR DESCRIPTION
## Problem

Authenticating Claude Code against the orchestrator's `/mcp` endpoint fails immediately with:

> SDK auth failed: redirect_uris must use a loopback IP literal over HTTP or an explicitly allowed HTTPS origin

Claude Code's MCP client dynamically registers its OAuth callback as `http://localhost:<port>/callback`, but `isAllowedRedirectUri` in `src/mcp-oauth.ts` only accepted literal loopback IPs (`127.x.x.x` / `::1`) over HTTP. `localhost` is a hostname, not an IP literal, so registration was rejected before the auth flow could start. Reproduced against the live testing orchestrator's `/mcp/register`.

## Fix

Accept the exact hostname `localhost` over HTTP alongside loopback IP literals (RFC 8252 §7.3 prefers IP literals, but real MCP clients register `localhost`). Everything else is unchanged and still rejected: other HTTP hostnames, non-HTTPS schemes, HTTPS origins not listed in `MCP_ALLOWED_REDIRECT_ORIGINS`, and URIs carrying credentials.

## Tests

- Flipped the test that deliberately pinned localhost rejection to expect acceptance.
- Added a test that a non-loopback HTTP hostname (`http://evil.example:8080/callback`) is still rejected.
- Full suite: 2437 passed (139 files); `npm run typecheck` clean.

## Deploy note

The fix only takes effect on the deployed orchestrator after a redeploy (`scripts/deploy-orchestrator.sh`); then re-run **Authenticate** on the `orch-ai-implement-testing` MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)