### PR TITLE
AII-421: Never approve with unresolved Claude findings

### DIFF
--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -280,6 +280,36 @@ describe("postPushReviewStep", () => {
     expect(invoke.mock.calls[1][0].prompt).toContain("1. Escape quoted user input");
   });
 
+  it("runs a fix pass when reviewer uses the findings alias", async () => {
+    const approvedWithFindings = JSON.stringify({
+      approved: true,
+      findings: [{ title: "Missing guard", problem: "Null input reaches the write path.", required_fix: "Reject null input." }],
+      feedback: "One finding remains.",
+      score: 7,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: approvedWithFindings, exitCode: 0, tokensUsed: 100 }));
+
+    const out = await postPushReviewStep.run(
+      makeCtx(invoke),
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[1][0].prompt).toContain("Missing guard");
+    expect(invoke.mock.calls[1][0].prompt).toContain("Reject null input.");
+  });
+
   it("runs a fix pass when an external changes-requested review blocks internal approval", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
@@ -384,6 +414,62 @@ describe("postPushReviewStep", () => {
     ]);
     const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
     expect(reviewComment).toContain("External review findings are blocking this PR.");
+  });
+
+  it("does not approve when the GitHub Actions Claude review reports a prose blocking finding", async () => {
+    const reviewerJson = JSON.stringify({
+      approved: true,
+      issues: [],
+      feedback: "Internal reviewer approves.",
+      score: 9,
+      progress_delta: 0,
+    });
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return { stdout: "[]", exitCode: 0 };
+      }
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/issues/42/comments?per_page=100")) {
+        return {
+          stdout: JSON.stringify([{
+            user: { login: "github-actions[bot]", type: "Bot" },
+            body: [
+              "**Claude finished the review**",
+              "",
+              "### Review: PR #42",
+              "",
+              "### Blocking",
+              "",
+              "**Missing regression test for the actual vulnerability that was fixed.**",
+              "The existing test would pass under the vulnerable implementation.",
+              "",
+              "### Everything else",
+              "",
+              "No other changes are required.",
+            ].join("\n"),
+            html_url: "https://example.com/claude-review",
+          }]),
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const ctx = makeCtx(invoke);
+
+    const out = await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[1][0].prompt).toContain("Missing regression test for the actual vulnerability that was fixed.");
   });
 
   it("preserves opportunistic external collection when reviewProviders is undefined", async () => {
@@ -1461,7 +1547,7 @@ describe("postPushReviewStep", () => {
     expect(fixComment).toContain("Notes:\nNo behavior changes.");
   });
 
-  it("approves with no fix cycle and lists minor external findings when the verdict has only minor[] entries", async () => {
+  it("withholds approval and initiates a fix pass when the verdict has only minor[] entries", async () => {
     const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "lgtm", score: 9, progress_delta: 0 });
     const ghComments: string[] = [];
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -1491,13 +1577,15 @@ describe("postPushReviewStep", () => {
       { report: vi.fn(async () => undefined) },
     );
 
-    expect(out.approved).toBe(true);
-    expect(invoke).toHaveBeenCalledTimes(1);
-    const approvalComment = ghComments.find((c) => c.includes("✅"));
-    expect(approvalComment).toContain("Unaddressed external review findings (non-blocking):");
-    expect(approvalComment).toContain("Consider extracting this to a helper function");
-    expect(approvalComment).toContain("Rename variable for clarity");
-    expect(approvalComment).toContain("**Merge readiness:** Ready to merge.");
+    expect(out.approved).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("Required external review findings");
+    expect(fixPrompt).toContain("Consider extracting this to a helper function");
+    expect(fixPrompt).toContain("Rename variable for clarity");
+    const reviewComment = ghComments.find((c) => c.includes("Reviewer found issues"));
+    expect(reviewComment).toContain("External review findings are blocking this PR.");
+    expect(ghComments.some((c) => c.includes("**Merge readiness:** Ready to merge."))).toBe(false);
   });
 
   it("withholds approval and initiates a fix pass when the verdict has blocking[] entries", async () => {

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -190,6 +190,7 @@ describe("postPushReviewStep", () => {
     );
     expect(out.approved).toBe(false);
     expect(out.iterations).toBe(2);
+    expect(out.terminationReason).toBe("iterations_exhausted");
     expect(gitPushCalls.length).toBe(1); // only one fix-pass-and-push happens before the cap-iteration which doesn't push
     expect(gitPushCalls[0]).toEqual([
       "push",

--- a/src/__tests__/review-ledger.test.ts
+++ b/src/__tests__/review-ledger.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   collectExternalReviewFindingsFromGh,
   extractClaudeSummaryFindings,
+  extractGithubActionsClaudeReviewFindings,
   extractVerdictMarkerFindings,
   formatReviewLedgerForPrompt,
   type GhSpawn,
@@ -122,6 +123,97 @@ Late reviews are not persisted.
         body: "Callback lifecycle can drop feedback Late reviews are not persisted.",
         url: "https://example.com/claude-review",
       },
+    ]);
+  });
+});
+
+describe("extractGithubActionsClaudeReviewFindings", () => {
+  it("extracts prose under the live Claude Actions blocking heading", () => {
+    const body = [
+      "**Claude finished the review**",
+      "",
+      "### Review: PR #302",
+      "",
+      "### Blocking",
+      "",
+      "**Missing regression test for the actual vulnerability that was fixed.**",
+      "The existing test would pass under the vulnerable implementation.",
+      "",
+      "### Everything else",
+      "",
+      "No other changes are required.",
+    ].join("\n");
+
+    expect(extractGithubActionsClaudeReviewFindings(body, "https://example.com/review")).toEqual([
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Missing regression test for the actual vulnerability that was fixed. The existing test would pass under the vulnerable implementation.",
+        url: "https://example.com/review",
+      },
+    ]);
+  });
+
+  it("accepts an explicit clean verdict when no finding signal is present", () => {
+    const body = [
+      "**Claude finished the review**",
+      "",
+      "### Review complete ✅",
+      "",
+      "No correctness, security, or style issues found.",
+    ].join("\n");
+
+    expect(extractGithubActionsClaudeReviewFindings(body)).toEqual([]);
+  });
+
+  it("accepts recognized finding sections that explicitly report no findings", () => {
+    const body = [
+      "**Claude finished the review**",
+      "",
+      "### Review complete ✅",
+      "",
+      "### Blocking",
+      "No blocking issues found.",
+      "",
+      "### Minor",
+      "No minor issues found.",
+    ].join("\n");
+
+    expect(extractGithubActionsClaudeReviewFindings(body)).toEqual([]);
+  });
+
+  it("does not treat no-blockers prose as clean when a minor finding follows", () => {
+    const body = [
+      "**Claude finished the review**",
+      "",
+      "### Review complete",
+      "",
+      "No blocking issues found. Minor issue: rename this variable for clarity.",
+    ].join("\n");
+
+    expect(extractGithubActionsClaudeReviewFindings(body)).toEqual([
+      expect.objectContaining({
+        source: "claude-review-summary",
+        severity: "medium",
+        body: expect.stringContaining("Minor issue"),
+      }),
+    ]);
+  });
+
+  it("fails closed when a completed review has neither findings nor an explicit clean verdict", () => {
+    const body = [
+      "**Claude finished the review**",
+      "",
+      "### Review",
+      "",
+      "The implementation follows the surrounding patterns.",
+    ].join("\n");
+
+    expect(extractGithubActionsClaudeReviewFindings(body)).toEqual([
+      expect.objectContaining({
+        source: "claude-review-summary",
+        severity: "medium",
+      }),
     ]);
   });
 });
