### PR TITLE
feat: pause dispatch while a deploy holds work back (AII-356)

### DIFF
--- a/src/__tests__/deploy-hold.test.ts
+++ b/src/__tests__/deploy-hold.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type * as DedupModule from "../dedup.js";
+import type * as DeployHoldModule from "../deploy-hold.js";
+import type * as RunnerModeModule from "../runner-mode.js";
+
+let dbPath: string;
+let dedup: typeof DedupModule;
+let hold: typeof DeployHoldModule;
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(
+    os.tmpdir(),
+    `deploy-hold-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  hold = await import("../deploy-hold.js");
+  const runnerMode: typeof RunnerModeModule = await import("../runner-mode.js");
+  runnerMode.initSettingsTable(); // the hold is a `settings` row; runner-mode owns that DDL
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("deploy hold", () => {
+  it("is not held on a fresh database", () => {
+    expect(hold.isDeployHeld()).toBe(false);
+  });
+
+  it("holds after set, and setting again is idempotent", () => {
+    hold.setDeployHold();
+    expect(hold.isDeployHeld()).toBe(true);
+    hold.setDeployHold();
+    expect(hold.isDeployHeld()).toBe(true);
+  });
+
+  it("clear releases the hold and reports that one was set", () => {
+    hold.setDeployHold();
+    expect(hold.clearDeployHold()).toBe(true);
+    expect(hold.isDeployHeld()).toBe(false);
+  });
+
+  it("clear reports false when nothing was held — a boot after a clean shutdown", () => {
+    expect(hold.clearDeployHold()).toBe(false);
+    expect(hold.isDeployHeld()).toBe(false);
+  });
+
+  it("reads false rather than throwing when the settings table is missing", async () => {
+    // A read failure must not wedge dispatch: isDeployHeld swallows it and reports "not held".
+    // Simulated by a database that never had initSettingsTable() run against it.
+    vi.resetModules();
+    const bareDbPath = path.join(
+      os.tmpdir(),
+      `deploy-hold-bare-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+    );
+    process.env.DEDUP_DB_PATH = bareDbPath;
+    const bareDedup: typeof DedupModule = await import("../dedup.js");
+    const bareHold: typeof DeployHoldModule = await import("../deploy-hold.js");
+
+    expect(bareHold.isDeployHeld()).toBe(false);
+
+    bareDedup.closeDb();
+    try {
+      fs.unlinkSync(bareDbPath);
+    } catch {
+      /* ignore */
+    }
+    process.env.DEDUP_DB_PATH = dbPath;
+  });
+
+  it("survives a process boundary — the boot clear releases it, a restart alone does not", async () => {
+    hold.setDeployHold();
+    dedup.closeDb();
+
+    // A new process against the same volume: fresh modules, same sqlite file.
+    vi.resetModules();
+    dedup = await import("../dedup.js"); // reassigned so afterEach closes this handle
+    const hold2: typeof DeployHoldModule = await import("../deploy-hold.js");
+
+    expect(hold2.isDeployHeld()).toBe(true);
+    expect(hold2.clearDeployHold()).toBe(true);
+    expect(hold2.isDeployHeld()).toBe(false);
+  });
+});

