### PR TITLE
AII-430: refuse planning dispatch when the runner callback path is unconfigured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,12 +84,15 @@ CLAUDE_CODE_OAUTH_TOKEN=
 # orchestrator (e.g. https://your-orchestrator.fly.dev). This is not Fly-specific:
 # Fly Machines, GitHub Actions, and local Docker all report through it, and the
 # GHA path receives it as a workflow input rather than an environment variable.
-# Without this and RUNNER_TOKEN_SECRET, runner-callback features are disabled —
-# most visibly, a planning run never reports completion and the issue stalls.
+# Without this and RUNNER_TOKEN_SECRET, runner-callback features are disabled.
+# Planning dispatch is refused outright when either is missing (AII-430): a
+# planning run that cannot report never reaches Plan-Complete, and planning
+# carries no dedup entry, so the issue would re-dispatch every poll forever.
 # Local dev (`npm run dev:local`, RUNNER_MODE=local) defaults this to
 # http://host.docker.internal:$PORT automatically — leave it blank there.
 RUNNER_CALLBACK_BASE_URL=
-# Shared secret used to sign/verify runner callback tokens (HMAC).
+# Shared secret used to sign/verify runner callback tokens (HMAC). Unlike the
+# base URL above, this has no local-dev default — planning is refused without it.
 RUNNER_TOKEN_SECRET=
 
 # Shared secret for the /api/gap-fill-trigger endpoint that the comment-trigger

