### PR TITLE
Fix initial-run feature branch publishing isolation

### DIFF
--- a/docs/feature-branch-grouping.md
+++ b/docs/feature-branch-grouping.md
@@ -108,8 +108,9 @@ a cancelled child doesn't block the parent forever.
 - At dispatch time, `resolveBaseBranch` (`src/feature-branch.ts`) walks the chain and
   **creates each branch that doesn't exist, cut from the previous one** (or from the repo
   base for the first), returning the branch the PR should target. Branch creation is
-  idempotent and **fails open**: any GitHub error falls back to the base branch, so a
-  grouping failure never blocks the work.
+  idempotent and **fails closed for grouped work**: a GitHub error leaves the issue
+  queued for the next poll instead of silently dispatching it against the repository
+  base branch.
 
 This resolution is the same in all execution modes — the resolved branch is passed to the
 runner as the `base_branch` workflow input (GitHub Actions) or as the runner's default
@@ -251,8 +252,9 @@ Feature-branch grouping is supported on **both providers**:
   orchestrator's done-on-merge path only sets the custom field, never the native status,
   so without the OR the cascade would stall waiting for a manual status move. The gating
   children query fails **closed** (candidates are deferred for the poll rather than
-  dispatched prematurely); the branch-targeting ancestor walk fails **open** (chains
-  default to the base branch).
+  dispatched prematurely). Jira's provider-side ancestor discovery still fails open
+  when it cannot discover a chain; once a non-empty chain is attached, remote branch
+  materialization fails closed and leaves the issue queued rather than targeting base.
 
 ---
 

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -72,6 +72,7 @@ printf '%s\n' "\${GITHUB_TOKEN-unset}" > "${binDir}/github-token.txt"
 printf '%s\n' "\${GH_TOKEN-unset}" > "${binDir}/gh-token.txt"
 printf '%s\n' "\${GH_ENTERPRISE_TOKEN-unset}" > "${binDir}/gh-enterprise-token.txt"
 printf '%s\n' "\${GITHUB_ENTERPRISE_TOKEN-unset}" > "${binDir}/github-enterprise-token.txt"
+printf '%s\n' "\${GIT_PASSWORD-unset}" > "${binDir}/git-password.txt"
 git remote get-url origin > "${binDir}/origin-url.txt" 2>/dev/null || true
 printf '%s\n' '${resultLine}'
 exit 0
@@ -228,6 +229,7 @@ describe.skipIf(isWindows)("ClaudeCliExecutor", () => {
     vi.stubEnv("GH_TOKEN", "gh-write-token");
     vi.stubEnv("GH_ENTERPRISE_TOKEN", "gh-enterprise-write-token");
     vi.stubEnv("GITHUB_ENTERPRISE_TOKEN", "github-enterprise-write-token");
+    vi.stubEnv("GIT_PASSWORD", "git-write-password");
     const tokenizedOrigin = "https://x-access-token:github-write-token@github.com/acme/app.git";
     execFileSync("git", ["init", "-q"], { cwd: binDir });
     execFileSync("git", ["remote", "add", "origin", tokenizedOrigin], { cwd: binDir });
@@ -238,6 +240,7 @@ describe.skipIf(isWindows)("ClaudeCliExecutor", () => {
     expect(readFileSync(join(binDir, "gh-token.txt"), "utf-8").trim()).toBe("unset");
     expect(readFileSync(join(binDir, "gh-enterprise-token.txt"), "utf-8").trim()).toBe("unset");
     expect(readFileSync(join(binDir, "github-enterprise-token.txt"), "utf-8").trim()).toBe("unset");
+    expect(readFileSync(join(binDir, "git-password.txt"), "utf-8").trim()).toBe("unset");
     expect(readFileSync(join(binDir, "origin-url.txt"), "utf-8").trim()).toBe("https://github.com/acme/app.git");
     expect(execFileSync("git", ["remote", "get-url", "origin"], { cwd: binDir, encoding: "utf-8" }).trim()).toBe(tokenizedOrigin);
   });
@@ -256,5 +259,20 @@ describe.skipIf(isWindows)("ClaudeCliExecutor", () => {
     expect(readFileSync(join(binDir, "github-token.txt"), "utf-8").trim()).toBe("github-write-token");
     expect(readFileSync(join(binDir, "gh-token.txt"), "utf-8").trim()).toBe("gh-write-token");
     expect(readFileSync(join(binDir, "origin-url.txt"), "utf-8").trim()).toBe(tokenizedOrigin);
+  });
+
+  it("leaves SSH origins unchanged while withholding environment credentials", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    installEnvironmentRecordingClaude();
+    vi.stubEnv("GITHUB_TOKEN", "github-write-token");
+    const sshOrigin = "ssh://git@github.com/acme/app.git";
+    execFileSync("git", ["init", "-q"], { cwd: binDir });
+    execFileSync("git", ["remote", "add", "origin", sshOrigin], { cwd: binDir });
+
+    await new ClaudeCliExecutor(binDir, "summary", false).invoke({ prompt: "p", model: "m" });
+
+    expect(readFileSync(join(binDir, "github-token.txt"), "utf-8").trim()).toBe("unset");
+    expect(readFileSync(join(binDir, "origin-url.txt"), "utf-8").trim()).toBe(sshOrigin);
+    expect(execFileSync("git", ["remote", "get-url", "origin"], { cwd: binDir, encoding: "utf-8" }).trim()).toBe(sshOrigin);
   });
 });

