### PR TITLE
Support project-specific knowledge graphs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,10 @@ OAUTH_ALLOWED_EMAILS=
 # Docker deployments. For local dev (npm run dev), start the sidecar manually
 # and set this explicitly; unset → /mcp returns 503.
 KG_SIDECAR_URL=
+# GitHub owner/repo for the knowledge-graph source cloned into the orchestrator
+# image at build time. Defaults to BuildDownAI/knowledge-graph-ai-implement.
+# Set this per project when the orchestrator should bundle a project-specific KG.
+KG_SOURCE_REPO=
 #
 # MCP clients authenticate via OAuth 2.0 (no pre-shared secret).
 # Requires OAUTH_REDIRECT_BASE_URL + at least one OAuth provider configured above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,9 @@ Bindings for the KG skills (bd-kg-search, kg recon — format: skills `plugin/sk
 - kg.local_search_tool: mcp__ai-implement-kg__kg_hybrid_search
 - kg.prefer:       orchestrator
 
+Project-specific orchestrator instances can override the bundled graph with `KG_SOURCE_REPO=owner/repo`.
+The value is a GitHub repo identifier, not a URL; see `docs/kg-sidecar.md`.
+
 ## Architecture
 
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY workflows/ ./workflows/
 # GitHub token out of image history and build logs — it is readable only inside
 # the RUN that uses it and is never written to any ENV/ARG.
 #
-# To build WITH the sidecar (requires read access to BuildDownAI/knowledge-graph-ai-implement):
+# To build WITH the sidecar (requires read access to KG_SOURCE_REPO, default BuildDownAI/knowledge-graph-ai-implement):
 #   docker build --secret id=kg_token,env=GH_TOKEN .
 #   fly deploy --remote-only --build-secret kg_token="$(gh auth token)"
 #
@@ -68,15 +68,24 @@ COPY workflows/ ./workflows/
 # which exports KG_EMBEDDINGS_DEGRADED=1 and surfaces the fact via GET / and the
 # deploy notification. The || true copy guards below are exempt: they are part of
 # the deliberate sidecar-less mode, not unexpected failures.
+ARG KG_SOURCE_REPO=BuildDownAI/knowledge-graph-ai-implement
+ENV KG_SOURCE_REPO=$KG_SOURCE_REPO
 COPY kg/ /app/kg/
 RUN --mount=type=secret,id=kg_token,required=false \
