### PR TITLE
feat(deploy): act on an available deployment — auto-deploy or notify (AII-359)

### DIFF
--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -2246,4 +2246,78 @@ describe("GET /api/deployment-status", () => {
     expect(res.body.held).toBe(true);
     expect(res.body.inFlight).toEqual([{ kind: "workflow-sync", count: 1 }]);
   });
+
+  it("reports whether a notification webhook exists, so the toggle can explain itself", async () => {
+    // Without this the page cannot tell an enabled announcement from an inert one, and
+    // would show "no webhook configured" forever regardless of the truth.
+    const token = await login("secret");
+    const withHook = { ...adminConfig("secret"), notifyWebhookUrl: "https://hook.example.com" };
+
+    const req = new MockRequest("/api/deployment-status", "GET", { authorization: `Bearer ${token}` });
+    const res = new MockResponse();
+    admin.handleAdminRequest(req as never, res as never, withHook, makeFakeRegistry(provider), {});
+    await res.done;
+    expect(JSON.parse(res.body).notifyConfigured).toBe(true);
+
+    expect((await statusRequest(token)).body.notifyConfigured).toBe(false);
+  });
+
+  it("reports the last acted commit, so the page knows what automatic deploying already handled", async () => {
+    const { setLastActedCommit } = await import("../deploy-policy.js");
+    const token = await login("secret");
+
+    expect((await statusRequest(token)).body.lastActedCommit).toBeNull();
+    setLastActedCommit("def5678");
+    expect((await statusRequest(token)).body.lastActedCommit).toBe("def5678");
+  });
+});
+
+describe("POST /api/deploy-policy", () => {
+  async function policyRequest(token: string, body: unknown): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+    const req = new MockRequest("/api/deploy-policy", "POST", { authorization: `Bearer ${token}` }, JSON.stringify(body));
+    const res = new MockResponse();
+    admin.handleAdminRequest(req as never, res as never, adminConfig("secret"), makeFakeRegistry(provider), {});
+    await res.done;
+    return { statusCode: res.statusCode, body: res.body ? JSON.parse(res.body) : {} };
+  }
+
+  it("rejects an unauthenticated request", async () => {
+    const res = await policyRequest("not-a-session", { autoDeploy: true });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects a non-boolean rather than coercing it", async () => {
+    // "false" is a truthy string. Coercing would enable unattended deploying because
+    // a caller sent the wrong type, which is not a small bug.
+    const token = await login("secret");
+    const res = await policyRequest(token, { autoDeploy: "false" });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns the full policy so the page renders the server's view", async () => {
+    // The two flags interact — autoDeploy being on makes notifyAvailable inert — so an
+    // optimistic client-side update can disagree with what the server actually stored.
+    const token = await login("secret");
+    const res = await policyRequest(token, { autoDeploy: true });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ autoDeploy: true, notifyAvailable: true });
+  });
+
+  it("leaves the unnamed flag untouched", async () => {
+    const token = await login("secret");
+    await policyRequest(token, { notifyAvailable: false });
+    const res = await policyRequest(token, { autoDeploy: true });
+    expect(res.body).toEqual({ autoDeploy: true, notifyAvailable: false });
+  });
+
+  it("surfaces the policy on the deployment-status read the page already makes", async () => {
+    const token = await login("secret");
+    await policyRequest(token, { autoDeploy: true });
+
+    const req = new MockRequest("/api/deployment-status", "GET", { authorization: `Bearer ${token}` });
+    const res = new MockResponse();
+    admin.handleAdminRequest(req as never, res as never, adminConfig("secret"), makeFakeRegistry(provider), {});
+    await res.done;
+    expect(JSON.parse(res.body)).toMatchObject({ autoDeploy: true, notifyAvailable: true });
+  });
 });

--- a/src/__tests__/deploy-notify.test.ts
+++ b/src/__tests__/deploy-notify.test.ts
@@ -263,3 +263,43 @@ describe("shutdown → boot cycle", () => {
     expect(kinds).toEqual(["shutdown", "restarted"]);
   });
 });
+
+describe("postAvailableNotice", () => {
+  it("names the commit and does not pretend an image exists", async () => {
+    onFly(IMAGE_A);
+    await deployNotify.postAvailableNotice(config, "def5678abcdef");
+
+    expect(notify.notifyDeploy).toHaveBeenCalledOnce();
+    const [type, url, payload] = vi.mocked(notify.notifyDeploy).mock.calls[0];
+    expect(type).toBe("slack");
+    expect(url).toBe(config.notifyWebhookUrl);
+    expect(payload).toMatchObject({
+      kind: "available",
+      appName: "ai-implement-testing-orchestrator",
+      region: "iad",
+      imageRef: null,
+      commit: "def5678abcdef",
+    });
+  });
+
+  it("posts off Fly too, unlike the boot and shutdown notices", async () => {
+    // Those gate on FLY_IMAGE_REF because they describe this machine's own lifecycle
+    // and would fire on every local Ctrl-C. Availability is a fact about the repository
+    // against the running commit, and is meaningful wherever self-deploy is configured.
+    await deployNotify.postAvailableNotice(config, "def5678");
+    expect(notify.notifyDeploy).toHaveBeenCalledOnce();
+  });
+
+  it("stays silent with no webhook configured", async () => {
+    onFly(IMAGE_A);
+    await deployNotify.postAvailableNotice({ ...config, notifyWebhookUrl: null }, "def5678");
+    expect(notify.notifyDeploy).not.toHaveBeenCalled();
+  });
+
+  it("swallows a webhook failure rather than failing the poll", async () => {
+    // It runs as a poll passenger; a dead webhook must not stall dispatch.
+    onFly(IMAGE_A);
+    vi.mocked(notify.notifyDeploy).mockRejectedValueOnce(new Error("Slack webhook failed: 500"));
+    await expect(deployNotify.postAvailableNotice(config, "def5678")).resolves.toBeUndefined();
+  });
+});