--- a/src/__tests__/executor.test.ts
+++ b/src/__tests__/executor.test.ts
@@ -4,6 +4,7 @@ const isWindows = process.platform === "win32";
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
 import { ClaudeCliExecutor } from "../pipeline/executor.js";
 
 let binDir: string;
@@ -57,6 +58,29 @@ exit 0
   chmodSync(path, 0o755);
 }
 
+function installEnvironmentRecordingClaude(): void {
+  const resultLine = JSON.stringify({
+    type: "result",
+    subtype: "success",
+    result: "ok",
+    num_turns: 1,
+    duration_ms: 1,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  });
+  const script = `#!/usr/bin/env bash
+printf '%s\n' "\${GITHUB_TOKEN-unset}" > "${binDir}/github-token.txt"
+printf '%s\n' "\${GH_TOKEN-unset}" > "${binDir}/gh-token.txt"
+printf '%s\n' "\${GH_ENTERPRISE_TOKEN-unset}" > "${binDir}/gh-enterprise-token.txt"
+printf '%s\n' "\${GITHUB_ENTERPRISE_TOKEN-unset}" > "${binDir}/github-enterprise-token.txt"
+git remote get-url origin > "${binDir}/origin-url.txt" 2>/dev/null || true
+printf '%s\n' '${resultLine}'
+exit 0
+`;
+  const path = join(binDir, "claude");
+  writeFileSync(path, script);
+  chmodSync(path, 0o755);
+}
+
 const SUCCESS_LINES = [
   JSON.stringify({ type: "system", subtype: "init", model: "claude-x", cwd: "/workspace" }),
   JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "pnpm check" } }] } }),
