### PR TITLE
Local: exercise planning and the full AI loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ You should look elsewhere if:
 
 ## Try it locally
 
-You can run a complete implementation-and-review loop in Docker without setting up
-a tracker, GitHub App, orchestrator, or web UI. Local runs operate on a checkout you
-choose and leave the resulting file changes there for you to inspect.
+You can run a complete planning, implementation, and review loop in Docker without
+setting up a tracker, GitHub App, orchestrator, or web UI. Local runs operate on a
+checkout you choose and leave the resulting file changes there for you to inspect.
 
 You need Docker, Node 24, and one Claude credential:
 
@@ -80,11 +80,12 @@ else. It uses model credits and usually takes a few minutes:
 ```bash
 npm run dev:run -- \
   --workspace "$PWD" \
-  --task examples/local-demo/task.md
+  --task examples/local-demo/task.md \
+  --phase full
 ```
 
-The command streams the implementation and review loop. When it finishes, inspect
-what it did:
+The command plans the task, passes that plan into implementation, and runs the
+review/fix loop. When it finishes, inspect what it did:
 
 ```bash
 git status --short
@@ -103,6 +104,38 @@ git restore --staged --worktree examples/local-demo/message.txt
 
 Every run prints its artifact directory. By default, complete logs, summaries, and
 run metadata are saved under `.dev-runs/<timestamp>/` in the AI-Implement checkout.
+Planning and full-loop runs also save the assembled plan as `plan.md` there.
+
+### Exercise planning and implementation separately
+
+Use `--phase` to choose the test surface:
+
+| Phase | What it exercises |
+| --- | --- |
+| `planning` | Reads `PLANNING.md` (or the built-in planning prompt), produces a plan, and stops before implementation. |
+| `implementation` | Runs implementation and review without a planning pass. This remains the default. |
+| `full` | Runs planning, passes the exact resulting plan into implementation, and completes the review/fix loop. |
+
+For example, iterate on a repository's `PLANNING.md` without spending tokens on an
+implementation:
+
+```bash
+TARGET_REPO="$HOME/src/my-project"
+TASK_FILE="$HOME/ai-tasks/add-health-check.md"
+
+npm run dev:run -- \
+  --workspace "$TARGET_REPO" \
+  --task "$TASK_FILE" \
+  --phase planning
+```
+
+Inspect the printed artifact directory's `plan.md` to compare planning-prompt
+changes. The mounted target checkout also contains the individual planning files
+under `ai-output/comments/`; the harness adds `ai-output/` to the repository-local
+Git exclude so those scratch files do not enter the implementation diff or a commit.
+Use `--phase full` when you want to test whether those planning decisions actually
+survive the handoff into implementation. Edit `WORKFLOW.md` to iterate on
+implementation behavior independently.
 
 ### Implement a task in another local repo
 
@@ -139,14 +172,15 @@ TASK_FILE="$HOME/ai-tasks/add-health-check.md"
 cd "$AI_IMPLEMENT_DIR"
 npm run dev:run -- \
   --workspace "$TARGET_REPO" \
-  --task "$TASK_FILE"
+  --task "$TASK_FILE" \
+  --phase full
 ```
 
 `--workspace` is how you choose the repository; do not put a repository path in
 the task document. AI-Implement detects the GitHub `owner/repo` from the checkout's
 `origin` remote and uses its current branch unless the optional task field `base` is
-set. If the target repo has a `WORKFLOW.md`, the run follows it; otherwise it uses
-the built-in implementation prompt.
+set. If the target repo has `PLANNING.md` or `WORKFLOW.md`, the corresponding phase
+follows it; otherwise that phase uses its built-in prompt.
 
 Use a clean checkout or review pre-existing changes carefully. The local pipeline
 does not create a branch, commit, push, or pull request—it leaves the implementation

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -102,13 +102,11 @@ chown coder:coder /home/coder/.gitconfig 2>/dev/null || true
 export WORKSPACE_DIR
 RUNNER_PHASE="${RUNNER_PHASE:-implementation}"
 export RUNNER_PHASE
-# Only "planning" has a dedicated entry. "implementation" and "gap-analysis"
-# both run run-autonomous.js (gap-fill is an implementation run with PR_NUMBER set),
-# so they intentionally share the default branch.
-if [ "$RUNNER_PHASE" = "planning" ]; then
-  RUNNER_ENTRY="run-planning.js"
-else
-  RUNNER_ENTRY="run-autonomous.js"
-fi
+case "$RUNNER_PHASE" in
+  planning) RUNNER_ENTRY="run-planning.js" ;;
+  local-planning) RUNNER_ENTRY="run-local-planning.js" ;;
+  full) RUNNER_ENTRY="run-local-full-loop.js" ;;
+  *) RUNNER_ENTRY="run-autonomous.js" ;;
+esac
 log "Invoking TS pipeline (node /app/dist/$RUNNER_ENTRY, phase=$RUNNER_PHASE)..."
 exec dbus-run-session -- su -p coder -c "HOME=/home/coder exec node /app/dist/$RUNNER_ENTRY"

