### PR TITLE
Docs: KG architecture reference, centred on the deploy monolith

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Entry points for areas that are easy to miss. Each names the module to start fro
 | Parent/child grouping and roll-up | `src/feature-branch.ts`, `src/merge-up.ts` | [docs/feature-branch-grouping.md](docs/feature-branch-grouping.md) |
 | Dispatch envelope (`RunConfigV1`) | `src/run-config.ts` | [docs/workflow-envelope.md](docs/workflow-envelope.md) |
 | Runner image selection | `src/repo-image.ts` | [docs/runner-images.md](docs/runner-images.md) |
+| Knowledge graph end-to-end (ingest → snapshot → image → serve) | `Dockerfile` KG stages, `docker-entrypoint.sh` | [docs/kg-architecture.md](docs/kg-architecture.md) |
 | KG sidecar and `/mcp` | `src/mcp.ts`, `src/mcp-oauth.ts` | [docs/kg-sidecar.md](docs/kg-sidecar.md) |
 | Deploying, clients, Bedrock | `src/deploy.ts` and its `deploy-*` siblings | [docs/deployment.md](docs/deployment.md) |
 | Ticketing provider abstraction | `src/providers/` — `linear.ts`, `jira.ts`, `registry.ts` | |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,6 +6,8 @@ Reference for `src/deploy.ts`, `scripts/provision-client.sh`, `clients/`, `.gith
 
 ## Deploy paths
 
+Every path below ships the orchestrator **and** the knowledge graph as one image: a data refresh is a code deploy, and a code deploy re-materializes the graph from the KG repository's default branch. [kg-architecture.md](kg-architecture.md#the-monolith) covers what that couples.
+
 Three ways an orchestrator gets deployed, in descending order of how often they are actually used.
 
 ### Self-deploy — the standard path

--- a/docs/kg-architecture.md
+++ b/docs/kg-architecture.md
@@ -1,0 +1,238 @@
+# Knowledge-graph architecture
+
+End-to-end shape of the knowledge graph: the two repositories it spans, the technology at each
+lifecycle stage, and the single fact that governs every operational decision — **the orchestrator
+and the KG are one deployable unit.**
+
+Reference for `BuildDownAI/knowledge-graph-ai-implement` (`kg_ingest/`, `kg_query/`, `snapshot/`),
+the KG stages of `Dockerfile`, `docker-entrypoint.sh`, and `src/deploy.ts`. For the `/mcp` endpoint,
+the OAuth flow, and the ways a build ships degraded, see [kg-sidecar.md](kg-sidecar.md). For deploy
+paths and their flags, see [deployment.md](deployment.md).
+
+## The monolith
+
+The orchestrator, the MCP proxy, and the knowledge graph's data ship in **one Docker image**, run in
+**one Fly machine**, and carry **one release version**. There is no separate KG service, no separate
+app, no separate lifecycle. The sidecar listens on `127.0.0.1:8765` and is unreachable from outside
+the container.
+
+This is a deliberate trade: it removes a service to operate, a network hop, and a second set of
+credentials. What it costs is that graph data and orchestrator code cannot move independently. Six
+consequences follow, and every one of them has surprised somebody.
+
+### A data refresh is a code deploy
+
+Updating the graph means building a new image and replacing the machine. `runDeploy` takes a deploy
+hold first, so **dispatch stops**, then waits for in-flight work to drain — up to 75 minutes, after
+which the deploy fails rather than interrupting a run. A KG refresh during a busy period therefore
+either waits or fails.
+
+Refreshing the graph is an operational event on the pipeline, not a data-only change. Plan it like
+a release.
+
+### A code deploy is a data refresh
+
+The Dockerfile clones the KG repository with `git clone --depth 1` and **no ref pin**, so every build
+takes whatever is on that repository's default branch (`main`) at that moment.
+
+An orchestrator release that touches nothing about the KG will still re-materialize the graph from
+the newest committed snapshot. **The graph's age stamp can change without anyone running a refresh.**
+An operator who deploys a code fix and then finds the graph newer than they left it is seeing this,
+not a bug.
+
+The reverse also holds, and it is the sequencing rule in `bd-kg-refresh`: confirm the snapshot push
+has landed *before* triggering the deploy. The deploy is the only thing that picks it up.
+
+### A broken snapshot blocks unrelated code deploys
+
+Of the four KG build stages, three fail soft. The graph materialize step does not — it is the one KG
+stage with no fallback, so a snapshot that will not parse fails the whole image build.
+
+That is correct for the graph and awkward for everything else: while the KG default branch carries a
+bad snapshot, **no orchestrator deploy succeeds**, including a fix for an unrelated production
+problem. The recovery is to repair or revert the snapshot in the KG repository first.
+
+### Rollback is all-or-nothing
+
+Rolling the orchestrator back to an earlier release rolls the graph back with it. The two cannot be
+versioned apart, because they are the same artifact.
+
+### Coupling is at deploy time, not run time
+
+The monolith does **not** couple availability. Sidecar failure is non-fatal at every stage: a missing
+entry point, a crash, or a readiness timeout all leave `KG_SIDECAR_URL` unset and let the orchestrator
+boot normally. `/mcp` degrades and every other route is unaffected.
+
+So a dead graph never takes the pipeline down. Only a *deploy* joins their fates.
+
+### Resources are shared
+
+The machine runs at **512 MB** — raised from 256 MB for the sidecar in AII-322. The published setup
+docs still describe 256 MB, which is right only for an orchestrator built without the KG.
+
+Memory is also shared at build time, and that has bitten once already: the embed step was OOM-killed
+at ~21k quads once DocSection cards entered the graph (KGB-8). Growth in the graph is a constraint on
+the image build, not only on query latency.
+
+## The five stages
+
+```
+STAGE 1  INGEST     local machine, python >= 3.10        the only stage that fetches source data
+STAGE 2  COMMIT     git — snapshot/parts/*.nt            the transport between the repos
+STAGE 3  BUILD      Docker: node:24-slim + python venv   the graph is materialized here
+STAGE 4  SERVE      Fly machine, 512 MB                  lazy load on first query
+STAGE 5  ACCESS     MCP client over HTTPS + OAuth
+```
+
+The repository boundary sits between stages 2 and 3. `knowledge-graph-ai-implement` owns the
+mechanism and the data. `AI-Implement` owns the image, the proxy, and the release.
+
+### Stage 1 — Ingest
+
+Runs on an operator's machine. **Nothing here runs in production**; the container ships no ingest path.
+
+| Library | Role |
+|---|---|
+| `rdflib` >= 7.0 | Builds the graph. Every ingest module emits triples. |
+| `pyshacl` >= 0.30 | Validates against `ontology/shapes.ttl`; reports `SHACL conforms`. |
+| `python-frontmatter` | Parses ADRs, plans, and solutions docs into `kg:Decision` / `kg:Learning`. |
+| `requests` | Linear GraphQL API. Raises without `LINEAR_API_KEY`, so a tracker run never silently produces an empty graph. |
+| `beautifulsoup4` + `lxml` | Crawls documentation sites into `DocSite` / `DocPage` / `DocSection`. Imported lazily. |
+| `pyyaml` | Reads `sources.yml`, the scope manifest. |
+| `subprocess` → `git`, `gh` | The git spine: commits, files, PRs. No Python git binding. |
+| `fastembed` + `numpy` | Builds the vector index. Imported lazily, so the core ingest never depends on them. |
+
+The graph has two layers. The **spine** is deterministic — git, GitHub, tracker. The **semantic**
+layer is parsed or extracted, and every node carries provenance. Vocabularies are `rdf`, `rdfs`,
+`owl`, `prov`, `dcterms`, `skos`, `foaf`, `xsd`, defined in `ontology/kg.ttl`.
+
+The ingest stamps `dcterms:modified` on the spine IRI before serialization (AII-326), so the age
+lands in the committed snapshot rather than being computed at build time.
+
+### Stage 2 — Committed formats
+
+| Artifact | Format | Committed | Size |
+|---|---|---|---|
+| `snapshot/parts/*.nt` | N-Triples, split by subject type, sorted | Yes | ~5.7 MB |
+| `snapshot/digest.md` | Markdown inventory, one line per issue | Yes | ~44 KB |
+| `out/graph.trig` | TriG — the loadable form | No, gitignored | ~15 MB |
+| `out/embeddings.npz` | NumPy zip: vectors, iris, types, titles, snippets, meta | No, gitignored | — |
+
+Determinism is the point. No blank nodes, stable IRIs from stable keys, everything sorted, no
+timestamps in the parts. Identical data produces identical bytes, so a tracker refresh shows a diff
+in `issue.nt` and `comment.nt` and nothing else. `cat snapshot/parts/*.nt` reconstitutes the graph,
+which makes the parts a checked-in backup as well as a transport.
+
+### Stage 3 — Image build
+
+| Step | Technology | On failure |
+|---|---|---|
+| Clone the KG repo | BuildKit `--mount=type=secret` | Soft — sidecar-less image |
+| `pip install` into `/app/kg/.venv` | `python3 -m venv` | Soft |
+| Warm the model | `fastembed`, ONNX into `FASTEMBED_CACHE_PATH` | Soft — lexical only |
+| Materialize `--no-embed` | `rdflib` reads `*.nt`, writes `graph.trig` | **Hard — build fails** |
+| Materialize with embed | `fastembed` + `numpy` | Soft — writes `.embeddings-failed` |
+
+The base image is `node:24-slim`, not Alpine: `fastembed` and `onnxruntime` ship glibc wheels only.
+
+Every soft failure that skips real work must leave a receipt. The embed step writes
+`/app/kg/.embeddings-failed`, which `docker-entrypoint.sh` turns into `KG_EMBEDDINGS_DEGRADED=1` at
+boot, surfaced as `kgDegraded` on `GET /`, in the deploy notification, and in `get_tenant_health`
+(AII-422). See [deployment.md](deployment.md#kg-embeddings-health).
+
+### Stage 4 — Serve
+
+**Python sidecar** on `127.0.0.1:8765`:
+
+| Library | Runtime role |
+|---|---|
+| `mcp` (FastMCP) | The MCP server. `transport="streamable-http"` under `KG_HTTP=1`, else stdio. |
+| `rdflib` | The database. Parses `graph.trig` into a `Dataset`, flattens quads into one union `Graph`, runs SPARQL SELECT in process. |
+| `numpy` | Cosine similarity as one normalized matrix-vector product. No ANN index at this scale. |
+| `fastembed` | Embeds the **query** at request time — `BAAI/bge-small-en-v1.5`, 384 dimensions, ONNX, no torch. |
+| `requests` | Only under `KG_BACKEND=stardog`. That seam is evaluated, not committed. |
+
+**Node orchestrator**, same container:
+
+| Library | Runtime role |
+|---|---|
+| `node:http` / `node:https` | `src/mcp.ts` is a hand-written JSON-RPC proxy. It uses no MCP SDK. |
+| `openid-client` | OIDC delegation for `/mcp/authorize`. |
+| `node:crypto` | PKCE, auth codes, token hashing. |
+| `better-sqlite3` | `mcp_refresh_tokens` and the rest of the SQLite file. |
+
+**Loading is lazy.** Three singletons build on first use, not at boot: the store parses `graph.trig`
+on the first `kg_*` call, the index reads `embeddings.npz` on the first semantic query, and
+`TextEmbedding` loads ONNX weights from the baked cache once.
+
+The entrypoint's readiness poll only proves the port accepts connections — any HTTP response counts.
+The first real query pays the parse and the model load. **Booting is not serving**, and this is why.
+
+### Stage 5 — Search behaviour
+
+`kg_hybrid_search` is the preferred tool. It fuses lexical SPARQL and vector cosine with Reciprocal
+Rank Fusion (`RRF_K = 60`). An exact-identifier boost of `1.0` dominates any RRF sum (~0.03), so issue
+keys and `SCREAMING_SNAKE` flags lead. A missing index sets `degraded: true` and returns lexical
+results; it never raises.
+
+Six read-only KG tools: `kg_search`, `kg_semantic_search`, `kg_hybrid_search`, `kg_neighbors`,
+`kg_provenance`, `kg_path`. The orchestrator adds its own diagnostics — `get_tenant_health`,
+`list_projects`, `get_fleet_report` and others — which answer from SQLite and need no sidecar.
+
+## Freshness
+
+**There is no runtime ingestion.** Nothing crawls or re-materializes while the orchestrator runs.
+Graph age has two inputs: when the snapshot was committed, and when the image was built. A perfectly
+healthy sidecar can serve a months-old view, and nothing in a query response says so.
+
+The one reliable signal is `dcterms:modified` on `https://kg.builddown.dev/resource/graph/spine`,
+read with `kg_neighbors`. Compare it against the ingest date. An unchanged stamp after a deploy means
+the build served the old snapshot — usually because the push had not landed, or because the remote
+builder's git cache served a stale `--depth 1` clone. Both are benign. Wait, redeploy, re-verify.
+
+## Process: refresh is redeploy
+
+Run `bd-kg-refresh`, or these steps by hand.
+
+1. **Reconcile scope.** Call `list_projects` on the orchestrator MCP, diff against `sources.yml`, and
+   commit the manifest before ingesting.
+2. **Ingest** in the KG checkout:
+   `./.venv/bin/python -m kg_ingest.cli --repo ../AI-Implement --tracker --secondary`
+3. **Read the report.** Quads, cards, `SHACL conforms`, the age stamp, and the docs-crawl line. Treat
+   `embeddings SKIPPED` as a warning, not an aside.
+4. **Commit and push** `snapshot/` to `main`. Generated data goes straight to the default branch.
+5. **Confirm the push landed** with `git log origin/main`. This is the monolith's sequencing rule:
+   the deploy is what reads the snapshot, so a deploy that races the push builds the old graph.
+6. **Self-deploy** — `POST /api/deploy` with an admin session token. Expect `202`, or `409` if one is
+   already running. Never a plain `fly deploy`; see [deployment.md](deployment.md#deploy-paths).
+7. **Verify live.** Non-empty results, `degraded: false`, and an age stamp equal to step 3. Check
+   `kgDegraded` on `GET /` as well — a lexical-only image answers queries and looks healthy.
+
+Steps 5 to 7 exist entirely because of the monolith. In a two-service design the data would be
+reloadable on its own; here it rides a release, so the release has to be sequenced and verified.
+
+## Failure history
+
+Each of these shipped a degraded or blocked deploy, and each is now covered by a guard.
+
+| Date | Failure | Fix |
+|---|---|---|
+| 2026-08-07 | Sidecar deployed by hand from an rsync'd tree; `kg/` empty in git, machine at 256 MB | AII-322 — build-secret clone, materialize from snapshot, 512 MB committed |
+| 2026-08 | "No embeddings" reports blamed on the embed step | AII-323 — it was the Docker layer cache reusing a stale materialize layer; a build secret is not a cache key, so `--no-cache` is mandatory |
+| 2026-08 | Model fetched from the network at build and at query time | AII-323 — bake the model into `FASTEMBED_CACHE_PATH`, warm it as its own step |
+| 2026-08 | Type-filtered tools returned empty against a loaded graph | `sources.yml` missing from the image; without it the server falls back to a placeholder IRI namespace |
+| 2026-08-18 | Self-deploy v111 built the previous snapshot; v112 minutes later was correct | Remote-builder git-cache lag on a `--depth 1` clone — wait and redeploy |
+| 2026-08-19 | v115 shipped lexical-only after the embed step was OOM-killed at ~21k quads / 1,438 cards | KGB-8 — free the rdflib graph before embedding, pre-allocate the output array, embed in slices of 64 |
+| 2026-08-20 | A degraded build was indistinguishable from a healthy one | AII-422 — `.embeddings-failed` receipt, `KG_EMBEDDINGS_DEGRADED`, `kgDegraded` on health, notification, and `get_tenant_health` |
+
+## Lineage
+
+| Wave | Issues | Result |
+|---|---|---|
+| MCP endpoint | AII-296, AII-297, AII-302 | `/mcp` route, OAuth, single-machine deploy |
+| Durable image | AII-322, AII-323 | Build-secret clone, materialize from snapshot, baked model |
+| Shared graph | AII-324, AII-326, AII-327, AII-328, AII-329 | Orchestrator KG as source of truth, age stamp, skills migrated |
+| Usability | AII-346 | Refresh tokens — hourly re-auth was unusable |
+| Deploy ownership | AII-353, AII-355 | Self-deploy, source stamps, availability |
+| Docs ingestion | KGB-2 through KGB-5, KGA-2, BDS-38 | Crawl, section chunks, citable anchors |
+| Scaling | KGB-8, AII-422 | Bounded-memory embedding, and a receipt when it still fails |

--- a/docs/kg-sidecar.md
+++ b/docs/kg-sidecar.md
@@ -4,6 +4,8 @@ The orchestrator bundles a Python knowledge-graph sidecar that serves `kg_*` too
 
 Reference for `docker-entrypoint.sh`, the KG stages of `Dockerfile`, `src/mcp.ts`, `src/mcp-oauth.ts`, and `src/deploy.ts`. `CLAUDE.md` carries the summary and points here.
 
+This document is the orchestrator's half. For the graph's full lifecycle — the ingest stack in the KG repository, the committed snapshot format, and what it means that the orchestrator and the KG are one deployable unit — see [kg-architecture.md](kg-architecture.md).
+
 ## Deploy shape
 
 The sidecar runs **inside the orchestrator container on loopback** — no separate service, no public port, no second Fly app. `docker-entrypoint.sh` starts it on `127.0.0.1:8765`, waits for it, exports `KG_SIDECAR_URL`, and only then executes Node.


### PR DESCRIPTION
## What

Adds `docs/kg-architecture.md` — the end-to-end reference for the knowledge graph, and cross-links it from `CLAUDE.md`, `docs/kg-sidecar.md`, and `docs/deployment.md`.

## Why

`docs/kg-sidecar.md` documents the orchestrator's half: the `/mcp` endpoint, the image stages, the OAuth flow, and the ways a build ships degraded. Nothing documented the other half — the ingest stack in `knowledge-graph-ai-implement`, the committed snapshot format, or what it means operationally that the graph rides inside the orchestrator image.

## The point of the doc

**The orchestrator and the KG are one deployable unit.** The doc leads with that, because every operational surprise traces back to it:

- **A data refresh is a code deploy.** It takes the deploy hold, stops dispatch, and drains in-flight work for up to 75 minutes before the release.
- **A code deploy is a data refresh.** The Dockerfile clones the KG repo with `--depth 1` and no ref pin, so any release re-materializes the graph from `main` and can move the age stamp with nobody running a refresh.
- **A broken snapshot blocks unrelated deploys.** Graph materialize is the one hard-failure KG stage.
- **Rollback is all-or-nothing.**
- **Runtime is *not* coupled.** Sidecar failure stays non-fatal, so a dead graph never takes the pipeline down. Only deploys join their fates.
- **Resources are shared** — 512 MB, and the embed step's memory ceiling is a constraint on graph growth (KGB-8).

## Also covers

- Technology at each of the five stages: ingest (`rdflib`, `pyshacl`, `frontmatter`, `requests`, `bs4`/`lxml`, `fastembed`), committed formats, image build, serve (FastMCP, rdflib SPARQL, numpy cosine), and search behaviour (RRF, exact-ID boost).
- The freshness contract — no runtime ingestion, and `dcterms:modified` on the spine IRI as the only reliable age signal.
- The refresh process, with the sequencing and verification steps marked as consequences of the monolith.
- Dated failure history: AII-322, AII-323, the `sources.yml` namespace fallback, remote-builder cache lag, KGB-8, AII-422 — each with the guard that now covers it.

## Verification

Docs and one `CLAUDE.md` table row. No code changes. Claims checked against `Dockerfile`, `docker-entrypoint.sh`, `src/deploy.ts` (`DRAIN_TIMEOUT_MS`, `deployArgs`), `fly.toml`, the KG repo's `kg_ingest/` and `kg_query/`, and the knowledge graph itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)