### PR TITLE
fix(deploy): scope the availability token and stop duplicate shutdown notices (AII-353)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Entry points for areas that are easy to miss. Each names the module to start fro
 | Dispatch envelope (`RunConfigV1`) | `src/run-config.ts` | [docs/workflow-envelope.md](docs/workflow-envelope.md) |
 | Runner image selection | `src/repo-image.ts` | [docs/runner-images.md](docs/runner-images.md) |
 | KG sidecar and `/mcp` | `src/mcp.ts`, `src/mcp-oauth.ts` | [docs/kg-sidecar.md](docs/kg-sidecar.md) |
-| Deploying, clients, Bedrock | `src/deploy.ts` | [docs/deployment.md](docs/deployment.md) |
+| Deploying, clients, Bedrock | `src/deploy.ts` and its `deploy-*` siblings | [docs/deployment.md](docs/deployment.md) |
 | Ticketing provider abstraction | `src/providers/` — `linear.ts`, `jira.ts`, `registry.ts` | |
 | Execution backends | `src/fly-machines.ts`, `src/local-docker.ts`, `src/github.ts` | |
 | Runner callbacks and tokens | `src/runner-callback.ts`, `src/runner-token.ts`, `src/token-vending.ts` | |

--- a/src/__tests__/deploy-availability.test.ts
+++ b/src/__tests__/deploy-availability.test.ts
@@ -5,7 +5,7 @@ import type * as GithubModule from "../github.js";
 
 // Both dependencies exist only to reach GitHub; what matters here is what they
 // return, so each is replaced by a spy exposing the single function we call.
-vi.mock("../github-app-auth.js", () => ({ getInstallationToken: vi.fn() }));
+vi.mock("../github-app-auth.js", () => ({ getScopedInstallationToken: vi.fn() }));
 vi.mock("../github.js", () => ({ getBranchSha: vi.fn() }));
 
 const RUNNING = "1111111111111111111111111111111111111111";
@@ -35,7 +35,10 @@ beforeEach(async () => {
   vi.resetModules();
   githubAppAuth = await import("../github-app-auth.js");
   github = await import("../github.js");
-  vi.mocked(githubAppAuth.getInstallationToken).mockResolvedValue("installation-token");
+  vi.mocked(githubAppAuth.getScopedInstallationToken).mockResolvedValue({
+    token: "installation-token",
+    expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  });
   availability = await import("../deploy-availability.js");
 });
 
