### PR TITLE
docs: land the local-first ADRs and the domain glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,55 @@
+# AI-Implement Glossary
+
+## Developer harness
+
+The developer harness runs AI-Implement against a live, bind-mounted checkout for maintainer testing. It can change that checkout and never publishes its changes.
+
+**Not to be confused with:** A local run, which uses an isolated copy and leaves the source checkout unchanged.
+
+## Local run
+
+A local run processes one Markdown task in an isolated copy of a clean local checkout. It returns local artifacts and does not require a tracker or GitHub App.
+
+**Not to be confused with:** The developer harness or GitHub publication.
+
+## Local artifact
+
+A local artifact is a reviewable result from a local run, including the patch, changed-file list, test summary, run summary, and logs.
+
+**Not to be confused with:** A GitHub branch or pull request.
+
+## Task document
+
+A task document is a Markdown file that states one product outcome, its acceptance criteria, and optional run limits. It contains no repository path, credential, publication setting, or queue dependency.
+
+**Not to be confused with:** A generated implementation plan or a tracker issue.
+
+## Demo run
+
+A demo run is a local run against the bundled disposable repository and task. It lets a user inspect AI-Implement without mounting a repository from the host.
+
+**Not to be confused with:** A local run against the user's own repository.
+
+## Managed run
+
+A managed run starts through the always-on orchestrator and reports its lifecycle through configured external services. It can publish a branch and pull request.
+
+**Not to be confused with:** A local run, which needs no orchestrator, tracker, or GitHub identity.
+
+## Selected repository
+
+The selected repository is the host Git repository that the user mounts read-only at `/repo` and names with `--repo /repo`. AI-Implement prints its resolved Git root before the run starts.
+
+**Not to be confused with:** The isolated working copy where the pipeline makes changes.
+
+## Local run success
+
+A local run succeeds only when the full plan, implement, test, review, and summary loop completes with approval. Starting or completing the Docker container is not enough.
+
+**Not to be confused with:** A partial run, which preserves artifacts but returns a nonzero exit code.
+
+## Trusted repository
+
+A trusted repository is source code that the user permits Claude Code to inspect, change in an isolated copy, and execute with network access. AI-Implement removes the model credential from setup and test processes that it starts, but commands started by Claude Code may inherit that credential.
+
+**Not to be confused with:** A sandbox for hostile code. The first local release does not provide that guarantee.

