### PR TITLE
Fix GitHub Actions run correlation under concurrent dispatches

### DIFF
--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -66,6 +66,69 @@ describe("jobs table", () => {
     expect(jobs[0].status).toBe("running");
   });
 
+  it("attachJobRunIdIfMissing does not replace an existing exact run", () => {
+    const jobId = log.appendLog({ issueId: "issue-1" });
+    log.claimJobRunId(jobId, 12345);
+
+    const attached = log.attachJobRunIdIfMissing(jobId, 67890);
+
+    expect(attached).toBe(false);
+    expect(log.getJobById(jobId)).toMatchObject({
+      runId: 12345,
+      status: "running",
+    });
+  });
+
+  it("attachJobRunIdIfMissing does not attach to a terminal row with no run ID", () => {
+    const jobId = log.appendLog({ issueId: "issue-1" });
+    log.updateJobStatus(jobId, "completed", "success");
+
+    const attached = log.attachJobRunIdIfMissing(jobId, 67890);
+
+    expect(attached).toBe(false);
+    expect(log.getJobById(jobId)).toMatchObject({
+      runId: null,
+      status: "completed",
+      conclusion: "success",
+    });
+  });
+
+  it("claimJobRunId releases a nonterminal sibling that heuristically claimed the run", () => {
+    const firstJobId = log.appendLog({ issueId: "issue-1" });
+    const secondJobId = log.appendLog({ issueId: "issue-2" });
+    log.updateJobRunId(firstJobId, 101);
+    log.updateJobRunId(secondJobId, 202);
+
+    const released = log.claimJobRunId(secondJobId, 101);
+
+    expect(released).toBe(1);
+    const jobs = log.listLog();
+    expect(jobs.find((job) => job.id === firstJobId)).toMatchObject({
+      runId: null,
+      status: "dispatched",
+    });
+    expect(jobs.find((job) => job.id === secondJobId)).toMatchObject({
+      runId: 101,
+      status: "running",
+    });
+  });
+
+  it("claimJobRunId preserves target terminal status on a late progress retry", () => {
+    const jobId = log.appendLog({ issueId: "issue-1" });
+    log.updateJobStatus(jobId, "completed", "success");
+    const completedAt = log.getJobById(jobId)?.completedAt;
+
+    const released = log.claimJobRunId(jobId, 101);
+
+    expect(released).toBe(0);
+    expect(log.getJobById(jobId)).toMatchObject({
+      runId: 101,
+      status: "completed",
+      conclusion: "success",
+      completedAt,
+    });
+  });
+
   it("updateJobStatus sets terminal state with completion time", () => {
     const jobId = log.appendLog({ issueId: "issue-1" });
     log.updateJobRunId(jobId, 12345);

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -115,6 +115,7 @@ describe("jobs table", () => {
 
   it("claimJobRunId preserves target terminal status on a late progress retry", () => {
     const jobId = log.appendLog({ issueId: "issue-1" });
+    log.updateJobRunId(jobId, 101);
     log.updateJobStatus(jobId, "completed", "success");
     const completedAt = log.getJobById(jobId)?.completedAt;
 
@@ -126,6 +127,48 @@ describe("jobs table", () => {
       status: "completed",
       conclusion: "success",
       completedAt,
+    });
+  });
+
+  it("claimJobRunId repairs a target terminalized against the wrong run", () => {
+    const jobId = log.appendLog({ issueId: "issue-1" });
+    log.updateJobRunId(jobId, 202);
+    log.updateJobStatus(jobId, "failed", "failure");
+    log.markJobNotified(jobId);
+
+    const released = log.claimJobRunId(jobId, 101);
+
+    expect(released).toBe(0);
+    expect(log.getJobById(jobId)).toMatchObject({
+      runId: 101,
+      status: "running",
+      conclusion: null,
+      completedAt: null,
+      notifiedAt: null,
+    });
+  });
+
+  it("claimJobRunId reopens a terminal sibling that claimed the exact run", () => {
+    const siblingJobId = log.appendLog({ issueId: "issue-1" });
+    const exactJobId = log.appendLog({ issueId: "issue-2" });
+    log.updateJobRunId(siblingJobId, 101);
+    log.updateJobStatus(siblingJobId, "completed", "success");
+    log.markJobNotified(siblingJobId);
+    log.updateJobRunId(exactJobId, 202);
+
+    const released = log.claimJobRunId(exactJobId, 101);
+
+    expect(released).toBe(1);
+    expect(log.getJobById(siblingJobId)).toMatchObject({
+      runId: null,
+      status: "dispatched",
+      conclusion: null,
+      completedAt: null,
+      notifiedAt: null,
+    });
+    expect(log.getJobById(exactJobId)).toMatchObject({
+      runId: 101,
+      status: "running",
     });
   });
 

--- a/src/__tests__/jobs.test.ts
+++ b/src/__tests__/jobs.test.ts
@@ -94,8 +94,8 @@ describe("jobs table", () => {
   });
 
   it("claimJobRunId releases a nonterminal sibling that heuristically claimed the run", () => {
-    const firstJobId = log.appendLog({ issueId: "issue-1" });
-    const secondJobId = log.appendLog({ issueId: "issue-2" });
+    const firstJobId = log.appendLog({ issueId: "issue-1", repo: "org/repo" });
+    const secondJobId = log.appendLog({ issueId: "issue-2", repo: "org/repo" });
     log.updateJobRunId(firstJobId, 101);
     log.updateJobRunId(secondJobId, 202);
 
@@ -149,8 +149,8 @@ describe("jobs table", () => {
   });
 
   it("claimJobRunId reopens a terminal sibling that claimed the exact run", () => {
-    const siblingJobId = log.appendLog({ issueId: "issue-1" });
-    const exactJobId = log.appendLog({ issueId: "issue-2" });
+    const siblingJobId = log.appendLog({ issueId: "issue-1", repo: "org/repo" });
+    const exactJobId = log.appendLog({ issueId: "issue-2", repo: "org/repo" });
     log.updateJobRunId(siblingJobId, 101);
     log.updateJobStatus(siblingJobId, "completed", "success");
     log.markJobNotified(siblingJobId);
@@ -170,6 +170,36 @@ describe("jobs table", () => {
       runId: 101,
       status: "running",
     });
+  });
+
+  it("claimJobRunId never resets a job from another repository", () => {
+    const foreignJobId = log.appendLog({ issueId: "issue-1", repo: "other/repo" });
+    const exactJobId = log.appendLog({ issueId: "issue-2", repo: "org/repo" });
+    log.updateJobRunId(foreignJobId, 101);
+    log.updateJobStatus(foreignJobId, "completed", "success");
+    log.markJobNotified(foreignJobId);
+    log.updateJobRunId(exactJobId, 202);
+
+    const released = log.claimJobRunId(exactJobId, 101);
+
+    expect(released).toBe(0);
+    expect(log.getJobById(foreignJobId)).toMatchObject({
+      runId: 101,
+      status: "completed",
+      conclusion: "success",
+    });
+    expect(log.getJobById(exactJobId)).toMatchObject({
+      runId: 101,
+      status: "running",
+    });
+  });
+
+  it("indexes run IDs used by exact and heuristic correlation", () => {
+    const indexes = dedup.getDb()
+      .prepare("PRAGMA index_list(dispatch_log)")
+      .all() as Array<{ name: string }>;
+
+    expect(indexes.map((index) => index.name)).toContain("idx_dispatch_log_run_id");
   });
 
   it("updateJobStatus sets terminal state with completion time", () => {

--- a/src/__tests__/reporter.test.ts
+++ b/src/__tests__/reporter.test.ts
@@ -81,4 +81,24 @@ describe("TokenStepReporter", () => {
     });
     expect(JSON.parse(String(calls[0].init.body))).toEqual({ step: STEP });
   });
+
+  it("includes the GitHub run ID when the workflow provides one", async () => {
+    vi.stubEnv("GITHUB_RUN_ID", "32595525188");
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const reporter = new TokenStepReporter("https://orchestrator.example", "progress-token", {
+      fetchImpl: async (url, init) => {
+        calls.push({ url: String(url), init: init! });
+        return response(200);
+      },
+      retryDelaysMs: [],
+    });
+
+    await reporter.report(STEP);
+
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      step: STEP,
+      githubRunId: 32595525188,
+    });
+    vi.unstubAllEnvs();
+  });
 });

--- a/src/__tests__/runner-callback.test.ts
+++ b/src/__tests__/runner-callback.test.ts
@@ -401,6 +401,86 @@ describe("handleRunnerProgress", () => {
       },
     ]);
   });
