### PR TITLE
Docs: adopt the diagram convention (mermaid flows, tables for data, ASCII only in CLAUDE.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,8 @@ Entry points for areas that are easy to miss. Each names the module to start fro
 | Admin SSO / OIDC | `src/oauth/`, `src/admin-session.ts` | |
 | Admin SPA | `src/admin-ui/` | |
 
+**Diagram convention:** flow diagrams in `docs/`, issue bodies, and PR descriptions are mermaid (validated with `mermaid-cli` before commit); tabular data is a table; ASCII only in this file. Full rule: [docs/README.md](docs/README.md).
+
 ## Running locally
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,21 @@ Two tiers, distinguished by what a file *is* rather than what it covers.
 
 Two references live outside this directory because they are consumed directly rather than read: `.env.example` is the canonical list of orchestrator environment variables, and `CLAUDE.md` is the index that points at everything here.
 
+## Diagram conventions
+
+Adopted 2026-08-24 (from the AII-424 / PR #327 review):
+
+- **Flow diagrams in rendered markdown use mermaid** (```` ```mermaid ```` blocks). GitHub,
+  Linear, and the Mintlify docs site all render it natively — the same source draws everywhere.
+- **Validate before committing:** `npx -y @mermaid-js/mermaid-cli -i <file>.mmd -o /tmp/out.svg`.
+  A mermaid syntax error renders as an error box, which is worse than ASCII art.
+- **Tabular data uses markdown tables**, never a diagram — if the content is rows and columns
+  wearing box art, it is a table.
+- **ASCII diagrams are reserved for agent-context files** (`CLAUDE.md`), which are consumed as
+  raw text every invocation. Everywhere a human sees rendered markdown, mermaid wins.
+
+This applies to `docs/`, tracker issue bodies, and PR descriptions alike.
+
 ## Typed artifacts
 
 | Directory | Contents |


### PR DESCRIPTION
Follow-up to #327. The rule, stated once in `docs/README.md` (new **Diagram conventions** section) with a one-line pointer in `CLAUDE.md` so agents writing issues and PR bodies see it every invocation:

- Flow diagrams in rendered markdown → mermaid, validated with `mermaid-cli` before commit
- Tabular data → markdown tables, never box art
- ASCII reserved for agent-context files (`CLAUDE.md`)
- Applies to `docs/`, tracker issue bodies, and PR descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)