### PR TITLE
fix: parse SSE-framed sidecar tools/list so kg_* tools reach /mcp clients

### DIFF
--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -270,6 +270,35 @@ describe("handleMcpRequest", () => {
       expect(names).toContain("kg_search");
     });
 
+    it("merges kg_* tools from an SSE-framed sidecar response (streamable-HTTP)", async () => {
+      const mockProxyReq = new PassThrough();
+      const mockProxyRes = new PassThrough();
+      Object.assign(mockProxyRes, { statusCode: 200, headers: { "content-type": "text/event-stream" } });
+      mockHttpRequest.mockImplementationOnce((_o: unknown, cb: (r: unknown) => void) => {
+        process.nextTick(() => {
+          cb(mockProxyRes);
+          mockProxyRes.push(": ping\n\n");
+          mockProxyRes.push(
+            `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [{ name: "kg_hybrid_search", description: "hybrid" }] } })}\n\n`,
+          );
+          mockProxyRes.push(null);
+        });
+        return mockProxyReq;
+      });
+      const result = await callMcp(
+        { authorization: "Bearer tok" },
+        true,
+        SIDECAR_URL,
+        BASE_URL,
+        "POST",
+        '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}',
+      );
+      expect(result.statusCode).toBe(200);
+      const names = JSON.parse(result.body).result.tools.map((t: { name: string }) => t.name);
+      expect(names).toContain("get_tenant_health");
+      expect(names).toContain("kg_hybrid_search");
+    });
+
     it("returns only diagnostic tools when sidecar returns invalid JSON", async () => {
       const mockProxyReq = new PassThrough();
       const mockProxyRes = new PassThrough();

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -299,6 +299,84 @@ describe("handleMcpRequest", () => {
       expect(names).toContain("kg_hybrid_search");
     });
 
+    it("joins multi-line SSE data fields before parsing", async () => {
+      const payload = JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [{ name: "kg_search" }] } });
+      const mid = Math.floor(payload.length / 2);
+      const mockProxyReq = new PassThrough();
+      const mockProxyRes = new PassThrough();
+      Object.assign(mockProxyRes, { statusCode: 200, headers: { "content-type": "text/event-stream" } });
+      mockHttpRequest.mockImplementationOnce((_o: unknown, cb: (r: unknown) => void) => {
+        process.nextTick(() => {
+          cb(mockProxyRes);
+          mockProxyRes.push(`event: message\ndata: ${payload.slice(0, mid)}\ndata:${payload.slice(mid)}\n\n`);
+          mockProxyRes.push(null);
+        });
+        return mockProxyReq;
+      });
+      const result = await callMcp(
+        { authorization: "Bearer tok" },
+        true,
+        SIDECAR_URL,
+        BASE_URL,
+        "POST",
+        '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}',
+      );
+      const names = JSON.parse(result.body).result.tools.map((t: { name: string }) => t.name);
+      expect(names).toContain("kg_search");
+    });
+
+    it("returns only diagnostic tools when the sidecar replies with a JSON-RPC error over SSE", async () => {
+      const mockProxyReq = new PassThrough();
+      const mockProxyRes = new PassThrough();
+      Object.assign(mockProxyRes, { statusCode: 400, headers: { "content-type": "text/event-stream" } });
+      mockHttpRequest.mockImplementationOnce((_o: unknown, cb: (r: unknown) => void) => {
+        process.nextTick(() => {
+          cb(mockProxyRes);
+          mockProxyRes.push(
+            `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: "server-error", error: { code: -32600, message: "Bad Request: Missing session ID" } })}\n\n`,
+          );
+          mockProxyRes.push(null);
+        });
+        return mockProxyReq;
+      });
+      const result = await callMcp(
+        { authorization: "Bearer tok" },
+        true,
+        SIDECAR_URL,
+        BASE_URL,
+        "POST",
+        '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}',
+      );
+      const parsed = JSON.parse(result.body);
+      expect(parsed.result.tools.some((t: { name: string }) => t.name === "get_tenant_health")).toBe(true);
+      expect(parsed.result.tools.some((t: { name: string }) => t.name.startsWith("kg_"))).toBe(false);
+    });
+
+    it("returns only diagnostic tools when the SSE stream carries only pings", async () => {
+      const mockProxyReq = new PassThrough();
+      const mockProxyRes = new PassThrough();
+      Object.assign(mockProxyRes, { statusCode: 200, headers: { "content-type": "text/event-stream" } });
+      mockHttpRequest.mockImplementationOnce((_o: unknown, cb: (r: unknown) => void) => {
+        process.nextTick(() => {
+          cb(mockProxyRes);
+          mockProxyRes.push(": ping\n\n: ping\n\n");
+          mockProxyRes.push(null);
+        });
+        return mockProxyReq;
+      });
+      const result = await callMcp(
+        { authorization: "Bearer tok" },
+        true,
+        SIDECAR_URL,
+        BASE_URL,
+        "POST",
+        '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}',
+      );
+      const parsed = JSON.parse(result.body);
+      expect(parsed.result.tools.some((t: { name: string }) => t.name === "get_tenant_health")).toBe(true);
+      expect(parsed.result.tools.some((t: { name: string }) => t.name.startsWith("kg_"))).toBe(false);
+    });
+
     it("returns only diagnostic tools when sidecar returns invalid JSON", async () => {
       const mockProxyReq = new PassThrough();
       const mockProxyRes = new PassThrough();

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -164,29 +164,43 @@ function callDiagnosticTool(name: string, args: Record<string, unknown>): unknow
 
 // ---- Sidecar proxy helpers ----
 
+interface SidecarRpcResponse {
+  result?: { tools?: unknown[] };
+  error?: unknown;
+}
+
 /**
  * Extract the JSON-RPC response from a sidecar reply. The Python MCP SDK's
  * streamable-HTTP transport frames responses as SSE (`event:`/`data:` lines)
- * rather than a bare JSON body, so both encodings must be handled.
+ * rather than a bare JSON body, so both encodings must be handled. Returns
+ * the first event carrying a `result` (falling back to one carrying an
+ * `error`), or null if nothing in the reply is a JSON-RPC response.
  */
-function parseSidecarRpcResponse(
-  raw: string,
-  contentType: string | undefined,
-): { result?: { tools?: unknown[] } } | null {
+function parseSidecarRpcResponse(raw: string, contentType: string | undefined): SidecarRpcResponse | null {
   if (contentType?.includes("text/event-stream")) {
-    for (const line of raw.split("\n")) {
-      if (!line.startsWith("data:")) continue;
+    let errorReply: SidecarRpcResponse | null = null;
+    // Events are separated by blank lines; one event's data may span several
+    // data: lines, joined with newlines before parsing.
+    for (const event of raw.split(/\r?\n\r?\n/)) {
+      const data = event
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).replace(/^ /, ""))
+        .join("\n");
+      if (!data) continue;
       try {
-        const parsed = JSON.parse(line.slice(5).trim()) as { result?: { tools?: unknown[] } };
-        if (parsed && typeof parsed === "object" && "result" in parsed) return parsed;
+        const parsed = JSON.parse(data) as SidecarRpcResponse;
+        if (!parsed || typeof parsed !== "object") continue;
+        if ("result" in parsed) return parsed;
+        if ("error" in parsed) errorReply ??= parsed;
       } catch {
         // keep scanning; other events (pings, notifications) may share the stream
       }
     }
-    return null;
+    return errorReply;
   }
   try {
-    return JSON.parse(raw) as { result?: { tools?: unknown[] } };
+    return JSON.parse(raw) as SidecarRpcResponse;
   } catch {
     return null;
   }
@@ -220,6 +234,10 @@ function fetchSidecarToolsList(
         if (!parsed) {
           console.error(
             `[mcp] KG sidecar tools/list unparseable (status ${proxyRes.statusCode}, content-type ${proxyRes.headers["content-type"]}): ${raw.slice(0, 200)}`,
+          );
+        } else if (!parsed.result) {
+          console.error(
+            `[mcp] KG sidecar tools/list returned no result (status ${proxyRes.statusCode}): ${JSON.stringify(parsed.error ?? parsed).slice(0, 200)}`,
           );
         }
         resolve(parsed?.result?.tools ?? []);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -164,6 +164,34 @@ function callDiagnosticTool(name: string, args: Record<string, unknown>): unknow
 
 // ---- Sidecar proxy helpers ----
 
+/**
+ * Extract the JSON-RPC response from a sidecar reply. The Python MCP SDK's
+ * streamable-HTTP transport frames responses as SSE (`event:`/`data:` lines)
+ * rather than a bare JSON body, so both encodings must be handled.
+ */
+function parseSidecarRpcResponse(
+  raw: string,
+  contentType: string | undefined,
+): { result?: { tools?: unknown[] } } | null {
+  if (contentType?.includes("text/event-stream")) {
+    for (const line of raw.split("\n")) {
+      if (!line.startsWith("data:")) continue;
+      try {
+        const parsed = JSON.parse(line.slice(5).trim()) as { result?: { tools?: unknown[] } };
+        if (parsed && typeof parsed === "object" && "result" in parsed) return parsed;
+      } catch {
+        // keep scanning; other events (pings, notifications) may share the stream
+      }
+    }
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as { result?: { tools?: unknown[] } };
+  } catch {
+    return null;
+  }
+}
+
 function fetchSidecarToolsList(
   kgSidecarUrl: string,
   body: Buffer,
@@ -187,14 +215,14 @@ function fetchSidecarToolsList(
       const chunks: Buffer[] = [];
       proxyRes.on("data", (chunk: Buffer) => chunks.push(chunk));
       proxyRes.on("end", () => {
-        try {
-          const parsed = JSON.parse(Buffer.concat(chunks).toString()) as {
-            result?: { tools?: unknown[] };
-          };
-          resolve(parsed.result?.tools ?? []);
-        } catch {
-          resolve([]);
+        const raw = Buffer.concat(chunks).toString();
+        const parsed = parseSidecarRpcResponse(raw, proxyRes.headers["content-type"]);
+        if (!parsed) {
+          console.error(
+            `[mcp] KG sidecar tools/list unparseable (status ${proxyRes.statusCode}, content-type ${proxyRes.headers["content-type"]}): ${raw.slice(0, 200)}`,
+          );
         }
+        resolve(parsed?.result?.tools ?? []);
       });
       proxyRes.on("error", () => resolve([]));
     });


### PR DESCRIPTION
## Problem

`/mcp` clients only ever see the five orchestrator diagnostic tools — `kg_hybrid_search` and the other `kg_*` tools never appear, even with a fully healthy KG sidecar. This has been true on every deploy; it was masked because the failure is completely silent.

## Root cause

The Python MCP SDK's streamable-HTTP transport (the sidecar's `KG_HTTP=1` mode) frames JSON-RPC responses as **SSE** — `content-type: text/event-stream` with the payload on a `data:` line. `fetchSidecarToolsList` in `src/mcp.ts` ran a bare `JSON.parse` on that body, threw, and resolved to `[]` in a bare `catch`, so the `tools/list` merge silently degraded to diagnostics-only.

Reproduced by running the sidecar locally in HTTP mode and replaying the MCP handshake: `initialize` → `notifications/initialized` → `tools/list` returns all six `kg_*` tools, SSE-framed. Everything else in the chain (OAuth, session propagation through the verbatim proxy, `tools/call` forwarding) was already correct — the bug was confined to the one function that parses the sidecar's `tools/list` for the merge.

## Fix

- New `parseSidecarRpcResponse` handles both encodings: SSE (scanning `data:` lines, skipping pings/notifications) and plain JSON.
- An unparseable sidecar reply now logs status, content-type, and a body snippet via `console.error` instead of being swallowed — the silent-failure shape is what let this ship broken.

## Tests

- New test: SSE-framed sidecar `tools/list` (including a ping event) merges `kg_hybrid_search` alongside the diagnostic tools.
- Existing invalid-JSON and plain-JSON merge tests still pass unchanged.
- Full suite: 2438 passed (139 files); `npm run typecheck` clean.

## After merge

Redeploy the orchestrator, then reconnect `/mcp` — `kg_hybrid_search` should finally appear, and the CLAUDE.md `kg.search_tool` binding becomes real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)