-    if [ -f /run/secrets/kg_token ] && [ -s /run/secrets/kg_token ]; then \
-        echo "[kg] secret present — cloning BuildDownAI/knowledge-graph-ai-implement" \
+    kg_owner="${KG_SOURCE_REPO%%/*}" \
+    && kg_repo="${KG_SOURCE_REPO#*/}" \
+    && if [ "$kg_owner" = "$KG_SOURCE_REPO" ] || [ -z "$kg_owner" ] || [ -z "$kg_repo" ] || [ "$kg_repo" != "${kg_repo%%/*}" ]; then \
+        echo "[kg] invalid KG_SOURCE_REPO: $KG_SOURCE_REPO" >&2; exit 1; \
+    fi \
+    && case "$kg_owner" in *[!A-Za-z0-9-]* | -* | *- ) echo "[kg] invalid KG_SOURCE_REPO owner: $KG_SOURCE_REPO" >&2; exit 1 ;; esac \
+    && case "$kg_repo" in *[!A-Za-z0-9._-]* ) echo "[kg] invalid KG_SOURCE_REPO repo: $KG_SOURCE_REPO" >&2; exit 1 ;; esac \
+    && if [ -f /run/secrets/kg_token ] && [ -s /run/secrets/kg_token ]; then \
+        echo "[kg] secret present — cloning ${KG_SOURCE_REPO}" \
         && apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
         && rm -rf /var/lib/apt/lists/* \
         && KG_TOKEN="$(cat /run/secrets/kg_token)" \
         && git clone --depth 1 \
-               "https://x-access-token:${KG_TOKEN}@github.com/BuildDownAI/knowledge-graph-ai-implement.git" \
+               "https://x-access-token:${KG_TOKEN}@github.com/${KG_SOURCE_REPO}.git" \
                /tmp/kg-src \
         && unset KG_TOKEN \
         && mkdir -p /app/kg \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,7 +34,7 @@ Four things must be true, and they are not all reported the same way:
 - **`FLY_DEPLOY_TOKEN`** is set, scoped to this app. `FLY_SESSIONS_TOKEN` is a different credential and cannot deploy the orchestrator.
 - **The running image carries its source stamps.** `AI_IMPLEMENT_SOURCE_REPO` (as `owner/repo`) and `AI_IMPLEMENT_SOURCE_BRANCH` are both required; an image built without them cannot self-deploy at all. `AI_IMPLEMENT_SOURCE_COMMIT` is not required — without it a deploy still runs, but availability reports *unknown* rather than telling you a new version exists.
 - **An admin auth method is configured** — SSO providers or `ADMIN_ACCESS_CODE`. Every `/api/` route answers 503 otherwise, this one included.
-- **The GitHub App installation can read this repository and the KG repository.** Both tokens are minted from it, each scoped to one repo with `contents: read`.
+- **The GitHub App installation can read this repository and the configured KG repository.** Both tokens are minted from it, each scoped to one repo with `contents: read`. The KG repository defaults to `BuildDownAI/knowledge-graph-ai-implement`; set `KG_SOURCE_REPO=owner/repo` for a project-specific graph. The Docker build arg is baked into the image as a non-secret environment value so later self-deploys keep using the same graph repo unless runtime env overrides it.
 
 The first two and the app name collapse into a single `501`, which says the orchestrator cannot deploy itself without saying which piece is missing. The third is a different 503, raised at the `/api/` gate before this route is reached. The fourth is **not checked up front** — a token that cannot read a repository surfaces as a failed build, after the hold has already been taken and released.
 
@@ -60,6 +60,7 @@ export GH_TOKEN="$(gh auth token)"
 
 fly deploy --remote-only --no-cache \
     --build-secret kg_token="$GH_TOKEN" \
+    --build-arg KG_SOURCE_REPO="${KG_SOURCE_REPO:-BuildDownAI/knowledge-graph-ai-implement}" \
     --build-arg SOURCE_COMMIT="$(git rev-parse HEAD)" \
     --build-arg SOURCE_REPO=BuildDownAI/AI-Implement \
     --build-arg SOURCE_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
@@ -77,11 +78,17 @@ curl -s -w '\n%{http_code}\n' -X POST https://<app-name>.fly.dev/mcp -d '{}'
 Every flag above is load-bearing, and each was learned from a silently degraded deploy:
 
 - **`--build-secret`** — the KG is cloned at build time through it. Without it the build fail-softs to a sidecar-less image and reports success.
+- **`--build-arg KG_SOURCE_REPO`** — the GitHub `owner/repo` to clone for the sidecar. Omit it to use `BuildDownAI/knowledge-graph-ai-implement`; set it to a project-specific graph such as `Answer9-llc/knowledge-graph-answer9-app` when needed. URLs and malformed values are rejected.
 - **`--no-cache`** — a build secret is not part of the layer cache key, so a repeat deploy otherwise reuses a stale, possibly sidecar-less clone layer even when the secret is present.
 - **`--build-arg SOURCE_*`** — the stamps. Omit `SOURCE_REPO` or `SOURCE_BRANCH` and the image you just deployed cannot deploy itself, which is how a manual recovery quietly disables the automatic path.
 - **`--app`** — always explicit. A default would let a fork deploy itself over the upstream app.
 
 Substitute your own `SOURCE_REPO` when deploying a fork; it must be `owner/repo`, and a malformed value logs a warning and disables self-deploy on the resulting image.
+
+`KG_SOURCE_REPO` is not a secret. Manual deploys bake the build arg into the image as `ENV KG_SOURCE_REPO`,
+and `loadConfig()` reads that value at runtime for the next self-deploy. A Fly secret or environment
+variable with the same name still wins at runtime, which is useful for changing the graph repo before
+the next deploy; the next image will then bake that resolved value.
 
 ### Fly's native GitHub integration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,7 +88,8 @@ Substitute your own `SOURCE_REPO` when deploying a fork; it must be `owner/repo`
 `KG_SOURCE_REPO` is not a secret. Manual deploys bake the build arg into the image as `ENV KG_SOURCE_REPO`,
 and `loadConfig()` reads that value at runtime for the next self-deploy. A Fly secret or environment
 variable with the same name still wins at runtime, which is useful for changing the graph repo before
-the next deploy; the next image will then bake that resolved value.
+the next deploy; the next image will then bake that resolved value. A malformed runtime override logs a
+warning and disables self-deploy instead of crashing the orchestrator or silently selecting a different graph.
 
 ### Fly's native GitHub integration
 

--- a/docs/kg-architecture.md
+++ b/docs/kg-architecture.md
@@ -4,10 +4,11 @@ End-to-end shape of the knowledge graph: the two repositories it spans, the tech
 lifecycle stage, and the single fact that governs every operational decision — **the orchestrator
 and the KG are one deployable unit.**
 
-Reference for `BuildDownAI/knowledge-graph-ai-implement` (`kg_ingest/`, `kg_query/`, `snapshot/`),
-the KG stages of `Dockerfile`, `docker-entrypoint.sh`, and `src/deploy.ts`. For the `/mcp` endpoint,
-the OAuth flow, and the ways a build ships degraded, see [kg-sidecar.md](kg-sidecar.md). For deploy
-paths and their flags, see [deployment.md](deployment.md).
+Reference for the configured KG source repository (`BuildDownAI/knowledge-graph-ai-implement` by
+default; override with `KG_SOURCE_REPO` for project-specific graphs), its `kg_ingest/`, `kg_query/`,
+and `snapshot/` directories, the KG stages of `Dockerfile`, `docker-entrypoint.sh`, and
+`src/deploy.ts`. For the `/mcp` endpoint, the OAuth flow, and the ways a build ships degraded, see
+[kg-sidecar.md](kg-sidecar.md). For deploy paths and their flags, see [deployment.md](deployment.md).
 
 ## The monolith
 
@@ -84,7 +85,7 @@ STAGE 4  SERVE      Fly machine, 512 MB                  lazy load on first quer
 STAGE 5  ACCESS     MCP client over HTTPS + OAuth
 ```
 
-The repository boundary sits between stages 2 and 3. `knowledge-graph-ai-implement` owns the
+The repository boundary sits between stages 2 and 3. The configured KG source repository owns the
 mechanism and the data. `AI-Implement` owns the image, the proxy, and the release.
 
 ### Stage 1 — Ingest

--- a/docs/kg-sidecar.md
+++ b/docs/kg-sidecar.md
@@ -39,7 +39,13 @@ Inside the container the question is settled without a request at all: `docker-e
 
 The knowledge-graph repository is private. A **BuildKit build secret** mounts a GitHub token for exactly one `RUN` layer to clone it; the token is never written to `ARG`, `ENV`, or image history.
 
-**Where that token comes from is an operational prerequisite, not a detail.** A self-deploy mints it from the GitHub App installation, scoped to the knowledge-graph repository alone with `contents: read` — which only works if that repository is part of the installation. The installation grants selected repositories rather than the whole organisation, so it has to be added deliberately. Without it the mint fails with a 422 naming an inaccessible repository, before any build starts; the deploy reports a failure rather than shipping a sidecar-less image, which is the one good thing about failing this early. A manual deploy sidesteps the question entirely by passing an operator's own token.
+The source repository defaults to `BuildDownAI/knowledge-graph-ai-implement`. Set `KG_SOURCE_REPO`
+to another GitHub `owner/repo` value, for example `Answer9-llc/knowledge-graph-answer9-app`,
+when an orchestrator instance should bundle a project-specific graph. This is deliberately a repo
+identifier, not a URL: `src/deploy.ts` validates it before minting a repo-scoped installation token,
+and the Dockerfile validates the same build arg before constructing the clone URL.
+
+**Where that token comes from is an operational prerequisite, not a detail.** A self-deploy mints it from the GitHub App installation, scoped to the configured knowledge-graph repository alone with `contents: read` — which only works if that repository is part of the installation. The installation grants selected repositories rather than the whole organisation, so it has to be added deliberately. Without it the mint fails with a 422 naming an inaccessible repository, before any build starts; the deploy reports a failure rather than shipping a sidecar-less image, which is the one good thing about failing this early. A manual deploy sidesteps the question entirely by passing an operator's own token.
 
 That requirement is a consequence of automating the deploy, and it is worth understanding rather than working around. The operator script that preceded self-deploy cloned the repository with `gh auth token` — a *human's* credential, which reached the repository because that human could. An orchestrator has no human behind it; its only GitHub identity is the App installation, so access that used to be ambient has to be granted explicitly. The gap was always there, and borrowing a person's credentials merely hid it.
 

--- a/src/__tests__/deploy.test.ts
+++ b/src/__tests__/deploy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import os from "node:os";
 import path from "node:path";
+import { readFileSync } from "node:fs";
 import type * as DeployModule from "../deploy.js";
 
 let deploy: typeof DeployModule;
@@ -17,6 +18,7 @@ beforeEach(async () => {
 const ARGS = {
   app: "orchestrator",
   kgToken: "kg-token",
+  kgSourceRepo: "BuildDownAI/knowledge-graph-ai-implement",
   sourceCommit: "abc1234",
   sourceRepo: "Owner/Repo",
   sourceBranch: "testing",
@@ -41,6 +43,7 @@ describe("deployArgs", () => {
     // Without the secret the KG clone fail-softs and /mcp ships dead.
     expect(args).toContain("--build-secret");
     expect(args).toContain("kg_token=kg-token");
+    expect(args).toContain("KG_SOURCE_REPO=BuildDownAI/knowledge-graph-ai-implement");
     // A build secret is not part of the layer cache key, so a repeat deploy would
     // otherwise reuse a stale, possibly sidecar-less layer.
     expect(args).toContain("--no-cache");
@@ -63,6 +66,31 @@ describe("deployArgs", () => {
     expect(() => deploy.deployArgs({ ...ARGS, [field]: "" })).toThrow(
       new RegExp(`empty ${field}`),
     );
+  });
+
+  it("accepts a configured project-specific KG repo", () => {
+    const args = deploy.deployArgs({ ...ARGS, kgSourceRepo: "Answer9-llc/knowledge-graph-answer9-app" });
+    expect(args).toContain("KG_SOURCE_REPO=Answer9-llc/knowledge-graph-answer9-app");
+  });
+
+  it.each([
+    "https://github.com/Answer9-llc/knowledge-graph-answer9-app",
+    "Answer9-llc/knowledge-graph-answer9-app.git;echo nope",
+    "Answer9-llc",
+    "Answer9-llc/knowledge-graph-answer9-app/extra",
+    "../knowledge-graph-answer9-app",
+  ])("rejects malformed KG source repo %s", (kgSourceRepo) => {
+    expect(() => deploy.deployArgs({ ...ARGS, kgSourceRepo })).toThrow(/KG_SOURCE_REPO/);
+  });
+});
+
+describe("Dockerfile KG source repo wiring", () => {
+  it("persists the KG_SOURCE_REPO build arg into the runtime image for later self-deploys", () => {
+    const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
+
+    expect(dockerfile).toContain("ARG KG_SOURCE_REPO=BuildDownAI/knowledge-graph-ai-implement");
+    expect(dockerfile).toContain("ENV KG_SOURCE_REPO=$KG_SOURCE_REPO");
+    expect(dockerfile).toContain('[ "$kg_owner" = "$KG_SOURCE_REPO" ]');
   });
 });
 
@@ -89,6 +117,7 @@ describe("makeStartDeploy", () => {
     pollIntervalMs: 60_000,
     githubAppId: "1",
     githubAppPrivateKey: "key",
+    kgSourceRepo: "BuildDownAI/knowledge-graph-ai-implement",
   };
 
   it("returns a starter when everything a deploy needs is present", () => {
@@ -174,6 +203,7 @@ describe("canSelfDeploy", () => {
     pollIntervalMs: 60_000,
     githubAppId: "1",
     githubAppPrivateKey: "key",
+    kgSourceRepo: "BuildDownAI/knowledge-graph-ai-implement",
   };
 
   it("is true when a token, an app and build stamps are all present", () => {
@@ -249,6 +279,7 @@ describe("makeStartDeploy onBuildFailure callback", () => {
       pollIntervalMs: 60_000,
       githubAppId: "1",
       githubAppPrivateKey: "key",
+      kgSourceRepo: "BuildDownAI/knowledge-graph-ai-implement",
       onBuildFailure,
     })!;
 

--- a/src/__tests__/deploy.test.ts
+++ b/src/__tests__/deploy.test.ts
@@ -84,6 +84,24 @@ describe("deployArgs", () => {
   });
 });
 
+describe("readKgSourceRepo", () => {
+  it("uses the backwards-compatible default when the setting is absent", () => {
+    expect(deploy.readKgSourceRepo(undefined)).toBe("BuildDownAI/knowledge-graph-ai-implement");
+  });
+
+  it("accepts a valid project-specific repository", () => {
+    expect(deploy.readKgSourceRepo("Answer9-llc/knowledge-graph-answer9-app")).toBe(
+      "Answer9-llc/knowledge-graph-answer9-app",
+    );
+  });
+
+  it("warns and disables self-deploy for a malformed explicit value", () => {
+    const warn = vi.fn();
+    expect(deploy.readKgSourceRepo("https://github.com/Answer9-llc/kg", warn)).toBeNull();
+    expect(warn).toHaveBeenCalledWith("[deploy] invalid KG_SOURCE_REPO; self-deploy disabled");
+  });
+});
+
 describe("Dockerfile KG source repo wiring", () => {
   it("persists the KG_SOURCE_REPO build arg into the runtime image for later self-deploys", () => {
     const dockerfile = readFileSync(new URL("../../Dockerfile", import.meta.url), "utf8");
@@ -124,7 +142,7 @@ describe("makeStartDeploy", () => {
     expect(typeof deploy.makeStartDeploy(configured)).toBe("function");
   });
 
-  it.each(["flyDeployToken", "flyOrchestratorApp", "selfDeployTarget"] as const)(
+  it.each(["flyDeployToken", "flyOrchestratorApp", "selfDeployTarget", "kgSourceRepo"] as const)(
     "returns undefined when %s is missing, so the route answers 501",
     (field) => {
       // Undefined here is what distinguishes "cannot deploy" from "deploy failed" —
@@ -210,7 +228,7 @@ describe("canSelfDeploy", () => {
     expect(deploy.canSelfDeploy(configured)).toBe(true);
   });
 
-  it.each(["flyDeployToken", "flyOrchestratorApp", "selfDeployTarget"] as const)(
+  it.each(["flyDeployToken", "flyOrchestratorApp", "selfDeployTarget", "kgSourceRepo"] as const)(
     "is false without %s",
     (field) => {
       // The predicate is the single definition of "can this orchestrator deploy itself",

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -74,6 +74,23 @@ export function parseKgSourceRepo(value: string | null | undefined): KgSourceRep
   return { owner, repo, fullName: `${owner}/${repo}` };
 }
 
+/**
+ * Resolve the configured KG repository without making a typo fatal to the
+ * orchestrator. An invalid explicit value disables self-deploy rather than
+ * silently switching a project instance back to the default graph.
+ */
+export function readKgSourceRepo(
+  value: string | null | undefined,
+  warn: (message: string) => void = console.warn,
+): string | null {
+  try {
+    return parseKgSourceRepo(value).fullName;
+  } catch {
+    warn("[deploy] invalid KG_SOURCE_REPO; self-deploy disabled");
+    return null;
+  }
+}
+
 const DEPLOY_TIMEOUT_MS = 20 * 60 * 1000;
 // A runner job is force-terminated 60 minutes after its dispatch,
 // so with new dispatches paused the in-flight set always drains.