--- a/src/__tests__/in-flight-work.test.ts
+++ b/src/__tests__/in-flight-work.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type * as DedupModule from "../dedup.js";
+import type * as LogModule from "../log.js";
+import type * as WorkflowSyncQueueModule from "../workflow-sync-queue.js";
+import type * as InFlightWorkModule from "../in-flight-work.js";
+import type * as ReviewFixQueueModule from "../review-fix-queue.js";
+import type * as ReconciliationModule from "../reconciliation.js";
+
+let dbPath: string;
+let dedup: typeof DedupModule;
+let log: typeof LogModule;
+let queue: typeof WorkflowSyncQueueModule;
+let inFlight: typeof InFlightWorkModule;
+let reviewFix: typeof ReviewFixQueueModule;
+let reconciliation: typeof ReconciliationModule;
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(
+    os.tmpdir(),
+    `in-flight-work-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  log = await import("../log.js");
+  queue = await import("../workflow-sync-queue.js");
+  inFlight = await import("../in-flight-work.js");
+  reviewFix = await import("../review-fix-queue.js");
+  reconciliation = await import("../reconciliation.js");
+  dedup.getDb(); // workflow_sync_queue + review_fix_queue DDL lives here
+  log.initLogTable();
+  reconciliation.initReconciliationTable();
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+/** A dispatch_log row defaults to 'dispatched', which is in-flight. */
+function dispatchJob(issueId: string): number {
+  return log.appendLog({ issueId, repo: "org/app", phase: "implementation" });
+}
+
+describe("getInFlightWork", () => {
+  it("reports nothing on an idle orchestrator", () => {
+    expect(inFlight.getInFlightWork()).toEqual([]);
+  });
+
+  it("counts in-flight runner jobs", () => {
+    dispatchJob("issue-1");
+    dispatchJob("issue-2");
+
+    expect(inFlight.getInFlightWork()).toEqual([{ kind: "runner-job", count: 2 }]);
+  });
+
+  it("ignores runner jobs that reached a terminal status", () => {
+    const done = dispatchJob("issue-1");
+    const live = dispatchJob("issue-2");
+    log.updateJobStatus(done, "completed");
+
+    expect(inFlight.getInFlightWork()).toEqual([{ kind: "runner-job", count: 1 }]);
+    expect(live).toBeGreaterThan(0);
+  });
+
+  it("counts a running workflow sync but not a queued one", () => {
+    queue.enqueueWorkflowSync("QUEUED"); // pending — resumes in the next process
+    const running = queue.enqueueWorkflowSync("RUNNING");
+    queue.updateWorkflowSyncStatus(running.id, "running");
+
+    expect(inFlight.getInFlightWork()).toEqual([{ kind: "workflow-sync", count: 1 }]);
+  });
+
+  it("reports every executing kind at once", () => {
+    dispatchJob("issue-1");
+    const running = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(running.id, "running");
+
+    expect(inFlight.getInFlightWork()).toEqual([
+      { kind: "runner-job", count: 1 },
+      { kind: "workflow-sync", count: 1 },
+    ]);
+  });
+
+  it("ignores the queues whose 'dispatched' means finished, not executing", () => {
+    // These two rows would each permanently block every future deploy if the predicate
+    // treated 'dispatched' as in-execution:
+    //   reconciliation_queue — 'dispatched' is set AFTER markMerged succeeds
+    //   review_fix_queue     — 'dispatched' is set after the runner launches and is never cleared
+    // The runner a review fix launches is already counted through dispatch_log, so counting the
+    // queue row would double-count it while it runs and never stop counting it afterwards.
+    const rec = reconciliation.enqueueReconciliation({
+      issueId: "issue-1",
+      issueIdentifier: "AII-1",
+      prNumber: 1,
+      repo: "org/app",
+      mergeCommitSha: "abc123",
+    });
+    reconciliation.updateReconciliationStatus(rec, "dispatched");
+
+    const fix = reviewFix.enqueueReviewFix({
+      issueId: "issue-2",
+      issueIdentifier: "AII-2",
+      repo: "org/app",
+      prNumber: 2,
+      reason: "late review feedback",
+    });
+    reviewFix.updateReviewFixStatus(fix, "dispatched");
+
+    expect(inFlight.getInFlightWork()).toEqual([]);
+  });
+});

--- a/src/__tests__/workflow-sync-queue.test.ts
+++ b/src/__tests__/workflow-sync-queue.test.ts
@@ -241,6 +241,26 @@ describe("runWorkflowSync executor", () => {
     expect(queue.countRunningWorkflowSyncs()).toBe(0);
   });
 
+  it("reclaims a stale running row to pending even while a deploy holds work back", async () => {
+    seedMapping("ENG");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    queue.updateWorkflowSyncStatus(id, "running");
+    // Age it past the stale window — an orchestrator that crashed mid-sync.
+    dedup
+      .getDb()
+      .prepare("UPDATE workflow_sync_queue SET updated_at = ? WHERE id = ?")
+      .run(Date.now() - queue.STALE_RUNNING_MS - 1000, id);
+    deployHold.setDeployHold();
+
+    await queue.runWorkflowSync(id, CREDS);
+
+    expect(workflowSync.syncWorkflowTemplates).not.toHaveBeenCalled();
+    // Left 'running' the row would count as in-flight work for the whole hold, and a deploy
+    // gated on that count reaching zero could never clear the hold that freezes it.
+    expect(queue.getWorkflowSyncById(id)?.status).toBe("pending");
+    expect(queue.countRunningWorkflowSyncs()).toBe(0);
+  });
+
   it("runs the deferred sync once the hold clears", async () => {
     seedMapping("ENG");
     const { id } = queue.enqueueWorkflowSync("ENG");

--- a/src/__tests__/workflow-sync-queue.test.ts
+++ b/src/__tests__/workflow-sync-queue.test.ts
@@ -6,6 +6,8 @@ import type * as DedupModule from "../dedup.js";
 import type * as ConfigModule from "../config.js";
 import type * as WorkflowSyncQueueModule from "../workflow-sync-queue.js";
 import type * as WorkflowSyncModule from "../workflow-sync.js";
+import type * as DeployHoldModule from "../deploy-hold.js";
+import type * as RunnerModeModule from "../runner-mode.js";
 import { DEFAULT_TICKETING_CONFIG } from "../providers/ticketing-config.js";
 
 // runWorkflowSync (the executor) imports syncWorkflowTemplates from this module; mock it so the
@@ -24,6 +26,7 @@ let dedup: typeof DedupModule;
 let config: typeof ConfigModule;
 let queue: typeof WorkflowSyncQueueModule;
 let workflowSync: typeof WorkflowSyncModule;
+let deployHold: typeof DeployHoldModule;
 
 const CREDS = { githubAppId: "test-app-id", githubAppPrivateKey: "test-key" };
 
@@ -49,8 +52,11 @@ beforeEach(async () => {
   config = await import("../config.js");
   queue = await import("../workflow-sync-queue.js");
   workflowSync = await import("../workflow-sync.js");
+  deployHold = await import("../deploy-hold.js");
   dedup.getDb(); // creates workflow_sync_queue (its DDL lives in getDb)
   config.initMappingsTable(); // executor tests seed a mapping
+  const runnerMode: typeof RunnerModeModule = await import("../runner-mode.js");
+  runnerMode.initSettingsTable(); // the deploy hold is a `settings` row; runner-mode owns that DDL
 });
 
 afterEach(() => {
@@ -162,6 +168,16 @@ describe("workflow sync queue — lifecycle & dedup", () => {
       .run(Date.now() - queue.STALE_RUNNING_MS - 1000, id);
     expect(queue.getStaleRunningWorkflowSyncs().map((j) => j.id)).toEqual([id]);
   });
+
+  it("countRunningWorkflowSyncs counts only rows the worker is actively processing", () => {
+    queue.enqueueWorkflowSync("A"); // pending — durable, resumes in the next process
+    const b = queue.enqueueWorkflowSync("B");
+    const c = queue.enqueueWorkflowSync("C");
+    queue.updateWorkflowSyncStatus(b.id, "running");
+    queue.updateWorkflowSyncStatus(c.id, "completed");
+
+    expect(queue.countRunningWorkflowSyncs()).toBe(1);
+  });
 });
 
 describe("runWorkflowSync executor", () => {
@@ -209,6 +225,34 @@ describe("runWorkflowSync executor", () => {
 
     expect(workflowSync.syncWorkflowTemplates).not.toHaveBeenCalled();
     expect(queue.getWorkflowSyncById(id)?.status).toBe("running"); // left untouched for the live runner
+  });
+
+  it("defers without touching the row while a deploy holds work back", async () => {
+    seedMapping("ENG");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    deployHold.setDeployHold();
+
+    await queue.runWorkflowSync(id, CREDS);
+
+    expect(workflowSync.syncWorkflowTemplates).not.toHaveBeenCalled();
+    // Still 'pending', never 'running': the safety net re-runs it with no special-casing, and it
+    // never counts toward the in-flight work the deploy is waiting on.
+    expect(queue.getWorkflowSyncById(id)?.status).toBe("pending");
+    expect(queue.countRunningWorkflowSyncs()).toBe(0);
+  });
+
+  it("runs the deferred sync once the hold clears", async () => {
+    seedMapping("ENG");
+    const { id } = queue.enqueueWorkflowSync("ENG");
+    deployHold.setDeployHold();
+    await queue.runWorkflowSync(id, CREDS);
+
+    deployHold.clearDeployHold();
+    vi.mocked(workflowSync.syncWorkflowTemplates).mockResolvedValueOnce(RESULT);
+    await queue.runWorkflowSync(id, CREDS);
+
+    expect(workflowSync.syncWorkflowTemplates).toHaveBeenCalledOnce();
+    expect(queue.getWorkflowSyncById(id)?.status).toBe("completed");
   });
 });
 

--- a/src/deploy-hold.ts
+++ b/src/deploy-hold.ts
@@ -1,0 +1,31 @@
+import { getDb } from "./dedup.js";
+
+const DEPLOY_HOLD_KEY = "deploy_hold";
+
+/** True while a deploy is holding new work back. */
+export function isDeployHeld(): boolean {
+  try {
+    const row = getDb()
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(DEPLOY_HOLD_KEY) as { value: string } | undefined;
+    return row?.value === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setDeployHold(): void {
+  getDb()
+    .prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, '1')")
+    .run(DEPLOY_HOLD_KEY);
+}
+
+/**
+ * Clears the hold. Returns whether one was set — at boot that means the previous
+ * process died mid-deploy, which is the only place the distinction is observable.
+ */
+export function clearDeployHold(): boolean {
+  const held = isDeployHeld();
+  getDb().prepare("DELETE FROM settings WHERE key = ?").run(DEPLOY_HOLD_KEY);
+  return held;
+}

--- a/src/in-flight-work.ts
+++ b/src/in-flight-work.ts
@@ -1,0 +1,30 @@
+import { getInFlightJobs } from "./log.js";
+import { countRunningWorkflowSyncs } from "./workflow-sync-queue.js";
+
+/** A category of work executing right now. Callers render or count it. */
+export interface InFlightWork {
+  kind: "runner-job" | "workflow-sync";
+  count: number;
+}
+
+/**
+ * Everything currently executing — not everything queued. Queued work is durable
+ * and resumes in the next process, so it belongs to no caller's blocking set.
+ *
+ * Every dispatch surface writes a dispatch_log row, so in-flight jobs cover issue
+ * dispatch, review fixes and gap-fills alike; workflow sync is the one worker that
+ * executes outside that table.
+ *
+ * An empty array means nothing is executing.
+ */
+export function getInFlightWork(): InFlightWork[] {
+  const work: InFlightWork[] = [];
+
+  const runnerJobs = getInFlightJobs().length;
+  if (runnerJobs > 0) work.push({ kind: "runner-job", count: runnerJobs });
+
+  const syncs = countRunningWorkflowSyncs();
+  if (syncs > 0) work.push({ kind: "workflow-sync", count: syncs });
+
+  return work;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { rememberCandidates, resolveInFlightSiblings, selectIssuesToDispatch, se
 import { notify, notifyCompletion, notifyText } from "./notify.js";
 import { postBootNotice, postShutdownNotice, recordShutdown } from "./deploy-notify.js";
 import { refreshAvailability, readStampedTarget, type SelfDeployTarget } from "./deploy-availability.js";
+import { clearDeployHold, isDeployHeld } from "./deploy-hold.js";
 import { remediateStuckJob, remediateFailedJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
 import { handleAdminRequest } from "./admin.js";
@@ -277,6 +278,8 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
       console.error("[deploy] availability check failed:", err);
     }
   }
+  // One read per tick so all three dispatch surfaces agree, even if the hold is set part-way through a poll.
+  const deployHeld = isDeployHeld();
 
   const allMappings = Object.values(getMappings());
   const providers = await registry.forAllMappings(allMappings);
@@ -423,12 +426,21 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
       return isAlreadyDispatched(issueId) || inFlightIssueIds.has(issueId) || isParked(issueId, phase);
     };
 
-    const toProcess = selectIssuesToDispatch(
-      allCandidates,
-      teamRepoMap,
-      inProgressCountsByTeam,
-      isDispatchBlocked,
-    );
+    // A deploy is holding new work back. Skipping selection cannot lose work:
+    // selectIssuesToDispatch is pure, and markDispatched runs only after a
+    // successful dispatch — so every candidate stays queued with dedup untouched.
+    if (deployHeld && allCandidates.length > 0) {
+      console.log(`[deploy] Dispatch paused — ${allCandidates.length} candidate(s) stay queued`);
+    }
+
+    const toProcess = deployHeld
+      ? []
+      : selectIssuesToDispatch(
+          allCandidates,
+          teamRepoMap,
+          inProgressCountsByTeam,
+          isDispatchBlocked,
+        );
 
     // AII-278 Finding 3: in-flight issues carry AI-Working and drop OUT of the
     // candidate snapshot, so filtering allCandidates made the in-flight set
@@ -581,32 +593,36 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
   // Process any pending reconciliation jobs triggered by merged PRs
   await processReconciliations(config, registry);
 
-  // Process pending late review feedback that arrived after the original run.
-  await processReviewFixQueue(config);
+  // Both of these launch runner jobs, so they pause with issue dispatch —
+  // otherwise the hold would block on work it is itself still creating.
+  if (!deployHeld) {
+    // Process pending late review feedback that arrived after the original run.
+    await processReviewFixQueue(config);
 
-  // Drain orchestrator-mediated /ai-implement comment gap-fills.
-  await drainCommentGapfillQueue({
-    getMappings,
-    runnerMode: getRunnerMode().mode,
-    notifyType: config.notifyType,
-    notifyWebhookUrl: config.notifyWebhookUrl,
-    runnerCallbackBaseUrl: config.runnerCallbackBaseUrl,
-    runnerTokenSecret: config.runnerTokenSecret,
-    getInstallationToken: (owner) => getInstallationToken(config.githubAppId, config.githubAppPrivateKey, owner),
-    resolveRunnerImage: (mapping, ghToken) => resolveDispatchRunnerImage(config, mapping, ghToken),
-    checkContract: (params) => resolveWorkflowContract(params),
-    dispatch: dispatchWorkflow,
-    postComment: postPrComment,
-    onDispatchFailure: surfaceDispatchFailure,
-    flySessionsToken: config.flySessionsToken,
-    flySessionsApp: config.flySessionsApp,
-    flySessionsRegion: config.flySessionsRegion,
-    flyOrchestratorApp: config.flyOrchestratorApp,
-    tenantId: config.tenantId,
-    anthropicApiKey: config.anthropicApiKey,
-    claudeOAuthToken: config.claudeOAuthToken,
-    sessionImage: config.sessionImage,
-  });
+    // Drain orchestrator-mediated /ai-implement comment gap-fills.
+    await drainCommentGapfillQueue({
+      getMappings,
+      runnerMode: getRunnerMode().mode,
+      notifyType: config.notifyType,
+      notifyWebhookUrl: config.notifyWebhookUrl,
+      runnerCallbackBaseUrl: config.runnerCallbackBaseUrl,
+      runnerTokenSecret: config.runnerTokenSecret,
+      getInstallationToken: (owner) => getInstallationToken(config.githubAppId, config.githubAppPrivateKey, owner),
+      resolveRunnerImage: (mapping, ghToken) => resolveDispatchRunnerImage(config, mapping, ghToken),
+      checkContract: (params) => resolveWorkflowContract(params),
+      dispatch: dispatchWorkflow,
+      postComment: postPrComment,
+      onDispatchFailure: surfaceDispatchFailure,
+      flySessionsToken: config.flySessionsToken,
+      flySessionsApp: config.flySessionsApp,
+      flySessionsRegion: config.flySessionsRegion,
+      flyOrchestratorApp: config.flyOrchestratorApp,
+      tenantId: config.tenantId,
+      anthropicApiKey: config.anthropicApiKey,
+      claudeOAuthToken: config.claudeOAuthToken,
+      sessionImage: config.sessionImage,
+    });
+  }
 
   // Crash-recovery safety net for workflow syncs. (NOT the primary trigger. the admin handlers fire runWorkflowSync immediately on save) 
   // this only re-runs jobs that lost their runner to a restart or a wedge.
@@ -3125,6 +3141,11 @@ async function main(): Promise<void> {
   initReconciliationTable();
   initStepLogTable();
   initMcpOAuthTables();
+
+  // A process that died mid-deploy must not leave dispatch paused forever.
+  if (clearDeployHold()) {
+    console.warn("[main] Cleared a hold left by the previous deployment process, resuming paused dispatches...");
+  }
 
   const config = loadConfig();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,7 +278,8 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
       console.error("[deploy] availability check failed:", err);
     }
   }
-  // One read per tick so all three dispatch surfaces agree, even if the hold is set part-way through a poll.
+  // Read once for the surfaces this poll owns, so they agree even if the hold is set part-way through a tick.
+  // runWorkflowSync reads it independently — the admin fire-immediately path has no tick to share.
   const deployHeld = isDeployHeld();
 
   const allMappings = Object.values(getMappings());
@@ -595,7 +596,9 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
 
   // Both of these launch runner jobs, so they pause with issue dispatch —
   // otherwise the hold would block on work it is itself still creating.
-  if (!deployHeld) {
+  if (deployHeld) {
+    console.log("[deploy] Review-fix and gap-fill drains paused. self-deployment in progress");
+  } else {
     // Process pending late review feedback that arrived after the original run.
     await processReviewFixQueue(config);
 

--- a/src/workflow-sync-queue.ts
+++ b/src/workflow-sync-queue.ts
@@ -1,6 +1,7 @@
 import { getDb } from "./dedup.js";
 import { getMappings } from "./config.js";
 import { syncWorkflowTemplates, classifySyncError, type WorkflowSyncResult, type ClassifiedSyncError } from "./workflow-sync.js";
+import { isDeployHeld } from "./deploy-hold.js";
 
 export type WorkflowSyncStatus = "pending" | "running" | "completed" | "failed";
 
@@ -82,6 +83,14 @@ export function getStaleRunningWorkflowSyncs(olderThanMs = STALE_RUNNING_MS, lim
   return rows.map(mapRow);
 }
 
+/** Rows the sync worker is actively processing. Queued ('pending') rows are durable and resume. */
+export function countRunningWorkflowSyncs(): number {
+  const row = getDb()
+    .prepare("SELECT COUNT(*) AS n FROM workflow_sync_queue WHERE status = 'running'")
+    .get() as { n: number };
+  return row.n;
+}
+
 export function updateWorkflowSyncStatus(
   id: number,
   status: WorkflowSyncStatus,
@@ -108,7 +117,13 @@ export async function runWorkflowSync(jobId: number, creds: WorkflowSyncCreds): 
   // A `running` row past the stale window is fair game (the safety net reclaims a crashed run).
   if (job.status === "running" && Date.now() - job.updatedAt < STALE_RUNNING_MS) return;
 
-  
+  // A deploy is waiting for work to drain; starting one here would block it on work it just created.
+  // The row stays 'pending', so the poll-loop safety net runs it once the hold clears.
+  if (isDeployHeld()) {
+    console.log(`[workflow-sync] Deferred sync #${jobId} — deploy in progress`);
+    return;
+  }
+
   updateWorkflowSyncStatus(jobId, "running");
 
   // Re-read the mapping at RUN time, not enqueue time: 