--- a/session/entrypoint.sh
+++ b/session/entrypoint.sh
@@ -102,6 +102,7 @@ chown coder:coder /home/coder/.gitconfig 2>/dev/null || true
 export WORKSPACE_DIR
 RUNNER_PHASE="${RUNNER_PHASE:-implementation}"
 export RUNNER_PHASE
+# Managed gap-analysis is an implementation run with PR_NUMBER set, so it uses the default entry.
 case "$RUNNER_PHASE" in
   planning) RUNNER_ENTRY="run-planning.js" ;;
   local-planning) RUNNER_ENTRY="run-local-planning.js" ;;

--- a/src/__tests__/dev-harness-cli.test.ts
+++ b/src/__tests__/dev-harness-cli.test.ts
@@ -20,10 +20,106 @@ function makeHandle(): DevRunHandle {
       profiles: undefined,
     },
     workspace: "/tmp/workspace",
+    phase: "implementation",
   };
 }
 
 describe("runDevHarnessCli", () => {
+  it("passes planning phase through the public CLI", async () => {
+    const deps: DevHarnessCliDependencies = {
+      startDevRun: vi.fn().mockResolvedValue(makeHandle()),
+      streamLogs: vi.fn().mockResolvedValue(undefined),
+      streamLogsUntilShellReady: vi.fn(),
+      getRunStatus: vi.fn().mockResolvedValue({ exitCode: 0 }),
+      collectRunArtifacts: vi.fn().mockResolvedValue(undefined),
+      stopSession: vi.fn(),
+      spawnDocker: vi.fn(),
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+      now: () => Date.now(),
+    };
+
+    await runDevHarnessCli(
+      ["--workspace", "/tmp/workspace", "--task", "/tmp/task.md", "--phase", "planning"],
+      deps,
+    );
+
+    expect(deps.startDevRun).toHaveBeenCalledWith(expect.objectContaining({ phase: "planning" }));
+  });
+
+  it("passes the full planning-to-implementation loop through the public CLI", async () => {
+    const deps: DevHarnessCliDependencies = {
+      startDevRun: vi.fn().mockResolvedValue(makeHandle()),
+      streamLogs: vi.fn().mockResolvedValue(undefined),
+      streamLogsUntilShellReady: vi.fn(),
+      getRunStatus: vi.fn().mockResolvedValue({ exitCode: 0 }),
+      collectRunArtifacts: vi.fn().mockResolvedValue(undefined),
+      stopSession: vi.fn(),
+      spawnDocker: vi.fn(),
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+      now: () => Date.now(),
+    };
+
+    await runDevHarnessCli(
+      ["--workspace", "/tmp/workspace", "--task", "/tmp/task.md", "--phase", "full"],
+      deps,
+    );
+
+    expect(deps.startDevRun).toHaveBeenCalledWith(expect.objectContaining({ phase: "full" }));
+  });
+
+  it("rejects an unknown phase before starting Docker", async () => {
+    const deps: DevHarnessCliDependencies = {
+      startDevRun: vi.fn(),
+      streamLogs: vi.fn(),
+      streamLogsUntilShellReady: vi.fn(),
+      getRunStatus: vi.fn(),
+      collectRunArtifacts: vi.fn(),
+      stopSession: vi.fn(),
+      spawnDocker: vi.fn(),
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+      now: () => Date.now(),
+    };
+
+    const exitCode = await runDevHarnessCli(
+      ["--workspace", "/tmp/workspace", "--task", "/tmp/task.md", "--phase", "other"],
+      deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(deps.startDevRun).not.toHaveBeenCalled();
+    expect(deps.writeStderr).toHaveBeenCalledWith(expect.stringContaining("implementation, planning, or full"));
+  });
+
+  it.each([
+    ["--until", "setup"],
+    ["--shell"],
+  ])("rejects implementation-only option %s for a full-loop run", async (...extraArgs: string[]) => {
+    const deps: DevHarnessCliDependencies = {
+      startDevRun: vi.fn(),
+      streamLogs: vi.fn(),
+      streamLogsUntilShellReady: vi.fn(),
+      getRunStatus: vi.fn(),
+      collectRunArtifacts: vi.fn(),
+      stopSession: vi.fn(),
+      spawnDocker: vi.fn(),
+      writeStdout: vi.fn(),
+      writeStderr: vi.fn(),
+      now: () => Date.now(),
+    };
+
+    const exitCode = await runDevHarnessCli(
+      ["--workspace", "/tmp/workspace", "--task", "/tmp/task.md", "--phase", "full", ...extraArgs],
+      deps,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(deps.startDevRun).not.toHaveBeenCalled();
+    expect(deps.writeStderr).toHaveBeenCalledWith(expect.stringContaining("only supported for --phase implementation"));
+  });
+
   it("collects shell-mode artifacts before removing the container", async () => {
     const events: string[] = [];
     const deps: DevHarnessCliDependencies = {

--- a/src/__tests__/dev-harness-planning-artifacts.test.ts
+++ b/src/__tests__/dev-harness-planning-artifacts.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { collectPlanningArtifact } from "../dev-harness/planning-artifacts.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("collectPlanningArtifact", () => {
+  it("saves ordered planning comments as plan.md in the run artifacts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dev-plan-artifact-"));
+    roots.push(root);
+    const workspace = join(root, "workspace");
+    const artifactsDir = join(root, "artifacts");
+    const commentsDir = join(workspace, "ai-output", "comments");
+    mkdirSync(commentsDir, { recursive: true });
+    mkdirSync(artifactsDir, { recursive: true });
+    writeFileSync(join(commentsDir, "02-acceptance.md"), "## Acceptance\nShip it.\n");
+    writeFileSync(join(commentsDir, "01-map.md"), "## Map\nChange one file.\n");
+
+    await collectPlanningArtifact(workspace, artifactsDir);
+
+    const planPath = join(artifactsDir, "plan.md");
+    expect(existsSync(planPath)).toBe(true);
+    expect(readFileSync(planPath, "utf-8")).toBe(
+      "## Map\nChange one file.\n\n## Acceptance\nShip it.\n",
+    );
+  });
+});

--- a/src/__tests__/dev-harness-planning-artifacts.test.ts
+++ b/src/__tests__/dev-harness-planning-artifacts.test.ts
@@ -30,4 +30,18 @@ describe("collectPlanningArtifact", () => {
       "## Map\nChange one file.\n\n## Acceptance\nShip it.\n",
     );
   });
+
+  it("does not create plan.md when the run produced no planning comments", async () => {
+    const root = mkdtempSync(join(tmpdir(), "dev-plan-artifact-"));
+    roots.push(root);
+    const workspace = join(root, "workspace");
+    const artifactsDir = join(root, "artifacts");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(artifactsDir, { recursive: true });
+
+    const collected = await collectPlanningArtifact(workspace, artifactsDir);
+
+    expect(collected).toBe(false);
+    expect(existsSync(join(artifactsDir, "plan.md"))).toBe(false);
+  });
 });