@@ -324,16 +341,17 @@ export interface StartDeployConfig {
   pollIntervalMs: number;
   githubAppId: string;
   githubAppPrivateKey: string;
-  kgSourceRepo: string;
+  kgSourceRepo: string | null;
   /** Called when the build or release step fails, so the caller can record the outcome. */
   onBuildFailure?: (commit: string, err: unknown) => void;
 }
 
-/** `StartDeployConfig` with the three optional fields proven present. */
+/** `StartDeployConfig` with every optional deploy prerequisite proven present. */
 type SelfDeployReady = StartDeployConfig & {
   flyDeployToken: string;
   flyOrchestratorApp: string;
   selfDeployTarget: SelfDeployTarget;
+  kgSourceRepo: string;
 };
 
 /**
@@ -395,8 +413,8 @@ export function makeStartDeploy(
 
 /**
  * Whether this orchestrator can deploy itself: a token with deploy rights, an app to
- * deploy, and build stamps naming what to build.
+ * deploy, build stamps naming what to build, and a validated KG source repository.
  */
 export function canSelfDeploy(config: StartDeployConfig): config is SelfDeployReady {
-  return Boolean(config.flyDeployToken && config.flyOrchestratorApp && config.selfDeployTarget);
+  return Boolean(config.flyDeployToken && config.flyOrchestratorApp && config.selfDeployTarget && config.kgSourceRepo);
 }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -14,6 +14,7 @@ import type { SelfDeployTarget } from "./deploy-availability.js";
 export interface DeployArgsInput {
   app: string;
   kgToken: string;
+  kgSourceRepo: string;
   sourceCommit: string;
   sourceRepo: string;
   sourceBranch: string;
@@ -29,6 +30,7 @@ export interface RunDeployInput {
   commit: string;
   githubAppId: string;
   githubAppPrivateKey: string;
+  kgSourceRepo: string;
   pollIntervalMs: number;
 }
 
@@ -44,11 +46,33 @@ const FLYCTL_SHA256: Record<string, string> = {
 // Only the tail of flyctl's output is kept: flyctl's errors land at the end, the head is apt output.
 const FLYCTL_LOG_TAIL_BYTES = 64 * 1024;
 
-// The KG repository the image clones at build time. The Dockerfile holds the other
-// copy of this; the two must agree or the scoped token cannot read it and the build
-// fail-softs to a sidecar-less image.
-const KG_OWNER = "BuildDownAI";
-const KG_REPO = "knowledge-graph-ai-implement";
+// The KG repository the image clones at build time unless a deployment overrides it.
+// The Dockerfile holds the same default. Keep them in sync.
+export const DEFAULT_KG_SOURCE_REPO = "BuildDownAI/knowledge-graph-ai-implement";
+
+export interface KgSourceRepo {
+  owner: string;
+  repo: string;
+  fullName: string;
+}
+
+const GITHUB_OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const GITHUB_REPO_RE = /^[A-Za-z0-9._-]+$/;
+
+export function parseKgSourceRepo(value: string | null | undefined): KgSourceRepo {
+  const raw = (value || DEFAULT_KG_SOURCE_REPO).trim();
+  const parts = raw.split("/");
+  if (parts.length !== 2) {
+    throw new Error(`[deploy] KG_SOURCE_REPO must be an owner/repo GitHub repository, got "${raw}"`);
+  }
+
+  const [owner, repo] = parts;
+  if (!GITHUB_OWNER_RE.test(owner) || !GITHUB_REPO_RE.test(repo) || repo.length > 100) {
+    throw new Error(`[deploy] KG_SOURCE_REPO must be an owner/repo GitHub repository, got "${raw}"`);
+  }
+
+  return { owner, repo, fullName: `${owner}/${repo}` };
+}
 
 const DEPLOY_TIMEOUT_MS = 20 * 60 * 1000;
 // A runner job is force-terminated 60 minutes after its dispatch,
@@ -65,7 +89,8 @@ const DRAIN_TIMEOUT_MS = 75 * 60 * 1000;
 * machine is touched — comes back to this function.
 */
 export async function runDeploy(input: RunDeployInput): Promise<void> {
-  const { app, flyDeployToken, owner, repo, branch, commit, githubAppId, githubAppPrivateKey, pollIntervalMs } = input;
+  const { app, flyDeployToken, owner, repo, branch, commit, githubAppId, githubAppPrivateKey, kgSourceRepo, pollIntervalMs } = input;
+  const kgSource = parseKgSourceRepo(kgSourceRepo);
   
   setDeployHold();
   try {
@@ -85,9 +110,9 @@ export async function runDeploy(input: RunDeployInput): Promise<void> {
       scratch,
     );
     
-    const kg = await getScopedInstallationToken(githubAppId, githubAppPrivateKey, KG_OWNER, {
+    const kg = await getScopedInstallationToken(githubAppId, githubAppPrivateKey, kgSource.owner, {
       permissions: { contents: "read" },
-      repositories: [KG_REPO],
+      repositories: [kgSource.repo],
     });
     
     console.log(`[deploy] deploying ${owner}/${repo}@${commit.slice(0, 7)} to ${app}`);
@@ -96,6 +121,7 @@ export async function runDeploy(input: RunDeployInput): Promise<void> {
       deployArgs({
         app,
         kgToken: kg.token,
+        kgSourceRepo: kgSource.fullName,
         sourceCommit: commit,
         sourceRepo: `${owner}/${repo}`,
         sourceBranch: branch,
@@ -212,6 +238,7 @@ export function deployArgs(input: DeployArgsInput): string[] {
     "--no-cache",
     // --build-secret takes only NAME=VALUE, so the token rides in argv; execFile runs flyctl without a shell.
     "--build-secret", `kg_token=${input.kgToken}`,
+    "--build-arg", `KG_SOURCE_REPO=${parseKgSourceRepo(input.kgSourceRepo).fullName}`,
     "--build-arg", `SOURCE_COMMIT=${input.sourceCommit}`,
     "--build-arg", `SOURCE_REPO=${input.sourceRepo}`,
     "--build-arg", `SOURCE_BRANCH=${input.sourceBranch}`,
@@ -297,6 +324,7 @@ export interface StartDeployConfig {
   pollIntervalMs: number;
   githubAppId: string;
   githubAppPrivateKey: string;
+  kgSourceRepo: string;
   /** Called when the build or release step fails, so the caller can record the outcome. */
   onBuildFailure?: (commit: string, err: unknown) => void;
 }
@@ -349,6 +377,7 @@ export function makeStartDeploy(
         pollIntervalMs: config.pollIntervalMs,
         githubAppId: config.githubAppId,
         githubAppPrivateKey: config.githubAppPrivateKey,
+        kgSourceRepo: config.kgSourceRepo,
       }).catch((err) => {
         console.error("[deploy] failed:", err);
         config.onBuildFailure?.(head, err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { isKgDegraded, postAvailableNotice, postBootNotice, postShutdownNotice, 
 import { refreshAvailability, readStampedTarget, type SelfDeployTarget, getAvailability } from "./deploy-availability.js";
 import { clearDeployHold, isDeployHeld } from "./deploy-hold.js";
 import { decideAvailabilityAction, getDeployPolicy, getLastActedCommit, setLastActedCommit } from "./deploy-policy.js";
-import { canSelfDeploy, DEFAULT_KG_SOURCE_REPO, makeStartDeploy, parseKgSourceRepo } from "./deploy.js";
+import { canSelfDeploy, makeStartDeploy, readKgSourceRepo } from "./deploy.js";
 import { remediateStuckJob, remediateFailedJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
 import { handleAdminRequest } from "./admin.js";
@@ -117,7 +117,7 @@ interface AppConfig {
   localRunnerImage: string;
   localRunnerOrchestratorUrl: string | null;
   kgSidecarUrl: string | null;
-  kgSourceRepo: string;
+  kgSourceRepo: string | null;
   selfDeployTarget: SelfDeployTarget | null; // build-stamped; null when the image carries no stamps
 }
 
@@ -239,7 +239,7 @@ function loadConfig(): AppConfig {
     localRunnerImage: process.env.LOCAL_RUNNER_IMAGE || "ai-implement-runner:local",
     localRunnerOrchestratorUrl: process.env.LOCAL_RUNNER_ORCHESTRATOR_URL || null,
     kgSidecarUrl: process.env.KG_SIDECAR_URL || null,
-    kgSourceRepo: parseKgSourceRepo(process.env.KG_SOURCE_REPO || DEFAULT_KG_SOURCE_REPO).fullName,
+    kgSourceRepo: readKgSourceRepo(process.env.KG_SOURCE_REPO),
     selfDeployTarget: readStampedTarget(process.env),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { isKgDegraded, postAvailableNotice, postBootNotice, postShutdownNotice, 
 import { refreshAvailability, readStampedTarget, type SelfDeployTarget, getAvailability } from "./deploy-availability.js";
 import { clearDeployHold, isDeployHeld } from "./deploy-hold.js";
 import { decideAvailabilityAction, getDeployPolicy, getLastActedCommit, setLastActedCommit } from "./deploy-policy.js";
-import { canSelfDeploy, makeStartDeploy } from "./deploy.js";
+import { canSelfDeploy, DEFAULT_KG_SOURCE_REPO, makeStartDeploy, parseKgSourceRepo } from "./deploy.js";
 import { remediateStuckJob, remediateFailedJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
 import { handleAdminRequest } from "./admin.js";
@@ -117,6 +117,7 @@ interface AppConfig {
   localRunnerImage: string;
   localRunnerOrchestratorUrl: string | null;
   kgSidecarUrl: string | null;
+  kgSourceRepo: string;
   selfDeployTarget: SelfDeployTarget | null; // build-stamped; null when the image carries no stamps
 }
 
@@ -238,6 +239,7 @@ function loadConfig(): AppConfig {
     localRunnerImage: process.env.LOCAL_RUNNER_IMAGE || "ai-implement-runner:local",
     localRunnerOrchestratorUrl: process.env.LOCAL_RUNNER_ORCHESTRATOR_URL || null,
     kgSidecarUrl: process.env.KG_SIDECAR_URL || null,
+    kgSourceRepo: parseKgSourceRepo(process.env.KG_SOURCE_REPO || DEFAULT_KG_SOURCE_REPO).fullName,
     selfDeployTarget: readStampedTarget(process.env),
   };
 }


### PR DESCRIPTION
## Summary
- Make the bundled knowledge-graph source configurable with a validated GitHub owner/repo identifier.
- Preserve that repository selection in the runtime image and across later self-deploys.
- Keep the existing AI-Implement graph as the backward-compatible default and document the project-specific deployment path.

## Verification
- Full Vitest suite: 168 files, 3,227 tests passed.
- Targeted deploy suite: 33 tests passed.
- TypeScript build passed.
- git diff --check passed.

This changes deployment infrastructure and should be merged through the normal human review gate.