@@ -72,6 +96,7 @@ beforeEach(() => {
 afterEach(() => {
   process.env.PATH = originalPath;
   rmSync(binDir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -194,5 +219,42 @@ describe.skipIf(isWindows)("ClaudeCliExecutor", () => {
     expect(argv).toContain("claude-sonnet-4-6");
     expect(argv).toContain("--max-turns");
     expect(argv).toContain("7");
+  });
+
+  it("withholds GitHub write credentials from initial implementation sessions", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    installEnvironmentRecordingClaude();
+    vi.stubEnv("GITHUB_TOKEN", "github-write-token");
+    vi.stubEnv("GH_TOKEN", "gh-write-token");
+    vi.stubEnv("GH_ENTERPRISE_TOKEN", "gh-enterprise-write-token");
+    vi.stubEnv("GITHUB_ENTERPRISE_TOKEN", "github-enterprise-write-token");
+    const tokenizedOrigin = "https://x-access-token:github-write-token@github.com/acme/app.git";
+    execFileSync("git", ["init", "-q"], { cwd: binDir });
+    execFileSync("git", ["remote", "add", "origin", tokenizedOrigin], { cwd: binDir });
+
+    await new ClaudeCliExecutor(binDir, "summary", false).invoke({ prompt: "p", model: "m" });
+
+    expect(readFileSync(join(binDir, "github-token.txt"), "utf-8").trim()).toBe("unset");
+    expect(readFileSync(join(binDir, "gh-token.txt"), "utf-8").trim()).toBe("unset");
+    expect(readFileSync(join(binDir, "gh-enterprise-token.txt"), "utf-8").trim()).toBe("unset");
+    expect(readFileSync(join(binDir, "github-enterprise-token.txt"), "utf-8").trim()).toBe("unset");
+    expect(readFileSync(join(binDir, "origin-url.txt"), "utf-8").trim()).toBe("https://github.com/acme/app.git");
+    expect(execFileSync("git", ["remote", "get-url", "origin"], { cwd: binDir, encoding: "utf-8" }).trim()).toBe(tokenizedOrigin);
+  });
+
+  it("preserves GitHub credentials for gap-fill sessions that own their existing PR branch", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    installEnvironmentRecordingClaude();
+    vi.stubEnv("GITHUB_TOKEN", "github-write-token");
+    vi.stubEnv("GH_TOKEN", "gh-write-token");
+    const tokenizedOrigin = "https://x-access-token:github-write-token@github.com/acme/app.git";
+    execFileSync("git", ["init", "-q"], { cwd: binDir });
+    execFileSync("git", ["remote", "add", "origin", tokenizedOrigin], { cwd: binDir });
+
+    await new ClaudeCliExecutor(binDir, "summary", true).invoke({ prompt: "p", model: "m" });
+
+    expect(readFileSync(join(binDir, "github-token.txt"), "utf-8").trim()).toBe("github-write-token");
+    expect(readFileSync(join(binDir, "gh-token.txt"), "utf-8").trim()).toBe("gh-write-token");
+    expect(readFileSync(join(binDir, "origin-url.txt"), "utf-8").trim()).toBe(tokenizedOrigin);
   });
 });

--- a/src/__tests__/feature-branch.test.ts
+++ b/src/__tests__/feature-branch.test.ts
@@ -88,14 +88,14 @@ describe("resolveBaseBranch", () => {
     expect(vi.mocked(fetch).mock.calls.length).toBe(0);
   });
 
-  it("fails open to defaultBranch when branch creation errors", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("fails closed when a grouped branch cannot be resolved", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500, text: async () => "boom" } as Response);
 
-    const base = await resolveBaseBranch({ ghToken: "t", issue: makeIssue([{ identifier: "OOL-78", mode: "feature" }]), mapping: makeMapping() });
-
-    expect(base).toBe("testing");
-    expect(warn).toHaveBeenCalled();
+    await expect(resolveBaseBranch({
+      ghToken: "t",
+      issue: makeIssue([{ identifier: "OOL-78", mode: "feature" }]),
+      mapping: makeMapping(),
+    })).rejects.toThrow(/refusing to dispatch against "testing"/);
   });
 });
 

--- a/src/__tests__/pipeline-loader.test.ts
+++ b/src/__tests__/pipeline-loader.test.ts
@@ -289,6 +289,7 @@ describe("loadPipelineDefinition", () => {
       repoRepo: "api",
       githubToken: "tok",
       branch: "main",
+      clonedRef: "base-sha",
     });
 
     const step = pipeline.steps.find((s) => s.id === "push")!;
@@ -301,6 +302,7 @@ describe("loadPipelineDefinition", () => {
     expect(inputs.machineNonce).toBe("nonce");
     expect(inputs.branchName).toBe("ai-implement/eng-42-add-profile-page");
     expect(inputs.baseBranch).toBe("main");
+    expect(inputs.baseRef).toBe("base-sha");
     expect(inputs.prTitle).toBe("ENG-42: Add profile page");
   });
 

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -211,7 +211,14 @@ describe("postPushReviewStep", () => {
     expect(ghComments.some((c) => c.includes("cap") && c.includes("Blocking issues:\n1. bug"))).toBe(true);
     expect(ctx.llmExecutor.invoke).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ maxTurns: 12 }),