--- a/src/__tests__/deploy-policy.test.ts
+++ b/src/__tests__/deploy-policy.test.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as DedupModule from "../dedup.js";
+import type * as RunnerModeModule from "../runner-mode.js";
+import type * as DeployPolicyModule from "../deploy-policy.js";
+
+let dbPath: string;
+let dedup: typeof DedupModule;
+let runnerMode: typeof RunnerModeModule;
+let policy: typeof DeployPolicyModule;
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `deploy-policy-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  dedup = await import("../dedup.js");
+  runnerMode = await import("../runner-mode.js");
+  policy = await import("../deploy-policy.js");
+  runnerMode.initSettingsTable();
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try { fs.unlinkSync(dbPath); } catch { /* ignore */ }
+});
+
+describe("getDeployPolicy", () => {
+  it("defaults automatic deploying off and the availability notice on", () => {
+    // The whole feature's safety rests on the first half: an orchestrator that has
+    // never been configured must not deploy itself. The second half is the one a
+    // refactor silently inverts, because "absent means false" is the reflex.
+    expect(policy.getDeployPolicy()).toEqual({ autoDeploy: false, notifyAvailable: true });
+  });
+
+  it("distinguishes an explicit off from an absent key", () => {
+    // These are different states and the defaults differ, so collapsing them would
+    // make the notice impossible to turn off — every write of "0" would read back true.
+    policy.setDeployPolicy({ notifyAvailable: false });
+    expect(policy.getDeployPolicy().notifyAvailable).toBe(false);
+  });
+
+  it("reads back an enabled flag", () => {
+    policy.setDeployPolicy({ autoDeploy: true });
+    expect(policy.getDeployPolicy().autoDeploy).toBe(true);
+  });
+
+  it("treats an unrecognised stored value as off rather than throwing", () => {
+    // Only "1" is on. A value written by a future version, or corrupted, must not
+    // enable unattended deploying by being merely non-empty.
+    dedup.getDb().prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('deploy_auto', 'yes')").run();
+    expect(policy.getDeployPolicy().autoDeploy).toBe(false);
+  });
+});
+
+describe("setDeployPolicy", () => {
+  it("writes only the flags named in the patch", () => {
+    // A page holding a stale copy of the other flag would otherwise revert it on
+    // every toggle — the reason this takes a patch rather than a whole policy.
+    policy.setDeployPolicy({ autoDeploy: true, notifyAvailable: false });
+    policy.setDeployPolicy({ autoDeploy: false });
+
+    expect(policy.getDeployPolicy()).toEqual({ autoDeploy: false, notifyAvailable: false });
+  });
+
+  it("is a no-op when the patch names nothing", () => {
+    policy.setDeployPolicy({ autoDeploy: true });
+    policy.setDeployPolicy({});
+    expect(policy.getDeployPolicy().autoDeploy).toBe(true);
+  });
+});
+
+describe("decideAvailabilityAction", () => {
+  // No database, no clock, no module state — every input is an argument, so the table
+  // below is the function's entire behaviour and can be enumerated rather than sampled.
+  const base = () => ({
+    configured: true,
+    available: true as boolean | null,
+    headCommit: "def5678" as string | null,
+    held: false,
+    policy: { autoDeploy: false, notifyAvailable: true },
+    lastActedCommit: null as string | null,
+  });
+
+  it("deploys when automatic deploying is on and the commit is new", () => {
+    const input = { ...base(), policy: { autoDeploy: true, notifyAvailable: true } };
+    expect(policy.decideAvailabilityAction(input)).toBe("deploy");
+  });
+
+  it("announces when automatic deploying is off", () => {
+    expect(policy.decideAvailabilityAction(base())).toBe("notify");
+  });
+
+  it("prefers deploying over announcing when both are enabled", () => {
+    // The shutdown notice already announces the pause, so a second notice would
+    // double-ping one event.
+    const input = { ...base(), policy: { autoDeploy: true, notifyAvailable: true } };
+    expect(policy.decideAvailabilityAction(input)).toBe("deploy");
+  });
+
+  it("does nothing when both are off", () => {
+    const input = { ...base(), policy: { autoDeploy: false, notifyAvailable: false } };
+    expect(policy.decideAvailabilityAction(input)).toBe("none");
+  });
+
+  it.each([
+    ["this orchestrator cannot deploy itself", { configured: false }],
+    ["availability is unknown", { available: null }],
+    ["availability is resolved false", { available: false }],
+    ["the head commit is unresolved", { headCommit: null }],
+    ["a deploy already holds", { held: true }],
+    ["this commit was already acted on", { lastActedCommit: "def5678" }],
+  ])("does nothing when %s", (_label, patch) => {
+    // Each of these is checked with automatic deploying ON, so a regression that drops
+    // the guard shows up as an unattended deploy rather than a silent no-op.
+    const input = { ...base(), policy: { autoDeploy: true, notifyAvailable: true }, ...patch };
+    expect(policy.decideAvailabilityAction(input)).toBe("none");
+  });
+
+  it("acts again once the head moves past the last acted commit", () => {
+    const input = { ...base(), headCommit: "aaa1111", lastActedCommit: "def5678" };
+    expect(policy.decideAvailabilityAction(input)).toBe("notify");
+  });
+
+  it("holds suppress the announcement too, not just the deploy", () => {
+    // Announcing a deployment that is already being built is noise, not news.
+    const input = { ...base(), held: true };
+    expect(policy.decideAvailabilityAction(input)).toBe("none");
+  });
+});
+
+describe("last acted commit", () => {
+  it("reads null before anything has been acted on", () => {
+    expect(policy.getLastActedCommit()).toBeNull();
+  });
+
+  it("round-trips a commit across a write", () => {
+    policy.setLastActedCommit("def5678");
+    expect(policy.getLastActedCommit()).toBe("def5678");
+  });
+
+  it("overwrites rather than accumulating", () => {
+    policy.setLastActedCommit("def5678");
+    policy.setLastActedCommit("aaa1111");
+    expect(policy.getLastActedCommit()).toBe("aaa1111");
+  });
+});

--- a/src/__tests__/deploy.test.ts
+++ b/src/__tests__/deploy.test.ts
@@ -201,3 +201,37 @@ describe("resolveFlyctl", () => {
     );
   });
 });
+
+describe("canSelfDeploy", () => {
+  const configured = {
+    flyDeployToken: "fly-token",
+    flyOrchestratorApp: "orchestrator",
+    selfDeployTarget: { owner: "Owner", repo: "Repo", branch: "testing", runningCommit: "abc" },
+    pollIntervalMs: 60_000,
+    githubAppId: "1",
+    githubAppPrivateKey: "key",
+  };
+
+  it("is true when a token, an app and build stamps are all present", () => {
+    expect(deploy.canSelfDeploy(configured)).toBe(true);
+  });
+
+  it.each(["flyDeployToken", "flyOrchestratorApp", "selfDeployTarget"] as const)(
+    "is false without %s",
+    (field) => {
+      // The predicate is the single definition of "can this orchestrator deploy itself",
+      // asserted directly here rather than only through makeStartDeploy's return. A type
+      // predicate's body is not verified by the compiler, so this table is what holds it
+      // honest — a fourth requirement belongs in it.
+      expect(deploy.canSelfDeploy({ ...configured, [field]: null })).toBe(false);
+    },
+  );
+
+  it("agrees with whether makeStartDeploy produces a starter", () => {
+    // They must never disagree: the route answers 501 on the starter's absence while
+    // the poll passenger gates on the predicate.
+    expect(deploy.canSelfDeploy(configured)).toBe(deploy.makeStartDeploy(configured) !== undefined);
+    const unconfigured = { ...configured, flyDeployToken: null };
+    expect(deploy.canSelfDeploy(unconfigured)).toBe(deploy.makeStartDeploy(unconfigured) !== undefined);
+  });
+});

--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -406,4 +406,49 @@ describe("notifyDeploy", () => {
       ).rejects.toThrow("500");
     });
   });
+
+  describe("availability notice", () => {
+    const available: DeployNotification = {
+      ...deployBase,
+      kind: "available",
+      imageRef: null,
+      downtimeMs: null,
+      commit: "def5678abcdef0123456789",
+    };
+
+    it("names the waiting commit as the version, shortened", async () => {
+      await notifyDeploy("slack", "https://webhook.example.com/slack", available);
+      expect(slackText()).toContain("def5678");
+      expect(slackText()).not.toContain("def5678abcdef");
+    });
+
+    it("does not broadcast — an invitation, not an interruption", async () => {
+      // Only the shutdown notice earns an @channel: it is the one telling people
+      // their dispatches have stopped. This one is asking for a decision.
+      await notifyDeploy("slack", "https://webhook.example.com/slack", available);
+      expect(slackText()).not.toContain("<!channel>");
+      expect(slackText()).toContain("Deployment available");
+    });
+
+    it("carries the commit on teams as well, with no per-provider work", async () => {
+      await notifyDeploy("teams", "https://webhook.example.com/teams", available);
+      expect(teamsFacts()).toContainEqual({ title: "Version", value: "def5678" });
+    });
+
+    it("omits the version rather than rendering an empty one without a commit", async () => {
+      await notifyDeploy("teams", "https://webhook.example.com/teams", { ...available, commit: null });
+      expect(teamsFacts().map((f) => f.title)).not.toContain("Version");
+    });
+
+    it("never falls back to the image ref", async () => {
+      // There is no image for an available deployment. A stale ref would name the
+      // *running* version as though it were the one waiting — worse than showing none.
+      await notifyDeploy("teams", "https://webhook.example.com/teams", {
+        ...available,
+        commit: null,
+        imageRef: "registry.fly.io/ai-implement-testing-orchestrator:deployment-STALE",
+      });
+      expect(teamsFacts().map((f) => f.title)).not.toContain("Version");
+    });
+  });
 });

--- a/src/admin-ui/__tests__/deployments.test.ts
+++ b/src/admin-ui/__tests__/deployments.test.ts
@@ -148,6 +148,103 @@ describe("deployments page", () => {
     expect(cta).toContain("deployments-deploy-btn");
   });
 
+  it("declares the policy card ids", () => {
+    for (const id of [
+      "deployments-policy",
+      "deployments-auto",
+      "deployments-notify",
+      "deployments-auto-hint",
+      "deployments-notify-hint",
+    ]) {
+      expect(deploymentsHtml).toContain(`id="${id}"`);
+    }
+  });
+
+  it("groups both switches under one question, using the settings card pattern", () => {
+    // They are two answers to "what happens when a deployment becomes available", not
+    // independent preferences — the framing is what stops them reading as unrelated.
+    expect(deploymentsHtml).toContain('class="card" id="deployments-policy"');
+    expect(deploymentsHtml).toContain("When a deployment becomes available");
+    expect(deploymentsHtml).toContain('class="checkbox-row"');
+  });
+
+  it("hides the policy card when self-deploy is unconfigured", () => {
+    expect(deploymentsScript).toContain("getElementById('deployments-policy').hidden = !configured");
+  });
+
+  it("saves both flags through the policy endpoint", () => {
+    expect(deploymentsScript).toContain("window.api('/api/deploy-policy', { method: 'POST'");
+    expect(deploymentsScript).toContain("window.saveDeployPolicy = saveDeployPolicy");
+  });
+
+  it("re-renders from the server after saving rather than trusting the checkbox", () => {
+    // The flags interact, so an optimistic update can show a hint that is not yet true.
+    const save = deploymentsScript.slice(deploymentsScript.indexOf("async function saveDeployPolicy"));
+    expect(save.slice(0, save.indexOf("\n  }"))).toContain("loadDeployments()");
+  });
+
+  it("explains the combination that does nothing", () => {
+    // Automatic deploying makes the announcement inert. Two switches that look
+    // independent while one silences the other is the confusion worth pre-empting.
+    expect(deploymentsScript).toContain("No effect while automatic deploying is on");
+    // Names the way to enable it rather than only reporting that it is off — an
+    // unavailable capability the operator cannot discover is worse than a dead switch.
+    expect(deploymentsScript).toContain("NOTIFY_WEBHOOK_URL");
+  });
+
+  it("does not claim a deploy is deferred while that deploy is running", () => {
+    // Observed live: the status tile read "Building" while the hint said the commit
+    // "applies from the next push". Both true in isolation, contradictory side by side.
+    expect(deploymentsScript).toContain("if (held) return 'On — the deploy in progress above is the current one.';");
+    expect(deploymentsScript).toContain("autoHint(data, available, held)");
+  });
+
+  it("offers the manual path when automatic deploying cannot act on the waiting commit", () => {
+    // One attempt per commit means enabling the toggle does not reach back for a commit
+    // already announced. Saying so, and naming the button, is the whole point.
+    expect(deploymentsScript).toContain("applies from the next push");
+    expect(deploymentsScript).toContain("Deploy now to release it immediately");
+  });
+
+  it("declares every id exactly once", () => {
+    // The page is one concatenated string, so a duplicated block is easy to introduce
+    // and silent: getElementById returns the first match, leaving the copy rendered but
+    // permanently stale. A toContain assertion cannot see it — a count can.
+    const ids = [...deploymentsHtml.matchAll(/id="([a-z-]+)"/g)].map((m) => m[1]);
+    expect(ids).toHaveLength(new Set(ids).size);
+  });
+
+  it("orders the body: tiles, then the policy, then the deploy control", () => {
+    const at = (id: string) => deploymentsHtml.indexOf(`id="${id}"`);
+    expect(at("deployments-kpis")).toBeLessThan(at("deployments-policy"));
+    expect(at("deployments-policy")).toBeLessThan(at("deployments-cta"));
+  });
+
+  it("saves on submit rather than on every click", () => {
+    // Writing per click makes an accidental tick a live config change, and gives the
+    // 30s poll a window to clobber a half-made decision.
+    expect(deploymentsHtml).toContain('id="deployments-policy-save"');
+    expect(deploymentsHtml).toContain('onchange="window.refreshPolicyDirty()"');
+    expect(deploymentsHtml).not.toContain('onchange="window.saveDeployPolicy()"');
+  });
+
+  it("does not overwrite unsaved checkboxes on a poll", () => {
+    expect(deploymentsScript).toContain("if (!policyDirty()) {");
+  });
+
+  it("disables the announcement switch when no webhook exists", () => {
+    expect(deploymentsScript).toContain("notifyEl.disabled = !data.notifyConfigured");
+  });
+
+  it("keeps an unavailable announcement switch out of the form entirely", () => {
+    // Forced unchecked so a greyed-but-ticked box cannot claim something is being sent,
+    // excluded from the dirty check so Save is not lit forever against a stored true,
+    // and omitted from the patch so saving cannot overwrite the stored preference.
+    expect(deploymentsScript).toContain("if (!data.notifyConfigured) notifyEl.checked = false;");
+    expect(deploymentsScript).toContain("!notifyEl.disabled && notifyEl.checked !== savedPolicy.notifyAvailable");
+    expect(deploymentsScript).toContain("if (!notifyEl.disabled) patch.notifyAvailable = notifyEl.checked;");
+  });
+
   it("keeps the page subtitle static", () => {
     // A state-dependent subtitle duplicates the Availability tile. Dynamic subtitles
     // are this codebase's collection-count convention (issues, pulls, runners); this

--- a/src/admin-ui/components.ts
+++ b/src/admin-ui/components.ts
@@ -214,6 +214,7 @@ export const componentsCss = `
 .btn-primary:hover { background: #2a2a28; border-color: #2a2a28; }
 [data-theme="dark"] .btn-primary { background: var(--fg-primary); color: var(--bg-app); }
 [data-theme="dark"] .btn-primary:hover { background: #fff; }
+[data-theme="dark"] .btn-primary:disabled { background: var(--bg-active); color: var(--fg-secondary); border-color: var(--border-default); }
 
 .btn-accent {
   background: var(--accent);

--- a/src/admin-ui/pages/deployments.ts
+++ b/src/admin-ui/pages/deployments.ts
@@ -25,6 +25,27 @@ export const deploymentsHtml = `
       </div>
     </div>
 
+    <div class="card" id="deployments-policy" hidden>
+      <div class="card-header"><h2 class="card-title">When a deployment becomes available...</h2></div>
+      <div class="card-body">
+        <label class="checkbox-row" id="deployments-auto-row">
+          <input type="checkbox" id="deployments-auto" onchange="window.refreshPolicyDirty()">
+          <span>Deploy it automatically</span>
+        </label>
+        <div class="kpi-trend text-secondary" id="deployments-auto-hint" style="margin-left: 24px"></div>
+
+        <label class="checkbox-row" id="deployments-notify-row">
+          <input type="checkbox" id="deployments-notify" onchange="window.refreshPolicyDirty()">
+          <span>Announce it to the notification webhook</span>
+        </label>
+        <div class="kpi-trend text-secondary" id="deployments-notify-hint" style="margin-left: 24px"></div>
+
+        <div style="margin-top: 12px">
+          <button class="btn btn-primary btn-sm" id="deployments-policy-save" onclick="window.saveDeployPolicy()" disabled>Save</button>
+        </div>
+      </div>
+    </div>
+
     <div id="deployments-cta" hidden style="text-align: center">
       <div style="display: inline-flex; flex-direction: column; align-items: center; gap: 8px">
         <button class="btn btn-accent btn-lg" id="deployments-deploy-btn" onclick="window.triggerDeploy()">Deploy now</button>
@@ -90,6 +111,46 @@ export const deploymentsScript = `
     document.getElementById('deployments-error').hidden = true;
   }
 
+  function autoHint(data, available, held) {
+    if (!data.autoDeploy) {
+      return 'Off — an available deployment is announced instead, and you decide when to release it.';
+    }
+    // A deploy in flight already has its own tile saying what is happening. Repeating
+    // "applies from the next push" beside it reads as a contradiction, because the
+    // commit being deployed is the one the per-commit guard has just consumed.
+    if (held) return 'On — the deploy in progress above is the current one.';
+    // One attempt per commit, so switching this on does not reach back for a commit
+    // already announced. Name it, and name the way out.
+    if (available === true && data.headCommit && data.headCommit === data.lastActedCommit) {
+      return short(data.headCommit) + ' is available now but was already announced, so this applies from the next push. Use Deploy now to release it immediately.';
+    }
+    return 'A push to ' + (data.branch || 'the watched branch') + ' pauses dispatch and releases without asking.';
+  }
+
+  function notifyHint(data) {
+    if (!data.notifyConfigured) return 'Unavailable — set NOTIFY_WEBHOOK_URL on the orchestrator to announce available deployments here.';
+    if (data.autoDeploy) return 'No effect while automatic deploying is on — the restart notice already announces the pause.';
+    return 'Sent once per commit, to the same webhook as run notifications.';
+  }
+
+  // What the server last told us. Kept so an edit can be detected, and so the 30s poll
+  // does not silently revert a checkbox someone has ticked but not yet saved.
+  let savedPolicy = null;
+
+  function policyDirty() {
+    if (!savedPolicy) return false;
+    // A disabled announcement switch is not part of the form: it is forced unchecked
+    // while no webhook exists, which would otherwise read as permanently dirty against
+    // a stored true and leave Save lit forever.
+    const notifyEl = document.getElementById('deployments-notify');
+    const notifyChanged = !notifyEl.disabled && notifyEl.checked !== savedPolicy.notifyAvailable;
+    return document.getElementById('deployments-auto').checked !== savedPolicy.autoDeploy || notifyChanged;
+  }
+
+  function refreshPolicyDirty() {
+    document.getElementById('deployments-policy-save').disabled = !policyDirty();
+  }
+
   async function loadDeployments() {
     clearMessage();
 
@@ -119,6 +180,36 @@ export const deploymentsScript = `
     document.getElementById('deployments-kpis').hidden = !configured;
 
     document.getElementById('deployments-cta').hidden = !configured || held || available !== true;
+
+    // The policy card follows the tiles: meaningless on an orchestrator that cannot
+    // deploy itself, where the banner below is the whole story.
+    document.getElementById('deployments-policy').hidden = !configured;
+
+    const autoEl = document.getElementById('deployments-auto');
+    const notifyEl = document.getElementById('deployments-notify');
+
+    // Computed against the *previous* server state, before it is replaced below — the
+    // poll must not overwrite a checkbox that is ticked and not yet saved.
+    if (!policyDirty()) {
+      autoEl.checked = !!data.autoDeploy;
+      notifyEl.checked = !!data.notifyAvailable;
+    }
+    savedPolicy = { autoDeploy: !!data.autoDeploy, notifyAvailable: !!data.notifyAvailable };
+    refreshPolicyDirty();
+
+    // Nothing can be announced without somewhere to announce to, so the control says so
+    // by being unavailable rather than by being a switch that quietly does nothing.
+    // Unchecked as well as disabled: the stored value may be true, but nothing is being
+    // announced, and a ticked-but-greyed box claims otherwise. The stored value is never
+    // written from here, so it returns intact once a webhook exists.
+    notifyEl.disabled = !data.notifyConfigured;
+    if (!data.notifyConfigured) notifyEl.checked = false;
+    const notifyRow = document.getElementById('deployments-notify-row');
+    notifyRow.style.opacity = data.notifyConfigured ? '' : '0.5';
+    notifyRow.style.cursor = data.notifyConfigured ? '' : 'not-allowed';
+
+    document.getElementById('deployments-auto-hint').textContent = autoHint(data, available, held);
+    document.getElementById('deployments-notify-hint').textContent = notifyHint(data);
 
     // Deploy status is only meaningful once a deploy is under way, so the whole tile appears with the hold 
     const statusKpi = document.getElementById('deployments-status-kpi');
@@ -207,8 +298,32 @@ export const deploymentsScript = `
     }
   }
 
+  async function saveDeployPolicy() {
+    clearMessage();
+    // Sends only the two flags, and re-renders from the response rather than the
+    // checkbox state — the server's view is what decides whether the other flag is
+    // still meaningful, and an optimistic update would show a hint that is not true yet.
+    // Omits the announcement flag while it is unavailable, so saving cannot overwrite a
+    // stored preference with the forced-unchecked display. The endpoint takes a patch
+    // precisely so one control can stay out of a write.
+    const notifyEl = document.getElementById('deployments-notify');
+    const patch = { autoDeploy: document.getElementById('deployments-auto').checked };
+    if (!notifyEl.disabled) patch.notifyAvailable = notifyEl.checked;
+    try {
+      const res = await window.api('/api/deploy-policy', { method: 'POST', body: JSON.stringify(patch) });
+      if (!res.ok && res.status !== 401) {
+        showMessage('error', 'Could not save the deployment policy — the toggles may not reflect what is stored.');
+      }
+    } catch (err) {
+      showMessage('error', 'Could not save the deployment policy — ' + String(err));
+    }
+    loadDeployments();
+  }
+
   window.loadDeployments = loadDeployments;
   window.triggerDeploy = triggerDeploy;
+  window.saveDeployPolicy = saveDeployPolicy;
+  window.refreshPolicyDirty = refreshPolicyDirty;
   window.registerPage('deployments', function () { loadDeployments(); setInterval(loadDeployments, 30000); });
 })();
 `;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -30,6 +30,7 @@ import { listParked, unpark } from "./dispatch-breaker.js";
 import { createSession, isValidSession, getRequestToken, accessCodeMatches } from "./admin-session.js";
 import type { DeployStart } from "./deploy.js";
 import { getAvailability, type SelfDeployTarget } from "./deploy-availability.js";
+import { getDeployPolicy, getLastActedCommit, setDeployPolicy, type DeployPolicy } from "./deploy-policy.js";
 import { isDeployHeld } from "./deploy-hold.js";
 import { getInFlightWork } from "./in-flight-work.js";
 import { notifyText } from "./notify.js";
@@ -248,7 +249,16 @@ export function handleAdminRequest(
         headCommit: availability?.headCommit ?? null,
         repo: target ? `${target.owner}/${target.repo}` : null,
         branch: target?.branch ?? null,
+        ...getDeployPolicy(),
+        // a notice with no webhook goes nowhere, and automatic deploying will not act on a commit it has already announced.
+        notifyConfigured: Boolean(config.notifyWebhookUrl),
+        lastActedCommit: getLastActedCommit(),
       });
+      return true;
+    }
+
+    if (url === "/api/deploy-policy" && method === "POST") {
+      handleSetDeployPolicy(req, res);
       return true;
     }
 
@@ -857,6 +867,31 @@ async function handleDeployTrigger(
     json(res, 202, { deploying: result.commit });
   } catch (err) {
     console.error("[admin] deploy trigger failed:", err);
+    json(res, 500, { error: "Internal server error" });
+  }
+}
+
+async function handleSetDeployPolicy(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<void> {
+  try {
+    const body = JSON.parse(await readBody(req)) as Partial<Record<keyof DeployPolicy, unknown>>;
+    const patch: Partial<DeployPolicy> = {};
+    for (const key of ["autoDeploy", "notifyAvailable"] as const) {
+      if (body[key] === undefined) continue;
+      // Reject rather than coerce: a string "false" is truthy, and silently enabling
+      // automatic deploying because a caller sent the wrong type is not a small bug.
+      if (typeof body[key] !== "boolean") {
+        json(res, 400, { error: `${key} must be a boolean` });
+        return;
+      }
+      patch[key] = body[key];
+    }
+    setDeployPolicy(patch);
+    json(res, 200, getDeployPolicy());
+  } catch (err) {
+    console.error("[admin] deploy policy update failed:", err);
     json(res, 500, { error: "Internal server error" });
   }
 }

--- a/src/deploy-notify.ts
+++ b/src/deploy-notify.ts
@@ -118,3 +118,24 @@ export async function postBootNotice(config: DeployNotifyConfig): Promise<void> 
     console.error("[deploy-notify] boot notice failed:", err);
   }
 }
+
+/**
+ * Announces a deployment the operator has to decide about. Unlike the boot and
+ * shutdown notices this does not gate on FLY_IMAGE_REF: those describe this machine's
+ * own lifecycle and would fire on every local Ctrl-C, while availability is a fact
+ * about the repository against the running commit and is meaningful on any host.
+ */
+export async function postAvailableNotice(config: DeployNotifyConfig, commit: string): Promise<void> {
+  if (!config.notifyWebhookUrl) return;
+  try {
+    await notifyDeploy(config.notifyType, config.notifyWebhookUrl, {
+      kind: "available",
+      appName: process.env.FLY_APP_NAME || "orchestrator",
+      region: process.env.FLY_REGION || null,
+      imageRef: null,
+      commit,
+    });
+  } catch (err) {
+    console.error("[deploy-notify] availability notice failed:", err);
+  }
+}

--- a/src/deploy-policy.ts
+++ b/src/deploy-policy.ts
@@ -1,0 +1,101 @@
+import { getDb } from "./dedup.js";
+
+const AUTO_DEPLOY_KEY = "deploy_auto";
+const NOTIFY_AVAILABLE_KEY = "deploy_notify_available";
+const LAST_ACTED_COMMIT_KEY = "deploy_last_acted_commit";
+
+export type AvailabilityAction = "deploy" | "notify" | "none";
+
+export interface DeployPolicy {
+  /** Opt-in — deploy without being asked. Off unless explicitly enabled. */
+  autoDeploy: boolean;
+  /** Opt-out — announce an available deployment. On unless explicitly disabled. */
+  notifyAvailable: boolean;
+}
+
+export interface AvailabilityDecisionInput {
+  configured: boolean; // Whether this orchestrator can deploy itself at all — token, app and build stamps.
+  available: boolean | null;
+  headCommit: string | null;
+  held: boolean;
+  policy: DeployPolicy;
+  lastActedCommit: string | null;
+}
+
+/**
+ * What to do about the current availability. Pure — every input is passed in, so the
+ * poll loop's only job is to gather them and carry out the verdict.
+ */
+export function decideAvailabilityAction(input: AvailabilityDecisionInput): AvailabilityAction {
+  const { configured, available, headCommit, held, policy, lastActedCommit } = input;
+
+  // Nothing is actionable on an orchestrator that cannot deploy itself
+  if (!configured) return "none";
+
+  // Only a confirmed new deployment is actionable. `null` is unknown, and acting on
+  // unknown would deploy an orchestrator that may already be current.
+  if (available !== true || !headCommit) return "none";
+
+  // A deploy already holds. The starter would refuse it anyway, and announcing a
+  // deployment that is already being built is noise rather than news.
+  if (held) return "none";
+
+  // One action per head commit, and deliberately shared by both branches: it bounds
+  // the automatic attempt that a failing build must not repeat every cycle, and the
+  // notice that must not repeat every poll. A new push is what re-arms either.
+  if (headCommit === lastActedCommit) return "none";
+
+  if (policy.autoDeploy) return "deploy";
+  return policy.notifyAvailable ? "notify" : "none";
+}
+
+/**
+ * The default is a parameter because the two flags default in opposite directions,
+ * and it doubles as the answer when the database is unreachable. Both flags then
+ * degrade to "behave as if unconfigured", which is the safe direction for each:
+ * automatic deploying stays off, and notifications stay on rather than going quiet.
+ */
+function readFlag(key: string, whenAbsent: boolean): boolean {
+  try {
+    const row = getDb()
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(key) as { value: string } | undefined;
+    return row ? row.value === "1" : whenAbsent;
+  } catch {
+    return whenAbsent;
+  }
+}
+
+export function getDeployPolicy(): DeployPolicy {
+  return {
+    autoDeploy: readFlag(AUTO_DEPLOY_KEY, false),
+    notifyAvailable: readFlag(NOTIFY_AVAILABLE_KEY, true),
+  };
+}
+
+/** The head commit this orchestrator last deployed or announced, across restarts. */
+export function getLastActedCommit(): string | null {
+  try {
+    const row = getDb()
+      .prepare("SELECT value FROM settings WHERE key = ?")
+      .get(LAST_ACTED_COMMIT_KEY) as { value: string } | undefined;
+    return row?.value ?? null;
+  } catch {
+    // Unreadable reads as "not acted yet". The alternative — treating an error as
+    // already-acted — would silently disable automatic deploying rather than repeat it.
+    return null;
+  }
+}
+
+/** Patch rather than replace, so toggling one flag cannot clobber the other. */
+export function setDeployPolicy(patch: Partial<DeployPolicy>): void {
+  const write = getDb().prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)");
+  if (patch.autoDeploy !== undefined) write.run(AUTO_DEPLOY_KEY, patch.autoDeploy ? "1" : "0");
+  if (patch.notifyAvailable !== undefined) write.run(NOTIFY_AVAILABLE_KEY, patch.notifyAvailable ? "1" : "0");
+}
+
+export function setLastActedCommit(sha: string): void {
+  getDb()
+    .prepare("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+    .run(LAST_ACTED_COMMIT_KEY, sha);
+}

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -318,6 +318,13 @@ export interface StartDeployConfig {
   githubAppPrivateKey: string;
 }
 
+/** `StartDeployConfig` with the three optional fields proven present. */
+type SelfDeployReady = StartDeployConfig & {
+  flyDeployToken: string;
+  flyOrchestratorApp: string;
+  selfDeployTarget: SelfDeployTarget;
+};
+
 /**
  * Builds the trigger's entry point, or undefined when this orchestrator cannot deploy
  * itself — which is what lets the route answer 501 rather than failing partway.
@@ -325,9 +332,8 @@ export interface StartDeployConfig {
 export function makeStartDeploy(
   config: StartDeployConfig,
 ): (() => Promise<DeployStart>) | undefined {
-  if (!config.flyDeployToken || !config.selfDeployTarget || !config.flyOrchestratorApp) {
-    return undefined;
-  }
+  if (!canSelfDeploy(config)) return undefined;
+
   const target = config.selfDeployTarget;
   const app = config.flyOrchestratorApp;
   const flyDeployToken = config.flyDeployToken;
@@ -370,4 +376,12 @@ export function makeStartDeploy(
       throw err;
     }
   };
+}
+
+/**
+ * Whether this orchestrator can deploy itself: a token with deploy rights, an app to
+ * deploy, and build stamps naming what to build.
+ */
+export function canSelfDeploy(config: StartDeployConfig): config is SelfDeployReady {
+  return Boolean(config.flyDeployToken && config.flyOrchestratorApp && config.selfDeployTarget);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,11 @@ import type { TicketingProvider, IssueLifecycleState, FeatureNodeRollUp } from "
 import type { TicketIssue } from "./providers/types.js";
 import { rememberCandidates, resolveInFlightSiblings, selectIssuesToDispatch, selectFileOverlapDeferrals, getOrFetchPlanningContexts } from "./poll-selection.js";
 import { notify, notifyCompletion, notifyText } from "./notify.js";
-import { postBootNotice, postShutdownNotice, recordShutdown } from "./deploy-notify.js";
-import { refreshAvailability, readStampedTarget, type SelfDeployTarget } from "./deploy-availability.js";
+import { postAvailableNotice, postBootNotice, postShutdownNotice, recordShutdown } from "./deploy-notify.js";
+import { refreshAvailability, readStampedTarget, type SelfDeployTarget, getAvailability } from "./deploy-availability.js";
 import { clearDeployHold, isDeployHeld } from "./deploy-hold.js";
-import { makeStartDeploy } from "./deploy.js";
+import { decideAvailabilityAction, getDeployPolicy, getLastActedCommit, setLastActedCommit } from "./deploy-policy.js";
+import { canSelfDeploy, makeStartDeploy } from "./deploy.js";
 import { remediateStuckJob, remediateFailedJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
 import { handleAdminRequest } from "./admin.js";
@@ -279,6 +280,52 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
       });
     } catch (err) {
       console.error("[deploy] availability check failed:", err);
+    }
+    
+    // Act on what the refresh above found.
+    try {
+      // A factory over config with no state of its own, so building one per tick is
+      // free and behaves identically to the server's — the hold that actually
+      // serializes deploys lives in SQLite, not in this closure.
+      const startDeploy = makeStartDeploy(config);
+      const availability = getAvailability();
+      const head = availability?.headCommit ?? null;
+
+      const action = decideAvailabilityAction({
+        configured: canSelfDeploy(config),
+        available: availability?.available ?? null,
+        headCommit: head,
+        held: isDeployHeld(),
+        policy: getDeployPolicy(),
+        lastActedCommit: getLastActedCommit(),
+      });
+
+      if (action !== "none" && head) {
+        // Recorded before acting, not after. A successful self-deploy kills this
+        // process inside the await below, so a write afterwards would never land and
+        // every boot would retry the same commit forever.
+        setLastActedCommit(head);
+
+        if (action === "deploy") {
+          console.log(`[deploy] Auto-deploying ${head.slice(0, 7)} — dispatch pauses now`);
+          const result = await startDeploy?.();
+          if (result && !result.started) {
+            console.warn(`[deploy] Auto-deploy did not start: ${result.reason}`);
+          }
+          // The starter resolves HEAD itself, one round trip after the cached read
+          // above. A push landing in that window means the commit recorded as acted on
+          // is not the commit being deployed — so correct it to what actually went out,
+          // or a later poll would retry the commit that really failed.
+          if (result?.started && result.commit !== head) {
+            console.log(`[deploy] head moved during the trigger: deploying ${result.commit.slice(0, 7)}`);
+            setLastActedCommit(result.commit);
+          }
+        } else {
+          await postAvailableNotice(config, head);
+        }
+      }
+    } catch (err) {
+      console.error("[deploy] availability action failed:", err);
     }
   }
   // Read once for the surfaces this poll owns, so they agree even if the hold is set part-way through a tick.

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -46,11 +46,12 @@ export interface CompletionNotification {
 }
 
 export interface DeployNotification {
-  kind: "shutdown" | "deployed" | "restarted";
+  kind: "shutdown" | "deployed" | "restarted" | "available";
   appName: string;
   region: string | null;
   imageRef: string | null; // Full FLY_IMAGE_REF, only the deployment-<id> tag is displayed.
   downtimeMs?: number | null; // Gap between the shutdown notice and the boot that answered it, when both were observed.
+  commit?: string | null; // Only the "available" kind — there is no image to reference yet.
 }
 
 // Human label for a run phase, reused across notification kinds (dispatch, completion, …).
@@ -89,6 +90,13 @@ const DEPLOY_EVENTS: Record<DeployNotification["kind"], {
     teamsIcon: "&#x21BB;",
     title: "Orchestrator back up",
     summary: "Same version — a restart, not a new deploy.",
+    broadcast: false,
+  },
+  available: {
+    slackEmoji: ":arrow_up:",
+    teamsIcon: "&#x2B06;",
+    title: "Deployment available",
+    summary: "Deploy from /admin#deployments when you are ready.",
     broadcast: false,
   },
 };
@@ -433,6 +441,8 @@ function imageTag(imageRef: string | null): string | null {
 // The shutdown notice runs in the outgoing process, so its ref is the version being replaced:
 // printing it would be ambiguous (two differing versions for same deploy, same version twice for a restart)
 function displayedVersion(n: DeployNotification): string | null {
+  // An availability notice names the commit that is waiting; no image exists yet.
+  if (n.kind === "available") return n.commit ? n.commit.slice(0, 7) : null;
   return n.kind === "shutdown" ? null : imageTag(n.imageRef);
 }
 


### PR DESCRIPTION
Closes AII-359.

Nothing acted on an available deployment before this — availability was derived and rendered, and then sat there. This adds the decision: with automatic deploying on, the orchestrator claims the deploy hold on the poll tick that sees a new head commit; with it off, the deployment is announced so an operator picks the moment.

## What changed

**`src/deploy-policy.ts` (new)** — two settings, the per-commit memory, and `decideAvailabilityAction`, a pure function over availability, both settings, the hold, and the last commit acted on. Pure because nothing can import `src/index.ts` (it runs `main()` on import), so logic left in the poll loop has no possible coverage.

**`src/notify.ts`** — an `available` notification kind. `DEPLOY_EVENTS` is a `Record` keyed on the union, so a new kind costs one table entry and the compiler refuses to build without it; both renderers were untouched.

**`src/index.ts`** — a contained poll passenger beside the existing availability refresh. Separate `try` from the refresh on purpose: a failed refresh leaves availability stale, and acting on stale availability is what the per-commit guard already handles.

**`src/admin-ui/pages/deployments.ts`** — a policy card grouping both switches under one question, saved on submit rather than per click.

## Three deviations from the issue text

**`configured` is an input to the decision, not a caller-side check.** The issue lists five inputs and omits it, but splitting the rule between the function and its caller is how two half-rules drift apart. It comes from a new `canSelfDeploy` **type predicate** in `deploy.ts` rather than from `makeStartDeploy` returning `undefined` — inferring the fact from another function's return contract would silently change meaning the moment that function grew a new early return. `makeStartDeploy` is now its first consumer, so there is one definition with two access paths: `index.ts` reads it directly, `admin.ts` observes it through injection.

**An unavailable announcement switch leaves the form entirely** — forced unchecked, excluded from the dirty check, and omitted from the save patch. A greyed-but-ticked box claims something is being sent; excluding it from the patch means the stored preference survives and returns when a webhook is configured. The hint names `NOTIFY_WEBHOOK_URL` rather than only reporting that it is off.

**One incidental CSS fix.** `[data-theme="dark"] .btn-primary` has equal specificity to `.btn:disabled` and is declared later, so **every disabled primary button rendered as though it were live in dark mode**. Pre-existing — `stepper.ts` disables one — and surfaced here because this page has the first disabled primary anyone looked at in dark mode.

## Acceptance criteria

| Criterion | How it's met | Key files |
|---|---|---|
| Auto off never deploys | `decideAvailabilityAction` returns `notify`/`none` | `deploy-policy.ts` |
| Announced once per commit, not per poll | `lastActedCommit`, recorded before acting | `deploy-policy.ts`, `index.ts` |
| Silent with no webhook or self-deploy unconfigured | `notifyConfigured` gate, `configured` guard | `admin.ts`, `deploy-policy.ts` |
| Auto on pauses dispatch before the build | hold claimed by `startDeploy`, then drain | `deploy.ts` |
| A failed deploy is not retried for that commit | commit recorded before the attempt | `index.ts` |
| A failed deploy leaves the hold cleared | `runDeploy` catch | `deploy.ts` |
| Manual control still deploys an already-attempted commit | route bypasses both gates | `admin.ts` |
| No second deploy while one is in progress | atomic hold claim | `deploy.ts` |
| Decision covered without performing a deploy | 21 tests, no I/O | `deploy-policy.test.ts` |
| Both settings visible and changeable | policy card | `pages/deployments.ts` |

## Verification

`npm run typecheck` and `npm test` — 156 files, 2860 tests. Every changed file also type-checks clean under a throwaway tsconfig that includes `src/__tests__`, which the normal typecheck excludes.

Every guard was mutation-tested: the inverted or removed `configured` check, the dropped hold and per-commit guards, notify-before-deploy precedence, the availability notice falling back to an image ref or broadcasting, the disabled switch rejoining the form, and the poll clobbering unsaved edits. All fail as they should.

**Live run** — local orchestrator with hand-set stamps, auto on, deploying a throwaway Fly app:

```
[deploy] Auto-deploying 3f74cc3 — dispatch pauses now
[deploy] Review-fix and gap-fill drains paused. self-deployment in progress   (cycles #1–#40)
[deploy] ai-implement-deploy-test released; this process was not replaced     (cycle #40)
[poll]   Starting poll cycle #41   — no second Auto-deploying
```

Fly **v5** released, `/mcp` answering **401** and `/` answering 200, so the sidecar shipped. Because the local stamp never moves, availability stayed `true` after the release — making `lastActedCommit` the only thing preventing a deploy every fifteen seconds. On a genuine self-deploy the new process boots with the new stamp and availability computes `false`, so the guard is redundant there; this run tested it in the one configuration where it is load-bearing.

A prior run with an invalid token proved the other half: flyctl exits 1, the hold clears, dispatch resumes, and the commit is not retried. **A failed attempt consumes the commit's one try, deliberately** — otherwise a persistently broken build re-arms every poll and dispatch spends its life paused.

## Deliberately out of scope

**A failed deploy logs but does not surface on the page**, which returns to Available with no indication of why the hold cleared. That is AII-360's scope, which already promises a durable failure record distinguishable from a release.

**An eight-minute `--no-cache` build shows no elapsed time**, which is indistinguishable from a hang — observed live. Also AII-360: it needs a `deploy_started_at` to report duration anyway, so a timer built here would be rewritten.

**Self-replacement is untested** — SIGINT mid-`await`, the hold surviving, and the boot clear releasing it. Shared with AII-357's outstanding rung and folded into this block's end-to-end step.

**Stale bookkeeping on the non-success paths.** The success path self-corrects when the starter's own HEAD resolution differs from the cached one, but a head-unknown result or a thrown starter leaves the pre-recorded commit in place. Narrow, and it only ever causes one skipped retry.

## Follow-ups

- AII-395 — the nav count still only updates while the Deployments page is open.
- One automatic attempt per commit is fixed, matching GitHub Actions' one-automatic-run-per-push. A configurable count is a reasonable follow-up if transient failures prove common, and AII-360's durable record is what would answer that.