+
+  it("uses authenticated progress to correct a swapped concurrent run association", async () => {
+    const dispatchId = "dispatch-correct";
+    const { token } = runnerTokens.mintRunToken({
+      issueId: "correct-issue",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      audience: "progress",
+      dispatchId,
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const correctJobId = log.appendLog({
+      issueId: "correct-issue",
+      issueIdentifier: "ENG-1",
+      teamKey: "ENG",
+      repo: "o/r",
+      dispatchId,
+      executionMode: "github-actions",
+    });
+    const siblingJobId = log.appendLog({
+      issueId: "sibling-issue",
+      issueIdentifier: "ENG-2",
+      teamKey: "ENG",
+      repo: "o/r",
+      dispatchId: "dispatch-sibling",
+      executionMode: "github-actions",
+    });
+
+    // The heuristic lookup raced and assigned each job the other run.
+    log.updateJobRunId(correctJobId, 222);
+    log.updateJobRunId(siblingJobId, 111);
+
+    const res = await runnerCallback.handleRunnerProgress({
+      authorization: `Bearer ${token}`,
+      body: { step: STEP, githubRunId: 111 },
+      secret: SECRET,
+    });
+
+    expect(res.status).toBe(200);
+    const jobs = log.listLog();
+    expect(jobs.find((job) => job.id === correctJobId)).toMatchObject({
+      runId: 111,
+      status: "running",
+    });
+    expect(jobs.find((job) => job.id === siblingJobId)).toMatchObject({
+      runId: null,
+      status: "dispatched",
+    });
+  });
+
+  it("rejects a malformed GitHub run ID without changing the job", async () => {
+    const dispatchId = "dispatch-invalid-run";
+    const { token } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      audience: "progress",
+      dispatchId,
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const jobId = log.appendLog({
+      issueId: "i",
+      teamKey: "ENG",
+      repo: "o/r",
+      dispatchId,
+      executionMode: "github-actions",
+    });
+
+    const res = await runnerCallback.handleRunnerProgress({
+      authorization: `Bearer ${token}`,
+      body: { step: STEP, githubRunId: -1 },
+      secret: SECRET,
+    });
+
+    expect(res).toMatchObject({ status: 400, body: { error: "invalid_github_run_id" } });
+    expect(log.listLog().find((job) => job.id === jobId)?.runId).toBeNull();
+    expect(stepLog.getStepsByJobId(jobId)).toEqual([]);
+  });
 });
 
 describe("handleRunnerPlanningContext", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import { canSelfDeploy, makeStartDeploy } from "./deploy.js";
 import { remediateStuckJob, remediateFailedJob } from "./stuck-watchdog.js";
 import type { StuckWatchdogConfig } from "./stuck-watchdog.js";
 import { handleAdminRequest } from "./admin.js";
-import { initLogTable, appendLog, countPriorDispatches, completeOrphanedPlanningJobs, updateJobRunId, updateJobStatus, updateJobPrUrl, markJobNotified, getInFlightJobs, getInFlightIssueIds, getUnnotifiedTerminalJobs, getClaimedRunIds, suppressStaleNotifications, invalidateNonce, getJobByMachineId, resetStuckAttempts, getRecentFailedRunUrls } from "./log.js";
+import { initLogTable, appendLog, countPriorDispatches, completeOrphanedPlanningJobs, attachJobRunIdIfMissing, updateJobRunId, updateJobStatus, updateJobPrUrl, markJobNotified, getInFlightJobs, getInFlightIssueIds, getUnnotifiedTerminalJobs, getClaimedRunIds, suppressStaleNotifications, invalidateNonce, getJobById, getJobByMachineId, resetStuckAttempts, getRecentFailedRunUrls } from "./log.js";
 import { isParked, recordDispatchFailure, recordDispatchSuccess, initDispatchBreakerTable } from "./dispatch-breaker.js";
 import type { Job, JobStatus } from "./log.js";
 import { getInstallationToken, getAppSlug } from "./github-app-auth.js";
@@ -1678,8 +1678,11 @@ async function postDispatch(
         getClaimedRunIds(),
       );
       if (runId) {
-        updateJobRunId(jobId, runId);
-        console.log(`[poll] Linked ${issue.identifier} to run ${runId}`);
+        if (attachJobRunIdIfMissing(jobId, runId)) {
+          console.log(`[poll] Linked ${issue.identifier} to run ${runId}`);
+        } else {
+          console.log(`[poll] Skipped heuristic run link for ${issue.identifier}; job already has a run ID`);
+        }
       } else {
         console.log(`[poll] Run ID not yet available for ${issue.identifier}, will retry next cycle`);
       }
@@ -1865,13 +1868,19 @@ async function monitorGitHubActionsJob(
     );
 
     if (runId) {
-      updateJobRunId(job.id, runId);
-      claimedRunIds.add(runId);
-      job.runId = runId;
-      console.log(`[monitor] Found run ID ${runId} for job ${job.id} (${job.issueIdentifier})`);
+      if (attachJobRunIdIfMissing(job.id, runId)) {
+        claimedRunIds.add(runId);
+        job.runId = runId;
+        console.log(`[monitor] Found run ID ${runId} for job ${job.id} (${job.issueIdentifier})`);
+      } else {
+        console.log(`[monitor] Skipped heuristic run link for job ${job.id} (${job.issueIdentifier}); job already has a run ID`);
+        return;
+      }
     } else if (Date.now() - job.dispatchedAt > RUN_ID_TIMEOUT_MS) {
+      if (!isMonitorRunIdStillCurrent(job)) return;
       console.warn(`[monitor] Job ${job.id} (${job.issueIdentifier}) timed out waiting for run ID`);
       const provider = await providerForJob(registry, job);
+      if (!isMonitorRunIdStillCurrent(job)) return;
       await remediateStuckJob(watchdogConfig, provider, job, "run_not_found");
       return;
     } else {
@@ -1882,6 +1891,7 @@ async function monitorGitHubActionsJob(
   // Check run status
   const runStatus = await getWorkflowRunStatus(ghToken, owner, repo, job.runId);
   if (!runStatus) return;
+  if (!isMonitorRunIdStillCurrent(job)) return;
 
   // Detect stuck: non-terminal past the configured workflow timeout plus reconciliation grace.
   const watchdog = githubActionsWatchdogDecision({
@@ -1897,6 +1907,7 @@ async function monitorGitHubActionsJob(
         `(threshold ${watchdog.jobTimeoutMinutes}m + ${watchdog.graceMinutes}m grace)`,
     );
     const provider = await providerForJob(registry, job);
+    if (!isMonitorRunIdStillCurrent(job)) return;
     await remediateStuckJob(watchdogConfig, provider, job, runStatus.status);
     return;
   }
@@ -1931,6 +1942,7 @@ async function monitorGitHubActionsJob(
       }
     }
 
+    if (!isMonitorRunIdStillCurrent(job)) return;
     updateJobStatus(job.id, jobStatus, runStatus.conclusion, prUrl);
     console.log(`[monitor] Job ${job.id} (${job.issueIdentifier}) → ${jobStatus} (${runStatus.conclusion})`);
 
@@ -1957,6 +1969,16 @@ async function monitorGitHubActionsJob(
   else if (job.status === "dispatched") {
     updateJobRunId(job.id, job.runId);
   }
+}
+
+function isMonitorRunIdStillCurrent(job: Job): boolean {
+  const current = getJobById(job.id);
+  if (!current) return false;
+  if (current.runId === job.runId) return true;
+  console.log(
+    `[monitor] Skipping stale cycle for job ${job.id} (${job.issueIdentifier}); run ID changed from ${job.runId ?? "none"} to ${current.runId ?? "none"}`,
+  );
+  return false;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1957,11 +1957,13 @@ async function monitorGitHubActionsJob(
     // parent would strand In Progress — finalize it here so merge-up opens the roll-up PR.
     if (jobStatus === "completed" && !prUrl && job.phase !== "planning" && job.groupingParent) {
       const provider = await providerForJob(registry, job);
+      if (!isMonitorRunIdStillCurrent(job)) return;
       await finalizeNoOpGroupingParent(provider, job);
     }
 
     if (jobStatus === "failed") {
       const provider = await providerForJob(registry, job);
+      if (!isMonitorRunIdStillCurrent(job)) return;
       await remediateFailedJob(watchdogConfig, provider, job, runStatus.conclusion ?? "failure");
     }
   }

--- a/src/log.ts
+++ b/src/log.ts
@@ -130,6 +130,7 @@ function ensureLogColumns(): void {
   if (!names.has("grouping_parent")) {
     db.exec("ALTER TABLE dispatch_log ADD COLUMN grouping_parent INTEGER NOT NULL DEFAULT 0");
   }
+  db.exec("CREATE INDEX IF NOT EXISTS idx_dispatch_log_run_id ON dispatch_log(run_id)");
 
   // Migrate legacy rows: jobs that were never actually tracked by the run
   // monitor should show 'unknown', not a misleading terminal status.
@@ -251,13 +252,19 @@ export function attachJobRunIdIfMissing(jobId: number, runId: number): boolean {
 
 /**
  * Authoritatively binds the run reported by a job's authenticated progress token.
- * Any sibling holding that run was matched heuristically and is reopened so it can
- * discover its own run. A terminal target is preserved only when it already owns
- * this exact run, which makes late progress retries harmless.
+ * Any sibling in the same repository holding that run was matched heuristically
+ * and is reopened so it can discover its own run. Repository scoping prevents a
+ * runner token from mutating another repository's jobs. A terminal target is
+ * preserved only when it already owns this exact run, which makes late progress
+ * retries harmless.
  */
 export function claimJobRunId(jobId: number, runId: number): number {
   const db = getDb();
   return db.transaction(() => {
+    const target = db
+      .prepare("SELECT repo FROM dispatch_log WHERE id = ?")
+      .get(jobId) as { repo: string | null } | undefined;
+
     const released = db
       .prepare(
         `UPDATE dispatch_log
@@ -267,9 +274,10 @@ export function claimJobRunId(jobId: number, runId: number): number {
              completed_at = NULL,
              notified_at = NULL
          WHERE run_id = ?
-           AND id != ?`,
+           AND id != ?
+           AND repo = ?`,
       )
-      .run(runId, jobId);
+      .run(runId, jobId, target?.repo ?? null);
 
     db.prepare(
       `UPDATE dispatch_log

--- a/src/log.ts
+++ b/src/log.ts
@@ -241,6 +241,41 @@ export function updateJobRunId(jobId: number, runId: number): void {
     .run(runId, jobId);
 }
 
+export function attachJobRunIdIfMissing(jobId: number, runId: number): boolean {
+  const result = getDb()
+    .prepare("UPDATE dispatch_log SET run_id = ?, status = 'running' WHERE id = ? AND run_id IS NULL AND status IN ('dispatched', 'running')")
+    .run(runId, jobId);
+  return result.changes > 0;
+}
+
+export function claimJobRunId(jobId: number, runId: number): number {
+  const db = getDb();
+  return db.transaction(() => {
+    const released = db
+      .prepare(
+        `UPDATE dispatch_log
+         SET run_id = NULL, status = 'dispatched', conclusion = NULL, completed_at = NULL
+         WHERE run_id = ?
+           AND id != ?
+           AND status NOT IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed')`,
+      )
+      .run(runId, jobId);
+
+    db.prepare(
+      `UPDATE dispatch_log
+       SET run_id = ?,
+           status = CASE
+             WHEN status IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed') THEN status
+             ELSE 'running'
+           END
+       WHERE id = ?`,
+    )
+      .run(runId, jobId);
+
+    return released.changes;
+  })();
+}
+
 export function updateJobStatus(
   jobId: number,
   status: JobStatus,

--- a/src/log.ts
+++ b/src/log.ts
@@ -241,6 +241,7 @@ export function updateJobRunId(jobId: number, runId: number): void {
     .run(runId, jobId);
 }
 
+/** Best-effort heuristic binding. An authenticated callback may have won the race already. */
 export function attachJobRunIdIfMissing(jobId: number, runId: number): boolean {
   const result = getDb()
     .prepare("UPDATE dispatch_log SET run_id = ?, status = 'running' WHERE id = ? AND run_id IS NULL AND status IN ('dispatched', 'running')")
@@ -248,29 +249,54 @@ export function attachJobRunIdIfMissing(jobId: number, runId: number): boolean {
   return result.changes > 0;
 }
 
+/**
+ * Authoritatively binds the run reported by a job's authenticated progress token.
+ * Any sibling holding that run was matched heuristically and is reopened so it can
+ * discover its own run. A terminal target is preserved only when it already owns
+ * this exact run, which makes late progress retries harmless.
+ */
 export function claimJobRunId(jobId: number, runId: number): number {
   const db = getDb();
   return db.transaction(() => {
     const released = db
       .prepare(
         `UPDATE dispatch_log
-         SET run_id = NULL, status = 'dispatched', conclusion = NULL, completed_at = NULL
+         SET run_id = NULL,
+             status = 'dispatched',
+             conclusion = NULL,
+             completed_at = NULL,
+             notified_at = NULL
          WHERE run_id = ?
-           AND id != ?
-           AND status NOT IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed')`,
+           AND id != ?`,
       )
       .run(runId, jobId);
 
     db.prepare(
       `UPDATE dispatch_log
-       SET run_id = ?,
-           status = CASE
-             WHEN status IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed') THEN status
+       SET status = CASE
+             WHEN run_id = ? AND status IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed')
+               THEN status
              ELSE 'running'
-           END
+           END,
+           conclusion = CASE
+             WHEN run_id = ? AND status IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed')
+               THEN conclusion
+             ELSE NULL
+           END,
+           completed_at = CASE
+             WHEN run_id = ? AND status IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed')
+               THEN completed_at
+             ELSE NULL
+           END,
+           notified_at = CASE
+             WHEN run_id = ? AND status IN ('completed', 'review_failed', 'failed', 'timed_out', 'dispatch-failed')
+               THEN notified_at
+             ELSE NULL
+           END,
+           run_id = ?
        WHERE id = ?`,
     )
-      .run(runId, jobId);
+      .run(runId, runId, runId, runId, runId, jobId);
 
     return released.changes;
   })();

--- a/src/pipeline/reporter.ts
+++ b/src/pipeline/reporter.ts
@@ -55,6 +55,7 @@ export class HttpStepReporter implements StepReporter {
 export class TokenStepReporter implements StepReporter {
   private readonly fetchImpl: typeof fetch;
   private readonly retryDelaysMs: number[];
+  private readonly githubRunId: number | null;
 
   constructor(
     private readonly callbackUrl: string,
@@ -63,11 +64,13 @@ export class TokenStepReporter implements StepReporter {
   ) {
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.retryDelaysMs = options.retryDelaysMs ?? [250, 1000, 2500];
+    this.githubRunId = parseGithubRunId(process.env.GITHUB_RUN_ID);
   }
 
   async report(step: Step): Promise<void> {
     const url = `${this.callbackUrl.replace(/\/$/, "")}/runner/progress`;
     const attempts = this.retryDelaysMs.length + 1;
+    const body = this.githubRunId === null ? { step } : { step, githubRunId: this.githubRunId };
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
       try {
@@ -77,7 +80,7 @@ export class TokenStepReporter implements StepReporter {
             "Content-Type": "application/json",
             Authorization: `Bearer ${this.progressToken}`,
           },
-          body: JSON.stringify({ step }),
+          body: JSON.stringify(body),
         });
         if (res.ok) return;
         if (!isRetryableStatus(res.status) || attempt === attempts) {
@@ -111,6 +114,13 @@ function errorSummary(err: unknown): string {
     return `${err.name}: ${err.message}${causeMessage}`;
   }
   return String(err);
+}
+
+function parseGithubRunId(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  if (!/^[1-9]\d*$/.test(value)) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -1,4 +1,4 @@
-import { getJobByDispatchId, updateJobPrUrl, updateJobStatus } from "./log.js";
+import { claimJobRunId, getJobByDispatchId, updateJobPrUrl, updateJobStatus } from "./log.js";
 import type { Step } from "./pipeline/types.js";
 import type { TicketingProvider } from "./providers/types.js";
 import { remediateFailedJob, type StuckWatchdogConfig } from "./stuck-watchdog.js";
@@ -40,6 +40,7 @@ export interface HandleRunnerResultOutput {
 
 export interface RunnerProgressBody {
   step: Step;
+  githubRunId?: number;
 }
 
 export interface HandleRunnerProgressInput {
@@ -121,6 +122,16 @@ function validateStepBody(body: unknown): Step | HandleRunnerResultOutput {
   if (!s.started_at || typeof s.started_at !== "string") return bad(400, "invalid_step_started_at");
 
   return raw.step as Step;
+}
+
+function validateGithubRunId(body: unknown): number | null | HandleRunnerResultOutput {
+  const raw = body as { githubRunId?: unknown } | null | undefined;
+  if (!raw || typeof raw !== "object" || !("githubRunId" in raw)) return null;
+  return typeof raw.githubRunId === "number" &&
+    Number.isSafeInteger(raw.githubRunId) &&
+    raw.githubRunId > 0
+    ? raw.githubRunId
+    : bad(400, "invalid_github_run_id");
 }
 
 export async function handleRunnerResult(
@@ -327,8 +338,15 @@ export async function handleRunnerProgress(
   const stepOrError = validateStepBody(input.body);
   if ("status" in stepOrError && "body" in stepOrError) return stepOrError;
 
+  const githubRunIdOrError = validateGithubRunId(input.body);
+  if (githubRunIdOrError && typeof githubRunIdOrError === "object") return githubRunIdOrError;
+
   const job = getJobByDispatchId(verified.claims.dispatchId);
   if (!job) return bad(404, "job_not_found");
+
+  if (typeof githubRunIdOrError === "number") {
+    claimJobRunId(job.id, githubRunIdOrError);
+  }
 
   upsertStepRecord(job.id, stepOrError);
   return { status: 200, body: { acknowledged: true } };


### PR DESCRIPTION
## Summary

- include the workflow run ID in authenticated progress callbacks
- make exact callback correlation authoritative over heuristic matches
- prevent late heuristic and stale monitor cycles from undoing exact bindings
- reopen a sibling that was terminalized against the wrong run while preserving legitimate late retries

## Verification

- Full Vitest suite: 168 files, 3,228 tests passed
- TypeScript typecheck passed
- Production build passed
- Diff check passed

## Context

Two simultaneous Answer9 implementations were assigned each other’s Actions run by the recent-unclaimed-run heuristic. Their callback tokens still identified the correct dispatch, so this change uses the callback’s GITHUB_RUN_ID to repair and lock the association while retaining the heuristic as a pre-callback fallback.