--- a/src/__tests__/planning-callback-guard.test.ts
+++ b/src/__tests__/planning-callback-guard.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { planningDispatchBlockReason } from "../runner-callback.js";
+
+const URL = "https://orchestrator.example.com";
+const SECRET = "a-secret";
+
+describe("planningDispatchBlockReason", () => {
+  it("allows the dispatch when both the callback URL and the token secret are set", () => {
+    expect(
+      planningDispatchBlockReason({ runnerCallbackBaseUrl: URL, runnerTokenSecret: SECRET }),
+    ).toBeNull();
+  });
+
+  it("blocks and names the variable when the callback base URL is missing", () => {
+    const reason = planningDispatchBlockReason({
+      runnerCallbackBaseUrl: null,
+      runnerTokenSecret: SECRET,
+    });
+    expect(reason).toMatch(/RUNNER_CALLBACK_BASE_URL/);
+    expect(reason).not.toMatch(/RUNNER_TOKEN_SECRET/);
+  });
+
+  it("blocks and names the variable when the token secret is missing", () => {
+    const reason = planningDispatchBlockReason({
+      runnerCallbackBaseUrl: URL,
+      runnerTokenSecret: null,
+    });
+    expect(reason).toMatch(/RUNNER_TOKEN_SECRET/);
+    expect(reason).not.toMatch(/RUNNER_CALLBACK_BASE_URL/);
+  });
+
+  it("names both variables when neither is set", () => {
+    const reason = planningDispatchBlockReason({
+      runnerCallbackBaseUrl: null,
+      runnerTokenSecret: null,
+    });
+    expect(reason).toMatch(/RUNNER_CALLBACK_BASE_URL and RUNNER_TOKEN_SECRET/);
+  });
+
+  // An empty string is what the dispatch path actually produces when the env var
+  // is present but blank, so it must block rather than read as configured.
+  it("treats an empty string as missing", () => {
+    expect(
+      planningDispatchBlockReason({ runnerCallbackBaseUrl: "", runnerTokenSecret: SECRET }),
+    ).toMatch(/RUNNER_CALLBACK_BASE_URL/);
+    expect(
+      planningDispatchBlockReason({ runnerCallbackBaseUrl: URL, runnerTokenSecret: "" }),
+    ).toMatch(/RUNNER_TOKEN_SECRET/);
+  });
+
+  it("explains why the dispatch is refused, not just that it was", () => {
+    const reason = planningDispatchBlockReason({
+      runnerCallbackBaseUrl: null,
+      runnerTokenSecret: null,
+    });
+    expect(reason).toMatch(/Plan-Complete/);
+    expect(reason).toMatch(/every poll/);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ import { runReconciliations } from "./reconcile-merged.js";
 import { resolveSessionImage, resolveDefaultRunnerImage, resolveRunnerImageForDispatch, type SessionImageStatus } from "./repo-image.js";
 import { getStepRecord, initStepLogTable } from "./step-log.js";
 import { getOrchestratorSettings } from "./orchestrator-settings.js";
-import { handleRunnerPlanningContext, handleRunnerProgress, handleRunnerResult } from "./runner-callback.js";
+import { handleRunnerPlanningContext, handleRunnerProgress, handleRunnerResult, planningDispatchBlockReason } from "./runner-callback.js";
 import type { RunnerProgressBody, RunnerResultBody } from "./runner-callback.js";
 import { mintRunToken, PLANNING_TTL_SECONDS, IMPLEMENTATION_TTL_SECONDS } from "./runner-tokens.js";
 import { handleGapFillTrigger } from "./gap-fill-trigger.js";
@@ -969,6 +969,17 @@ async function dispatchPlanning(
   if (!planningEligibility.eligible) {
     console.log(
       `[poll] Skipping planning for ${issue.identifier}: forced runner mode "${runnerMode}" but team ${issue.scopeKey} is ineligible — ${planningEligibility.reason}`,
+    );
+    return;
+  }
+
+  // AII-430: every planning execution path (GHA, Fly, local Docker) advances the
+  // ticket through the runner callback. Without it the run cannot report, the
+  // label never reaches Plan-Complete, and planning re-dispatches every poll.
+  const callbackBlockReason = planningDispatchBlockReason(config);
+  if (callbackBlockReason) {
+    console.error(
+      `[poll] Refusing to dispatch planning for ${issue.identifier}: ${callbackBlockReason}`,
     );
     return;
   }

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -10,6 +10,47 @@ import { renderClassification, TROUBLESHOOTING_URL, type Classification } from "
 
 export type RunnerPhase = "planning" | "implementation" | "gap-analysis";
 
+/**
+ * AII-430: planning depends entirely on the runner callback to advance.
+ *
+ * The runner posts the plan through /runner/result, and that is what moves the
+ * ticket to Plan-Complete. Without the callback the plan is dropped, the label
+ * never advances, and the issue is eligible for planning again on the next
+ * poll — a full Claude planning run burned every cycle, forever.
+ *
+ * Three things that normally bound a retry loop all miss this case:
+ *   - Planning deliberately never writes to the dedup table (`dispatchSession`
+ *     is called with `doMarkDispatched: false`), so the label is the only brake.
+ *   - The dispatch breaker scores it a *success*: a run that cannot report
+ *     still exits 0, so `recordDispatchSuccess` resets the counter each cycle.
+ *   - Boot only warns that the callback path is disabled, then carries on.
+ *
+ * `resolveRunnerCallbackBaseUrl` already defaults the URL under
+ * RUNNER_MODE=local, so in practice the secret is the half most likely to be
+ * missing — but both are checked, since an explicit-URL deployment that omits
+ * the secret lands in the same loop.
+ *
+ * Returns a human-readable reason to refuse the dispatch, or null when the
+ * callback path is configured.
+ */
+export function planningDispatchBlockReason(config: {
+  runnerCallbackBaseUrl: string | null;
+  runnerTokenSecret: string | null;
+}): string | null {
+  const missing = [
+    config.runnerCallbackBaseUrl ? null : "RUNNER_CALLBACK_BASE_URL",
+    config.runnerTokenSecret ? null : "RUNNER_TOKEN_SECRET",
+  ].filter((name): name is string => name !== null);
+
+  if (missing.length === 0) return null;
+
+  return (
+    `planning needs the runner callback to post the plan and set Plan-Complete, `
+    + `but the callback path is disabled (${missing.join(" and ")} not set) — `
+    + `dispatching would re-run planning every poll without ever advancing the issue`
+  );
+}
+
 export interface RunnerResultBody {
   phase: RunnerPhase;
   outcome: "success" | "failure";


### PR DESCRIPTION
Closes AII-430 · https://linear.app/eudoxus/issue/AII-430

## The bug

Planning depends entirely on the runner callback to advance: the runner posts the plan through `/runner/result`, and that is what moves the ticket to `Plan-Complete`. With `RUNNER_CALLBACK_BASE_URL` or `RUNNER_TOKEN_SECRET` unset, `dispatchPlanning` dispatched anyway. The run completed, the plan was dropped, the label never advanced, and the issue was eligible again on the next poll.

**A full Claude planning run, every 60 seconds, indefinitely.** Nothing counted it and nothing notified.

## Why nothing caught it

Three mechanisms that normally bound a retry loop each miss this case, for different reasons:

1. **Planning deliberately carries no dedup entry.** `dispatchSession` is called with `doMarkDispatched: false`, and two comments in `dispatchPlanning` say so outright — *"Intentionally do NOT call markDispatched() — dedup table stays clear."* The label is the only brake, and the label is exactly what the missing callback would have moved. The poll skip test (`src/index.ts:481`) is `isAlreadyDispatched || inFlightIssueIds.has || isParked`: the first is never set for planning, the second clears the moment the job goes terminal.

2. **The dispatch breaker scores it as a _success_.** `src/index.ts:2433` — `if (job.status === "completed") recordDispatchSuccess(...)`. A planning run that cannot report still **exits 0**: the job succeeded, the agent just had nowhere to send the plan. So every cycle *resets the consecutive-failure counter to zero*. The breaker counts failed jobs; this is a successful job with a dropped result, which is a shape it cannot see.

3. **Boot only warns.** `console.warn("[main] runner callback path disabled…")`, then carries on.

## Prior partial fix

This was already rediscovered once. `resolveRunnerCallbackBaseUrl` (`src/runner-mode.ts:133`) carries the docstring: *"Without it, planning runs complete but can never report results, so the orchestrator re-dispatches planning forever."*

That fix defaults the **URL** under `RUNNER_MODE=local` — one half of one case. `runnerTokenSecret` has no default at all (`process.env.RUNNER_TOKEN_SECRET || null`, `src/index.ts:184`), so an explicit-URL deployment that omits the secret lands in the same loop. This checks both halves.

## The change

- **`src/runner-callback.ts`** — new `planningDispatchBlockReason(config)`. Pure predicate over two nullable strings, no I/O, returns a reason string or `null`. The message names the missing variable(s) so the operator doesn't have to infer them, and states the consequence.
- **`src/index.ts`** — called early in `dispatchPlanning`, after the `planningWorkflowFile` and AII-306 eligibility guards and **before** any work is done (before `buildPlanningContextInputs`, which makes tracker calls). Matches the sibling guards' log-and-return style; `console.error` + `return`, no throw.
- **`.env.example`** — both variables now state the consequence, and `RUNNER_TOKEN_SECRET` notes it has no local-dev default unlike the base URL.

## Testing

- 6 new cases: both set → allowed; each missing alone (asserting the *other* variable is **not** named); both missing; empty strings — which is what the dispatch path actually produces from a blank env var, so it must block rather than read as configured; and that the reason explains the consequence, not just the fact.
- **Full suite: 169 files / 3249 tests pass.**
- `npx tsc --noEmit` clean.
- The new test file was **type-checked explicitly** with a throwaway tsconfig, since `typecheck` excludes `src/__tests__` and vitest strips types without checking them.

## Behaviour change worth flagging

An orchestrator running today without the callback config will stop dispatching planning instead of looping. That is the intent — but if any deployment is somehow relying on planning dispatch succeeding without a callback, it will now see `[poll] Refusing to dispatch planning for …` in the logs rather than silent churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)