### PR TITLE
CLAUDE.md: KG binding-doc citation follows the skills bd-shared restructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,11 @@ Bindings for the BuildDown skills (bd-build-up, bd-build-down, bd-summit-push, e
 
 ## Knowledge graph
 
-Bindings for the KG skills (bd-kg-search, kg recon — format: skills `docs/kg-binding.md`):
+Bindings for the KG skills (bd-kg-search, kg recon — format: skills `plugin/skills/bd-shared/kg-binding.md`):
+
+> **Path note (skills PR #49):** the skills repo moved its shared docs from `docs/` into
+> `plugin/skills/bd-shared/`. Stubs remain at the old `docs/` paths, so old citations still
+> resolve. Use the `bd-shared/` path in new references.
 
 - kg.present:      true
 - kg.orchestrator: https://ai-implement-testing-orchestrator.fly.dev


### PR DESCRIPTION
Companion to skills PR #49: the shared skill docs moved from `docs/` to `plugin/skills/bd-shared/`. This updates the KG block's citation and notes the move (stubs remain at the old paths). One prose change, no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)