--- a/src/__tests__/dev-harness.test.ts
+++ b/src/__tests__/dev-harness.test.ts
@@ -163,6 +163,32 @@ describe("startDevRun", () => {
     expect(cfg.runnerPhase).toBe("implementation");
   });
 
+  it("routes a full run to the full-loop entry while keeping a valid implementation envelope", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "");
+    makeSpawnSyncMock("");
+
+    const handle = await startDevRun({ workspace: "/tmp/repo", task: "task.md", phase: "full" });
+
+    const opts = vi.mocked(launchLocalSession).mock.calls[0]![0];
+    expect(opts.publicEnv["RUNNER_PHASE"]).toBe("full");
+    expect(decodeRunConfig(opts.publicEnv["AI_IMPLEMENT_RUN_CONFIG"]!).runnerPhase).toBe("implementation");
+    expect(handle.phase).toBe("full");
+  });
+
+  it("routes planning-only runs through the validating local planner", async () => {
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "");
+    makeSpawnSyncMock("");
+
+    const handle = await startDevRun({ workspace: "/tmp/repo", task: "task.md", phase: "planning" });
+
+    const opts = vi.mocked(launchLocalSession).mock.calls[0]![0];
+    expect(opts.publicEnv["RUNNER_PHASE"]).toBe("local-planning");
+    expect(decodeRunConfig(opts.publicEnv["AI_IMPLEMENT_RUN_CONFIG"]!).runnerPhase).toBe("planning");
+    expect(handle.phase).toBe("planning");
+  });
+
   it("includes profiles in the run config when the task file has profiles", async () => {
     vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
     vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "");

--- a/src/__tests__/entrypoint-shellcheck.test.ts
+++ b/src/__tests__/entrypoint-shellcheck.test.ts
@@ -232,6 +232,8 @@ describe("session/entrypoint.sh", () => {
   it("exec's the phase-selected TS runner as the final step", () => {
     const content = readFileSync("session/entrypoint.sh", "utf-8");
     expect(content).toContain('RUNNER_ENTRY="run-planning.js"');
+    expect(content).toContain('RUNNER_ENTRY="run-local-planning.js"');
+    expect(content).toContain('RUNNER_ENTRY="run-local-full-loop.js"');
     expect(content).toContain('RUNNER_ENTRY="run-autonomous.js"');
     expect(content).toContain('exec dbus-run-session -- su -p coder -c "HOME=/home/coder exec node /app/dist/$RUNNER_ENTRY"');
   });

--- a/src/__tests__/local-full-loop.test.ts
+++ b/src/__tests__/local-full-loop.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 
 const isWindows = process.platform === "win32";
 import { runLocalFullLoop } from "../local/full-loop.js";
 import { PipelineRunner } from "../pipeline/runner.js";
 import type { LLMExecutor, PipelineDefinition, StepModule } from "../pipeline/types.js";
+import { getDiff } from "../pipeline/steps/feedback-loop.js";
 
 function makeMockExecutor(exitCode = 0): LLMExecutor {
   return {
@@ -248,6 +250,42 @@ describe("runLocalFullLoop", () => {
 
     expect(result.planningContext).toContain("Context data");
     expect(capturedPlanningContext).toContain("Context data");
+  });
+
+  it("keeps planning scratch files out of the implementation review diff", async () => {
+    spawnSync("git", ["init"], { cwd: ws });
+    spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: ws });
+    spawnSync("git", ["config", "user.name", "Test"], { cwd: ws });
+    writeFileSync(join(ws, "source.txt"), "original\n");
+    spawnSync("git", ["add", "source.txt"], { cwd: ws });
+    spawnSync("git", ["commit", "-m", "initial"], { cwd: ws });
+
+    let reviewedDiff = "";
+    const { pipeline, runner } = makeFeedbackLoopPipeline({
+      run: vi.fn().mockImplementation(async (ctx) => {
+        reviewedDiff = getDiff(String(ctx.data.workspaceDir));
+        return {
+          approved: true,
+          iterations: 1,
+          terminationReason: "approved",
+          passes: [],
+          finalFeedback: "",
+        };
+      }),
+    });
+
+    await runLocalFullLoop({
+      workspaceDir: ws,
+      issueIdentifier: "TEST-1",
+      issueTitle: "Test",
+      issueDescription: "Desc",
+      planningExecutor: planningExecutorWithPlan(),
+      llmExecutor: makeMockExecutor(0),
+      pipeline,
+      runner,
+    });
+
+    expect(reviewedDiff).not.toContain("ai-output/comments");
   });
 
   it("exposes phase outcomes, review status, limits, passes, and tokenSummary in the result", async () => {

--- a/src/__tests__/run-local-full-loop.test.ts
+++ b/src/__tests__/run-local-full-loop.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { encodeRunConfig } from "../run-config.js";
+import { runLocalFullLoopFromEnv } from "../run-local-full-loop.js";
+
+describe("runLocalFullLoopFromEnv", () => {
+  it("runs planning and implementation from the dev-run task envelope", async () => {
+    const runFullLoop = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      classification: "success",
+      planningExitCode: 0,
+      implementationExitCode: 0,
+      reviewApproved: true,
+      iterations: 1,
+    });
+    const output: string[] = [];
+    const runConfig = encodeRunConfig({
+      v: 1,
+      issue: {
+        id: "issue-1",
+        identifier: "LOCAL-1",
+        title: "Add health check",
+        description: "Implement the endpoint.",
+      },
+      runnerPhase: "implementation",
+      maxTurns: 25,
+      maxIterations: 2,
+    });
+
+    const exitCode = await runLocalFullLoopFromEnv(
+      {
+        AI_IMPLEMENT_RUN_CONFIG: runConfig,
+        WORKSPACE_DIR: "/workspace",
+        CLAUDE_MODEL: "claude-test-model",
+      },
+      {
+        runFullLoop,
+        writeStdout: (text) => output.push(text),
+      },
+    );
+
+    expect(runFullLoop).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceDir: "/workspace",
+      issueId: "issue-1",
+      issueIdentifier: "LOCAL-1",
+      issueTitle: "Add health check",
+      issueDescription: "Implement the endpoint.",
+      maxTurns: 25,
+      maxIterations: 2,
+      model: "claude-test-model",
+    }));
+    expect(exitCode).toBe(0);
+    expect(output.join("\n")).toContain("planning -> implementation -> review");
+    expect(output.join("\n")).toContain("classification=success");
+  });
+});

