### PR TITLE
ci: run the external Claude review on pushed commits

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,14 +13,6 @@ on:
   issue_comment:
     types: [created]
 
-# Collapse rapid push bursts: cancel the superseded run and review the settled head.
-# Group covers both PR events (pull_request.number) and comment-triggered re-runs
-# (issue.number). The fallback keeps the expression valid for neither-event contexts,
-# though in practice one of the two is always set.
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write
@@ -29,11 +21,10 @@ permissions:
 
 jobs:
   claude-review:
-    # Auto-run on same-repo PRs (opened/ready_for_review/synchronize). The top-level
-    # concurrency group cancels superseded runs on rapid pushes, so cost stays roughly
-    # "one review per quiet period". For fork PRs and re-runs, a maintainer must post
-    # `/claude-review` as a comment — forks must not auto-run on synchronize because
-    # pull_request_target has repository-secret access and that would be a priv-esc vector.
+    # Auto-run on same-repo PRs (opened/ready_for_review/synchronize). For fork PRs and
+    # re-runs, a maintainer must post `/claude-review` as a comment — forks must not
+    # auto-run on synchronize because pull_request_target has repository-secret access
+    # and that would be a priv-esc vector.
     if: |
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
@@ -44,6 +35,17 @@ jobs:
        (github.event.comment.author_association == 'OWNER' ||
         github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'COLLABORATOR'))
+    # Collapse rapid push bursts: cancel the superseded run and review the settled head.
+    # This MUST stay at job level, not workflow level. A workflow-level group is claimed
+    # the moment a run is created — before `if:` is evaluated — so any issue_comment (not
+    # just `/claude-review`), or a synchronize push to a draft PR, would cancel an
+    # in-flight legitimate review and then skip its own job. The killed review leaves no
+    # verdict, which the post-push gate correctly refuses, which resolves to
+    # review_failed and counts toward the dispatch breaker. At job level the group is
+    # only claimed once `if:` passes, so a skipped job cancels nothing.
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR head SHA

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,9 +9,17 @@ name: Claude PR review
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
+
+# Collapse rapid push bursts: cancel the superseded run and review the settled head.
+# Group covers both PR events (pull_request.number) and comment-triggered re-runs
+# (issue.number). The fallback keeps the expression valid for neither-event contexts,
+# though in practice one of the two is always set.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -20,10 +28,12 @@ permissions:
   id-token: write
 
 jobs:
-  review:
-    # Auto-run on same-repo PRs (opened/ready_for_review only — not synchronize,
-    # to control cost during iterative pushes). For fork PRs and re-runs, a
-    # maintainer must post `/claude-review` as a comment.
+  claude-review:
+    # Auto-run on same-repo PRs (opened/ready_for_review/synchronize). The top-level
+    # concurrency group cancels superseded runs on rapid pushes, so cost stays roughly
+    # "one review per quiet period". For fork PRs and re-runs, a maintainer must post
+    # `/claude-review` as a comment — forks must not auto-run on synchronize because
+    # pull_request_target has repository-secret access and that would be a priv-esc vector.
     if: |
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
@@ -86,5 +96,23 @@ jobs:
             comments only for specific code-line issues. Be concise — skip praise
             unless something is genuinely well-done. If the diff looks fine, say so
             briefly.
+
+            At the very end of your top-level sticky comment, append a machine-readable
+            verdict block on a single line, EXACTLY in this format (no extra whitespace
+            inside the markers):
+            <!-- claude-review-verdict {"blocking":[{"body":"...","path":"src/x.ts","line":12}],"minor":[{"body":"..."}]} -->
+
+            Rules for the verdict block:
+            - blocking[]: issues that must be fixed before merge (bugs, security, missing
+              requirements, data-loss risks). These gate approval and trigger a fix cycle.
+            - minor[]: everything else (style, cosmetic, future-task suggestions). These
+              are surfaced to the human merging but never trigger an automated fix cycle.
+            - Each entry: {"body":"full self-contained description","path":"file/path","line":42}
+              — path and line are optional; body is required and must be self-contained.
+            - Shorthand: bare strings also accepted, e.g. {"blocking":["full description"]}
+            - If nothing blocking or minor, use empty arrays: {"blocking":[],"minor":[]}
+            - Do NOT omit the verdict block even if you have nothing to report.
+            - NEVER use the sequence --> inside a finding body — it terminates the HTML
+              comment in rendered Markdown and will corrupt the verdict block.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Why this targets `main` specifically

This is the **only** file from the Close the Loop work that has to reach the default branch to take effect. Everything else ships with the orchestrator deploy from `testing`.

GitHub resolves `pull_request_target` workflows from the **default branch**, not from the branch a PR targets. So the version of `claude-review.yml` on `testing` has no effect on `testing`-targeting PRs.

That is measured, not assumed. On PRs #273, #274, #276 and #283 — all opened *after* the change landed on `testing` — the `claude-review` job did not run at all, while the `pull_request`-triggered `claude-code-review` job did. The external review has been resolving against `main`'s copy the whole time.

## What changes

- **`synchronize` added to the trigger.** Today the external review runs once when a PR opens and never again, so every gap-fill and fix-pass commit merges externally unreviewed. This is AII-312.
- **A concurrency group** collapses rapid push bursts into a single review of the settled head — the behaviour the original "control cost during iterative pushes" comment actually wanted.
- **Job renamed `review` → `claude-review`**, and the review prompt gains the machine-readable verdict block the post-push gate parses (AII-276).

## Why it matters now

The post-push gate was fixed to stop treating a *skipped* or *cancelled* check as a real review (AII-387, AII-389). That is correct, but with no review at the new head after a force-push it now fails closed, the run ends "Manual review required", and that resolves to `review_failed` — which the new dispatch breaker (AII-368) counts toward parking an issue after three consecutive.

This PR removes the cause. Without it, roughly the 13% of runs that need a second pass end unapproved and accumulate toward parks.

## Safety

- **Same-repo guard unchanged.** Fork PRs still require a maintainer to post `/claude-review`. `pull_request_target` carries repository secrets, so auto-running on fork pushes would be a privilege-escalation path. The `if:` condition is byte-identical to the current one apart from its comment.
- **Draft guard unchanged.**
- **No dual-copy concern.** `claude-review.yml` has no mirror under `workflows/` — it is repo-local and never synced to target repos.
- **`main` is not branch-protected**, so no required status check named `review` is broken by the job rename. The post-push gate's default check names include both `review` and `claude-review`.
- **Merge order does not matter.** The verdict block is safe in both directions: an orchestrator without the parser ignores it, one with the parser reads it. This can land before or after a `testing` deploy.

## Test plan

- [x] YAML parses; triggers, concurrency, job id, same-repo guard and draft guard all verified programmatically
- [x] Diff is exactly one file, byte-identical to the version already running on `testing`
- [ ] After merge: push a commit to an open PR and confirm a fresh `claude-review` run appears for the new head

Not merging this myself — it lands on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)