@@ -940,6 +1032,75 @@ describe("collectExternalReviewFindingsFromGh", () => {
         severity: "minor",
         body: "Consider extracting a helper",
         url: "https://example.com/verdict-comment",
+      },
+    ]);
+  });
+
+  it("uses the latest Claude Actions review comment so fixed findings do not remain forever", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (isPullReviewsRequest(args)) return { exitCode: 0, stdout: "[]" };
+      if (isIssueCommentsRequest(args)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              user: { login: "github-actions[bot]", type: "Bot" },
+              body: "**Claude finished the review**\n\n### Review: first pass\n\n### Blocking\n\nMissing regression coverage.",
+              html_url: "https://example.com/old-review",
+              created_at: "2026-08-18T18:00:00Z",
+            },
+            {
+              user: { login: "github-actions[bot]", type: "Bot" },
+              body: "**Claude finished the review**\n\n### Review complete ✅\n\nNo correctness, security, or style issues found.",
+              html_url: "https://example.com/latest-review",
+              created_at: "2026-08-18T18:05:00Z",
+            },
+          ]),
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([]);
+  });
+
+  it("does not let an unrelated bot verdict supersede the latest Claude review", () => {
+    const ghSpawn: GhSpawn = (args) => {
+      if (isPullReviewsRequest(args)) return { exitCode: 0, stdout: "[]" };
+      if (isIssueCommentsRequest(args)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              user: { login: "github-actions[bot]", type: "Bot" },
+              body: "**Claude finished the review**\n\n### Review: current head\n\n### Blocking\n\nMissing regression coverage.",
+              html_url: "https://example.com/claude-review",
+              created_at: "2026-08-18T18:00:00Z",
+            },
+            {
+              user: { login: "unrelated-check[bot]", type: "Bot" },
+              body: '<!-- claude-review-verdict {"blocking":[],"minor":[]} -->',
+              html_url: "https://example.com/unrelated-bot",
+              created_at: "2026-08-18T18:05:00Z",
+            },
+          ]),
+        };
+      }
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } } }),
+      };
+    };
+
+    expect(collectExternalReviewFindingsFromGh(ghSpawn, "42")).toEqual([
+      {
+        source: "claude-review-summary",
+        severity: "blocking",
+        body: "Missing regression coverage.",
+        url: "https://example.com/claude-review",
       },
     ]);
   });

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1190,7 +1190,12 @@ describe("runAutonomous", () => {
     const { pipeline, runner } = makeStepsPipeline([
       ["feedback-loop", { run: vi.fn().mockResolvedValue({ approved: true, iterations: 1, terminationReason: "approved" }) }],
       ["push", { run: vi.fn().mockResolvedValue({ prUrl: "https://github.com/o/r/pull/12", prNumber: 12, branchPushed: true, draft: false }) }],
-      ["post-push-review", { run: vi.fn().mockResolvedValue({ approved: false, iterations: 2, finalFeedback: "External Claude finding remains." }) }],
+      ["post-push-review", { run: vi.fn().mockResolvedValue({
+        approved: false,
+        iterations: 2,
+        finalFeedback: "External Claude finding remains.",
+        terminationReason: "iterations_exhausted",
+      }) }],
     ]);
 
     const result = await runAutonomous({
@@ -1206,10 +1211,12 @@ describe("runAutonomous", () => {
     const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
       outcome: string;
       failureCode?: string;
+      failureReason?: string;
       prUrl?: string;
     };
     expect(body.outcome).toBe("failure");
     expect(body.failureCode).toBe("REVIEW_UNAPPROVED");
+    expect(body.failureReason).toContain("iterations_exhausted");
     expect(body.prUrl).toBe("https://github.com/o/r/pull/12");
   });
 

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1073,6 +1073,7 @@ describe("runAutonomous", () => {
     vi.stubEnv("RUN_TOKEN", "run-token");
 
     const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+    const postPushReviewRun = vi.fn().mockRejectedValue(new Error("skipped step must not run"));
     const { pipeline, runner } = makeStepsPipeline([
       [
         "feedback-loop",
@@ -1097,7 +1098,9 @@ describe("runAutonomous", () => {
           }),
         },
       ],
+      ["post-push-review", { run: postPushReviewRun }],
     ]);
+    pipeline.steps[2].skip = () => true;
 
     const result = await runAutonomous({
       workspaceDir,
@@ -1109,8 +1112,13 @@ describe("runAutonomous", () => {
     });
 
     expect(result.exitCode).toBe(0);
-    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as { failureCode: string };
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
+      failureCode: string;
+      failureReason: string;
+    };
+    expect(postPushReviewRun).not.toHaveBeenCalled();
     expect(body.failureCode).toBe("MAX_TURNS_EXHAUSTED");
+    expect(body.failureReason).toContain("ran out of turns");
   });
 
   it("writes the autopsy comment file on unapproved runs", async () => {

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1174,6 +1174,37 @@ describe("runAutonomous", () => {
     expect(body.failureCode).toBeUndefined();
   });
 
+  it("does not report success when the post-push review rejects an internally approved PR", async () => {
+    vi.stubEnv("RUNNER_CALLBACK_URL", "https://orchestrator.example");
+    vi.stubEnv("RUN_TOKEN", "run-token");
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+    const { pipeline, runner } = makeStepsPipeline([
+      ["feedback-loop", { run: vi.fn().mockResolvedValue({ approved: true, iterations: 1, terminationReason: "approved" }) }],
+      ["push", { run: vi.fn().mockResolvedValue({ prUrl: "https://github.com/o/r/pull/12", prNumber: 12, branchPushed: true, draft: false }) }],
+      ["post-push-review", { run: vi.fn().mockResolvedValue({ approved: false, iterations: 2, finalFeedback: "External Claude finding remains." }) }],
+    ]);
+
+    const result = await runAutonomous({
+      workspaceDir,
+      pipeline,
+      runner,
+      reporter: new NoopStepReporter(),
+      llmExecutor: makeMockExecutor(0),
+      fetchImpl: mockFetch,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string) as {
+      outcome: string;
+      failureCode?: string;
+      prUrl?: string;
+    };
+    expect(body.outcome).toBe("failure");
+    expect(body.failureCode).toBe("REVIEW_UNAPPROVED");
+    expect(body.prUrl).toBe("https://github.com/o/r/pull/12");
+  });
+
   it("approved mounted run exits 0, posts success with no prUrl, writes no autopsy", async () => {
     vi.stubEnv("AI_IMPLEMENT_MODE", "local");
     vi.stubEnv("AI_IMPLEMENT_WORKSPACE_MODE", "mounted");

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -961,6 +961,55 @@ describe("runAutonomous", () => {
     expect(body.prUrl).toBe("https://github.com/o/r/pull/9");
   });
 
+  it("reports the push step's actual non-draft PR state when an unapproved run reuses a real PR", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { pipeline, runner } = makeStepsPipeline([
+      [
+        "feedback-loop",
+        {
+          run: vi.fn().mockResolvedValue({
+            approved: false,
+            iterations: 1,
+            finalFeedback: "not approved",
+            terminationReason: "iterations_exhausted",
+            passes: [],
+          }),
+        },
+      ],
+      [
+        "push",
+        {
+          run: vi.fn().mockResolvedValue({
+            prUrl: "https://github.com/o/r/pull/9",
+            prNumber: 9,
+            branchPushed: true,
+            draft: false,
+          }),
+        },
+      ],
+    ]);
+
+    try {
+      await runAutonomous({
+        workspaceDir,
+        pipeline,
+        runner,
+        reporter: new NoopStepReporter(),
+        llmExecutor: makeMockExecutor(0),
+      });
+    } finally {
+      const summary = error.mock.calls.map((call) => call.join(" ")).join("\n");
+      const warnings = warn.mock.calls.map((call) => call.join(" ")).join("\n");
+      error.mockRestore();
+      warn.mockRestore();
+      expect(summary).toContain("outcome: PR https://github.com/o/r/pull/9");
+      expect(summary).not.toContain("outcome: draft PR https://github.com/o/r/pull/9");
+      expect(warnings).toContain("PR opened: https://github.com/o/r/pull/9");
+      expect(warnings).not.toContain("draft PR opened: https://github.com/o/r/pull/9");
+    }
+  });
+
   it("gap-fill run (prNumber set, unapproved) skips push — outcome derivation still reports a coded failure with no prUrl", async () => {
     // Mirrors pipeline-loader.ts's push skip condition for gap-fill runs: Claude owns git on
     // the existing PR branch there, so a gap-fill run must not run push against an

--- a/src/pipeline/review-ledger.ts
+++ b/src/pipeline/review-ledger.ts
@@ -33,6 +33,8 @@ const TRUSTED_REVIEW_COMMENT_AUTHORS = new Set([
   "claude-code[bot]",
 ]);
 
+const GITHUB_ACTIONS_REVIEW_AUTHOR = "github-actions";
+
 export function collectExternalReviewFindingsFromGh(ghSpawn: GhSpawn, prNumber: string): ReviewLedgerFinding[] {
   const findings: ReviewLedgerFinding[] = [];
 
@@ -190,6 +192,110 @@ export function extractClaudeSummaryFindings(body: string, url?: string): Review
   }));
 }
 
+function classifyClaudeFindingHeading(value: string): ReviewLedgerSeverity | null {
+  const normalized = normalizeText(value).replace(/:$/, "");
+  if (/\b(?:blocking|changes requested|must fix|required fixes?)\b/i.test(normalized)) return "blocking";
+  if (/\b(?:minor|non-blocking|notes?)\b/i.test(normalized)) return "minor";
+  if (/\b(?:findings?|issues?|concerns?|problems?)\b/i.test(normalized)) return "medium";
+  return null;
+}
+
+function stripClaudeActionNoise(lines: string[]): string {
+  return lines
+    .filter((line) => !/^\s*[-*]\s+\[[ xX]\]\s+/.test(line))
+    .filter((line) => !/^\s*[·•]\s+Branch\s*:/i.test(line))
+    .join("\n")
+    .trim();
+}
+
+function hasExplicitCleanVerdict(body: string): boolean {
+  return /\bno\s+(?:correctness(?:,\s*security,?\s*or\s*style)?)?\s*(?:issues?|findings?|concerns?|changes)\s+(?:were\s+)?(?:found|required)\b/i.test(body);
+}
+
+function hasFindingSignal(body: string): boolean {
+  return /\b(?:one|two|three|\d+)\s+(?:minor\s+)?(?:issues?|findings?|concerns?|notes?)\b/i.test(body)
+    || /\b(?:issue|finding|concern)\s+(?:undercuts|remains|requires|needs|must)\b/i.test(body)
+    || /\bminor\s+(?:issue|finding|concern|note)\b/i.test(body)
+    || /\bminor\s*\(\s*non-blocking\s*\)/i.test(body);
+}
+
+function isExplicitlyEmptyFindingSection(body: string): boolean {
+  const normalized = normalizeText(body).replace(/^[*_`\s-]+|[*_`.\s-]+$/g, "");
+  return /^(?:none|nothing|n\/a|no\s+(?:(?:blocking|minor|non-blocking|material|actionable)\s+)?(?:issues?|findings?|concerns?|changes)(?:\s+(?:were\s+)?(?:found|required))?)$/i.test(normalized);
+}
+
+/**
+ * Parses the live comment shape emitted by anthropics/claude-code-action when it runs
+ * under GitHub Actions. The action has repeatedly omitted the requested verdict marker,
+ * so a completed external review must not be treated as clean merely because the marker
+ * is absent. Recognized finding sections are preserved; ambiguous output fails closed.
+ */
+export function extractGithubActionsClaudeReviewFindings(body: string, url?: string): ReviewLedgerFinding[] {
+  const findings: ReviewLedgerFinding[] = [];
+  const lines = body.split(/\r?\n/);
+  let severity: ReviewLedgerSeverity | null = null;
+  let sectionLines: string[] = [];
+  let recognizedSections = 0;
+  let explicitlyEmptySections = 0;
+
+  const flush = () => {
+    if (!severity) {
+      sectionLines = [];
+      return;
+    }
+    const findingBody = normalizeText(stripClaudeActionNoise(sectionLines));
+    if (findingBody) {
+      if (isExplicitlyEmptyFindingSection(findingBody)) {
+        explicitlyEmptySections += 1;
+      } else {
+        findings.push({
+          source: "claude-review-summary",
+          severity,
+          body: findingBody,
+          ...(url ? { url } : {}),
+        });
+      }
+    }
+    sectionLines = [];
+  };
+
+  for (const line of lines) {
+    const markdownHeading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    const boldHeading = line.match(/^\s*\*\*(.+?)\*\*\s*(.*)$/);
+    if (markdownHeading) {
+      flush();
+      severity = classifyClaudeFindingHeading(markdownHeading[1]);
+      if (severity) recognizedSections += 1;
+      continue;
+    }
+    if (boldHeading) {
+      const boldSeverity = classifyClaudeFindingHeading(boldHeading[1]);
+      if (boldSeverity) {
+        flush();
+        severity = boldSeverity;
+        recognizedSections += 1;
+        const trailingText = boldHeading[2].trim();
+        if (trailingText) sectionLines.push(trailingText);
+        continue;
+      }
+    }
+    if (severity) sectionLines.push(line);
+  }
+  flush();
+
+  if (findings.length > 0) return findings;
+  if (recognizedSections > 0 && explicitlyEmptySections === recognizedSections) return [];
+  if (hasExplicitCleanVerdict(body) && !hasFindingSignal(body)) return [];
+
+  const reviewBody = normalizeText(stripClaudeActionNoise(lines));
+  return [{
+    source: "claude-review-summary",
+    severity: "medium",
+    body: reviewBody || "External Claude review did not provide an explicit clean verdict.",
+    ...(url ? { url } : {}),
+  }];
+}
+
 export function formatReviewLedgerForPrompt(findings: ReviewLedgerFinding[]): string {
   if (findings.length === 0) {
     return "No unresolved external review findings.";
@@ -264,21 +370,28 @@ function collectClaudeIssueComments(ghSpawn: GhSpawn, prNumber: string, findings
   ]);
   if (!result || result.exitCode !== 0) return;
 
-  const comments = parseReviewPages(result.stdout);
+  const comments = parseReviewPages(result.stdout)
+    .map((comment, index) => ({ comment, index, timestamp: reviewCommentTimestamp(comment) }))
+    .sort((a, b) => b.timestamp - a.timestamp || b.index - a.index)
+    .map(({ comment }) => comment);
 
+  // Top-level Claude review comments are revision verdicts, not an append-only ledger.
+  // The live action currently posts a new comment for each head instead of updating a
+  // sticky comment, so the newest recognized verdict supersedes older review summaries.
+  // Formal CHANGES_REQUESTED reviews and unresolved threads remain independently collected.
   for (const comment of comments) {
     if (!isRecord(comment) || typeof comment.body !== "string" || isAiImplementComment(comment.body)) continue;
 
     const url = typeof comment.html_url === "string" ? comment.html_url : undefined;
 
-    // Verdict marker path: accept from bot accounts (user.type === "Bot") and
-    // already-trusted authors. A human commenter cannot post as a Bot-type account,
-    // so the marker is not forgeable by an arbitrary PR participant.
+    // Verdict marker path: accept only from the GitHub Actions bot or an
+    // already-trusted Claude author. Other integrations must not be able to
+    // supersede the latest Claude review by emitting a lookalike marker.
     if (isVerdictEligibleAuthor(comment)) {
       const verdictFindings = extractVerdictMarkerFindings(comment.body, url);
       if (verdictFindings !== null) {
         findings.push(...verdictFindings);
-        continue;
+        return;
       }
     }
 
@@ -286,8 +399,25 @@ function collectClaudeIssueComments(ghSpawn: GhSpawn, prNumber: string, findings
     // Claude App identity that posts without a verdict marker).
     if (isLikelyClaudeReviewComment(comment)) {
       findings.push(...extractClaudeSummaryFindings(comment.body, url));
+      return;
+    }
+
+    if (isGithubActionsClaudeReviewComment(comment)) {
+      findings.push(...extractGithubActionsClaudeReviewFindings(comment.body, url));
+      return;
     }
   }
+}
+
+function reviewCommentTimestamp(comment: unknown): number {
+  if (!isRecord(comment)) return 0;
+  const value = typeof comment.updated_at === "string"
+    ? comment.updated_at
+    : typeof comment.created_at === "string"
+      ? comment.created_at
+      : "";
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
 function collectUnresolvedReviewThreads(
@@ -446,6 +576,13 @@ function isLikelyClaudeReviewComment(comment: Record<string, unknown>): comment 
   return isClaudeAuthor(comment) && hasClaudeReviewHeading(comment.body);
 }
 
+function isGithubActionsClaudeReviewComment(comment: Record<string, unknown>): comment is Record<string, unknown> & { body: string } {
+  if (typeof comment.body !== "string" || isAiImplementComment(comment.body)) return false;
+  return isGithubActionsBotAuthor(comment)
+    && /\*\*Claude finished\b/i.test(comment.body)
+    && hasClaudeReviewHeading(comment.body);
+}
+
 function isAiImplementComment(body: string): boolean {
   return body.includes("<!-- ai-implement");
 }
@@ -456,18 +593,19 @@ function isClaudeAuthor(comment: Record<string, unknown>): boolean {
   return TRUSTED_REVIEW_COMMENT_AUTHORS.has(user.login.toLowerCase());
 }
 
-function isBotAuthor(comment: Record<string, unknown>): boolean {
+function isGithubActionsBotAuthor(comment: Record<string, unknown>): boolean {
   const user = comment.user;
-  if (!isRecord(user)) return false;
-  return user.type === "Bot";
+  if (!isRecord(user) || typeof user.login !== "string") return false;
+  return user.type === "Bot"
+    && normalizeReviewerLogin(user.login) === GITHUB_ACTIONS_REVIEW_AUTHOR;
 }
 
 function isVerdictEligibleAuthor(comment: Record<string, unknown>): boolean {
-  return isBotAuthor(comment) || isClaudeAuthor(comment);
+  return isGithubActionsBotAuthor(comment) || isClaudeAuthor(comment);
 }
 
 function hasClaudeReviewHeading(body: string): boolean {
-  return /(?:^|\n)\s{0,3}#{1,6}\s+(?:PR Review|Code Review|Follow-up Review|Code Review Complete|Changes Requested)\b/i.test(body);
+  return /(?:^|\n)\s{0,3}#{1,6}\s+(?:PR Review|Code Review|Claude Review|Follow-up Review|Code Review Complete|Review(?=\s*:|\s+complete\b|\s*$)|Changes Requested)\b/im.test(body);
 }
 
 function isClaudeBlockingHeading(value: string): boolean {

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -215,7 +215,9 @@ function parseReviewIssues(parsed: Record<string, unknown>): ReviewIssue[] {
       ? parsed.blockingIssues
       : Array.isArray(parsed.issues)
         ? parsed.issues
-        : [];
+        : Array.isArray(parsed.findings)
+          ? parsed.findings
+          : [];
 
   return source
     .map(parseReviewIssue)
@@ -370,18 +372,6 @@ function suppressDuplicateExternalFeedback(feedback: string, externalFindings: R
 
 function externalBlockingCommentBlock(hasExternalBlockers: boolean): string {
   return hasExternalBlockers ? "\n\nExternal review findings are blocking this PR." : "";
-}
-
-function minorExternalFindingsBlock(findings: ReviewLedgerFinding[]): string {
-  const minorFindings = findings.filter((f) => f.severity === "minor");
-  if (minorFindings.length === 0) return "";
-  const issues = minorFindings.map((finding) => {
-    const location = finding.path
-      ? `${finding.path}${typeof finding.line === "number" ? `:${finding.line}` : ""}: `
-      : "";
-    return issueFromString(`${location}${finding.body}`);
-  });
-  return `\n\nUnaddressed external review findings (non-blocking):\n${formatIssueList(issues)}`;
 }
 
 function shouldCollectExternalReviewFindings(reviewProviders: string[] | undefined): boolean {
@@ -831,7 +821,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       }
 
       const parsed = extractFirstJsonObject(reviewResult.stdout) as
-        | { approved?: boolean; feedback?: string; issues?: unknown[]; blocking_issues?: unknown[]; blockingIssues?: unknown[] }
+        | { approved?: boolean; feedback?: string; issues?: unknown[]; findings?: unknown[]; blocking_issues?: unknown[]; blockingIssues?: unknown[] }
         | null;
       if (!parsed) {
         feedback = compactErrorMessage(`Reviewer returned non-JSON output: ${reviewResult.stdout || "(empty stdout)"}`);
@@ -879,12 +869,14 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       const externalFindings: ReviewLedgerFinding[] = externalReviewState === "skipped"
         ? []
         : collectExternalReviewFindingsFromGh(ghSpawn, prNumber);
-      const hasExternalBlockers = externalFindings.some((finding) => finding.severity === "blocking");
+      // Approval is a zero-findings invariant. Severity controls presentation and
+      // prioritisation, not whether a reported Claude finding may be silently escaped.
+      const hasExternalFindings = externalFindings.length > 0;
 
       feedback = suppressDuplicateExternalFeedback(String(parsed.feedback ?? ""), externalFindings);
       let issues = parseReviewIssues(parsed);
       issues = dedupeIssuesAgainstExternalFindings(issues, externalFindings);
-      if (issues.length === 0 && parsed.approved === false && !hasExternalBlockers) {
+      if (issues.length === 0 && parsed.approved === false && !hasExternalFindings) {
         feedback = "Reviewer returned invalid structured review output: approved=false requires at least one blocking_issues[] entry.";
         await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
         break;
@@ -893,7 +885,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       // Fail closed: the internal verdict is clean and no blockers are visible, but the
       // external review check did not finish within the wait budget. Do not auto-approve
       // against a reviewer that is still in flight — defer to a human.
-      const internalApprovable = parsed.approved === true && issues.length === 0 && !hasExternalBlockers;
+      const internalApprovable = parsed.approved === true && issues.length === 0 && !hasExternalFindings;
       if (internalApprovable && externalReviewPending) {
         feedback = "External review did not complete within the wait budget; not auto-approving.";
         await reporter.report({
@@ -938,7 +930,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         postPrComment(
           ghSpawn,
           prNumber,
-          `${marker}\n✅ Approved (${iteration} iteration${iteration > 1 ? "s" : ""}).\n\n${feedback}${minorExternalFindingsBlock(externalFindings)}\n\n**Merge readiness:** Ready to merge.`,
+          `${marker}\n✅ Approved (${iteration} iteration${iteration > 1 ? "s" : ""}).\n\n${feedback}\n\n**Merge readiness:** Ready to merge.`,
           marker,
         );
         break;
@@ -954,7 +946,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         postPrComment(
           ghSpawn,
           prNumber,
-          `${marker}\n⚠️ Reached review cap (${maxIterations} iterations) without approval.${blockingIssuesBlock(issues)}${externalBlockingCommentBlock(hasExternalBlockers)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
+          `${marker}\n⚠️ Reached review cap (${maxIterations} iterations) without approval.${blockingIssuesBlock(issues)}${externalBlockingCommentBlock(hasExternalFindings)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
           marker,
         );
         break;
@@ -964,7 +956,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       postPrComment(
         ghSpawn,
         prNumber,
-        `${feedbackMarker}\n⚠️ Reviewer found issues — starting fix pass ${fixPassLabel(iteration, maxIterations)}...${blockingIssuesBlock(issues)}${externalBlockingCommentBlock(hasExternalBlockers)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
+        `${feedbackMarker}\n⚠️ Reviewer found issues — starting fix pass ${fixPassLabel(iteration, maxIterations)}...${blockingIssuesBlock(issues)}${externalBlockingCommentBlock(hasExternalFindings)}${reviewerSummaryBlock(feedback, issues)}\n\n**Merge readiness:** Not ready to merge.`,
         feedbackMarker,
       );
 

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -30,12 +30,21 @@ interface PostPushReviewInputs extends Record<string, unknown> {
 }
 
 type ExternalReviewState = "skipped" | "absent" | "running" | "completed";
+type PostPushReviewTerminationReason =
+  | "approved"
+  | "iterations_exhausted"
+  | "review_failed"
+  | "invalid_review"
+  | "external_review_pending"
+  | "fix_failed"
+  | "no_changes";
 
 interface PostPushReviewOutputs extends Record<string, unknown> {
   approved: boolean;
   iterations: number;
   finalFeedback: string;
   forcePushedRevisions: number;
+  terminationReason: PostPushReviewTerminationReason;
 }
 
 interface SpawnResult {
@@ -737,6 +746,7 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
     let approved = false;
     let feedback = "";
     let forcePushed = 0;
+    let terminationReason: PostPushReviewTerminationReason = "iterations_exhausted";
     const reviewHistory: ReviewFinding[] = [];
 
     while (iteration < maxIterations && !approved) {
@@ -797,6 +807,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
 
       const reviewResult = await context.llmExecutor.invoke({ prompt: reviewPrompt, model, maxTurns: REVIEW_MAX_TURNS });
       if (reviewResult.exitCode !== 0) {
+        terminationReason = "review_failed";
         const failure = `Reviewer LLM failed (${llmResultMessage(reviewResult)})`;
         feedback = compactErrorMessage(failure);
         await reporter.report({
@@ -824,6 +835,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         | { approved?: boolean; feedback?: string; issues?: unknown[]; findings?: unknown[]; blocking_issues?: unknown[]; blockingIssues?: unknown[] }
         | null;
       if (!parsed) {
+        terminationReason = "invalid_review";
         feedback = compactErrorMessage(`Reviewer returned non-JSON output: ${reviewResult.stdout || "(empty stdout)"}`);
         await reporter.report({
           id: `post-push-review.${iteration}`,
@@ -847,6 +859,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       }
 
       if (typeof parsed.approved !== "boolean") {
+        terminationReason = "invalid_review";
         feedback = "Reviewer returned invalid structured review output: expected approved:boolean.";
         await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
         break;
@@ -877,6 +890,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       let issues = parseReviewIssues(parsed);
       issues = dedupeIssuesAgainstExternalFindings(issues, externalFindings);
       if (issues.length === 0 && parsed.approved === false && !hasExternalFindings) {
+        terminationReason = "invalid_review";
         feedback = "Reviewer returned invalid structured review output: approved=false requires at least one blocking_issues[] entry.";
         await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
         break;
@@ -887,6 +901,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       // against a reviewer that is still in flight — defer to a human.
       const internalApprovable = parsed.approved === true && issues.length === 0 && !hasExternalFindings;
       if (internalApprovable && externalReviewPending) {
+        terminationReason = "external_review_pending";
         feedback = "External review did not complete within the wait budget; not auto-approving.";
         await reporter.report({
           id: `post-push-review.${iteration}`,
@@ -925,6 +940,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       });
 
       if (approved) {
+        terminationReason = "approved";
         const marker = `<!-- ai-implement post-push iter=${iteration} -->`;
         submitPrReview(ghSpawn, prNumber, `${AI_IMPLEMENT_NATIVE_REVIEW_MARKER}\nAI-Implement post-push review approved this PR.`);
         postPrComment(
@@ -937,6 +953,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       }
 
       if (iteration >= maxIterations) {
+        terminationReason = "iterations_exhausted";
         const marker = `<!-- ai-implement post-push iter=${iteration} -->`;
         submitPrReview(
           ghSpawn,
@@ -999,6 +1016,7 @@ ${externalReviewFindingsBlock(externalFindings)}
 
       const fixResult = await context.llmExecutor.invoke({ prompt: fixPrompt, model, maxTurns: FIX_MAX_TURNS });
       if (fixResult.exitCode !== 0) {
+        terminationReason = "fix_failed";
         const failure = compactErrorMessage(`Fix-pass LLM failed (${llmResultMessage(fixResult)})`);
         const marker = `<!-- ai-implement post-push iter=${iteration} fix-failed -->`;
         postPrComment(
@@ -1017,6 +1035,7 @@ ${externalReviewFindingsBlock(externalFindings)}
       const status = gitSpawn(["status", "--porcelain"]);
       if (status.exitCode !== 0) throw new Error(`git status failed: ${resultMessage(status)}`);
       if (!status.stdout.trim()) {
+        terminationReason = "no_changes";
         const marker = `<!-- ai-implement post-push iter=${iteration} no-changes -->`;
         submitPrReview(
           ghSpawn,
@@ -1069,7 +1088,13 @@ ${externalReviewFindingsBlock(externalFindings)}
       );
     }
 
-    return { approved, iterations: iteration, finalFeedback: feedback, forcePushedRevisions: forcePushed };
+    return {
+      approved,
+      iterations: iteration,
+      finalFeedback: feedback,
+      forcePushedRevisions: forcePushed,
+      terminationReason,
+    };
   },
 };
 

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -573,16 +573,14 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     // This is NOT a success: report a coded failure
     // so the ticket is updated and notifications fire, leave a run autopsy for
     // the ticket, and flag the GHA run — but keep the job green (warning only).
-    const authoritativeReviewOutputs = postPushReviewRequired && postPushReviewOutputs.approved !== true
+    const postPushReviewRejected = postPushReviewRequired && postPushReviewOutputs.approved !== true;
+    const authoritativeReviewOutputs = postPushReviewRejected
       ? postPushReviewOutputs
       : fbOutputs;
-    const postPushTerminationReason = typeof postPushReviewOutputs.terminationReason === "string"
-      ? postPushReviewOutputs.terminationReason
-      : "post_push_review_unapproved";
-    const terminationReason = postPushReviewRequired && postPushReviewOutputs.approved !== true
-      ? postPushTerminationReason
-      : typeof authoritativeReviewOutputs.terminationReason === "string"
-        ? authoritativeReviewOutputs.terminationReason
+    const terminationReason = typeof authoritativeReviewOutputs.terminationReason === "string"
+      ? authoritativeReviewOutputs.terminationReason
+      : postPushReviewRejected
+        ? "post_push_review_unapproved"
         : "unknown";
     const iterations = typeof authoritativeReviewOutputs.iterations === "number"
       ? authoritativeReviewOutputs.iterations
@@ -595,8 +593,9 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       `Automated review did not approve (${terminationReason} after ${iterations} iteration(s)). ` +
       finalFeedback.slice(0, 500);
 
+    const prKind = pushOutputs.draft === true ? "draft PR" : "PR";
     const prDisposition = prUrl
-      ? `${fbOutputs.approved === true ? "PR" : "draft PR"} ${prUrl}`
+      ? `${prKind} ${prUrl}`
       : "no PR";
     disposition = `${prDisposition} — review unapproved after ${iterations} iteration(s) (${terminationReason})`;
 
@@ -611,7 +610,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     });
     console.warn(
       `::warning::AI-Implement: review did not approve after ${iterations} iteration(s) (${terminationReason}) — ` +
-        (prUrl ? `draft PR opened: ${prUrl}` : "no PR opened"),
+        (prUrl ? `${prKind} opened: ${prUrl}` : "no PR opened"),
     );
     await postRunnerResult({
       workspaceDir,

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -503,8 +503,12 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
 
     const fbOutputs = context.getOutputs("feedback-loop");
     const pushOutputs = context.getOutputs("push");
+    const postPushReviewOutputs = context.getOutputs("post-push-review");
     const prUrl = typeof pushOutputs.prUrl === "string" ? pushOutputs.prUrl : undefined;
-    const approved = fbOutputs.approved === true;
+    const postPushReviewRequired = Boolean(prUrl)
+      && pipeline.steps.some((step) => step.id === "post-push-review");
+    const approved = fbOutputs.approved === true
+      && (!postPushReviewRequired || postPushReviewOutputs.approved === true);
 
     // Case B: grouping-parent run where the agent produced genuinely no changes. Push returned
     // a no-op (branchPushed=false, prUrl=null). Report success without a prUrl so the
@@ -558,20 +562,34 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
       return { exitCode: 0 };
     }
 
-    // The pipeline completed mechanically but the review loop never approved
-    // (or push produced no PR). This is NOT a success: report a coded failure
+    // The pipeline completed mechanically but either the internal loop or the
+    // authoritative post-push review did not approve (or push produced no PR).
+    // This is NOT a success: report a coded failure
     // so the ticket is updated and notifications fire, leave a run autopsy for
     // the ticket, and flag the GHA run — but keep the job green (warning only).
-    const terminationReason =
-      typeof fbOutputs.terminationReason === "string" ? fbOutputs.terminationReason : "unknown";
-    const iterations = typeof fbOutputs.iterations === "number" ? fbOutputs.iterations : 0;
-    const finalFeedback = typeof fbOutputs.finalFeedback === "string" ? fbOutputs.finalFeedback : "";
+    const authoritativeReviewOutputs = postPushReviewRequired && postPushReviewOutputs.approved !== true
+      ? postPushReviewOutputs
+      : fbOutputs;
+    const terminationReason = postPushReviewRequired && postPushReviewOutputs.approved !== true
+      ? "post_push_review_unapproved"
+      : typeof authoritativeReviewOutputs.terminationReason === "string"
+        ? authoritativeReviewOutputs.terminationReason
+        : "unknown";
+    const iterations = typeof authoritativeReviewOutputs.iterations === "number"
+      ? authoritativeReviewOutputs.iterations
+      : 0;
+    const finalFeedback = typeof authoritativeReviewOutputs.finalFeedback === "string"
+      ? authoritativeReviewOutputs.finalFeedback
+      : "";
     const failureCode = terminationReason === "max_turns" ? "MAX_TURNS_EXHAUSTED" : "REVIEW_UNAPPROVED";
     const failureReason =
       `Automated review did not approve (${terminationReason} after ${iterations} iteration(s)). ` +
       finalFeedback.slice(0, 500);
 
-    disposition = `${prUrl ? `draft PR ${prUrl}` : "no PR"} — review unapproved after ${iterations} iteration(s) (${terminationReason})`;
+    const prDisposition = prUrl
+      ? `${fbOutputs.approved === true ? "PR" : "draft PR"} ${prUrl}`
+      : "no PR";
+    disposition = `${prDisposition} — review unapproved after ${iterations} iteration(s) (${terminationReason})`;
 
     writeRunAutopsy(workspaceDir, {
       issueIdentifier,

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -576,8 +576,11 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     const authoritativeReviewOutputs = postPushReviewRequired && postPushReviewOutputs.approved !== true
       ? postPushReviewOutputs
       : fbOutputs;
+    const postPushTerminationReason = typeof postPushReviewOutputs.terminationReason === "string"
+      ? postPushReviewOutputs.terminationReason
+      : "post_push_review_unapproved";
     const terminationReason = postPushReviewRequired && postPushReviewOutputs.approved !== true
-      ? "post_push_review_unapproved"
+      ? postPushTerminationReason
       : typeof authoritativeReviewOutputs.terminationReason === "string"
         ? authoritativeReviewOutputs.terminationReason
         : "unknown";

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -505,7 +505,13 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     const pushOutputs = context.getOutputs("push");
     const postPushReviewOutputs = context.getOutputs("post-push-review");
     const prUrl = typeof pushOutputs.prUrl === "string" ? pushOutputs.prUrl : undefined;
-    const postPushReviewRequired = Boolean(prUrl)
+    // Mirror the post-push-review skip contract: a statically registered step is
+    // authoritative only when the internal review approved and push produced the
+    // branch/PR inputs that cause the step to run. Otherwise its outputs are empty.
+    const postPushReviewRequired = fbOutputs.approved === true
+      && pushOutputs.branchPushed === true
+      && Boolean(pushOutputs.prNumber)
+      && Boolean(prUrl)
       && pipeline.steps.some((step) => step.id === "post-push-review");
     const approved = fbOutputs.approved === true
       && (!postPushReviewRequired || postPushReviewOutputs.approved === true);


### PR DESCRIPTION
## Summary
- ingest the live GitHub Actions Claude review format, including markerless prose findings
- make every external Claude finding gate approval, regardless of severity
- require post-push review approval before the autonomous run reports success
- use only the latest trusted Claude verdict while preserving formal requested-changes reviews and unresolved threads
- fail closed on ambiguous output without letting unrelated bots supersede Claude

## Deliberate policy decision
A minor or stylistic Claude finding is intentionally allowed to consume the review budget and leave the PR unapproved. That conservative false-positive surface is the requested behavior for AII-421; it must not be weakened into an automatic approval path.

## Production regression
PR #302 received a Claude blocking finding but AI-Implement subsequently posted an approval. The exact comment shape is covered by regression tests.

## Verification
- npm test (160 files, 3022 tests)
- npm run typecheck
- git diff --check
- independent adversarial code review: no actionable findings

Linear: AII-421