--- a/src/__tests__/run-local-planning.test.ts
+++ b/src/__tests__/run-local-planning.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { encodeRunConfig } from "../run-config.js";
+import { runLocalPlanningFromEnv } from "../run-local-planning.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+describe("runLocalPlanningFromEnv", () => {
+  it("fails unless the planning phase produces a readable plan", async () => {
+    const runPlanning = vi.fn().mockResolvedValue({
+      exitCode: 1,
+      planningContext: "",
+      planFound: false,
+      diagnostics: "Planning process produced no readable Markdown plan",
+    });
+    const output: string[] = [];
+    const runConfig = encodeRunConfig({
+      v: 1,
+      issue: {
+        id: "issue-1",
+        identifier: "LOCAL-1",
+        title: "Plan the health check",
+        description: "Map the implementation.",
+      },
+      runnerPhase: "planning",
+    });
+
+    const exitCode = await runLocalPlanningFromEnv(
+      { AI_IMPLEMENT_RUN_CONFIG: runConfig, WORKSPACE_DIR: "/workspace" },
+      {
+        runPlanning,
+        writeStdout: (text) => output.push(text),
+        writeStderr: (text) => output.push(text),
+      },
+    );
+
+    expect(runPlanning).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceDir: "/workspace",
+      issueIdentifier: "LOCAL-1",
+      issueTitle: "Plan the health check",
+      issueDescription: "Map the implementation.",
+    }));
+    expect(exitCode).toBe(1);
+    expect(output.join("\n")).toContain("no readable Markdown plan");
+  });
+
+  it("keeps planning artifacts out of the target repository status", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "local-planning-runner-"));
+    try {
+      spawnSync("git", ["init"], { cwd: workspace });
+      spawnSync("git", ["config", "user.email", "test@example.com"], { cwd: workspace });
+      spawnSync("git", ["config", "user.name", "Test"], { cwd: workspace });
+      writeFileSync(join(workspace, "source.txt"), "original\n");
+      spawnSync("git", ["add", "source.txt"], { cwd: workspace });
+      spawnSync("git", ["commit", "-m", "initial"], { cwd: workspace });
+
+      const runConfig = encodeRunConfig({
+        v: 1,
+        issue: { id: "issue-1", identifier: "LOCAL-1", title: "Plan", description: "Plan it" },
+        runnerPhase: "planning",
+      });
+      const runPlanning = vi.fn().mockImplementation(async () => {
+        const comments = join(workspace, "ai-output", "comments");
+        mkdirSync(comments, { recursive: true });
+        writeFileSync(join(comments, "01-plan.md"), "# Plan\n");
+        return { exitCode: 0, planningContext: "# Plan\n", planFound: true, diagnostics: "" };
+      });
+
+      await runLocalPlanningFromEnv(
+        { AI_IMPLEMENT_RUN_CONFIG: runConfig, WORKSPACE_DIR: workspace },
+        { runPlanning, writeStdout: vi.fn(), writeStderr: vi.fn() },
+      );
+
+      const status = spawnSync("git", ["status", "--porcelain"], { cwd: workspace });
+      expect(status.stdout.toString()).not.toContain("ai-output");
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/dev-harness/cli.ts
+++ b/src/dev-harness/cli.ts
@@ -44,6 +44,7 @@ export async function runDevHarnessCli(
   let image: string | undefined;
   let untilStep: string | undefined;
   let shell = false;
+  let phase: "implementation" | "planning" | "full" = "implementation";
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -51,13 +52,26 @@ export async function runDevHarnessCli(
     else if ((arg === "--task" || arg === "-t") && args[i + 1]) task = args[++i] as string;
     else if (arg === "--image" && args[i + 1]) image = args[++i];
     else if (arg === "--until" && args[i + 1]) untilStep = args[++i];
+    else if (arg === "--phase") {
+      const value = args[i + 1];
+      if (value !== "implementation" && value !== "planning" && value !== "full") {
+        deps.writeStderr("Invalid --phase: expected implementation, planning, or full\n");
+        return 1;
+      }
+      phase = value;
+      i++;
+    }
     else if (arg === "--shell") shell = true;
   }
 
   if (!workspace || !task) {
     deps.writeStderr(
-      "Usage: npm run dev:run -- --workspace <dir> --task <task.md> [--image <image>] [--until <step>] [--shell]\n",
+      "Usage: npm run dev:run -- --workspace <dir> --task <task.md> [--phase implementation|planning|full] [--image <image>] [--until <step>] [--shell]\n",
     );
+    return 1;
+  }
+  if (phase !== "implementation" && (untilStep || shell)) {
+    deps.writeStderr("--until and --shell are only supported for --phase implementation\n");
     return 1;
   }
 
@@ -67,6 +81,7 @@ export async function runDevHarnessCli(
     image,
     untilStep,
     shell,
+    phase,
   });
 
   deps.writeStderr(

--- a/src/dev-harness/index.ts
+++ b/src/dev-harness/index.ts
@@ -16,8 +16,11 @@ import {
 } from "../local/session.js";
 import { parseTaskFileFromPath } from "./task-file.js";
 import type { ParsedTaskFile } from "./task-file.js";
+import { collectPlanningArtifact } from "./planning-artifacts.js";
 
 export type { ParsedTaskFile };
+
+export type DevRunPhase = "implementation" | "planning" | "full";
 
 export interface DevRunOptions {
   /** Absolute or relative path to the local target-repo checkout. */
@@ -38,6 +41,8 @@ export interface DevRunOptions {
   artifactsDir?: string;
   /** Extra env vars injected into the container. */
   env?: Record<string, string>;
+  /** Runner phase. Defaults to implementation. */
+  phase?: DevRunPhase;
   /**
    * Run only up through this named step (by step id), then stop. The critical
    * case is "setup": clone/mount → install → setup hook, no Claude invocation,
@@ -60,6 +65,7 @@ export interface DevRunHandle {
   startedAt: Date;
   task: ParsedTaskFile;
   workspace: string;
+  phase: DevRunPhase;
 }
 
 export interface DevRunResult {
@@ -144,11 +150,14 @@ export async function startDevRun(opts: DevRunOptions): Promise<DevRunHandle> {
   const issueId = randomUUID();
   const runId = randomUUID();
   const containerName = sanitizeContainerName(task.identifier);
+  const phase = opts.phase ?? "implementation";
+  const runnerPhase = phase === "full" ? "implementation" : phase;
+  const entryPhase = phase === "planning" ? "local-planning" : phase;
 
   const runConfig = encodeRunConfig({
     v: 1,
     issue: { id: issueId, identifier: task.identifier, title: task.title, description: task.description },
-    runnerPhase: "implementation",
+    runnerPhase,
     baseBranch: branch,
     ...(task.maxTurns !== undefined ? { maxTurns: task.maxTurns } : {}),
     ...(task.maxIterations !== undefined ? { maxIterations: task.maxIterations } : {}),
@@ -173,7 +182,7 @@ export async function startDevRun(opts: DevRunOptions): Promise<DevRunHandle> {
     SESSION_TOKEN: runId,
     MACHINE_NONCE: runId,
     SESSION_MODE: "autonomous",
-    RUNNER_PHASE: "implementation",
+    RUNNER_PHASE: entryPhase,
     ...(process.getuid ? { AI_IMPLEMENT_HOST_UID: String(process.getuid()) } : {}),
     ...(process.getgid ? { AI_IMPLEMENT_HOST_GID: String(process.getgid()) } : {}),
     ...(anthropicApiKey ? { ANTHROPIC_API_KEY: anthropicApiKey } : {}),
@@ -199,6 +208,7 @@ export async function startDevRun(opts: DevRunOptions): Promise<DevRunHandle> {
     startedAt: session.startedAt,
     task,
     workspace,
+    phase,
   };
 }
 
@@ -269,6 +279,10 @@ export async function collectRunArtifacts(
   });
   await writeFile(join(artifactsDir, "run.log"), logs);
 
+  if (handle.phase === "planning" || handle.phase === "full") {
+    await collectPlanningArtifact(workspace, artifactsDir);
+  }
+
   const diffstatResult = spawnSync("git", ["diff", "--stat"], {
     cwd: workspace,
     stdio: ["ignore", "pipe", "pipe"],
@@ -286,6 +300,7 @@ export async function collectRunArtifacts(
     containerId: containerId.slice(0, 12),
     identifier: task.identifier,
     title: task.title,
+    phase: handle.phase,
     exitCode,
     startedAt: startedAt.toISOString(),
     endedAt: new Date().toISOString(),

--- a/src/dev-harness/planning-artifacts.ts
+++ b/src/dev-harness/planning-artifacts.ts
@@ -1,0 +1,24 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export async function collectPlanningArtifact(
+  workspace: string,
+  artifactsDir: string,
+): Promise<boolean> {
+  const commentsDir = join(workspace, "ai-output", "comments");
+  let names: string[];
+  try {
+    names = (await readdir(commentsDir))
+      .filter((name) => name.endsWith(".md"))
+      .sort();
+  } catch {
+    return false;
+  }
+  if (names.length === 0) return false;
+
+  const planningComments = await Promise.all(
+    names.map((name) => readFile(join(commentsDir, name), "utf-8")),
+  );
+  await writeFile(join(artifactsDir, "plan.md"), planningComments.join("\n"), "utf-8");
+  return true;
+}

--- a/src/pipeline/scratch-exclude.ts
+++ b/src/pipeline/scratch-exclude.ts
@@ -70,3 +70,10 @@ export function prepareScratchExclusion(workspaceDir: string): void {
     }
   }
 }
+
+/** Apply scratch exclusion only when workspaceDir is a Git repository root. */
+export function prepareScratchExclusionIfGit(workspaceDir: string): void {
+  if (fs.existsSync(path.join(workspaceDir, ".git"))) {
+    prepareScratchExclusion(workspaceDir);
+  }
+}

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -18,7 +18,7 @@ import { decodeRunConfig, type RunConfigV1 } from "./run-config.js";
 import { writeRunAutopsy, writeRunStats } from "./run-autopsy.js";
 import { parsePlanningBlock } from "./planning-block.js";
 import type { LocalRunTokenSummary } from "./local/run-result.js";
-import { prepareScratchExclusion } from "./pipeline/scratch-exclude.js";
+import { prepareScratchExclusionIfGit } from "./pipeline/scratch-exclude.js";
 
 type RunAutopsyPasses = Array<{
   iteration: number;
@@ -756,9 +756,7 @@ export async function runAutonomousLocally(
   opts: RunLocalAutonomousOptions,
 ): Promise<RunLocalAutonomousResult> {
   const workspaceDir = opts.workspaceDir;
-  if (existsSync(join(workspaceDir, ".git"))) {
-    prepareScratchExclusion(workspaceDir);
-  }
+  prepareScratchExclusionIfGit(workspaceDir);
   const planningContext = opts.planningContext ?? "";
   const effectiveMaxTurns = opts.maxTurns ?? 50;
   const effectiveMaxIterations = opts.maxIterations ?? 3;

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -18,6 +18,7 @@ import { decodeRunConfig, type RunConfigV1 } from "./run-config.js";
 import { writeRunAutopsy, writeRunStats } from "./run-autopsy.js";
 import { parsePlanningBlock } from "./planning-block.js";
 import type { LocalRunTokenSummary } from "./local/run-result.js";
+import { prepareScratchExclusion } from "./pipeline/scratch-exclude.js";
 
 type RunAutopsyPasses = Array<{
   iteration: number;
@@ -755,6 +756,9 @@ export async function runAutonomousLocally(
   opts: RunLocalAutonomousOptions,
 ): Promise<RunLocalAutonomousResult> {
   const workspaceDir = opts.workspaceDir;
+  if (existsSync(join(workspaceDir, ".git"))) {
+    prepareScratchExclusion(workspaceDir);
+  }
   const planningContext = opts.planningContext ?? "";
   const effectiveMaxTurns = opts.maxTurns ?? 50;
   const effectiveMaxIterations = opts.maxIterations ?? 3;

--- a/src/run-local-full-loop.ts
+++ b/src/run-local-full-loop.ts
@@ -1,0 +1,50 @@
+import { runLocalFullLoop } from "./local/full-loop.js";
+import { decodeRunConfig } from "./run-config.js";
+
+export interface LocalFullLoopRunnerDependencies {
+  runFullLoop: typeof runLocalFullLoop;
+  writeStdout: (text: string) => void;
+}
+
+const DEFAULT_DEPENDENCIES: LocalFullLoopRunnerDependencies = {
+  runFullLoop: runLocalFullLoop,
+  writeStdout: (text) => process.stdout.write(text),
+};
+
+export async function runLocalFullLoopFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  deps: LocalFullLoopRunnerDependencies = DEFAULT_DEPENDENCIES,
+): Promise<number> {
+  const encoded = env.AI_IMPLEMENT_RUN_CONFIG;
+  if (!encoded) throw new Error("Missing required env var: AI_IMPLEMENT_RUN_CONFIG");
+
+  const config = decodeRunConfig(encoded);
+  const workspaceDir = env.WORKSPACE_DIR ?? "/workspace";
+
+  deps.writeStdout("[dev:run] full loop: planning -> implementation -> review\n");
+  const result = await deps.runFullLoop({
+    workspaceDir,
+    issueId: config.issue.id,
+    issueIdentifier: config.issue.identifier,
+    issueTitle: config.issue.title,
+    issueDescription: config.issue.description,
+    maxTurns: config.maxTurns,
+    maxIterations: config.maxIterations,
+    model: env.CLAUDE_MODEL,
+  });
+  deps.writeStdout(
+    `[dev:run] full loop complete: classification=${result.classification} ` +
+      `planning=${result.planningExitCode} implementation=${result.implementationExitCode} ` +
+      `review=${result.reviewApproved ? "approved" : "unapproved"}\n`,
+  );
+  return result.exitCode;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runLocalFullLoopFromEnv()
+    .then((exitCode) => process.exit(exitCode))
+    .catch((err) => {
+      process.stderr.write(`[dev:run] full loop failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/src/run-local-planning.ts
+++ b/src/run-local-planning.ts
@@ -1,8 +1,6 @@
 import { runPlanningLocally } from "./run-planning.js";
 import { decodeRunConfig } from "./run-config.js";
-import { prepareScratchExclusion } from "./pipeline/scratch-exclude.js";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { prepareScratchExclusionIfGit } from "./pipeline/scratch-exclude.js";
 
 export interface LocalPlanningRunnerDependencies {
   runPlanning: typeof runPlanningLocally;
@@ -25,9 +23,7 @@ export async function runLocalPlanningFromEnv(
 
   const config = decodeRunConfig(encoded);
   const workspaceDir = env.WORKSPACE_DIR ?? "/workspace";
-  if (existsSync(join(workspaceDir, ".git"))) {
-    prepareScratchExclusion(workspaceDir);
-  }
+  prepareScratchExclusionIfGit(workspaceDir);
   deps.writeStdout("[dev:run] planning: analyzing repository and writing plan artifacts\n");
   const result = await deps.runPlanning({
     workspaceDir,

--- a/src/run-local-planning.ts
+++ b/src/run-local-planning.ts
@@ -1,0 +1,55 @@
+import { runPlanningLocally } from "./run-planning.js";
+import { decodeRunConfig } from "./run-config.js";
+import { prepareScratchExclusion } from "./pipeline/scratch-exclude.js";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface LocalPlanningRunnerDependencies {
+  runPlanning: typeof runPlanningLocally;
+  writeStdout: (text: string) => void;
+  writeStderr: (text: string) => void;
+}
+
+const DEFAULT_DEPENDENCIES: LocalPlanningRunnerDependencies = {
+  runPlanning: runPlanningLocally,
+  writeStdout: (text) => process.stdout.write(text),
+  writeStderr: (text) => process.stderr.write(text),
+};
+
+export async function runLocalPlanningFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  deps: LocalPlanningRunnerDependencies = DEFAULT_DEPENDENCIES,
+): Promise<number> {
+  const encoded = env.AI_IMPLEMENT_RUN_CONFIG;
+  if (!encoded) throw new Error("Missing required env var: AI_IMPLEMENT_RUN_CONFIG");
+
+  const config = decodeRunConfig(encoded);
+  const workspaceDir = env.WORKSPACE_DIR ?? "/workspace";
+  if (existsSync(join(workspaceDir, ".git"))) {
+    prepareScratchExclusion(workspaceDir);
+  }
+  deps.writeStdout("[dev:run] planning: analyzing repository and writing plan artifacts\n");
+  const result = await deps.runPlanning({
+    workspaceDir,
+    issueIdentifier: config.issue.identifier,
+    issueTitle: config.issue.title,
+    issueDescription: config.issue.description,
+    model: env.CLAUDE_MODEL,
+  });
+
+  if (result.exitCode !== 0) {
+    deps.writeStderr(`[dev:run] planning failed: ${result.diagnostics}\n`);
+    return 1;
+  }
+  deps.writeStdout("[dev:run] planning complete: plan.md will be saved with run artifacts\n");
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runLocalPlanningFromEnv()
+    .then((exitCode) => process.exit(exitCode))
+    .catch((err) => {
+      process.stderr.write(`[dev:run] planning failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

- expose `--phase planning`, `--phase implementation`, and `--phase full` through `npm run dev:run`
- route planning-only runs through a validating local planner and full runs through the existing plan → implement → review engine
- save ordered planning output as `plan.md` in the printed run artifact directory
- exclude `ai-output/` scratch from local Git status and implementation review diffs
- update the quick demo and external-repository guide to exercise the full loop and document prompt-iteration workflows

## User-facing commands

```bash
npm run dev:run -- --workspace "$TARGET_REPO" --task "$TASK_FILE" --phase planning
npm run dev:run -- --workspace "$TARGET_REPO" --task "$TASK_FILE" --phase implementation
npm run dev:run -- --workspace "$TARGET_REPO" --task "$TASK_FILE" --phase full
```

## Validation

- TDD red/green coverage at the public CLI, Docker entrypoint, environment adapter, plan-artifact, and planning→implementation handoff seams
- `npm test`: 164 files, 3,138 tests passed
- `npm run build`
- final `ai-implement-runner:local` Docker image built successfully
- credential-free Docker smoke passed through the real `dev:run --phase planning` path, produced `plan.md`, left source files unchanged, and kept target Git status clean
- `git diff --check`
