### PR TITLE
Docs: add local quick demo and target-repo guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ what it did:
 ```bash
 git status --short
 git diff
-git diff --cached             # some successful review paths leave changes staged
+git diff --cached             # also inspect anything the implementation staged
 ```
 
 Reset the demo whenever you want to run it again:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ what it did:
 ```bash
 git status --short
 git diff
-git diff --cached             # also inspect anything the implementation staged
+git diff --cached
 ```
+
+The demo's one-file scope is an instruction to the model, not a filesystem
+boundary. Inspect all changed and staged files before keeping the result.
 
 Reset the demo whenever you want to run it again:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,111 @@ You should look elsewhere if:
 - You want a hosted "press a button, get a PR" experience without operating any infrastructure.
 - Your tickets tend to be sprawling or vague. Claude does well with focused, well-specified issues and poorly with everything else.
 
-## Quick start (local dev)
+## Try it locally
+
+You can run a complete implementation-and-review loop in Docker without setting up
+a tracker, GitHub App, orchestrator, or web UI. Local runs operate on a checkout you
+choose and leave the resulting file changes there for you to inspect.
+
+You need Docker, Node 24, and one Claude credential:
+
+```bash
+git clone https://github.com/BuildDownAI/AI-Implement.git
+cd AI-Implement
+asdf install                  # or install Node 24 another way
+npm install
+npm run build:runner:local    # build once; rebuild after runner changes
+
+# Choose one:
+export CLAUDE_CODE_OAUTH_TOKEN="<your token>"
+# export ANTHROPIC_API_KEY="<your API key>"
+
+# Optional: make your existing GitHub CLI credentials available to the run.
+export GH_TOKEN="$(gh auth token)"
+```
+
+You can put the same environment variables in AI-Implement's `.env` file instead.
+The local runner passes credentials through a temporary secret environment file,
+not as visible Docker command-line arguments.
+
+### Run the quick demo in this repo
+
+The included demo asks AI-Implement to change one tracked text file and nothing
+else. It uses model credits and usually takes a few minutes:
+
+```bash
+npm run dev:run -- \
+  --workspace "$PWD" \
+  --task examples/local-demo/task.md
+```
+
+The command streams the implementation and review loop. When it finishes, inspect
+what it did:
+
+```bash
+git status --short
+git diff
+git diff --cached             # some successful review paths leave changes staged
+```
+
+Reset the demo whenever you want to run it again:
+
+```bash
+git restore --staged --worktree examples/local-demo/message.txt
+```
+
+Every run prints its artifact directory. By default, complete logs, summaries, and
+run metadata are saved under `.dev-runs/<timestamp>/` in the AI-Implement checkout.
+
+### Implement a task in another local repo
+
+Create the task document outside the target repo so it does not become part of the
+implementation diff. For example, save this as `~/ai-tasks/add-health-check.md`:
+
+```markdown
+---
+title: Add a health-check endpoint
+id: LOCAL-1
+limits:
+  maxTurns: 50
+  maxIterations: 3
+---
+
+Add a `GET /health` endpoint that returns HTTP 200 and a JSON body containing
+`{"status":"ok"}`.
+
+Acceptance criteria:
+
+- Follow the repository's existing routing and response conventions.
+- Add automated coverage for the success response.
+- Run the repository's relevant tests and document the result.
+```
+
+Then run the harness from the AI-Implement checkout and point `--workspace` at
+the target checkout:
+
+```bash
+AI_IMPLEMENT_DIR="$HOME/src/AI-Implement"
+TARGET_REPO="$HOME/src/my-project"
+TASK_FILE="$HOME/ai-tasks/add-health-check.md"
+
+cd "$AI_IMPLEMENT_DIR"
+npm run dev:run -- \
+  --workspace "$TARGET_REPO" \
+  --task "$TASK_FILE"
+```
+
+`--workspace` is how you choose the repository; do not put a repository path in
+the task document. AI-Implement detects the GitHub `owner/repo` from the checkout's
+`origin` remote and uses its current branch unless the optional task field `base` is
+set. If the target repo has a `WORKFLOW.md`, the run follows it; otherwise it uses
+the built-in implementation prompt.
+
+Use a clean checkout or review pre-existing changes carefully. The local pipeline
+does not create a branch, commit, push, or pull request—it leaves the implementation
+in the target checkout so you stay in control of what ships.
+
+## Run the full orchestrator locally
 
 You'll need a Linear workspace or Jira project, a GitHub App you control, and an Anthropic API key (or AWS Bedrock access).
 

--- a/examples/local-demo/message.txt
+++ b/examples/local-demo/message.txt
@@ -1,0 +1,1 @@
+AI-Implement is ready for a local task.

--- a/examples/local-demo/task.md
+++ b/examples/local-demo/task.md
@@ -1,0 +1,16 @@
+---
+title: Complete the AI-Implement local quick demo
+id: LOCAL-DEMO-1
+limits:
+  maxTurns: 20
+  maxIterations: 1
+---
+
+Update only `examples/local-demo/message.txt`.
+
+Acceptance criteria:
+
+- Replace the file's entire contents with `AI-Implement completed this local task.`
+- Keep exactly one trailing newline.
+- Do not modify any other tracked file or add a dependency.
+- Verify the resulting file contents and run `git diff --check`.


### PR DESCRIPTION
## Summary

- put a Docker-first local quickstart near the top of the README
- add a runnable in-repo demo task with a deliberately tiny visible change
- document how `--workspace` targets another local checkout and what local mode does and does not publish
- document credentials, artifacts, task placement, and reset/inspection commands

## Validation

- parsed `examples/local-demo/task.md` with the production task parser
- `npm test -- --run src/__tests__/dev-harness-task-file.test.ts src/__tests__/dev-harness-cli.test.ts` (31 passed)
- `npm test` (3,125 passed; one sandbox-only loopback-bind failure passed when rerun outside the sandbox)
- `npm run typecheck`
- `git diff --check`