--- a/README.md
+++ b/README.md
@@ -360,9 +360,19 @@ custom/               Fork-local step/provider/pipeline overrides (see custom/RE
 scripts/              provision-client.sh (interactive onboarding for multi-tenant operators)
 session/              Entrypoint scripts for the Fly Machines runner image
 docs/                 Design notes, ADRs
+CONTEXT.md            Domain glossary — the terms the ADRs turn on (developer harness
+                      vs. local run, local artifact, task document, demo/managed run)
 .github/workflows/    deploy-clients.yml, sync-workflow.yml, build-runner.yml,
                       claude-review.yml
 ```
+
+## Vocabulary
+
+[`CONTEXT.md`](CONTEXT.md) is the domain glossary. It fixes the distinctions the
+architecture depends on — most importantly **developer harness** (bind-mounted live
+checkout, mutates it, never publishes) versus **local run** (isolated copy, source
+checkout untouched) — each with an explicit "not to be confused with". The ADRs in
+[`docs/adr/`](docs/adr/) are written in those terms.
 
 ## PR reviews
 

--- a/docs/adr/003-isolate-local-runs-from-source-checkouts.md
+++ b/docs/adr/003-isolate-local-runs-from-source-checkouts.md
@@ -1,7 +1,12 @@
-# 003. Isolate local runs from source checkouts
+# ADR 003: Isolate local runs from source checkouts
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Not yet integrated.** `src/local/workspace.ts` implements the isolated copy and `--include-dirty` opt-in, but has no callers outside its own test. The shipped `npm run dev:run` path (`src/dev-harness/index.ts`) sets `AI_IMPLEMENT_WORKSPACE_MODE=mounted` and bind-mounts the checkout **read-write**, mutating it in place — the developer-harness behaviour this ADR contrasts local runs against.
+
+---
 
 ## Context
 

--- a/docs/adr/003-isolate-local-runs-from-source-checkouts.md
+++ b/docs/adr/003-isolate-local-runs-from-source-checkouts.md
@@ -1,0 +1,30 @@
+# 003. Isolate local runs from source checkouts
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+AI-Implement already has a developer harness that bind-mounts a checkout into the runner. This design gives maintainers a fast loop for testing uncommitted hooks and workflow changes. It also lets the runner change the developer's files and Git index.
+
+The evaluator-facing local release has a different safety contract. A user must be able to inspect the result without risking changes to the selected checkout. The launcher must also avoid silently mixing unfinished local work into a generated patch.
+
+## Decision
+
+We keep two explicit workspace adapters.
+
+The developer harness keeps its live, bind-mounted workspace. A local run uses an isolated copy and leaves the source checkout unchanged.
+
+A local run accepts a clean checkout by default. If the checkout has local changes, the launcher stops before Docker starts. It lists the changed files and shows the exact `--include-dirty` command. That option copies tracked changes and non-ignored untracked files into the isolated workspace.
+
+## Alternatives considered
+
+- **Replace the developer harness with isolated execution** — rejected because maintainers need immediate access to uncommitted hook and workflow changes.
+- **Include local changes by default** — rejected because a run could silently include unfinished work or an untracked secret.
+- **Run directly in the source checkout** — rejected because the runner could change files, branches, or the Git index.
+
+## Consequences
+
+Local execution needs a workspace adapter boundary instead of one universal mount strategy. Tests must prove that local runs preserve the source checkout and that the developer harness keeps its current behavior.
+
+Users with local changes take one extra explicit action. In return, the default run is reproducible and safe to inspect.

--- a/docs/adr/004-use-one-runner-image-for-local-and-managed-runs.md
+++ b/docs/adr/004-use-one-runner-image-for-local-and-managed-runs.md
@@ -1,7 +1,12 @@
-# 004. Use one runner image for local and managed runs
+# ADR 004: Use one runner image for local and managed runs
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Partially integrated.** One runner image is shipped, as decided. The "explicit local command" the decision adds does not exist: there is no `local run` subcommand in `package.json`, the `Dockerfile`, or `session/entrypoint.sh`.
+
+---
 
 ## Context
 

--- a/docs/adr/004-use-one-runner-image-for-local-and-managed-runs.md
+++ b/docs/adr/004-use-one-runner-image-for-local-and-managed-runs.md
@@ -1,0 +1,30 @@
+# 004. Use one runner image for local and managed runs
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+The published runner image already contains the implementation pipeline, Claude Code, review loop, telemetry, and project detection. The local release needs the same behavior without a tracker, GitHub App, remote clone, push, or callback.
+
+A separate local image could provide a simpler entrypoint. It would also create a second release artifact that can drift from the managed execution path before the local product proves that it needs unique assets.
+
+## Decision
+
+We publish one runner image for local and managed runs when possible.
+
+The image gains an explicit local command. That command accepts a task document and an isolated local workspace. It does not require or fabricate GitHub inputs. The managed commands keep their current contracts.
+
+We add a separate image only when the local product needs enough unique assets to justify another release artifact.
+
+## Alternatives considered
+
+- **Publish a dedicated local image now** — rejected because two images can ship different pipeline, review, and telemetry behavior.
+- **Keep the current entrypoint and inject placeholder GitHub values** — rejected because the local path would appear GitHub-free while retaining hidden GitHub assumptions.
+- **Replace the managed image with a local-first image** — rejected because existing GitHub Actions and Fly execution must remain stable.
+
+## Consequences
+
+The runner entrypoint must select an explicit command before it validates mode-specific inputs. The local pipeline must structurally omit remote publication steps.
+
+Image tests must cover both local and managed commands. A local release cannot pass by weakening the existing managed-run contract.

--- a/docs/adr/005-run-the-full-ai-loop-in-local-mode.md
+++ b/docs/adr/005-run-the-full-ai-loop-in-local-mode.md
@@ -1,0 +1,28 @@
+# 005. Run the full AI loop in local mode
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+AI-Implement's value is not limited to generating a code change. The product maps the repository, states an acceptance bar and risks, implements the task, runs verification, reviews the result, and explains the outcome.
+
+The existing developer harness starts at implementation. Reusing that behavior without a visible planning result would make the evaluator-facing local release faster, but it would hide a central part of the product.
+
+## Decision
+
+Every local run executes the full loop: plan, implement, test, review, and summarize.
+
+The local runner saves the planning result with the run artifacts and continues automatically. The first release does not add a manual plan-approval gate. The terminal shows each phase and the final artifact path.
+
+## Alternatives considered
+
+- **Start at implementation** — rejected because the first trial would not demonstrate AI-Implement's planning value.
+- **Require manual plan approval** — rejected because it adds interaction before the local execution path proves itself.
+- **Run planning only for the demo** — rejected because the demo and user-repository paths would demonstrate different products.
+
+## Consequences
+
+A local run uses more time and model tokens than an implementation-only run. The demo must stay small enough to complete quickly.
+
+Tests and clean-room runs must measure time to the first planning result and the first diff. A failed planning phase must stop before implementation and preserve useful diagnostics.

--- a/docs/adr/005-run-the-full-ai-loop-in-local-mode.md
+++ b/docs/adr/005-run-the-full-ai-loop-in-local-mode.md
@@ -1,7 +1,12 @@
-# 005. Run the full AI loop in local mode
+# ADR 005: Run the full AI loop in local mode
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Integrated.** `src/local/full-loop.ts`, reached through `session/entrypoint.sh` (`RUNNER_ENTRY="run-local-full-loop.js"` under the `full` mode).
+
+---
 
 ## Context
 

--- a/docs/adr/006-keep-local-run-telemetry-on-device.md
+++ b/docs/adr/006-keep-local-run-telemetry-on-device.md
@@ -1,0 +1,28 @@
+# 006. Keep local run telemetry on device
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+The local release can measure phase timing, completion, model usage, and failure codes. Sending these events to a remote service would help measure the onboarding funnel.
+
+The same release asks a new user to mount source code and provide a model credential. Remote telemetry before the product proves value creates another trust decision and another network failure mode.
+
+## Decision
+
+The first local release sends no product telemetry to a remote service.
+
+It writes phase timing, outcome, token and cost summaries, and failure codes into the local run artifacts. It does not record credentials or repository content in telemetry fields.
+
+## Alternatives considered
+
+- **Send anonymous funnel events by default** — rejected because the user has not yet established trust in the product.
+- **Send events only for the bundled demo** — rejected because the demo must not carry a hidden network behavior that normal local runs do not have.
+- **Remove telemetry entirely** — rejected because local diagnostics and clean-room evaluation need structured evidence.
+
+## Consequences
+
+The team cannot measure real-world local onboarding centrally in the first release. Evaluators must choose to share artifacts or study results.
+
+A later release can add explicit, informed telemetry consent without changing the local artifact contract.

--- a/docs/adr/006-keep-local-run-telemetry-on-device.md
+++ b/docs/adr/006-keep-local-run-telemetry-on-device.md
@@ -1,7 +1,12 @@
-# 006. Keep local run telemetry on device
+# ADR 006: Keep local run telemetry on device
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Not yet integrated.** `writeRunArtifacts` in `src/local/artifacts.ts` carries the on-device telemetry fields this ADR specifies, but has no callers outside its own test.
+
+---
 
 ## Context
 

--- a/docs/adr/007-make-local-repository-selection-explicit.md
+++ b/docs/adr/007-make-local-repository-selection-explicit.md
@@ -1,0 +1,44 @@
+# 007. Make local repository selection explicit
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+Docker cannot use a host path unless the user mounts that path into the container. Inferring a repository from the current directory would hide this boundary and make it harder to run AI-Implement against another repository.
+
+The local release must make the selected repository obvious before any model work starts.
+
+## Decision
+
+The quickstart names the host repository path and mounts it at `/repo`. The local command also receives `--repo /repo`. The task document does not contain the repository path.
+
+The documented command uses this shape:
+
+```sh
+REPO=/path/to/repository
+TASK=/path/to/task.md
+
+docker run --rm -it \
+  -v "$REPO:/repo:ro" \
+  -v "$TASK:/task.md:ro" \
+  -v "$HOME/.ai-implement:/output" \
+  ghcr.io/builddownai/ai-implement-runner:latest local run --repo /repo --task /task.md
+```
+
+The launcher resolves the Git root from `/repo`, validates it, and prints the selected repository before it starts the run. The launcher then creates an isolated working copy. It does not change the mounted checkout.
+
+The repository also publishes a small convenience wrapper. It accepts host paths such as `--repo /path/to/repository` and `--task /path/to/task.md`, creates the required Docker mounts, and invokes the same container command. The wrapper is optional. It requires no installation and contains no pipeline logic.
+
+## Alternatives considered
+
+- **Infer the repository from the host current directory** — rejected because the container cannot see that directory without a mount, and the selected repository would be less obvious.
+- **Put the repository path in the task document** — rejected because task intent should be portable across machines and repositories.
+- **Clone from a GitHub URL** — rejected because the local release must work without GitHub credentials or a GitHub App.
+- **Put local-run behavior in the wrapper** — rejected because direct Docker use and wrapper use must have the same tested behavior.
+
+## Consequences
+
+The direct Docker command makes the host-to-container boundary explicit and works with any local Git repository. The wrapper gives users a shorter command without creating a second execution path.
+
+The project must test that the wrapper produces the documented Docker invocation.

--- a/docs/adr/007-make-local-repository-selection-explicit.md
+++ b/docs/adr/007-make-local-repository-selection-explicit.md
@@ -1,7 +1,12 @@
-# 007. Make local repository selection explicit
+# ADR 007: Make local repository selection explicit
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Not yet integrated.** `resolveRepository` in `src/local/workspace.ts` has no callers outside its own test, and the `local run --repo … --task …` invocation shown below is not runnable today — no such subcommand exists.
+
+---
 
 ## Context
 

--- a/docs/adr/008-preserve-artifacts-and-fail-clearly.md
+++ b/docs/adr/008-preserve-artifacts-and-fail-clearly.md
@@ -1,7 +1,12 @@
-# 008. Preserve artifacts and fail clearly
+# ADR 008: Preserve artifacts and fail clearly
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Not yet integrated.** The exit-code and artifact-retention behaviour lives in `src/local/artifacts.ts`, which has no callers outside its own test.
+
+---
 
 ## Context
 

--- a/docs/adr/008-preserve-artifacts-and-fail-clearly.md
+++ b/docs/adr/008-preserve-artifacts-and-fail-clearly.md
@@ -1,0 +1,26 @@
+# 008. Preserve artifacts and fail clearly
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+A local run can fail during planning, implementation, testing, or review. It can also reach a turn or iteration limit without approval. A zero exit code would hide these outcomes from scripts and evaluators. Automatic cleanup would remove the evidence needed to understand them.
+
+## Decision
+
+A failed, unapproved, or capped local run returns a nonzero exit code. It preserves all available artifacts and prints the outcome, the next repair action, and the absolute artifact path.
+
+Version one keeps every run until the user explicitly removes it by run ID. It performs no automatic pruning.
+
+## Alternatives considered
+
+- **Return zero when the container ran successfully** — rejected because container completion is not pipeline success.
+- **Delete failed-run artifacts** — rejected because failures need more evidence than successful runs.
+- **Prune old runs automatically** — rejected because an implicit retention policy can destroy evidence that the user still needs.
+
+## Consequences
+
+Shell scripts and clean-machine tests can trust the command exit code. Users can inspect partial work after any failure.
+
+The artifact directory can grow until the user runs the explicit cleanup command.

--- a/docs/adr/009-hide-model-credentials-from-repository-commands.md
+++ b/docs/adr/009-hide-model-credentials-from-repository-commands.md
@@ -1,0 +1,34 @@
+# 009. Limit model credential exposure in trusted repositories
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+The current runner passes its process environment to repository setup and verification hooks. That environment can contain `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. A repository command could read or transmit the model credential.
+
+Claude Code also receives the credential and can start shell commands. Anthropic does not document a supported way to guarantee that these child commands cannot access the credential. The first local release cannot honestly claim isolation from hostile repository code without a different credential-broker and command-sandbox design.
+
+Local runs need network access for the model provider and, when required, package registries. Removing all network access would prevent common setup and test workflows.
+
+## Decision
+
+The first local release supports trusted repositories and trusted task documents only. The quickstart states this boundary before the first run.
+
+AI-Implement removes the model credential from repository setup, test, verification, and teardown processes that it starts directly. Claude Code receives the credential. Commands started by Claude Code may inherit it.
+
+Repository commands keep normal container network access in version one. The container receives no host Docker socket and no GitHub credential. The selected repository mount is read-only, and all modifications happen in the isolated working copy.
+
+## Alternatives considered
+
+- **Pass the full runner environment to every AI-Implement child process** — rejected because setup and test code do not need the model credential.
+- **Disable container networking** — rejected because the model call and common dependency installation need network access.
+- **Give the container a GitHub token for future publication** — rejected because publication is outside the local release.
+- **Claim isolation from hostile repository code** — rejected because the current Claude Code process model cannot support that guarantee.
+- **Build a credential broker and command sandbox now** — deferred because it materially expands the local release and needs a separate security design.
+
+## Consequences
+
+The runner needs separate environment builders for the model process and AI-Implement-owned repository commands. Tests must prove that setup, test, verification, and teardown processes started by AI-Implement cannot read either supported model credential.
+
+Users must treat repository code and task documents as trusted, network-capable inputs. The quickstart and security notes must state this boundary.

--- a/docs/adr/009-limit-model-credential-exposure.md
+++ b/docs/adr/009-limit-model-credential-exposure.md
@@ -1,7 +1,12 @@
-# 009. Limit model credential exposure in trusted repositories
+# ADR 009: Limit model credential exposure in trusted repositories
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Not yet integrated.** No credential-stripping logic exists in `src/`. `src/dev-harness/index.ts` passes `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` straight into the container environment. **The exposure limit described here is not a guarantee that holds today.**
+
+---
 
 ## Context
 

--- a/docs/adr/010-use-a-minimal-portable-task-document.md
+++ b/docs/adr/010-use-a-minimal-portable-task-document.md
@@ -1,0 +1,30 @@
+# 010. Use a minimal portable task document
+
+**Status:** Accepted
+**Date:** 2026-08-18
+
+## Context
+
+The local release needs one task format for the command-line runner, examples, validation, and agent-assisted authoring. The existing developer harness format includes fields that describe its own execution environment. Those fields would couple task intent to one machine or publication workflow.
+
+## Decision
+
+A task document is Markdown with YAML front matter. `title` is the only required metadata field. Optional metadata can set a stable `id`, a base revision, named profiles, and run limits. The Markdown body describes the work and its acceptance criteria.
+
+The document does not contain a repository path, credentials, publication settings, or queue dependencies.
+
+The runner owns the schema and validator. The repository includes a portable task-authoring skill that calls the real validator. Installation of that skill is optional and manual. The local command does not install or change agent tools.
+
+The developer harness keeps a compatibility adapter for its current task fields.
+
+## Alternatives considered
+
+- **Reuse every developer harness field** — rejected because fields such as `repo` and `branch` mix task intent with execution context.
+- **Require a tracker-shaped document** — rejected because local evaluation should not require tracker concepts.
+- **Install the authoring skill automatically** — rejected because a Docker run should not change host agent configuration.
+
+## Consequences
+
+Users can write a task by hand, copy an example, or use the optional skill. All paths use the same validator and error messages.
+
+The compatibility adapter adds a small maintenance cost until the developer harness adopts the shared schema.

--- a/docs/adr/010-use-a-minimal-portable-task-document.md
+++ b/docs/adr/010-use-a-minimal-portable-task-document.md
@@ -1,7 +1,12 @@
-# 010. Use a minimal portable task document
+# ADR 010: Use a minimal portable task document
 
 **Status:** Accepted
+
 **Date:** 2026-08-18
+
+**Implementation status (verified 2026-08-24, branch `testing`):** **Integrated**, except the optional task-authoring skill. `src/task-document.ts` owns the schema and validator; `src/dev-harness/task-file.ts` is the compatibility adapter this ADR calls for.
+
+---
 
 ## Context
 


### PR DESCRIPTION
## Why

Eight ADRs and a domain glossary were written during the local-first onboarding work (branch `codex/local-first-onboarding`) and never committed. They lived as untracked files in one worktree; no PR was ever opened.

**These record a design direction. Most of it is not wired up.** An earlier version of this description said the work "has since shipped" — that was wrong, and review caught it. Every ADR now carries a dated **Implementation status** field stating exactly what is and is not integrated, verified against `testing`:

| ADR | Status |
|---|---|
| 003 · isolate local runs from source checkouts | **Not integrated** — `src/local/workspace.ts` has no callers outside its test; shipped `dev:run` bind-mounts **read-write** |
| 004 · one runner image for local and managed runs | **Partial** — one image yes; the "explicit local command" does not exist |
| 005 · run the full AI loop in local mode | **Integrated** — `src/local/full-loop.ts` via `session/entrypoint.sh` |
| 006 · keep local run telemetry on device | **Not integrated** — `writeRunArtifacts` has no callers |
| 007 · make local repository selection explicit | **Not integrated** — the `local run --repo …` invocation shown is not runnable |
| 008 · preserve artifacts and fail clearly | **Not integrated** — same module |
| 009 · limit model credential exposure | **Not integrated** — no stripping logic exists; **not a guarantee that holds today** |
| 010 · use a minimal portable task document | **Integrated** except the optional authoring skill |

Landing them with honest status is still worth it: the decisions were made and reasoned, and 005/010 are live code today with no recorded rationale. But nothing here should be read as a safety guarantee — particularly 003 and 009.

## Renumbering

The originals were drafted as **002–009**, before `002-admin-ui-html-escaping.md` landed on testing, so they would collide at 002. Landed here as **003–010**:

| Original | Here |
|---|---|
| 002 | 003 · isolate local runs from source checkouts |
| 003 | 004 · use one runner image for local and managed runs |
| 004 | 005 · run the full AI loop in local mode |
| 005 | 006 · keep local run telemetry on device |
| 006 | 007 · make local repository selection explicit |
| 007 | 008 · preserve artifacts and fail clearly |
| 008 | 009 · limit model credential exposure |
| 009 | 010 · use a minimal portable task document |

No ADR cross-references any other by number (verified by grep), so the renumber is mechanical. 009's filename was also corrected to match its own title.

## Convention

The new ADRs are harmonised onto the `# ADR NNN: Title` heading and `---` separator used by the committed 001 and 002, so `docs/adr/` has one template rather than two competing ones.

## `CONTEXT.md`

The domain glossary these ADRs are written in terms of, each entry with an explicit "not to be confused with":

- **developer harness** (bind-mounted live checkout, mutates it, never publishes) vs. **local run** (isolated copy, source untouched)
- **local artifact** vs. a GitHub branch/PR
- **task document** vs. a generated plan or tracker issue
- **demo run** vs. a local run against your own repo
- **managed run** vs. everything needing no orchestrator, tracker, or GitHub identity

That first distinction is exactly the one ADR 003 turns on, and exactly the one the shipped code does not yet honour — which is why it's worth writing down. Now linked from README (a Vocabulary section plus the layout tree); it was a new root-level file with no inbound link.

Documentation only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)