--- a/src/workflow-sync-queue.ts
+++ b/src/workflow-sync-queue.ts
@@ -114,11 +114,14 @@ export async function runWorkflowSync(jobId: number, creds: WorkflowSyncCreds): 
   const job = getWorkflowSyncById(jobId);
   if (!job) return; // row vanished — nothing to run
   // A fresh `running` row means a live runner already owns this job. Bail rather than double-fire the sync.
-  // A `running` row past the stale window is fair game (the safety net reclaims a crashed run).
-  if (job.status === "running" && Date.now() - job.updatedAt < STALE_RUNNING_MS) return;
+  if (job.status === "running") {
+    if (Date.now() - job.updatedAt < STALE_RUNNING_MS) return;
+    // A stale `running` row is a crashed run, reclaim it before the hold check.
+    updateWorkflowSyncStatus(jobId, "pending");
+  }
 
   // A deploy is waiting for work to drain; starting one here would block it on work it just created.
-  // The row stays 'pending', so the poll-loop safety net runs it once the hold clears.
+  // The row is left 'pending', so the poll-loop safety net runs it once the hold clears.
   if (isDeployHeld()) {
     console.log(`[workflow-sync] Deferred sync #${jobId} — deploy in progress`);
     return;


### PR DESCRIPTION
## Summary

Adds the guard the self-deploy work needs: a durable "a deploy is holding work back" flag, an inventory of what is currently executing, and a pause that stops every dispatch surface from starting new work while the flag is set.

Nothing here deploys. The flag has no writer yet — AII-357 sets it. This lands first so both halves are testable on their own by setting the state directly, which is how the live verification below was done.

The pause is lossless by construction: it skips *selection*, and `markDispatched` runs only after a successful dispatch, so refused work stays queued with dedup untouched and is re-evaluated on the next poll.

## Only two of the four queues named in the issue are real inputs

Worth reading before the diff, because the issue asked for something that would have broken the feature.

AII-356 specified the inventory as runner jobs plus in-execution rows across four queues. Checking each one's status vocabulary against its writers, `dispatched` does not mean the same thing in all of them:

| Table | Counts? | Why |
|---|---|---|
| `reconciliation_queue` | No | `dispatched` is set *after* `markMerged` succeeds — it is the success-terminal state |
| `review_fix_queue` | No | `dispatched` is set once the runner launches and is never cleared |
| `comment_gapfill_queue` | No | Transient, but the run it launched is already a `dispatch_log` row |
| `workflow_sync_queue` | Yes | `running` is real work invisible to `dispatch_log` |

Counting either of the first two would have left the orchestrator **permanently un-quiet** after the first merged PR or the first review fix — every future deploy blocked, silently, with no test written from the issue's wording catching it.

The simplification comes from a second check: every dispatch surface writes a `dispatch_log` row, so `getInFlightJobs()` already covers issue dispatch, review fixes and gap-fills alike. The inventory is two inputs, not five.

## What changed

**`src/in-flight-work.ts`** (new) — `getInFlightWork()` returns a positive inventory of what is executing, as `{ kind, count }` entries. Named for the codebase's existing vocabulary (`getInFlightJobs`, `getInFlightIssueIds`) and deliberately deploy-agnostic, so a future maintenance mode or graceful shutdown can use it unchanged.

**`src/deploy-hold.ts`** (new) — `isDeployHeld` / `setDeployHold` / `clearDeployHold`. A `settings` row rather than module state, because AII-360 needs the incoming process to distinguish "the deploy I scheduled finished" from "someone restarted me", and a durable flag found set at boot is the only thing carrying that across the process boundary. The read fails open, matching `getRunnerMode`.

**`src/index.ts`** — one hoisted `isDeployHeld()` read per poll tick, so all surfaces agree even if the flag flips mid-poll; empty `toProcess` in place of selection; the review-fix and comment-gapfill drains gated together; the boot clear after table init.

**`src/workflow-sync-queue.ts`** — `countRunningWorkflowSyncs()`, plus a hold check inside `runWorkflowSync` before the row flips to `running`. It goes in the shared executor rather than at the call site because the executor has **two** callers — the admin fire-immediately path and the poll safety net — and guarding only the poll would have missed the primary trigger entirely.

A stale `running` row is reclaimed to `pending` *before* that hold check. Reclaiming used to be implicit — the same write that claimed the job also reset its staleness timer — so inserting a guard between them would have frozen a crashed sync as `running` for the length of the hold, where it counts as in-flight work that a deploy gated on "wait for quiet" could never outlast. Caught in review; covered by `reclaims a stale running row to pending even while a deploy holds work back`.

Two modules rather than one is also what keeps imports acyclic: `workflow-sync-queue` imports the hold, and the inventory imports `workflow-sync-queue`.

### Deliberately left running while held

`monitorJobs` is the mechanism that *drains* the in-flight set — pausing it would mean jobs never reach terminal and the deploy waits forever on work it stopped watching. `processReconciliations` also stays live: it starts no runner, it is a tracker write with bounded retry, and interrupting it leaves the row `pending` for the next boot.

## Acceptance criteria

| Criterion | How it's met | Key files |
|---|---|---|
| Not-quiet with an in-flight runner job | `getInFlightWork` counts `dispatch_log` rows in `dispatched`/`running` | `in-flight-work.ts` |
| Not-quiet with a workflow sync running | `countRunningWorkflowSyncs` | `workflow-sync-queue.ts` |
| Quiet when work is merely queued | Pending rows excluded; covered by test | `in-flight-work.test.ts` |
| Reports which kind is responsible | Inventory returns `kind` + `count` per category | `in-flight-work.ts` |
| Nothing dispatched, nothing marked | Selection skipped entirely; verified live | `index.ts` |
| Refused work dispatches later | Verified live on both the issue and sync paths | `index.ts`, `workflow-sync-queue.ts` |
| Cleared on boot | `clearDeployHold()` after table init | `index.ts`, `deploy-hold.test.ts` |
| typecheck + tests pass | Clean; 2539 tests | — |

## Verification

`npm run typecheck` clean, full suite green on Node 24.

**The two poll-loop gates have no unit coverage and cannot get any** — no test file in this repo imports `../index`, because it calls `main()` on import. A local orchestrator run against a sandbox repo and a throwaway issue is their only coverage:

- Hold set before boot → `[main] Cleared a hold left by the previous deployment process, resuming paused dispatches...`
- Real candidate present → `[poll] Found 1 needing planning` then `[deploy] Dispatch paused — 1 candidate(s) stay queued`, repeated across polls, with `dispatched` and `dispatch_log` empty throughout
- Seven consecutive `[workflow-sync] Deferred sync #12 — deploy in progress`, alternating admin trigger and poll safety net
- Hold cleared → the deferred sync completed and the issue dispatched into a container
- Stopping that container mid-run had it classified `failed (exit 137)` and cleared for requeue; the re-armed hold then prevented the requeue

## Deliberately out of scope

**`/trigger/gap-fill` is a fourth dispatch surface and is intentionally not guarded here — tracked as AII-380.** It dispatches a runner straight from its HTTP handler and writes no `dispatch_log` row, so its runs are invisible to the inventory, to progress reporting, to gap-analysis result processing, and to monitoring. It predates the queue-based comment rail by two months and was never migrated. The right fix is to make it enqueue (or retire it), which deletes the code path rather than guarding it — so a guard here would be a stopgap removed by AII-380. The endpoint is dormant in every current deployment (`GAP_FILL_TRIGGER_SECRET` unset), so nothing is exposed meanwhile.

**`src/poll-selection.ts` is untouched**, despite the issue naming it. `selectIssuesToDispatch` is pure; reading the hold inside would make it impure and force every existing selection test to stub it, and the hold gates several surfaces, so one gate buried in a selection helper would split one policy across layers. Emptying `toProcess` at the call site is the same outcome with a smaller diff.

## Follow-ups

- **AII-380** — the untracked `/trigger/gap-fill` dispatch path, as above.
- The suite has an intermittent failure unrelated to this change: one test out of 2539 failed once, then passed eleven consecutive runs with no code change. The failing name wasn't captured. Flagging it so a stray red run isn't attributed here; worth capturing the name next time rather than re-running.
