### PR TITLE
docs: land the close-the-loop and campaign-reliability plans

### DIFF
--- a/docs/plans/2026-08-12-close-the-loop-design.md
+++ b/docs/plans/2026-08-12-close-the-loop-design.md
@@ -1,0 +1,60 @@
+# Close the Loop — Design Decisions
+
+**Date:** 2026-08-12 · **Tracker:** Linear (team AII) · **Repo:** BuildDownAI/AI-Implement
+**Baseline (frozen 2026-08-12, testing orchestrator):** 87.0% one-shot approval, 95.1% eventual, 1.13 avg passes, $1.31 avg cost (unplanned cohort). Planning A/B: no lift (86.7% one-shot, 1.20 passes, $1.59 — before planning-run cost). Retry storms: AII-253 = 120 dispatches; BDS-1/BDS-2 = 35 dispatches, zero merges. Zero max_turns hits.
+
+## Objective
+
+Make the AI-Implement harness measurable and self-limiting: cap runaway dispatch storms, expose a per-issue report card (MCP + admin), capture review-escape at merge time, and redesign the per-issue planning comments so each section reaches the consumer that can act on it — all measured against the frozen baseline.
+
+## Scope
+
+**In v1:**
+1. Dispatch circuit breaker (consecutive-failure park) — supersedes the dedup-TTL approach.
+2. `get_issue_report_card` + `get_fleet_report` MCP tools + one admin page; `terminationReason` persistence fix.
+3. Merge-time review-escape capture (passive, at `markMerged`); escape-rate in the report card.
+4. PLANNING.md redesign: Implementation Map / Acceptance Bar / Risks; Acceptance Bar wired into the review pass; planned-files machine block feeding the dispatch guard and a planned-vs-actual autopsy line; Jira `fetchPlanningContext` implemented against the new format (Wave 2).
+5. Revival of AII-276 (post-push gate reads the external review verdict) as a sibling.
+
+**Deferred:** findings→tracked-items workflow (AII-285), re-review of post-open commits (AII-312), run summaries to Linear (AII-130), phase legibility (AII-131/AII-208), learnings-comments v2 (→ BDS-32, skills repo).
+**Out of scope:** per-project admin field for the breaker threshold (env var only); any tracker-side workflow changes; KG ingest changes.
+
+## Decisions
+
+- **Breaker trip condition:** 3 consecutive failed/timed-out dispatches per issue+phase, counter reset on success. Matches the stuck watchdog's 3-attempt convention (AII-117) and AII-282's keep-simple rationale. Rejected: lifetime dispatch cap (blocks legitimate long-lived gap-fill work — AII-253 merged after many legitimate re-dispatches); cost budget (the worst storms fail cheaply — BDS-1/2 would never trip it).
+- **Breaker trip action:** park the issue — poll skips it; one classification ticket comment (failure class + run links + unpark instructions); webhook notify; visible in admin Runners view. Unpark is human-only (admin button).
+- **Breaker state lives in its own table** (`dispatch_breaker`: issue_id, phase, consecutive_failures, last_conclusion, parked_at) — it must survive dedup-row deletion, which happens on every failure. The poll gate checks it before dispatch.
+- **Dedup policy: explicit state supersedes TTL.** AII-259 (TTL) closes as superseded — a timer would auto-unpark storms. AII-194's orphan case (fast-failed dispatch leaves a dead dedup row) folds into the breaker: a fast-fail clears the row *and* counts a failure.
+- **Report card is compute-on-read** over dispatch_log / step_log / comment_gapfill_queue / review_fix_dispatches / reconciliation_queue / pr_merge_capture — no materialized columns at current scale. One aggregation module, two consumers: MCP tools on `/mcp` (OAuth-gated, read-only) and one admin SPA page. Supersedes AII-51 and AII-129.
+- **`terminationReason` fix:** the feedback-loop step's outputs (approved, iterations, terminationReason, passes[]) must land in `step_log.outputs_json`; today they are NULL everywhere and pass data is reconstructed from sub-steps.
+- **Review-escape capture is passive, at `markMerged`:** approval timestamp = last approved `review.N` step; fetch PR commits + reviews; bucket post-approval commits by author class (runner App bot / other bots / human); count external findings by source (claude-review / codex / human); store one `pr_merge_capture` row; `review_escape = approved-then-corrected`. No workflow change for the operator — fixing PRs directly with a local session remains fine and is now measured.
+- **Planning comments become three, each with a named consumer:** Implementation Map (implementer, grounding: approach ≤3 sentences, canonical `- Modify:` Files bullets, repo-discovered constraints and hazards, hard length cap), Acceptance Bar (review pass: falsifiable claims injected into the review prompt), Risks & Open Questions (human + implementer, unchanged). Work Units dies — nothing ever consumed it (the fetch never collected it; the `workUnits` parallel path in `implement.ts` has no producer and is removed). Test Plan dies — generic content delivered to the wrong phase.
+- **Machine block** (`<!-- ai-implement-planning v:1 … -->`) carries planned files → reused by the sibling file-overlap dispatch guard and by a planned-vs-actual line in the run autopsy (autopsy extended to successful runs).
+- **Context re-send discipline:** full planning context on pass 1; Map only on pass 2+.
+- **Seed-once migration:** the fetch accepts old AND new comment headers indefinitely; our four repos (AI-Implement, skills, docs, sandbox) get a one-time manual PLANNING.md re-seed. Jira provider implements `fetchPlanningContext` against the new format only.
+- **Rollout:** breaker on by default, `AI_IMPLEMENT_BREAKER_THRESHOLD` env var (default 3), documented in `.env.example` in the same change. Planning redesign carries a measurement gate: re-run the baseline after ~30 planned runs on the new format; the redesign must beat 87% one-shot / 1.13 passes or be revised.
+- **Testing:** vitest on the breaker state machine (fail/success/fast-fail/park/unpark transitions), merge-capture bucketing (no-review-step and gap-fill edge cases), report-card aggregation (fixtures incl. legacy no-telemetry rows), dual-prefix planning fetch, review-prompt injection. New test files get an explicit typecheck (the suite's known blind spot).
+- **Observability:** the report card *is* the observability surface; breaker trips additionally notify via webhook + ticket comment.
+
+## Overlap & Reconciliation
+
+- **AII-51 loop metrics** — Superset (ours). Action: close as superseded once the report-card issue files, link.
+- **AII-129 [Obs G2] telemetry + admin UI** — Superset (ours). Action: close as superseded, link.
+- **AII-130 [Obs G3] summaries to Linear** — Adjacent. Action: leave in Backlog, link from container.
+- **AII-285 findings accounting** — Adjacent (workflow vs. our measurement). Action: leave in Backlog, link; escape data decides its fate.
+- **AII-276 post-push gate x external review** — Dependency/sibling. Action: revive into this project, attach, `AI-Implement` label per wave plan.
+- **AII-312 review post-open commits** — Adjacent. Action: leave, link.
+- **AII-259 dedup TTL** — Superseded by explicit breaker state. Action: close with rationale + link.
+- **AII-194 orphaned dedup row** — Subset. Action: close as folded into the breaker issue, link.
+- **AII-2 auto-retry recoverable failures** — Superseded (the breaker + existing retry paths are the deliberate version). Action: close with rationale.
+- **AII-167 Jira planning artifacts** — Subset. Action: close as folded into the Wave-2 Jira child, link.
+- **AII-131 planning→implementation transition** — Adjacent. Action: leave, link.
+- **AII-46 reviewer structured JSON** — Stale/superseded by Acceptance Bar wiring. Action: close with rationale.
+- **AII-208 phase legibility** — Adjacent. Action: leave.
+- **BDS-32 learnings marking** — Related (other team). Action: post the v2 design (MLD sections + promotion ledger + report-card dependency) as a comment on BDS-32; link from container.
+- **BDS-35 review-audit process** — Adjacent. Action: leave, link.
+
+## Open Questions
+
+- Whether the admin report page needs per-project filtering in v1 (default: yes, it's one WHERE clause).
+- Exact bot-author allowlist for commit bucketing (default: the App's bot login = runner; `*[bot]` = bot; else human).

--- a/docs/plans/2026-08-12-close-the-loop-plan.md
+++ b/docs/plans/2026-08-12-close-the-loop-plan.md
@@ -1,0 +1,293 @@
+# Close the Loop — Implementation Plan
+
+> **For AI-Implement:** Each task below maps to a tracker issue. The pipeline picks up each issue independently — task descriptions are self-contained.
+
+**Goal:** Cap dispatch storms, ship the per-issue report card (MCP + admin), capture review escape at merge, and redesign planning comments so each section reaches its consumer — measured against the frozen 2026-08-12 baseline (87.0% one-shot, 1.13 avg passes, $1.31/run).
+
+**Architecture:** Three independent rails plus one redesign. Breaker: new `dispatch_breaker` table gates the poll. Report card: compute-on-read aggregation module with MCP + admin consumers. Escape capture: passive GitHub fetch at `markMerged`. Planning: new 3-comment template, dual-prefix fetch, Acceptance Bar injected into the review pass, machine block feeding the existing `parseDeclaredFiles` guard.
+
+**Tech stack:** Node 24 / TypeScript, better-sqlite3 (via `getDb()` from `src/dedup.ts` — never open a second handle), vitest. **`typecheck` excludes `src/__tests__` and vitest strips types unchecked — every new test file gets an explicit `npx tsc --noEmit -p` pass with a throwaway tsconfig.**
+
+**Tracker container:** Linear project (created at filing; both docs attached).
+
+---
+
+## File structure
+
+| File | Task | Responsibility |
+|---|---|---|
+| `src/dispatch-breaker.ts` (new) | 1 | breaker table + state machine, single owner of park/unpark |
+| `src/index.ts` | 1 | poll gate + failure/success accounting calls |
+| `src/admin.ts` | 2, 6 | parked-list/unpark endpoints; report endpoint |
+| `src/admin-ui/pages/runners.ts` | 2 | parked banner + unpark button |
+| `src/run-autonomous.ts` | 3, 9 | feedback-loop outputs reporting; autopsy on success |
+| `src/merge-capture.ts` (new) | 4 | `pr_merge_capture` table + capture-at-merge |
+| `src/reconcile-merged.ts` | 4 | call capture after `markMerged` |
+| `src/report-card.ts` (new) | 5 | all aggregation queries (issue card, fleet, runaways) |
+| `src/mcp.ts` | 5 | two new diagnostic tools |
+| `src/admin-ui/pages/reports.ts` (new) | 6 | report page |
+| `src/admin-ui/index.ts`, `src/admin-ui/sidebar.ts` | 6 | page registration |
+| `workflows/PLANNING.md` | 7 | v2 template (Map / Bar / Risks + machine block) |
+| `src/run-planning.ts` | 7 | built-in planning prompt → 3 comments |
+| `src/linear-planning-fetch.ts` | 7 | dual-prefix fetch (old + new headers) |
+| `src/pipeline/steps/implement.ts` | 7 | remove dead `workUnits` path |
+| `src/pipeline/steps/feedback-loop.ts` | 8 | split Bar from context; pass-aware resend |
+| `src/pipeline/steps/review.ts` | 8 | `acceptanceBar` input in review prompt |
+| `src/planning-block.ts` (new) | 9 | machine-block parser |
+| `src/poll-selection.ts` | 9 | guard accepts planning-block files |
+| `src/run-autopsy.ts` | 9 | planned-vs-actual line; success stat |
+| `src/providers/jira.ts` | 10 | real `fetchPlanningContext` |
+| `.env.example` | 1 | `DISPATCH_BREAKER_THRESHOLD` |
+
+---
+
+### Task 1: Dispatch circuit breaker core
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no (additive table, created on init like every other table)
+
+**Files:**
+- Create: `src/dispatch-breaker.ts`
+- Modify: `src/index.ts` (poll gate ~line 391; failure paths that call `deleteDispatched`/skip `markDispatched`; success path)
+- Modify: `.env.example` (new var, grouped with reaper/watchdog vars)
+- Test: `src/__tests__/dispatch-breaker.test.ts`
+
+**Parallel-safe with:** Tasks 3, 4, 7, AII-276 · **Blocked by:** —
+
+**Rubric:** Pattern anchor: `src/dedup.ts` (table init + accessor style), `src/stuck-watchdog.ts` (bounded-attempts + give-up notify). Test fixture: `src/__tests__/` sqlite-backed dedup tests. Trust boundary: none (internal state). Rollback: set `DISPATCH_BREAKER_THRESHOLD=0` to disable (0 = never trip). Observability: ticket comment + webhook notify on trip; parked rows in admin (Task 2). Parallel-safety: verified, no file overlap with peers.
+
+- [ ] **Step 1: failing tests** — state machine transitions:
+
+```ts
+import { recordDispatchFailure, recordDispatchSuccess, isParked, unpark } from "../dispatch-breaker.js";
+// threshold 3 via env in beforeEach
+it("parks on 3rd consecutive failure, not before", () => {
+  recordDispatchFailure("iss-1", "implementation", "exit_1");
+  recordDispatchFailure("iss-1", "implementation", "exit_1");
+  expect(isParked("iss-1", "implementation")).toBe(false);
+  recordDispatchFailure("iss-1", "implementation", "exit_1");
+  expect(isParked("iss-1", "implementation")).toBe(true);
+});
+it("success resets the counter", () => { /* 2 fails, success, 2 fails → not parked */ });
+it("phases count independently", () => { /* planning fails don't park implementation */ });
+it("unpark clears parked_at AND counter", () => { /* after unpark, 2 more fails → still not parked */ });
+it("threshold 0 disables tripping", () => { /* 10 fails → never parked */ });
+it("trip returns true exactly once (comment/notify fire once)", () => {
+  /* recordDispatchFailure returns {tripped: boolean}; 4th failure → tripped false */
+});
+```
+
+- [ ] **Step 2: implement `src/dispatch-breaker.ts`**
+
+```ts
+// Table (init pattern mirrors dedup.ts):
+// CREATE TABLE IF NOT EXISTS dispatch_breaker (
+//   issue_id TEXT NOT NULL, phase TEXT NOT NULL,
+//   consecutive_failures INTEGER NOT NULL DEFAULT 0,
+//   last_conclusion TEXT, last_failure_at INTEGER, parked_at INTEGER,
+//   PRIMARY KEY (issue_id, phase))
+export function recordDispatchFailure(issueId: string, phase: string, conclusion: string):
+  { tripped: boolean; failures: number } { /* upsert; trip when count reaches threshold() && !parked */ }
+export function recordDispatchSuccess(issueId: string, phase: string): void { /* reset counter, keep parked rows parked */ }
+export function isParked(issueId: string, phase: string): boolean {}
+export function unpark(issueId: string, phase?: string): boolean {}
+export function listParked(): Array<{ issueId: string; phase: string; failures: number; lastConclusion: string | null; parkedAt: number }> {}
+function threshold(): number { return Number(process.env.DISPATCH_BREAKER_THRESHOLD ?? 3); }
+```
+
+- [ ] **Step 3: wire `src/index.ts`.** (a) Poll gate: extend the `isAlreadyDispatched(issueId) || inFlightIssueIds.has(issueId)` predicate (~line 391) with `|| isParked(issueId, phase)`. (b) Every terminal-failure path that today clears/skips dedup (`deleteDispatched` at ~line 290, the intentionally-not-marked paths at ~962/~1084, and the monitor's failed/timed_out handling) calls `recordDispatchFailure(issueId, phase, conclusion)`; the **fast-failed dispatch path also clears its dedup row** (AII-194 fix — today it orphans). (c) Completion-success path calls `recordDispatchSuccess`. (d) On `tripped: true`: post one ticket comment via the mapping's provider (`provider.postComment`) — first line `**⛔ AI-Implement parked this issue**`, then failure count, last conclusion, run links from `dispatch_log`, and "Unpark: admin → Runners → Unpark, or ask the operator" — and send `notifyText` to the configured webhook. Comment posting is best-effort (log, never throw).
+- [ ] **Step 4: `.env.example`** — add `DISPATCH_BREAKER_THRESHOLD` with comment: consecutive failed dispatches per issue+phase before parking; `0` disables; default `3`.
+- [ ] **Step 5:** `npm test` + `npm run typecheck` + explicit test-file typecheck. Commit.
+
+---
+
+### Task 2: Breaker admin surface (parked list + unpark)
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Modify: `src/admin.ts` (GET `/api/parked`, POST `/api/parked/unpark` — mirror the existing dedup-delete endpoint at ~line 332)
+- Modify: `src/admin-ui/pages/runners.ts` (parked banner + per-row Unpark button, `window.api()` calls)
+- Test: `src/__tests__/admin-parked.test.ts` (endpoint behavior over a seeded breaker table)
+
+**Parallel-safe with:** 3, 4, 5, 7–10 · **Blocked by:** Task 1 (module exists)
+
+**Rubric:** Pattern anchor: existing Runners page + `admin.ts` dedup endpoints. Test fixture: existing admin endpoint tests. Trust boundary: admin auth already gates `/api/*` — no new surface. Rollback: mechanical. Observability: n/a (it *is* the surface). Parallel-safety: `src/admin.ts` also touched by Task 6 → **Task 6 is blocked by Task 2** (serialized hotspot).
+
+Steps: failing endpoint test (GET returns seeded parked rows; POST unparks and re-poll dispatches) → implement endpoints calling `listParked`/`unpark` → banner UI (`registerPage` IIFE convention, `window.esc()` for issue ids) → tests/typecheck → commit.
+
+---
+
+### Task 3: Persist feedback-loop outputs (terminationReason) to step_log
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Modify: `src/run-autonomous.ts` (the feedback-loop step report; fix is expected here — diagnose first)
+- Test: extend `src/__tests__/run-autonomous.test.ts`
+
+**Parallel-safe with:** 1, 2, 4, 7, AII-276 · **Blocked by:** — (Task 9 is blocked by this — shared `run-autonomous.ts`)
+
+**Rubric:** Pattern anchor: the sub-step reporting in `feedback-loop.ts` (~line 276: outputs assigned before final `reporter.report`). Test fixture: existing run-autonomous tests with a stub reporter. Trust boundary: none. Rollback: mechanical. Observability: `SELECT json_extract(outputs_json,'$.terminationReason') FROM step_log WHERE step_type='feedback-loop'` non-null on new runs — this is the acceptance probe.
+
+Steps: **Diagnose** — on the deployed data every `feedback-loop` row has `outputs_json='{}'` even though `feedbackLoopStep.run()` returns `{approved, iterations, finalFeedback, terminationReason, passes}` (`feedback-loop.ts:391`); trace where run-autonomous reports that step and why outputs are dropped (likely the step is reported `running` and never re-reported with outputs, or outputs are attached after the final report). Write the failing test asserting the reporter received the outputs object on the terminal report → fix → cap `finalFeedback` at 4KB in the reported outputs (callback payload hygiene) → tests/typecheck → commit.
+
+---
+
+### Task 4: Merge-time review-escape capture
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no (new table only)
+
+**Files:**
+- Create: `src/merge-capture.ts`
+- Modify: `src/reconcile-merged.ts` (call after successful `markMerged`, ~line 37, best-effort)
+- Test: `src/__tests__/merge-capture.test.ts`
+
+**Parallel-safe with:** 1, 2, 3, 7, 8, 10, AII-276 · **Blocked by:** —
+
+**Rubric:** Pattern anchor: `src/github.ts` App-auth REST helpers; `run-autopsy.ts` best-effort style. Test fixture: mocked `fetchImpl` pattern from `linear-planning-fetch.ts` tests. Trust boundary: GitHub API reads with existing App token — no new grants. Rollback: capture is best-effort and additive; a failure logs and never blocks reconciliation. Observability: capture-rate visible in report card (rows vs merged PRs).
+
+- [ ] **Step 1: failing tests** — author bucketing and escape logic:
+
+```ts
+it("buckets commits: app bot=runner, *[bot]=bot, else human", () => { /* three-author fixture */ });
+it("escape=true when approved and post-approval human/bot commits exist", () => {});
+it("escape=false when approval absent (never-approved draft PR merged manually)", () => {});
+it("no approval timestamp → all commits counted, approval_ts null", () => {});
+it("markMerged flow continues when GitHub fetch throws", () => {});
+```
+
+- [ ] **Step 2: implement.** Table: `pr_merge_capture (repo TEXT, pr_number INTEGER, issue_id TEXT, merged_at INTEGER, approval_ts INTEGER, commits_runner INTEGER, commits_bot INTEGER, commits_human INTEGER, post_approval_lines INTEGER, findings_json TEXT DEFAULT '{}', review_escape INTEGER, captured_at INTEGER, PRIMARY KEY (repo, pr_number))`. `capturePrMerge({repo, prNumber, issueId})`: approval_ts = `MAX(ended_at)` of approved `review.N` rows joined via `dispatch_log` for the issue; GET `/repos/:repo/pulls/:n/commits` and `/reviews` + `/comments`; bucket by author login (App bot slug = runner, `endsWith("[bot]")` = bot, else human); findings_json = counts per source; `review_escape = approval_ts != null && (post-approval human+bot commits > 0 || external findings > 0)`.
+- [ ] **Step 3:** wire into `reconcile-merged.ts` inside a try/catch logging `[merge-capture]`. Tests/typecheck. Commit.
+
+---
+
+### Task 5: Report-card module + MCP tools
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Create: `src/report-card.ts`
+- Modify: `src/mcp.ts` (append two entries to the diagnostic tools array ~line 34–58; two cases in `callDiagnosticTool` ~line 73)
+- Test: `src/__tests__/report-card.test.ts`
+
+**Parallel-safe with:** 2, 7, 8, 9, 10 · **Blocked by:** Task 3 (reads feedback-loop outputs first-class), Task 4 (escape columns read `pr_merge_capture`)
+
+**Rubric:** Pattern anchor: `get_issue_dispatch_status` (`mcp.ts:118`) for tool shape; `scripts/baseline-report.sql` is the *specification* of the aggregations — port its TEMP-view logic (fb_loop preferred, substep fallback, fixture filter) to SQL-in-TS. Test fixture: seeded sqlite with three eras of rows (no-telemetry legacy, substep-only, full feedback-loop outputs) asserting identical numbers to the script's hand-checked results. Trust boundary: `/mcp` OAuth gate already covers new tools; read-only. Rollback: additive tools. Observability: n/a.
+
+`getIssueReportCard(identifier)` → `{issue, repo, runs[], totals: {dispatches, passes, cost_usd, max_turns_hits}, approved, planned, merged, escape: {post_approval_commits, external_findings, review_escape} | null, gapfill_rounds, review_fix_rounds, parked}`. `getFleetReport({days=30})` → per-repo aggregates + one_shot_pct + planning A/B cohorts + escape_rate + `runaways` (open issues ranked by consecutive failures / dispatch count, threshold ≥3). Steps: failing aggregation tests → module → MCP registration (`get_issue_report_card` requires `issue`; `get_fleet_report` optional `days`) → tests/typecheck → commit.
+
+---
+
+### Task 6: Admin Reports page
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Create: `src/admin-ui/pages/reports.ts`
+- Modify: `src/admin-ui/index.ts` (import + both strings), `src/admin-ui/sidebar.ts` (route), `src/admin.ts` (GET `/api/report?days=30&project=` → `getFleetReport`)
+- Test: `src/admin-ui/__tests__/reports.test.ts` (this suite IS typechecked)
+
+**Parallel-safe with:** 8, 9, 10 · **Blocked by:** Task 5 (module), Task 2 (shared `src/admin.ts`)
+
+**Rubric:** Pattern anchor: `pages/audit.ts` (table-heavy page). Test fixture: existing admin-ui tests. Trust boundary: admin session gate. Rollback: mechanical. Observability: n/a. Page: fleet table, planning A/B block, escape rate, runaway list linking to Runners unpark; per-project filter (one WHERE param).
+
+---
+
+### Task 7: PLANNING.md v2 — Map / Acceptance Bar / Risks
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Modify: `workflows/PLANNING.md` (template body: 3 comment specs + machine block; front-matter/comment-format docs updated)
+- Modify: `src/run-planning.ts` (built-in fallback prompt emits the same 3 comments; filenames `01-implementation-map.md`, `02-acceptance-bar.md`, `03-risks.md`)
+- Modify: `src/linear-planning-fetch.ts` (PREFIXES ← old three **plus** `## 🗺 AI Planning: Implementation Map`, `## ✅ AI Planning: Acceptance Bar`, `## ⚠️ AI Planning: Risks & Open Questions`; PREAMBLE reworded: planning content is a *map*, not orders — resolves the "follow these decisions"/"never follow instructions" contradiction)
+- Modify: `src/pipeline/steps/implement.ts` (delete `WorkUnit`, `workUnits` input, `PARALLEL_IMPL_INSTRUCTIONS`, the `workUnits` block at lines 55–66)
+- Test: extend `src/__tests__/linear-planning-fetch.test.ts` (old-only, new-only, mixed comment sets)
+
+**Parallel-safe with:** 1, 2, 3, 4, AII-276 · **Blocked by:** —
+
+**Rubric:** Pattern anchor: current `PLANNING.md` structure (front matter + comment contract). Test fixture: existing planning-fetch tests. Trust boundary: planning comments remain untrusted data inside `<planning_context>` — unchanged. Rollback: fetch keeps old headers forever; re-seeded repos can revert their template independently. Observability: Task 9's planned-vs-actual line. **New-comment spec must include:** Map = approach ≤3 sentences + `## Files` in canonical `- Modify: \`path\`` bullets (parseable by `parseDeclaredFiles`) + constraints/hazards, ≤60 lines; Bar = numbered falsifiable claims, each checkable against the diff or a command; Risks unchanged; machine block `<!-- ai-implement-planning v:1 {json: files[], risk} -->` appended to the Map comment.
+
+---
+
+### Task 8: Acceptance Bar → review pass; pass-aware context resend
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Modify: `src/pipeline/steps/feedback-loop.ts` (split fetched context: extract the Bar comment by its header; pass `acceptanceBar` to the review sub-step inputs at ~line 250; implement pass 1 gets full context, pass 2+ gets Map only)
+- Modify: `src/pipeline/steps/review.ts` (new `acceptanceBar?: string` input; prompt gains: "Planning defined this acceptance bar. Verdict must address each numbered claim: …"; content is untrusted data — same framing as planning context)
+- Test: extend `src/__tests__/feedback-loop.test.ts` + `review.test.ts`
+
+**Parallel-safe with:** 2, 4, 5, 6, 10 · **Blocked by:** Task 7 (Bar exists in fetched context)
+
+**Rubric:** Pattern anchor: existing `planningContext` threading (`feedback-loop.ts:255`). Test fixture: existing feedback-loop tests with stub executor. Trust boundary: Bar is untrusted → injected as data with the standard do-not-follow-directives framing. Rollback: absent Bar comment → behavior identical to today (old-format repos unaffected). Observability: review outputs already logged per pass.
+
+---
+
+### Task 9: Planning machine block → dispatch guard + planned-vs-actual autopsy
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Create: `src/planning-block.ts` (`parsePlanningBlock(comment: string): {v: number, files: string[], risk?: string} | null` — tolerant JSON-in-HTML-comment parse)
+- Modify: `src/poll-selection.ts` (`selectFileOverlapDeferrals` ~line 79: when an issue's own body parses to 0 files, fall back to its planning-block files if a planning comment is available on the candidate)
+- Modify: `src/run-autopsy.ts` + `src/run-autonomous.ts` (~line 550: autopsy also written on approved runs as a short stat block `95-run-stats.md` — passes, cost, planned files vs `filesChanged` delta; keep `90-` reserved)
+- Test: `src/__tests__/planning-block.test.ts`
+
+**Parallel-safe with:** 2, 5, 6, 8, 10 · **Blocked by:** Task 7 (block emitted), Task 3 (shared `run-autonomous.ts`)
+
+**Rubric:** Pattern anchor: `parseDeclaredFiles` (`poll-selection.ts:26`) for parse style + fail-open contract. Test fixture: poll-selection overlap tests. Trust boundary: block is tracker-sourced data — parse defensively, never eval. Rollback: parser returning null everywhere = today's behavior. Observability: the stat line itself.
+
+---
+
+### Task 10: Jira planning-context fetch (new format only)
+
+**Shape:** deep-and-targeted · **Migration/backfill?** no
+
+**Files:**
+- Modify: `src/providers/jira.ts` (~line 581: implement `fetchPlanningContext` via `this.client` comment fetch; collect the three v2 headers, newest per header, same 40KB cap + `<planning_context>` sanitization — extract the shared assembly from `linear-planning-fetch.ts` into `src/planning-context-assembly.ts` and reuse)
+- Create: `src/planning-context-assembly.ts` (header-select + cap + sanitize, shared by both providers)
+- Modify: `src/linear-planning-fetch.ts` (delegate assembly to the shared module)
+- Test: `src/__tests__/jira-planning-fetch.test.ts`
+
+**Parallel-safe with:** 2, 5, 6, 8, 9 · **Blocked by:** Task 7 · **Folds:** AII-167
+
+**Rubric:** Pattern anchor: `linear-planning-fetch.ts` (assembly contract, ADF-to-text via existing jira helpers). Test fixture: linear-planning-fetch tests. Trust boundary: same untrusted framing. Rollback: returns `""` on any error — today's behavior. Observability: planned cohort appears for Jira repos in fleet report.
+
+---
+
+### Task 11 (operator, no pipeline label): Re-seed + re-baseline
+
+**Files:** target repos' `PLANNING.md` (AI-Implement, skills, docs, sandbox) — manual PRs; then after ~30 planned runs, re-run `scripts/baseline-report.sql` and compare against this plan's frozen baseline.
+
+**Blocked by:** 7, 8, 9. Routing: operator (no `AI-Implement` label). Acceptance: four repos on v2 template; a dated comparison comment on the container project (beat 87% one-shot / 1.13 passes, or file the revision).
+
+---
+
+## Cross-sibling file-intersection audit (declared `## Files` parse)
+
+All tasks parse ≥1 file via the canonical bullets. Pairwise verdicts for tasks claiming parallel-safety:
+
+- 1 ∩ {3,4,7} = ∅ (index.ts vs run-autonomous/merge-capture/planning files) ✓
+- 3 ∩ 9 = **`src/run-autonomous.ts`** → 9 Blocked by 3 ✓ (serialized)
+- 2 ∩ 6 = **`src/admin.ts`** → 6 Blocked by 2 ✓ (serialized)
+- 7 ∩ 8 = ∅ (implement.ts vs feedback-loop/review.ts) — 8 blocked by 7 anyway ✓
+- 7 ∩ 10 = **`src/linear-planning-fetch.ts`** → 10 Blocked by 7 ✓ (already serialized)
+- 4 ∩ 5 = ∅ (merge-capture writes table; report-card reads via SQL only) — 5 blocked by 4 anyway ✓
+- 5 ∩ 6 = ∅ on files (report-card.ts vs admin files) — 6 blocked by 5 anyway ✓
+- AII-276 ∩ all = ∅ (post-push gate files: `src/pipeline/steps/post-push-review.ts` area) ✓
+
+## Waves
+
+- **Wave 1 (Todo + label):** 1, 3, 4, 7, AII-276 (revived)
+- **Wave 2 (Backlog → promote as blockers merge):** 2 (←1), 5 (←3,4), 8 (←7), 9 (←7,3), 10 (←7), 6 (←5,2)
+- **Operator:** 11 (←7,8,9)
+
+**Critical path:** 7 → 8/9 → 11 (re-baseline) and 3/4 → 5 → 6. Two chains of depth 3 — with Wave 1 running in parallel, minimum ~3 dispatch generations.
+
+## Self-review notes
+
+- Every design-doc decision maps to a task (breaker→1/2; report card→5/6; terminationReason→3; escape→4; planning→7/8/9/10; measurement gate→11; AII-276→revival).
+- No TBDs; naming consistent (`dispatch_breaker`, `pr_merge_capture`, `parsePlanningBlock`, `DISPATCH_BREAKER_THRESHOLD`).
+- Reconciliation actions (close/fold/link for AII-2/46/51/129/167/194/259 + BDS-32 comment) execute at filing time, not as tasks.

--- a/docs/plans/2026-08-23-campaign-reliability-improvements.md
+++ b/docs/plans/2026-08-23-campaign-reliability-improvements.md
@@ -1,0 +1,211 @@
+# Campaign Reliability Improvements
+
+**Date:** 2026-08-23
+**Status:** Proposed
+**Related:** Answer9 ANS-899 through ANS-910 field-link build-up/build-down
+
+## Context
+
+The Answer9 field-link campaign exposed reliability problems that sit in
+AI-Implement's orchestration layer, not in the field-link product design alone.
+The product decisions were well explored, but implementation runs were hard to
+observe, hard to recover exactly, and too willing to create or continue work
+after useful warning signs appeared.
+
+This document lists AI-Implement changes that would make the next multi-issue
+campaign easier to run down. It does not propose replacing the publication
+token model. The push step already refreshes runner GitHub credentials for
+Fly/local runs. The remaining work is to audit every external write path and
+make point-of-use credential refresh, failure classification, and reporting
+consistent across GitHub Actions, ticket callbacks, comments, and PR publication.
+
+## Evidence
+
+- `docs/pipeline-architecture.md` says `preflight` records verification but
+  does not gate `push`. It also says `verify` is skipped when there is no
+  repo-provided hook.
+- `docs/pipeline-architecture.md` says adding a pipeline step without an
+  `applyWiring()` case gives that step empty inputs with no hard failure.
+- `WORKFLOW.md` for AI-Implement warns that the pipeline records validation
+  after review but does not block PR creation on failures.
+- `WORKFLOW.md` also warns that normal `typecheck` excludes test files under
+  `src/__tests__`, so a green pair of repo commands can still miss new test-file
+  type errors.
+- `docs/feature-branch-grouping.md` documents fail-open branch resolution: a
+  GitHub error while creating a feature branch falls back to the repo base
+  branch.
+- `src/step-log.ts`, `src/dedup.ts`, and the existing dispatch, step, and runner
+  token tables already persist useful operational state. The gap is that these
+  records do not yet provide one inspectable recovery identity and branch map.
+- `src/pipeline/steps/push.ts` already refreshes runner GitHub credentials before
+  remote lookup, push, and PR creation, while `src/linear-app-auth.ts` renews
+  cached Linear app tokens early and retries one unauthorized response. The
+  campaign failures therefore point to inconsistent coverage and reporting
+  across publication paths, not an absent token-refresh mechanism.
+- The Answer9 campaign had repeated timeout/retry cycles, duplicate or
+  abandoned attempts, feature-branch conflicts after sibling PRs merged, and
+  late preview failures that were easier for a human to see than for the
+  orchestrator to diagnose from the run state.
+
+## Proposed Changes
+
+### 1. Promote existing logs into durable run checkpoints
+
+Build on `dispatch_log`, `step_log`, and `runner_tokens` so long implementation
+runs expose useful state before the final PR step. At minimum, each run should
+make these fields durable and available through the admin UI or MCP surface:
+
+- the exact repo, base branch, target branch, and commit it started from;
+- the issue identifier, run id, phase, and attempt number;
+- the current implementation summary or partial summary;
+- the declared files from the issue and the files actually changed so far;
+- the last known model result, including turn count and termination reason.
+
+Checkpoint enrichment should be best-effort and must not erase the records that
+already exist. If final publication fails, operators should still be able to see
+what branch and diff the run reached without reconstructing it from Actions logs.
+
+### 2. Make branch recovery exact
+
+Recovery paths should act on a concrete run record, not only an issue key.
+Retrying ANS-902-style work should require the orchestrator to know:
+
+- whether an existing PR branch belongs to this run, a prior attempt, or a
+  superseded sibling;
+- whether the branch base was the repo default branch or a feature branch;
+- whether the attempted PR was opened, closed, merged, or never created;
+- which dedup row, dispatch log row, and provider state transition belong
+  together.
+
+Duplicate prevention should keep one active attempt per issue and phase unless
+the operator explicitly forks a recovery attempt. Removing a dedup row should
+unblock dispatch, but it should not erase the last-run recovery context.
+
+### 3. Capture operational context for sibling work
+
+For a grouped campaign, the orchestrator should store a branch map that is easy
+to inspect:
+
+| Field | Purpose |
+|---|---|
+| Issue | The tracker issue that owns the branch or PR |
+| Parent | The feature-node or multi-issue parent, if any |
+| Base SHA | The commit the run started from |
+| Target branch | Where the PR is intended to merge |
+| Owned files | Parsed `## Files` entries from the issue or planning output |
+| Actual files | Diff files captured at checkpoint or push time |
+| State | active, superseded, open PR, merged, failed, parked |
+
+This map should be visible in the admin UI and available through an API so a
+build-down can answer "what is this branch based on?" without reading multiple
+GitHub Actions logs by hand.
+
+### 4. Make verification repo-aware and fail closed on zero checks
+
+The runner should not infer "no checks configured" from the repository root
+alone. The target repo should be able to publish a small verification manifest
+or hook that says how to validate the changed surface. For Answer9, the relevant
+commands live under `frontend-poc/`, `mcp-server/`, and `packages/mcp-bridge/`.
+
+If a repository declares a verification manifest or hook contract, a run that
+changes non-doc files and discovers zero applicable checks should fail closed
+with a clear message. AI-Implement may apply the same rule without a repo hook
+only when it can confidently classify the changed surface as code. A docs-only
+run can declare that explicitly; an unknown surface should be reported as
+unknown rather than silently treated as verified.
+
+### 5. Add feature-branch observability and governance
+
+Feature-branch grouping should surface its fail-open cases as first-class
+warnings. If branch creation, branch comparison, or ancestor resolution falls
+back to the repo base branch, the run should:
+
+- mark the issue with a visible warning;
+- include the intended and actual base branch in the run log;
+- avoid dispatching siblings that depend on the missing branch until an
+  operator decides whether to continue.
+
+This keeps "fail open" available for single issues while making grouped
+campaigns less likely to lose their branch topology silently.
+
+### 6. Add stop-the-line signals
+
+The orchestrator should park a campaign or issue after repeated evidence that
+the implementation loop is not making useful progress. Good stop signals:
+
+- two consecutive timeout or max-turn exits for the same issue;
+- a second recovery attempt that edits the same files without producing a PR;
+- a branch-base mismatch inside a feature-node tree;
+- zero verification checks for a code-changing run;
+- repeated publication failures after useful local work exists.
+
+The stop action should preserve context and tell the operator what to inspect:
+last run link, target branch, current diff status, relevant logs, and the
+recommended recovery choices.
+
+### 7. Make point-of-use credential handling consistent
+
+Audit every GitHub and Linear external-write path. Preserve the push step's
+existing point-of-use refresh behavior and extend the same discipline, where
+needed, to GitHub Actions publication, ticket callbacks, comments, and any path
+that still uses credentials captured earlier in a long run.
+
+Report credential vending and external-write failures separately from
+implementation success. "Code was produced but publication failed" is a
+different state from "the agent failed to implement the issue."
+
+## Implementation Anchors
+
+- `src/pipeline/steps/preflight.ts` — root-only command discovery and zero-check
+  behavior.
+- `src/pipeline/pipeline-loader.ts` — pipeline wiring and hard failure for
+  unsupported or unwired steps.
+- `src/pipeline/steps/push.ts` — current GitHub credential refresh, push, and PR
+  publication behavior.
+- `src/feature-branch.ts` — feature-branch selection and fallback behavior.
+- `src/dedup.ts` — dispatch, deduplication, recovery, and runner-token state.
+- `src/step-log.ts` and `src/runner-result.ts` — durable phase evidence and run
+  termination reporting.
+- `src/linear-app-auth.ts` — Linear app-token caching, renewal, and retry.
+- `src/admin-ui/pages/audit.ts` and `src/admin-ui/pages/pipelines.ts` — operator
+  surfaces for checkpoints, topology warnings, and recovery state.
+
+## Sequencing
+
+1. Add run checkpoints and exact branch recovery metadata.
+2. Add repo-aware verification manifests or hooks, then fail closed on zero
+   applicable checks for code changes.
+3. Add feature-branch observability for fallback-to-base and sibling branch
+   drift.
+4. Add stop-the-line parking for repeated timeouts, duplicate attempts, and
+   publication failures.
+5. Audit external-write credential paths and make their refresh and failure
+   reporting consistent.
+
+This order gives operators better evidence before changing dispatch behavior.
+
+## Acceptance Criteria
+
+- A timed-out run leaves a durable checkpoint that names the issue, attempt,
+  base branch, target branch, base SHA, changed files, and termination reason.
+- An operator can distinguish active, superseded, failed, and merged attempts
+  for the same issue without deleting dedup state.
+- A non-doc run covered by a declared verification contract cannot succeed with
+  zero applicable checks; an unclassified surface is reported explicitly.
+- A feature-node run that falls back to the repo base branch records a visible
+  warning before sibling dispatch continues.
+- Publication failure after implementation is reported as a publication state,
+  not as an implementation failure.
+- Existing tests for push-step token vending and Linear app-token caching keep
+  passing, and new tests cover every publication path whose credential behavior
+  changes.
+
+## Non-Goals
+
+- Do not replace the publication token model.
+- Do not block documentation-only runs on application test suites.
+- Do not require every target repo to use the same package manager or root
+  layout.
+- Do not remove feature-branch fail-open behavior for simple leaf issues.
+- Do not make AI-Implement decide product decomposition. It should expose
+  campaign health and enforce operational safety rails.


### PR DESCRIPTION
## Why

Three plan documents were written but never committed, so they existed in exactly one working tree with no backup. `docs/plans/` is already a tracked directory with four committed siblings — these just never made it in.

## What's here

**`2026-08-12-close-the-loop-design.md`** (60 lines) and **`2026-08-12-close-the-loop-plan.md`** (293 lines)

Record the frozen testing-orchestrator baseline — 87.0% one-shot approval, 95.1% eventual, 1.13 avg passes, $1.31 avg cost on the unplanned cohort; planning A/B showed no lift; retry storms at AII-253 (120 dispatches) and BDS-1/BDS-2 (35 dispatches, zero merges) — and the four rails measured against it:

1. Dispatch breaker (new `dispatch_breaker` table gating the poll)
2. Per-issue report card (compute-on-read aggregation, MCP + admin consumers)
3. Review-escape capture at `markMerged`
4. Planning-comment redesign (3-comment template, Acceptance Bar into the review pass)

Parts have already shipped — AII-374 sent the Acceptance Bar to the review pass, and the report-card MCP tool exists — so landing these gives shipped work its written rationale instead of leaving the baseline numbers undocumented.

**`2026-08-23-campaign-reliability-improvements.md`** (211 lines, Status: Proposed)

What the Answer9 ANS-899..910 field-link campaign exposed in AI-Implement's orchestration layer: runs were hard to observe, hard to recover exactly, and too willing to create or continue work.

## Review note

These are historical planning records, not proposals for this PR to ratify. The 2026-08-12 pair should be read as *what was decided then*; the 2026-08-23 doc is genuinely still open for discussion.

Documentation only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)