+      expect.objectContaining({
+        maxTurns: 12,
+        tools: ["Read", "Glob", "Grep", "Bash(curl *)"],
+      }),
+    );
+    expect(ctx.llmExecutor.invoke).toHaveBeenNthCalledWith(
+      2,
+      expect.not.objectContaining({ tools: expect.anything() }),
     );
   });
 

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const isWindows = process.platform === "win32";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -31,6 +31,25 @@ function makeMockExecutor(exitCode = 0): LLMExecutor {
   return {
     invoke: vi.fn().mockResolvedValue({ stdout: "", exitCode, tokensUsed: 0 }),
   };
+}
+
+function installCredentialRecordingClaude(workspaceDir: string): string {
+  const tokenPath = join(workspaceDir, "claude-github-token.txt");
+  const resultLine = JSON.stringify({
+    type: "result",
+    subtype: "success",
+    result: "ok",
+    num_turns: 1,
+    duration_ms: 1,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  });
+  const claudePath = join(workspaceDir, "claude");
+  writeFileSync(
+    claudePath,
+    `#!/usr/bin/env bash\ncat >/dev/null\nprintf '%s\\n' "\${GITHUB_TOKEN-unset}" > ${JSON.stringify(tokenPath)}\nprintf '%s\\n' '${resultLine}'\n`,
+  );
+  chmodSync(claudePath, 0o755);
+  return tokenPath;
 }
 
 function makeSingleStepPipeline(stepId: string, mod: StepModule): {
@@ -131,6 +150,26 @@ describe("runAutonomous", () => {
     });
 
     expect(result.exitCode).toBe(1);
+  });
+
+  it.each([
+    { label: "initial implementation", prNumber: "", expectedToken: "unset" },
+    { label: "gap-fill", prNumber: "42", expectedToken: REQUIRED_ENV.GITHUB_TOKEN },
+  ])("routes repository write authority for $label runs", async ({ prNumber, expectedToken }) => {
+    const tokenPath = installCredentialRecordingClaude(workspaceDir);
+    vi.stubEnv("PATH", `${workspaceDir}:${process.env.PATH ?? ""}`);
+    vi.stubEnv("PR_NUMBER", prNumber);
+    const mod: StepModule = {
+      run: vi.fn(async (ctx) => {
+        await ctx.llmExecutor.invoke({ prompt: "record credentials", model: "claude-test" });
+        return {};
+      }),
+    };
+    const { pipeline, runner } = makeSingleStepPipeline("record-credentials", mod);
+
+    await runAutonomous({ workspaceDir, pipeline, runner, reporter: new NoopStepReporter() });
+
+    expect(readFileSync(tokenPath, "utf-8").trim()).toBe(expectedToken);
   });
 
   it("uses the checked-out branch when GITHUB_DEFAULT_BRANCH is not set", async () => {

--- a/src/__tests__/steps-push.test.ts
+++ b/src/__tests__/steps-push.test.ts
@@ -29,6 +29,7 @@ const BASE_INPUTS = {
   githubToken: "gh-token",
   branchName: "ai-implement/eng-42-feature",
   baseBranch: "main",
+  baseRef: "main",
 };
 
 function spawnResult(status: number, stdout = "", stderr = ""): ReturnType<typeof spawnSync> {
@@ -728,6 +729,15 @@ describe("pushStep", () => {
     expect(spawnSync).not.toHaveBeenCalled();
   });
 
+  it("fails closed when the immutable clone ref is missing", async () => {
+    const { baseRef: _baseRef, ...missingBaseRef } = BASE_INPUTS;
+
+    await expect(
+      pushStep.run(makeContext(), missingBaseRef, new NoopStepReporter()),
+    ).rejects.toThrow(/Missing immutable base ref/);
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
   it("logs a token-redacted push trace at stream log level", async () => {
     const prev = process.env.AI_IMPLEMENT_LOG_LEVEL;
     process.env.AI_IMPLEMENT_LOG_LEVEL = "stream";
@@ -955,6 +965,53 @@ describe("pushStep — Case A (agent-committed changes)", () => {
     expect(spawnSync).not.toHaveBeenCalledWith(
       "git", expect.arrayContaining(["commit"]), expect.anything(),
     );
+  });
+
+  it("uses the immutable clone ref when the agent committed on the checked-out grouped base", async () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const gitArgs = args as string[];
+      if (gitArgs[0] === "status") return spawnResult(0, "");
+      if (gitArgs[0] === "rev-list") {
+        return spawnResult(0, gitArgs.includes("clone-sha..HEAD") ? "1\n" : "0\n");
+      }
+      if (gitArgs[0] === "diff" && gitArgs[1] === "--diff-filter=d") {
+        return spawnResult(0, "src/app.ts\n");
+      }
+      if (gitArgs[0] === "diff" && gitArgs[1] === "--name-status") {
+        return spawnResult(0, "M\tsrc/app.ts\n");
+      }
+      if (gitArgs[0] === "rev-parse") return spawnResult(0, "agent-commit\n");
+      if (gitArgs[0] === "ls-remote") return spawnResult(0, "");
+      return spawnResult(0);
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: "https://github.com/acme/app/pull/21", number: 21 }),
+      text: async () => "",
+    } as Response);
+
+    await pushStep.run(
+      makeContext(),
+      {
+        ...BASE_INPUTS,
+        branchName: "ai-implement/ans-901-field-links",
+        baseBranch: "ai-implement/feature/ans-899",
+        baseRef: "clone-sha",
+      },
+      new NoopStepReporter(),
+    );
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["rev-list", "--count", "clone-sha..HEAD"],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+    const [, request] = vi.mocked(fetch).mock.calls[0];
+    expect(JSON.parse(String(request?.body))).toEqual(expect.objectContaining({
+      head: "ai-implement/ans-901-field-links",
+      base: "ai-implement/feature/ans-899",
+    }));
   });
 
   it("runs the sensitive-file guard against the committed diff in Case A", async () => {

--- a/src/__tests__/steps-review.test.ts
+++ b/src/__tests__/steps-review.test.ts
@@ -123,6 +123,16 @@ describe("reviewStep", () => {
     );
   });
 
+  it("constrains review sessions to read-only tools", async () => {
+    const executor = makeExecutor(APPROVED_JSON);
+
+    await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
+
+    expect(executor.invoke).toHaveBeenCalledWith(expect.objectContaining({
+      tools: ["Read", "Glob", "Grep", "Bash(curl *)"],
+    }));
+  });
+
   it("throws when executor returns non-zero exit code", async () => {
     const executor = makeExecutor("", 1);
     await expect(

--- a/src/feature-branch.ts
+++ b/src/feature-branch.ts
@@ -27,9 +27,10 @@ import { buildGroupingBranchName } from "./pipeline/branch-name.js";
  * `ensureBranchExists` is idempotent (422-tolerant), so an existing ancestor branch is
  * reused and only the missing tip of the chain is cut.
  *
- * Fails open: any error (branch creation, GitHub API) logs a warning and returns
- * mapping.defaultBranch so the issue still dispatches. Grouping is an enhancement,
- * not a gate.
+ * Fails closed for grouped issues: dispatching against mapping.defaultBranch after
+ * a resolution error would bypass the grouping contract and can open the child PR
+ * against the wrong base. The poller's outer issue guard logs the error and leaves
+ * the issue queued for a later retry.
  */
 export async function resolveBaseBranch(opts: {
   ghToken: string;
@@ -51,12 +52,12 @@ export async function resolveBaseBranch(opts: {
     }
     return target;
   } catch (err) {
-    console.warn(
-      `[poll] Feature-branch resolution failed for ${issue.identifier} ` +
-        `(chain ${chain.map((e) => `${e.mode}:${e.identifier}`).join(" -> ")}); falling back to base branch "${mapping.defaultBranch}":`,
-      err,
+    throw new Error(
+      `Feature-branch resolution failed for ${issue.identifier} ` +
+        `(chain ${chain.map((e) => `${e.mode}:${e.identifier}`).join(" -> ")}); ` +
+        `refusing to dispatch against "${mapping.defaultBranch}"`,
+      { cause: err },
     );
-    return mapping.defaultBranch;
   }
 }
 

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -1,4 +1,5 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import type { LLMExecutor, LLMResult, LogLevel } from "./types.js";
 import {
   parseLine,
@@ -8,6 +9,60 @@ import {
   summaryLine,
   type StreamEvent,
 } from "./claude-stream.js";
+
+const GITHUB_WRITE_CREDENTIAL_KEYS = [
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "GITHUB_ENTERPRISE_TOKEN",
+  "GH_ENTERPRISE_TOKEN",
+  "GIT_PASSWORD",
+] as const;
+
+function claudeEnvironment(allowRepositoryWrites: boolean): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  if (!allowRepositoryWrites) {
+    for (const key of GITHUB_WRITE_CREDENTIAL_KEYS) delete env[key];
+  }
+  return env;
+}
+
+function suspendOriginWriteCredential(workspaceDir: string): (() => void) | null {
+  const current = spawnSync("git", ["remote", "get-url", "origin"], {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (current.status !== 0) return null;
+
+  const originalRemote = current.stdout.toString().trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(originalRemote);
+  } catch {
+    return null;
+  }
+  if (!parsed.username && !parsed.password) return null;
+
+  parsed.username = "";
+  parsed.password = "";
+  const protectedRemote = parsed.toString();
+  const protect = spawnSync("git", ["remote", "set-url", "origin", protectedRemote], {
+    cwd: workspaceDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (protect.status !== 0) {
+    throw new Error("Failed to remove the repository write credential before invoking Claude");
+  }
+
+  return () => {
+    const restore = spawnSync("git", ["remote", "set-url", "origin", originalRemote], {
+      cwd: workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (restore.status !== 0) {
+      throw new Error("Failed to restore the repository credential after invoking Claude");
+    }
+  };
+}
 
 /**
  * Shells out to the Claude Code CLI in stream-json mode. Each JSONL event is
@@ -20,6 +75,7 @@ export class ClaudeCliExecutor implements LLMExecutor {
   constructor(
     private readonly workspaceDir: string,
     private readonly logLevel: LogLevel = "summary",
+    private readonly allowRepositoryWrites = false,
   ) {}
 
   invoke(params: {
@@ -28,7 +84,22 @@ export class ClaudeCliExecutor implements LLMExecutor {
     maxTurns?: number;
     tools?: string[];
   }): Promise<LLMResult> {
+    let restoreOrigin: (() => void) | null = null;
+    if (!this.allowRepositoryWrites) {
+      try {
+        restoreOrigin = suspendOriginWriteCredential(this.workspaceDir);
+      } catch (err) {
+        return Promise.reject(err);
+      }
+    }
+
     return new Promise((resolve, reject) => {
+      let originRestored = false;
+      const restoreProtectedOrigin = (): void => {
+        if (originRestored) return;
+        originRestored = true;
+        restoreOrigin?.();
+      };
       const args: string[] = [
         "--dangerously-skip-permissions",
         "--output-format",
@@ -46,11 +117,22 @@ export class ClaudeCliExecutor implements LLMExecutor {
       // `claude -p` reads the prompt from stdin, so there is no size ceiling.
       args.push("-p");
 
-      const proc = spawn("claude", args, {
-        cwd: this.workspaceDir,
-        stdio: ["pipe", "pipe", "pipe"],
-        env: { ...process.env },
-      });
+      let proc: ChildProcessWithoutNullStreams;
+      try {
+        proc = spawn("claude", args, {
+          cwd: this.workspaceDir,
+          stdio: ["pipe", "pipe", "pipe"],
+          env: claudeEnvironment(this.allowRepositoryWrites),
+        });
+      } catch (err) {
+        try {
+          restoreProtectedOrigin();
+          reject(err);
+        } catch (restoreErr) {
+          reject(restoreErr);
+        }
+        return;
+      }
 
       const events: StreamEvent[] = [];
       const stderrChunks: Buffer[] = [];
@@ -61,7 +143,12 @@ export class ClaudeCliExecutor implements LLMExecutor {
         // EPIPE here means the child exited before consuming the prompt. Mark
         // settled so the close handler doesn't log a phantom success summary.
         settled = true;
-        reject(err);
+        try {
+          restoreProtectedOrigin();
+          reject(err);
+        } catch (restoreErr) {
+          reject(restoreErr);
+        }
       });
       proc.stdin.end(params.prompt);
 
@@ -95,6 +182,12 @@ export class ClaudeCliExecutor implements LLMExecutor {
         if (stderr.trim()) console.error("[claude] stderr:", stderr.trim());
         const telemetry = extractTelemetry(events);
         console.log(summaryLine(telemetry));
+        try {
+          restoreProtectedOrigin();
+        } catch (err) {
+          reject(err);
+          return;
+        }
         resolve({
           stdout: finalText(events),
           stderr,
@@ -106,7 +199,12 @@ export class ClaudeCliExecutor implements LLMExecutor {
 
       proc.on("error", (err) => {
         settled = true;
-        reject(err);
+        try {
+          restoreProtectedOrigin();
+          reject(err);
+        } catch (restoreErr) {
+          reject(restoreErr);
+        }
       });
     });
   }

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -40,6 +40,7 @@ function suspendOriginWriteCredential(workspaceDir: string): (() => void) | null
   } catch {
     return null;
   }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
   if (!parsed.username && !parsed.password) return null;
 
   parsed.username = "";

--- a/src/pipeline/pipeline-loader.ts
+++ b/src/pipeline/pipeline-loader.ts
@@ -190,6 +190,7 @@ function applyWiring(step: YamlStep): StepDefinition {
             machineNonce: ctx.data.nonce,
             branchName: buildIssueBranchName(ctx.data.issueIdentifier, ctx.data.issueTitle, ctx.data.branchPrefix),
             baseBranch: ctx.getOutputs("clone").branch,
+            baseRef: ctx.getOutputs("clone").clonedRef,
             prTitle: `${ctx.data.issueIdentifier}: ${ctx.data.issueTitle}`,
             sensitiveFiles: ctx.data.sensitiveFiles,
             groupingParent: ctx.data.groupingParent,

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -9,6 +9,7 @@ import {
   formatReviewLedgerForPrompt,
   type ReviewLedgerFinding,
 } from "../review-ledger.js";
+import { READ_ONLY_ALLOWED_TOOLS } from "./read-only-tools.js";
 
 interface PostPushReviewInputs extends Record<string, unknown> {
   prNumber: string;
@@ -805,7 +806,12 @@ ${diffRes.stdout}
 
 Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string", "location": "file/function; omit when unknown", "problem": "full failing behavior", "required_fix": "full required fix"}], "score": int, "progress_delta": int, "feedback": "string"}.`;
 
-      const reviewResult = await context.llmExecutor.invoke({ prompt: reviewPrompt, model, maxTurns: REVIEW_MAX_TURNS });
+      const reviewResult = await context.llmExecutor.invoke({
+        prompt: reviewPrompt,
+        model,
+        maxTurns: REVIEW_MAX_TURNS,
+        tools: READ_ONLY_ALLOWED_TOOLS,
+      });
       if (reviewResult.exitCode !== 0) {
         terminationReason = "review_failed";
         const failure = `Reviewer LLM failed (${llmResultMessage(reviewResult)})`;

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -27,6 +27,8 @@ interface PushInputs extends Record<string, unknown> {
   machineNonce?: string;
   branchName: string;
   baseBranch?: string;
+  /** Immutable commit checked out at clone time. Used for diff/ahead checks even if the agent commits on the base branch. */
+  baseRef?: string;
   prTitle?: string;
   implementationSummary?: string;
   testsSummary?: string;
@@ -68,6 +70,10 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     if (!baseBranch) {
       throw new Error("Missing base branch for PR creation");
     }
+    const baseRef = String(inputs.baseRef ?? "").trim();
+    if (!baseRef) {
+      throw new Error("Missing immutable base ref for implementation diff");
+    }
     const prTitle = String(inputs.prTitle ?? `${issueIdentifier}: ${issueTitle || "AI implementation"}`);
 
     if (!branchName || branchName === baseBranch) {
@@ -79,7 +85,7 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     const hasWTChanges = hasWorkingTreeChanges(workspaceDir, githubToken);
     // Only check commits-ahead when working tree is clean: if there ARE working-tree changes
     // we always take the standard add→commit path regardless of prior commits.
-    const agentCommitted = !hasWTChanges && hasCommitsAheadOfBase(workspaceDir, baseBranch, githubToken);
+    const agentCommitted = !hasWTChanges && hasCommitsAheadOfBase(workspaceDir, baseRef, githubToken);
 
     if (!hasWTChanges && !agentCommitted) {
       if (inputs.groupingParent) {
@@ -127,19 +133,19 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
       commitSha = resolveCommitSha(workspaceDir);
     }
 
-    // Authoritative sensitive-file guard: scan the FULL committed diff (baseBranch..HEAD) —
+    // Authoritative sensitive-file guard: scan the FULL committed diff (baseRef..HEAD) —
     // the complete set of files that will land in the PR — before push. This closes the
     // mixed commit+working-tree gap where the standard path's --cached scan (newly-staged
     // files only) would miss files the agent committed itself earlier in the run (present in
     // HEAD but not the index). --diff-filter=d allows intentional deletions (e.g. removing a
     // committed secret); getCommittedDiffFiles fails closed on git error.
-    const committedDiffFiles = getCommittedDiffFiles(workspaceDir, baseBranch, githubToken);
+    const committedDiffFiles = getCommittedDiffFiles(workspaceDir, baseRef, githubToken);
     const committedSensitiveHits = findSensitiveFiles(committedDiffFiles, inputs.sensitiveFiles);
     if (committedSensitiveHits.length > 0) {
       throw new SensitiveFilesError(committedSensitiveHits);
     }
 
-    const changedFilesSummary = summarizeCommittedChanges(workspaceDir, githubToken, agentCommitted ? baseBranch : undefined);
+    const changedFilesSummary = summarizeCommittedChanges(workspaceDir, githubToken, agentCommitted ? baseRef : undefined);
     const prBody = buildPullRequestBody(context, inputs, changedFilesSummary);
 
     // The dispatch-time installation token may already be close to its one-hour

--- a/src/pipeline/steps/review.ts
+++ b/src/pipeline/steps/review.ts
@@ -2,6 +2,7 @@ import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { formatLlmResultDetail } from "../step-utils.js";
 import { extractFirstJsonObject } from "../json-extract.js";
 import { wrapWithPlanningGuard } from "../../planning-context-assembly.js";
+import { READ_ONLY_ALLOWED_TOOLS } from "./read-only-tools.js";
 
 interface ReviewInputs extends Record<string, unknown> {
   model?: string;
@@ -89,6 +90,7 @@ export const reviewStep: StepModule<ReviewInputs, ReviewOutputs> = {
     const result = await context.llmExecutor.invoke({
       prompt,
       model: model ?? "claude-sonnet-4-6",
+      tools: READ_ONLY_ALLOWED_TOOLS,
     });
 
     if (result.exitCode !== 0) {

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -433,7 +433,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
   implementationPrompt = appendPipelineOwnedGitInstructions(implementationPrompt, prNumber);
   implementationPrompt = appendOperatorInstruction(implementationPrompt, commentInstruction);
   const model = claudeModel || workflowModel || "claude-sonnet-4-6";
-  const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir, logLevel);
+  const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir, logLevel, Boolean(prNumber));
   const orchestratorUrl = process.env.ORCHESTRATOR_URL;
   const nonce = process.env.MACHINE_NONCE ?? "";
   if (orchestratorUrl && !nonce) {


### PR DESCRIPTION
## Root cause

Grouped dispatch selected the correct shared base, but initial implementation sessions still inherited a write-capable GitHub token and token-bearing origin. A stale target WORKFLOW.md told Claude to commit, push, and create its own PR, so it pushed the shared feature branch directly and opened feature-to-main before the pipeline publish step ran.

## Changes

- Remove GitHub write credentials and temporarily scrub the token-bearing origin during initial implementation and review model invocations; preserve existing writable gap-fill behavior.
- Compare agent-created commits against the immutable clone SHA, then publish them on the issue-scoped child branch.
- Make the immutable base ref mandatory for pipeline pushes.
- Constrain both pre-push and post-push reviewers to read-only tools while leaving repair passes writable.
- Fail closed when a declared grouping branch cannot be resolved instead of silently dispatching against the repository base.

## Verification

- Full Vitest suite: 165 files, 3167 tests passed.
- TypeScript typecheck passed.
- git diff --check passed.
- Independent code review approved after two findings were fixed.