@@ -115,6 +118,23 @@ describe("refreshAvailability", () => {
     const state = await availability.refreshAvailability(input());
 
     expect(state).toMatchObject({ available: true, runningCommit: RUNNING, headCommit: HEAD });
+  });
+
+  it("mints a token scoped to the one repository it reads", async () => {
+    // This runs on every poll cycle, so the broad installation-wide mint it used to make
+    // was the orchestrator's most frequently issued credential and its widest. The option
+    // shape also has to match the deploy path's mint exactly — the cache is keyed on
+    // (owner, permissions, repositories), so an identical shape means one token serves both.
+    vi.mocked(github.getBranchSha).mockResolvedValue(HEAD);
+
+    await availability.refreshAvailability(input());
+
+    expect(githubAppAuth.getScopedInstallationToken).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      "BuildDownAI",
+      { permissions: { contents: "read" }, repositories: ["AI-Implement"] },
+    );
   });
 
   it("reports up to date when the running commit is the branch head", async () => {

--- a/src/admin-ui/pages/deployments.ts
+++ b/src/admin-ui/pages/deployments.ts
@@ -35,7 +35,7 @@ export const deploymentsHtml = `
     <div class="card" id="deployments-policy" hidden>
       <div class="card-header"><h2 class="card-title">When a deployment becomes available...</h2></div>
       <div class="card-body">
-        <label class="checkbox-row" id="deployments-auto-row">
+        <label class="checkbox-row">
           <input type="checkbox" id="deployments-auto" onchange="window.refreshPolicyDirty()">
           <span>Deploy it automatically</span>
         </label>

--- a/src/deploy-availability.ts
+++ b/src/deploy-availability.ts
@@ -1,4 +1,4 @@
-import { getInstallationToken } from "./github-app-auth.js";
+import { getScopedInstallationToken } from "./github-app-auth.js";
 import { getBranchSha } from "./github.js";
 
 declare global {
@@ -78,7 +78,12 @@ export function getAvailability(): DeploymentAvailability | null {
 
 export async function refreshAvailability(input: AvailabilityInput): Promise<DeploymentAvailability> {
   const { appId, privateKey, owner, repo, branch, runningCommit } = input;
-  const token = await getInstallationToken(appId, privateKey, owner);
+  // Scoped to the single repository whose branch this reads. The options match the deploy
+  // path's mint exactly, so the two share one cache entry rather than minting separately.
+  const { token } = await getScopedInstallationToken(appId, privateKey, owner, {
+    permissions: { contents: "read" },
+    repositories: [repo],
+  });
   // null on 404 — a deleted or renamed branch reads as unknown, not as up to date.
   const headCommit = await getBranchSha(token, owner, repo, branch);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3284,7 +3284,15 @@ async function main(): Promise<void> {
 
   // total amount of time allotted for a graceful shutdown, otherwise the shutdown is forced
   const SHUTDOWN_BUDGET_MS = 10_000; // 10s
-  const shutdown = async (signal: string) => {
+  // Fly can send a second signal before the first shutdown finishes. The latch needs no
+  // reset: the forced-exit timer below is armed before any await, so the process always dies.
+  let shuttingDown = false;
+  const shutdown = async (signal: "SIGTERM" | "SIGINT") => {
+    if (shuttingDown) {
+      console.log(`[main] Received ${signal} while already shutting down; ignoring`);
+      return;
+    }
+    shuttingDown = true;
     console.log(`[main] Received ${signal}, shutting down...`);
     clearInterval(interval);
 


### PR DESCRIPTION
Cleanup pass across the self-deploy tree (AII-354 → AII-360), now that every child has merged. Scoped to feature cleanup — the `src/deploy/` directory move is deliberately **not** here, so this diff stays readable rather than being buried in path churn.

One change is a pre-existing defect rather than cleanup; it is folded in because live deploy testing surfaced it and it would otherwise fire on every self-deploy from here on. Called out separately below.

### Least-privilege token on the availability read

`refreshAvailability` minted an **installation-wide** token to read one branch's SHA, while the deploy path did the identical lookup with a token scoped to `contents: read` on a single repository. AII-355 predates the scoped helper that AII-357 introduced, so this was drift rather than a decision — and because availability runs on every poll cycle, the broad token was simultaneously the orchestrator's most frequently minted credential and its widest.

Both functions live in `github-app-auth.ts`, so the import edge already existed and no dependency cycle is possible. The scoped mint caches on `(owner, permissions, repositories)` against GitHub's real `expires_at` minus five minutes, so a 60-second poll mints roughly hourly rather than per cycle. The option shape deliberately matches `makeStartDeploy`'s exactly, so the availability read and the deploy's source fetch now share one cached token instead of minting separately.

Unchanged: the KG clone token, which is minted against its own owner and repository and keys to its own cache entry.

### Duplicate shutdown notifications (pre-existing)

`shutdown()` in `src/index.ts` had no re-entrancy guard, so every signal ran the whole body — a second shutdown notification, a second forced-exit timer, and a second `recordShutdown()`.

Observed live during a self-deploy of the testing orchestrator: Slack received two "Orchestrator restarting" messages for one release. The logs show why — `SIGINT` at `07:54:38`, `SIGTERM` six seconds later, forced exit at `07:54:48`.

The reason it reproduces reliably now is specific to this feature. `server.close()` waits for open connections to drain, and an admin page polling every thirty seconds holds one — so the process is still alive when the second signal arrives. Someone watching the Deployments page is the normal condition for triggering a deploy, so this would fire on most self-deploys rather than occasionally.

There is a second consequence beyond the noise: the duplicate `recordShutdown()` overwrites `deploy_last_shutdown_at`, so the next boot measures downtime from the *second* signal and under-reports it.

The handler dates from AII-255 and predates this tree; the fix is a one-way latch, safe without a reset because the forced-exit timer is armed before any `await` and bounds how long the process can stay latched. The signal parameter is narrowed to `"SIGTERM" | "SIGINT"` at the same time, since the two registrations are its only callers and both pass literals.

**This is not covered by a test.** Nothing imports `src/index.ts` — it calls `main()` on import — so the guard, the write-before-await ordering, and the timer-before-await ordering are all guaranteed only by reading the code. See Follow-ups.

### Dead identifier

`id="deployments-auto-row"` was declared in the markup and referenced by nothing — no script, no test. Its sibling `deployments-notify-row` is genuinely used for the disabled-state styling; this one was added symmetrically and never needed.

### Index correction

The subsystem table pointed at `src/deploy.ts` alone when the cluster is six `deploy-*` modules.

### Acceptance criteria

| Criterion | How it's met |
|---|---|
| Availability reads with a least-privilege token | `getScopedInstallationToken` with `contents: read` on the watched repo |
| No new dependency cycle | Same module as the previous import; `github-app-auth.ts` imports only `node:crypto` and `github-errors.js` |
| No extra API load | Cached per option tuple off GitHub's real expiry; shares an entry with the deploy path's mint |
| The scope cannot silently regress | A test asserts the exact option shape; verified by reverting the change and watching it fail |
| One shutdown notification per shutdown | Re-entrancy latch; verifiable on the next deploy by a single "Orchestrator restarting" in Slack |
| Nothing else orphaned | Every settings key has one owner, all four notification kinds have emitters, and every symbol the block added to a shared module is wired |
| `npm run typecheck` and `npm test` pass | 3126 passing, typecheck clean |

### Follow-ups

- The Deployments nav badge is another instance of AII-395 — it fills only from inside the page it points at, so the count appears after visiting that page rather than before.
- **Untestable shutdown logic.** The guard added here, and the two ordering properties around it, cannot be asserted while the handler lives inside `main()`. Extracting it behind an injected-dependency factory — the shape `makeStartDeploy` and `AdminDeps` already use — would make all three testable. Deferred rather than done here, and it is one instance of a broader problem with logic that only exists inside `main()`: the dispatch-pause gates from AII-356 are uncovered for the same reason. Worth planning as a piece of work rather than as a one-file change.
