### PR TITLE
feat: DB-backed SSO allowlist with an admin Access page (AII-339)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,12 @@ MICROSOFT_OAUTH_TENANT=
 
 # Authorization allowlist (fail-closed) — a verified email must match one of these
 # to be admitted. Comma-separated. Empty = deny everyone (SSO effectively locked out).
+#
+# These SEED the allowlist rather than being it. They apply while nothing is stored;
+# the first save on /admin#access hands authority to the database permanently, and
+# from then on these are shown on that page as stale and never consulted again.
+# A domain admits as `user`; only a listed address can be `admin`.
+# Full reference: docs/access-model.md
 OAUTH_ALLOWED_DOMAINS=your-company.com
 OAUTH_ALLOWED_EMAILS=
 
@@ -171,7 +177,14 @@ MCP_ACCESS_TOKEN_TTL=
 # =============================================================================
 
 PORT=8080
+
+# The orchestrator's single scheduling clock. One tick drives dispatch, monitoring, the reaper,
+# merge-ups, reconciliation and the self-deploy check, and periodic behaviour elsewhere derives
+# from this value rather than keeping its own timer — including how long the sign-in allowlist
+# may serve from memory before re-reading, which is what lets the recovery command take effect
+# without a restart. Lowering it raises tracker API traffic proportionally.
 POLL_INTERVAL_MS=60000
+
 DEDUP_DB_PATH=./dedup.sqlite
 
 # Used as the tenant id in multi-client deploys (falls back to FLY_APP_NAME).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Entry points for areas that are easy to miss. Each names the module to start fro
 | Stuck-run recovery | `src/reaper.ts`, `src/stuck-watchdog.ts` | |
 | Per-team dispatch capacity | `src/poll-selection.ts` | |
 | Run classification and autopsy | `src/completion-classification.ts`, `src/run-autopsy.ts` | |
-| Admin SSO / OIDC | `src/oauth/`, `src/admin-session.ts` | |
+| Admin SSO / OIDC, sign-in allowlist | `src/oauth/`, `src/admin-session.ts`, `src/access-entries.ts` | [docs/access-model.md](docs/access-model.md) |
 | Admin SPA | `src/admin-ui/` | |
 
 **Diagram convention:** flow diagrams in `docs/`, issue bodies, and PR descriptions are mermaid (validated with `mermaid-cli` before commit); tabular data is a table; ASCII only in this file. Full rule: [docs/README.md](docs/README.md).
@@ -162,7 +162,7 @@ Only the non-obvious ones are worth restating:
 
 - `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` — the only pair that throws at boot when absent. Everything else warns and degrades a feature.
 - `RUNNER_CALLBACK_BASE_URL` + `RUNNER_TOKEN_SECRET` — **not Fly-specific.** All three execution modes report through them; the GHA path receives the URL as a workflow input rather than an env var. Without them a planning run never reports completion and the issue stalls.
-- `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` — fail-closed. Empty means deny everyone.
+- `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` — fail-closed, and a **seed rather than the list**: they apply until the first save at `/admin#access`, then go inert while the stored list has entries. Empty and nothing stored means deny everyone.
 - `KG_SIDECAR_URL` — unset degrades `/mcp`, but an unauthenticated probe still gets **401** and cannot detect it. Only an unset `OAUTH_REDIRECT_BASE_URL` 503s every caller.
 - `AI_IMPLEMENT_LOG_LEVEL`, `AI_IMPLEMENT_RUNNER_LABEL`, `AI_IMPLEMENT_PROVIDER` — repo/org **Actions variables**, not orchestrator env, and effective only after the target repo re-syncs `claude-implement.yml`. `LOG_LEVEL` is `summary` (one result line per invocation — outcome, turns, duration, cost, tokens) or `stream` (additionally tees each tool call, not its output); telemetry is captured at both. `RUNNER_LABEL` overrides `runs-on`, default `ubuntu-latest` — pointing it at a larger runner roughly halves the CPU-bound implement job, but **write access to that variable lets the holder retarget the job to an arbitrary self-hosted runner that would then see the job's secrets.**
 - `AI_IMPLEMENT_SOURCE_COMMIT` / `_REPO` / `_BRANCH` — **stamped by the image build, not set by an operator** (`Dockerfile` build args). Self-deploy compares the stamp against the branch head, so an image built without all three goes inert and reports availability as *unknown*, never as up to date — a hand-run `fly deploy` that omits them silently disables the feature. No webhook or inbound reachability is needed; those only cut detection latency from one poll cycle to seconds.
@@ -268,7 +268,11 @@ Two paths feed one `reconciliation_queue` → `markMerged` worker: a **poll dete
 
 ## Admin UI and auth
 
-SSO via OIDC (Google, Microsoft) with a deprecated `ADMIN_ACCESS_CODE` fallback; the UI 503s when neither is configured. **Authorization and session identity key on different claims, and it is easy to state this backwards:** authorization is a fail-closed allowlist matched against the verified *email*, while the session stores the provider's stable `sub`, because email is mutable.
+SSO via OIDC (Google, Microsoft) with a deprecated `ADMIN_ACCESS_CODE` fallback; the UI 503s when neither is configured. The fail-closed allowlist is **database-backed and edited at `/admin#access`** — `OAUTH_ALLOWED_*` seed it and apply until the first save, which hands authority to the stored list permanently.
+
+Three things here are easy to state backwards. **A domain admits as `user`; only a listed address can be `admin`.** An entry is *declared* by address but **matched by provider + `sub` once bound** at first sign-in, so a rename keeps its role and a reassigned address inherits nothing. And an unreadable list answers **503, never 401** — the SPA logs out on 401, so a database fault must not eject everyone.
+
+Every authenticated request re-checks against an in-memory list, so a removal ends a session on the next request rather than at token expiry. **Full reference: [docs/access-model.md](docs/access-model.md)** — precedence, the audit trail, and the host command that recovers from lockout.
 
 The SPA at `/admin` is composed from string-exporting modules under `src/admin-ui/` with **no client-side build step** — all client JS is concatenated into one inline `<script>` at module load. Each `pages/<name>.ts` exports `<name>Html` and `<name>Script`; the script is an IIFE ending in `window.registerPage('<route>', …)`, and page scripts call `window.api()` and the HTML-escaping helpers (below) rather than bare globals. Adding a page means the module, both strings in `index.ts`, and a route in `sidebar.ts`.
 
@@ -276,11 +280,11 @@ The SPA at `/admin` is composed from string-exporting modules under `src/admin-u
 
 | Context | Helper | Why |
 |---|---|---|
-| Text content (`innerHTML`, `textContent`) | `window.esc()` | Escapes `&`, `<`, `>` via DOM round-trip |
+| Text interpolated into markup (`innerHTML`) | `window.esc()` | Escapes `&`, `<`, `>` via DOM round-trip. A value assigned to `textContent` needs **no** helper — it is never parsed as HTML |
 | Quoted attribute value (`title=`, `data-*`, path in `href=`) | `window.escAttr()` | Also escapes `"` and `'` |
 | Full URL in `href=`/`src=` (scheme from data) | `window.safeUrl()` | Validates scheme; `javascript:` returns `'#'` |
 
-`window.html` is a tagged template that calls `escAttr()` on every interpolation by default; when the preceding static chunk ends with `href=` or `src=` (with an optional opening quote), it also runs `safeUrl()` on the value first. Use `window.raw(markup)` to opt out for pre-built HTML. Use `html` for all new markup-building code. Do **not** use `esc()` inside a quoted attribute — that is the bug this rule prevents. Note: when a URL is assembled in a variable and then placed in `html`, the template cannot detect the URL context — call `safeUrl()` explicitly in that case.
+`window.html` is a tagged template that calls `escAttr()` on every interpolation by default; when the preceding static chunk ends with `href=` or `src=` (with an optional opening quote), it also runs `safeUrl()` on the value first, and `window.raw(markup)` opts out for pre-built HTML. **No page module uses it** — every call site concatenates strings with explicit `esc()`/`escAttr()`, because nesting a template literal inside the page's own script template means escaping every backtick and `${`. Follow the call sites. Do **not** use `esc()` inside a quoted attribute — that is the bug this rule prevents. And when a URL is assembled in a variable before being interpolated, no helper can detect the URL context — call `safeUrl()` explicitly there.
 
 Six routes (`channels`, `policies`, `secrets`, `mcp`, `webhooks`, `updates`) are still "Coming soon" stubs in `pages/stubs.ts`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,24 +15,26 @@ This service:
 1. Holds long-lived credentials for Linear, GitHub (via a GitHub App), and Fly.io.
 2. Dispatches GitHub Actions workflows in target repositories on the basis of Linear issue labels.
 3. Boots Fly Machines that run Claude Code with checkout access to those repos.
-4. Exposes an HTTP admin UI guarded by a single shared `ADMIN_ACCESS_CODE`.
+4. Exposes an HTTP admin UI and an authenticated `/mcp` endpoint, both guarded by a fail-closed sign-in allowlist behind OIDC SSO, with a deprecated shared `ADMIN_ACCESS_CODE` as a fallback.
 
 Anything in those four areas that allows an unauthenticated user to dispatch work, leak credentials, or read/modify SQLite state is in scope. The same holds for path traversal, SSRF, or template injection in the workflow files.
 
 ## What's out of scope
 
 - Vulnerabilities in dependencies that have not yet been disclosed upstream — please report those to the upstream project first.
-- Issues that require a privileged operator (e.g. someone who already has the `ADMIN_ACCESS_CODE`) to exploit themselves.
+- Issues that require an already-privileged operator to exploit themselves — someone holding the `ADMIN_ACCESS_CODE`, an identity already on the sign-in allowlist, or shell access to the host.
 - Bedrock / AWS account misconfiguration in *your* deployment.
 
 ## Operator hardening checklist
 
 If you're running this in production, the following are your responsibility, not the project's:
 
-- Rotate the `ADMIN_ACCESS_CODE` periodically and serve the admin UI over a private network or VPN-only host.
+- Configure SSO and leave `ADMIN_ACCESS_CODE` unset in production — an access-code session is unattributable, so nothing it does can be traced to a person. Where one is set, rotate it periodically.
+- Keep the sign-in allowlist to addresses rather than whole domains where you can, and review it at `/admin#access`; the change history beside it records every edit.
 - Keep the GitHub App's permissions minimal — `contents: write`, `pull_requests: write`, `actions: write`, and `issues: read` are typically sufficient.
 - Ensure the `dedup.sqlite` volume is encrypted at rest.
-- Audit `dispatch_log` regularly for unexpected dispatches (visible in the admin UI).
+- Serve the admin UI over a private network or VPN-only host.
+- Audit `dispatch_log` regularly for unexpected dispatches, and `access_audit` for changes to who can sign in (both visible in the admin UI).
 
 ## Disclosure
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Two tiers, distinguished by what a file *is* rather than what it covers.
 | [runner-images.md](runner-images.md) | The image resolution ladder, publishing channels, and why a private image constrains the execution mode |
 | [kg-sidecar.md](kg-sidecar.md) | The knowledge-graph sidecar, the `/mcp` proxy and its OAuth flow, and the image build |
 | [deployment.md](deployment.md) | Deploy paths, client instances, and the AWS Bedrock setup |
+| [access-model.md](access-model.md) | Who may sign in: the allowlist and its env-to-database handover, provider binding, the per-request re-check, the audit trail, and host recovery from lockout |
 
 Two references live outside this directory because they are consumed directly rather than read: `.env.example` is the canonical list of orchestrator environment variables, and `CLAUDE.md` is the index that points at everything here.
 

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -1,0 +1,124 @@
+# Access model
+
+Who may sign in to an orchestrator, and how that decision is made, stored, audited, and recovered.
+
+This is the reference for `src/access-entries.ts`, `src/access-audit.ts`, `src/access-recovery.ts`, `src/oauth/authorize.ts`, and the authorization halves of `src/admin-session.ts` and `src/mcp.ts`. `CLAUDE.md` carries the summary and points here.
+
+## The list
+
+One row per entry in `access_entries`, keyed on `(kind, value)`:
+
+| Column | Meaning |
+|--------|---------|
+| `kind` | `domain` (a whole email domain) or `address` (one person) |
+| `value` | The domain or address, lowercased and trimmed on write |
+| `role` | `user` or `admin` |
+| `provider` / `subject` | The OIDC identity this entry bound to on first sign-in; null until then |
+| `added_at` / `added_by` | When it was written, and the address of whoever wrote it |
+
+Two rules are enforced at write time rather than left to the caller:
+
+- **A domain admits as `user`. Only a listed address may be `admin`.** A domain entry saved with `admin` is refused. This is what makes "grandfather the existing identities as admin" a coherent instruction — a domain admits an unbounded set with nobody to enumerate.
+- **The list is capped at 200 entries**, because it is scanned on every authenticated request.
+
+## Where the list comes from
+
+`OAUTH_ALLOWED_DOMAINS` and `OAUTH_ALLOWED_EMAILS` **seed** the allowlist. They apply while nothing is stored, and the **first save at `/admin#access` hands authority to the database permanently** — from then on the environment values are displayed on that page as stale, and never consulted.
+
+The handover is deliberately operator-driven, never a boot-time migration. Two consequences worth knowing:
+
+- An existing deployment that never opens the Access page behaves exactly as it did before the page existed.
+- If the stored list is emptied, the environment values apply again — a lost volume degrades to the seed rather than locking everyone out.
+
+## How a request is decided
+
+```mermaid
+flowchart TD
+    R["Authenticated request<br/>(admin UI or /mcp)"] --> S{"Session or token<br/>valid?"}
+    S -- no --> U["401"]
+    S -- yes --> A{"Carries an<br/>address?"}
+    A -- "no — access code" --> OK["Allowed<br/>(exempt from re-check)"]
+    A -- yes --> L{"Allowlist<br/>readable?"}
+    L -- "never loaded" --> E["503 — not 401,<br/>so nobody is signed out"]
+    L -- yes --> M{"Matches an<br/>entry?"}
+    M -- no --> D["401, and the<br/>session is revoked"]
+    M -- yes --> OK
+```
+
+Matching runs in precedence order, and stops at the first hit:
+
+| Order | Entry | Matches when |
+|-------|-------|--------------|
+| 1 | Address, bound | `provider` **and** `subject` both equal the identity's |
+| 2 | Address, unbound | The entry's value equals the verified email |
+| 3 | Domain | The email's domain equals the entry's value |
+
+An address entry outranks a domain entry: it is the more specific grant, and the only one that can carry a role. A malformed identifier with no `@` has a domain equal to itself, and is excluded from rule 3 so it cannot match a domain entry.
+
+## Binding
+
+An entry is **declared** by address and **matched** by provider identity once bound. The first successful sign-in against an unbound address records the provider and the OIDC `sub`; from then on that entry matches on those two alone.
+
+- A **rename** keeps its role — the `sub` is stable across an address change.
+- A **reassigned address inherits nothing** — a new person holding an old address presents a different `sub` and does not match.
+- **Binding happens once.** A later sign-in cannot re-point an entry at another subject.
+- Known cost: the same person arriving via a second provider presents a different `sub` and will not match their bound entry. They need a fresh entry.
+
+Domain entries never bind, because they admit many identities.
+
+## Re-checking, and freshness
+
+Every authenticated request re-checks the identity against the list in force — the admin gate in `src/admin-session.ts` and the `/mcp` gate in `src/mcp.ts` share one matcher. A removal therefore ends a session on the requester's **next request**, rather than at token expiry, which for `/mcp` would otherwise be up to an hour.
+
+The list is held in memory, so the re-check costs no query. It is re-read in two situations:
+
+- **Immediately, on any write this process makes** — a save or a first-sign-in binding. Revocation through the admin UI is never delayed.
+- **Once per poll interval otherwise**, bounded by `POLL_INTERVAL_MS`. This covers writes made by *another process* — in practice the recovery command — which cannot invalidate this process's cache.
+
+That second case is why recovery needs no restart. It also means a hand-edit of the database converges within a poll instead of never.
+
+## Failure behaviour
+
+Authorization is **fail-closed**, and the two failure modes are deliberately different:
+
+- **A read fails while a good list is cached** — the cached list keeps serving, and a warning is logged at most once per window rather than on every request. Nobody is ejected by a transient database fault.
+- **A read fails with nothing ever cached** — the admin UI and `/mcp` deny, while polling and dispatch continue unaffected. The next request retries.
+
+A denial caused by an unreadable list answers **503, never 401**. The distinction is load-bearing: the admin SPA treats 401 as "your session ended" and logs the user out, so returning 401 here would sign out every operator over a database hiccup.
+
+## The audit trail
+
+Every change to the list writes a row to `access_audit`: when, who, which action (`save` or `recover`), and a before/after snapshot of the list. Snapshots are narrowed to `{kind, value, role}` at write time, so no caller can widen what gets stored.
+
+The trail has **no retention policy, deliberately** — it grows only when a human changes who can sign in, and pruning is the anti-goal for an audit record. It is scoped to access changes only; the general facility across every mutating admin route is separate, unbuilt work.
+
+The Access page renders the recent entries, summarising each as added / removed / role changed with counts.
+
+## Guards on a save
+
+- **Self-lockout** — a save whose resulting list would not admit its own author is refused. The check runs *inside* the transaction and against the real post-write result, so it cannot be fooled by predicting the outcome, and a refusal rolls back the whole save including its audit row.
+- **A signed-in identity is required.** `POST /api/access` answers 403 to a session with no address, because the change could not be attributed to anyone.
+
+## Recovery from lockout
+
+When nobody can sign in, recovery is a **command run on the host**, not a credential:
+
+```bash
+fly ssh console -a <app>
+node dist/access-recovery.js --email you@example.com          # add, keeping the existing list
+node dist/access-recovery.js --email you@example.com --only   # replace the list entirely
+```
+
+There is no standing credential to steal: the authority is shell access, which already implies reading the database and every secret. The change is audited with a **null actor**, since nobody authenticated for it, and announced on the notification webhook if one is configured — a failed notification does not fail the recovery.
+
+Adding an address already on the list **promotes** it rather than failing as a duplicate, which matters because a mangled role is one of the ways to get locked out. The change takes effect within one poll interval; no restart is needed.
+
+## Access-code sessions
+
+The deprecated `ADMIN_ACCESS_CODE` path remains for local development. Such a session carries no address, so it is **exempt from the re-check** — there is nothing to match — and it is **read-only on the Access page**, enforced server-side rather than only hidden in the UI.
+
+It holds no architectural responsibility, which is what keeps the deprecated path deletable.
+
+## Not yet built
+
+`role` is stored and displayed but **not enforced anywhere** — every authenticated identity still has full administrative access. Admin/User enforcement, per-page grants, and the guard against removing the last admin are separate work.

--- a/docs/kg-sidecar.md
+++ b/docs/kg-sidecar.md
@@ -121,7 +121,9 @@ fly deploy --remote-only       # degraded: /mcp returns 503, all other routes he
 | `GET /.well-known/oauth-protected-resource` | Resource metadata pointing at the authorization server |
 | `GET /.well-known/oauth-authorization-server` | RFC 8414 authorization-server metadata |
 
-Authorization is **fail-closed**: a verified identity must pass the same `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` allowlist as the admin UI.
+Authorization is **fail-closed**, against the same allowlist the admin UI uses — which is database-backed and edited at `/admin#access`, with `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` seeding it until the first save. See [access-model.md](access-model.md).
+
+The list is re-checked on **every `/mcp` request**, not only at sign-in. An access token otherwise outlives a removal by up to its full hour; re-checking closes that window to a single request. A removed identity gets the same 401 an invalid token does, while an unreadable allowlist answers 503 — a database fault must not look like a revoked token.
 
 ### Token lifetimes and rotation
 

--- a/src/__tests__/access-audit.test.ts
+++ b/src/__tests__/access-audit.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// dedup.ts freezes its DB path at import time, so each test sets a unique DEDUP_DB_PATH and
+// re-imports the modules fresh (the same isolation pattern the sibling suites use).
+let audit: typeof import("../access-audit.js");
+let access: typeof import("../access-entries.js");
+let dedup: typeof import("../dedup.js");
+let dbPath: string;
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `access-audit-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  audit = await import("../access-audit.js");
+  access = await import("../access-entries.js");
+  dedup = await import("../dedup.js");
+  audit.initAccessAuditTable();
+  access.initAccessEntriesTable();
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("recordAccessChange", () => {
+  it("stores both snapshots and the actor", () => {
+    audit.recordAccessChange({
+      actor: "ricardo@eudoxus.ai",
+      action: "save",
+      before: [{ kind: "domain", value: "eudoxus.ai", role: "user" }],
+      after: [
+        { kind: "domain", value: "eudoxus.ai", role: "user" },
+        { kind: "address", value: "ada@eudoxus.ai", role: "admin" },
+      ],
+    });
+
+    const [change] = audit.listAccessChanges();
+    expect(change).toMatchObject({ actor: "ricardo@eudoxus.ai", action: "save" });
+    expect(change.before).toHaveLength(1);
+    expect(change.after).toHaveLength(2);
+    expect(change.createdAt).toBeGreaterThan(0);
+  });
+
+  it("records an unattributable change as a null actor rather than inventing a person", () => {
+    audit.recordAccessChange({ actor: null, action: "recover", before: [], after: [] });
+    expect(audit.listAccessChanges()[0]).toMatchObject({ actor: null, action: "recover" });
+  });
+
+  it("stores only what an operator edits, never the binding or provenance", () => {
+    // An AccessEntry is assignable to AccessEntryInput, so a caller can hand over the wide shape.
+    const wide = [
+      {
+        kind: "address" as const,
+        value: "ada@eudoxus.ai",
+        role: "admin" as const,
+        provider: "google",
+        subject: "google|123",
+        addedAt: 1700000000000,
+        addedBy: "someone@eudoxus.ai",
+      },
+    ];
+    audit.recordAccessChange({ actor: null, action: "save", before: [], after: wide });
+
+    const raw = dedup.getDb().prepare("SELECT after_json FROM access_audit").get() as { after_json: string };
+    expect(JSON.parse(raw.after_json)).toEqual([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }]);
+  });
+});
+
+describe("listAccessChanges", () => {
+  it("returns nothing before any change is made", () => {
+    expect(audit.listAccessChanges()).toEqual([]);
+  });
+
+  it("orders newest first, breaking ties on id so same-millisecond writes stay ordered", () => {
+    for (const value of ["first@eudoxus.ai", "second@eudoxus.ai", "third@eudoxus.ai"]) {
+      audit.recordAccessChange({
+        actor: null,
+        action: "save",
+        before: [],
+        after: [{ kind: "address", value, role: "admin" }],
+      });
+    }
+    expect(audit.listAccessChanges().map((c) => c.after[0].value)).toEqual([
+      "third@eudoxus.ai",
+      "second@eudoxus.ai",
+      "first@eudoxus.ai",
+    ]);
+  });
+
+  it("caps the number of rows returned", () => {
+    for (let i = 0; i < 5; i++) {
+      audit.recordAccessChange({ actor: null, action: "save", before: [], after: [] });
+    }
+    expect(audit.listAccessChanges(2)).toHaveLength(2);
+  });
+
+  it("keeps a row whose snapshot cannot be parsed — it is still evidence a change happened", () => {
+    dedup
+      .getDb()
+      .prepare("INSERT INTO access_audit (created_at, actor, action, before_json, after_json) VALUES (?, ?, ?, ?, ?)")
+      .run(Date.now(), "ada@eudoxus.ai", "save", "{not json", "[]");
+
+    const [change] = audit.listAccessChanges();
+    expect(change.actor).toBe("ada@eudoxus.ai");
+    expect(change.before).toEqual([]);
+  });
+
+  it("narrows an unrecognised action to a save", () => {
+    dedup
+      .getDb()
+      .prepare("INSERT INTO access_audit (created_at, actor, action, before_json, after_json) VALUES (?, ?, ?, ?, ?)")
+      .run(Date.now(), null, "something-else", "[]", "[]");
+    expect(audit.listAccessChanges()[0].action).toBe("save");
+  });
+});
+
+describe("saveAccessEntries auditing", () => {
+  it("records a row for every write, so no change to the list escapes the trail", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], "ricardo@eudoxus.ai");
+    access.saveAccessEntries([], "ricardo@eudoxus.ai");
+
+    const changes = audit.listAccessChanges();
+    expect(changes).toHaveLength(2);
+    // Newest first: the removal, then the addition.
+    expect(changes[0].before).toHaveLength(1);
+    expect(changes[0].after).toEqual([]);
+    expect(changes[1].before).toEqual([]);
+    expect(changes[1].after).toEqual([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }]);
+  });
+
+  it("records nothing when the save is rejected", () => {
+    expect(() => access.saveAccessEntries([{ kind: "domain", value: "eudoxus.ai", role: "admin" }], null)).toThrow();
+    expect(audit.listAccessChanges()).toEqual([]);
+  });
+
+  it("does not record the binding of an entry that survives a save", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "user" }], null);
+    access.bindAccessEntry("ada@eudoxus.ai", "google", "google|123");
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+
+    const [latest] = audit.listAccessChanges();
+    expect(latest.before).toEqual([{ kind: "address", value: "ada@eudoxus.ai", role: "user" }]);
+    expect(latest.after).toEqual([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }]);
+  });
+});

--- a/src/__tests__/access-entries.test.ts
+++ b/src/__tests__/access-entries.test.ts
@@ -179,6 +179,28 @@ describe("bindAccessEntry", () => {
     expect(row.provider).toBeNull();
     expect(row.subject).toBeNull();
   });
+
+  // The three above assert on the stored row. Authorization reads the cache instead, so a binding
+  // that reaches the database and not the cache passes all of them while doing nothing.
+  it("takes effect against the live allowlist, without a refresh in between", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    // Warms the cache with the entry still unbound, and pins the pre-bind behaviour. Skip it and
+    // the assertion below passes vacuously, because a cold cache re-reads and sees the binding.
+    expect(access.recheckIdentity({ provider: "google", sub: "google|123", email: "ada@eudoxus.ai" }).status).toBe("ok");
+
+    access.bindAccessEntry("ada@eudoxus.ai", "google", "google|123");
+
+    const reassigned = access.recheckIdentity({ provider: "microsoft", sub: "ms|999", email: "ada@eudoxus.ai" });
+    expect(reassigned.status).toBe("denied");
+  });
+
+  it("keeps admitting the identity it bound to", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    access.recheckIdentity({ provider: "google", sub: "google|123", email: "ada@eudoxus.ai" });
+    access.bindAccessEntry("ada@eudoxus.ai", "google", "google|123");
+
+    expect(access.recheckIdentity({ provider: "google", sub: "google|123", email: "ada@eudoxus.ai" }).status).toBe("ok");
+  });
 });
 
 describe("parseAccessEntries", () => {
@@ -340,6 +362,16 @@ describe("getEffectiveAllowlist", () => {
     expect(effective.entries).toEqual([]);
   });
 
+  it("applies a save without a manual refresh, so no caller has to remember one", () => {
+    process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+    // Warm on the env list first; a cold cache would re-read and pass regardless of the save.
+    expect(access.getEffectiveAllowlist()!.source).toBe("env");
+
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+
+    expect(access.getEffectiveAllowlist()!.source).toBe("db");
+  });
+
   it("hands authority to the stored list once a row exists, ignoring the env from then on", () => {
     process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
     access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
@@ -362,11 +394,18 @@ describe("getEffectiveAllowlist", () => {
     expect(access.getEffectiveAllowlist()!.source).toBe("env");
   });
 
-  it("holds the list in memory until an explicit refresh, so the per-request check costs no query", () => {
+  it("holds the list in memory, so the per-request check costs no query", () => {
     process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
     expect(access.getEffectiveAllowlist()!.source).toBe("env");
 
-    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    // Inserted behind the module's back: every write it owns refreshes the cache itself, so only
+    // a read that re-queries could observe this row.
+    dedup
+      .getDb()
+      .prepare(
+        "INSERT INTO access_entries (kind, value, role, provider, subject, added_at, added_by) VALUES ('address', 'ada@eudoxus.ai', 'admin', NULL, NULL, 0, NULL)",
+      )
+      .run();
     expect(access.getEffectiveAllowlist()!.source).toBe("env");
 
     access.refreshEffectiveAllowlist();

--- a/src/__tests__/access-entries.test.ts
+++ b/src/__tests__/access-entries.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 // dedup.ts freezes its DB path at import time, so each test sets a unique DEDUP_DB_PATH and
 // re-imports the modules fresh (the same isolation pattern admin-session.test.ts uses).
 let access: typeof import("../access-entries.js");
+let audit: typeof import("../access-audit.js");
 let dedup: typeof import("../dedup.js");
 let dbPath: string;
 
@@ -14,8 +15,11 @@ beforeEach(async () => {
   dbPath = path.join(os.tmpdir(), `access-entries-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
   process.env.DEDUP_DB_PATH = dbPath;
   access = await import("../access-entries.js");
+  audit = await import("../access-audit.js");
   dedup = await import("../dedup.js");
   access.initAccessEntriesTable();
+  // saveAccessEntries records every write, so the audit table is a hard requirement here.
+  audit.initAccessAuditTable();
 });
 
 afterEach(() => {
@@ -174,6 +178,87 @@ describe("bindAccessEntry", () => {
     const row = rawRow("domain", "eudoxus.ai")!;
     expect(row.provider).toBeNull();
     expect(row.subject).toBeNull();
+  });
+});
+
+describe("parseAccessEntries", () => {
+  const ok = (raw: unknown) => {
+    const parsed = access.parseAccessEntries(raw);
+    if (!parsed.ok) throw new Error(`expected accept, got: ${parsed.error}`);
+    return parsed.entries;
+  };
+  const rejection = (raw: unknown) => {
+    const parsed = access.parseAccessEntries(raw);
+    return parsed.ok ? null : parsed.error;
+  };
+
+  it("accepts a well-formed list and normalizes each value", () => {
+    expect(
+      ok([
+        { kind: "domain", value: " Eudoxus.AI ", role: "user" },
+        { kind: "address", value: "Ada@Eudoxus.ai", role: "admin" },
+      ]),
+    ).toEqual([
+      { kind: "domain", value: "eudoxus.ai", role: "user" },
+      { kind: "address", value: "ada@eudoxus.ai", role: "admin" },
+    ]);
+  });
+
+  it("accepts an empty list — clearing the stored list is a legitimate edit", () => {
+    expect(ok([])).toEqual([]);
+  });
+
+  it("rejects anything that is not an array of objects", () => {
+    expect(rejection(undefined)).toMatch(/must be an array/);
+    expect(rejection("eudoxus.ai")).toMatch(/must be an array/);
+    expect(rejection([null])).toMatch(/must be an object/);
+  });
+
+  it("rejects an unknown kind or role rather than coercing it", () => {
+    expect(rejection([{ kind: "wildcard", value: "eudoxus.ai", role: "user" }])).toMatch(/kind must be/);
+    expect(rejection([{ kind: "address", value: "ada@eudoxus.ai", role: "owner" }])).toMatch(/role must be/);
+  });
+
+  it("rejects a missing or blank value", () => {
+    expect(rejection([{ kind: "address", role: "admin" }])).toMatch(/non-empty string/);
+    expect(rejection([{ kind: "address", value: "   ", role: "admin" }])).toMatch(/non-empty string/);
+  });
+
+  it("rejects an address that is not an address, which would otherwise save and match nobody", () => {
+    expect(rejection([{ kind: "address", value: "eudoxus.ai", role: "admin" }])).toMatch(/not an email address/);
+    expect(rejection([{ kind: "address", value: "ada@localhost", role: "admin" }])).toMatch(/not an email address/);
+  });
+
+  it("rejects a domain that is not a domain, for the same reason", () => {
+    expect(rejection([{ kind: "domain", value: "ada@eudoxus.ai", role: "user" }])).toMatch(/not a domain/);
+    expect(rejection([{ kind: "domain", value: "localhost", role: "user" }])).toMatch(/not a domain/);
+  });
+
+  it("rejects a duplicate, including one that only collides after normalizing", () => {
+    expect(
+      rejection([
+        { kind: "address", value: "ada@eudoxus.ai", role: "admin" },
+        { kind: "address", value: "ADA@eudoxus.ai", role: "user" },
+      ]),
+    ).toMatch(/listed twice/);
+  });
+
+  it("allows the same value under both kinds, which are different entries", () => {
+    // Nonsensical in practice, but they key differently and neither shadows the other.
+    expect(ok([
+      { kind: "domain", value: "eudoxus.ai", role: "user" },
+      { kind: "address", value: "ada@eudoxus.ai", role: "admin" },
+    ])).toHaveLength(2);
+  });
+
+  it("bounds the list, since it is scanned on every authenticated request", () => {
+    const many = Array.from({ length: 201 }, (_, i) => ({
+      kind: "address" as const,
+      value: `user${i}@eudoxus.ai`,
+      role: "user" as const,
+    }));
+    expect(rejection(many)).toMatch(/at most/);
+    expect(access.parseAccessEntries(many.slice(0, 200)).ok).toBe(true);
   });
 });
 

--- a/src/__tests__/access-entries.test.ts
+++ b/src/__tests__/access-entries.test.ts
@@ -426,6 +426,49 @@ describe("getEffectiveAllowlist", () => {
     warn.mockRestore();
   });
 
+  it("re-reads after one poll interval, so a write from another process lands without a restart", () => {
+    vi.useFakeTimers();
+    try {
+      process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+      expect(access.getEffectiveAllowlist()!.source).toBe("env");
+
+      // Stands in for the recovery command: a write this process cannot be told about, so only
+      // the age of the cached list can bring it into effect.
+      dedup
+        .getDb()
+        .prepare(
+          "INSERT INTO access_entries (kind, value, role, provider, subject, added_at, added_by) VALUES ('address', 'ada@eudoxus.ai', 'admin', NULL, NULL, 0, NULL)",
+        )
+        .run();
+      expect(access.getEffectiveAllowlist()!.source).toBe("env");
+
+      vi.advanceTimersByTime(60_000);
+      expect(access.getEffectiveAllowlist()!.source).toBe("db");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("warns once per window while a read keeps failing, not on every request", () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+      expect(access.getEffectiveAllowlist()!.entries).toHaveLength(1);
+      dedup.getDb().exec("DROP TABLE access_entries");
+
+      vi.advanceTimersByTime(60_000);
+      access.getEffectiveAllowlist(); // the window elapsed: one failed read, one warning
+      access.getEffectiveAllowlist(); // inside the new window: no read, no warning
+      access.getEffectiveAllowlist();
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("returns null when a read fails with nothing cached, and recovers on a later call", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     dedup.getDb().exec("DROP TABLE access_entries");

--- a/src/__tests__/access-entries.test.ts
+++ b/src/__tests__/access-entries.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// dedup.ts freezes its DB path at import time, so each test sets a unique DEDUP_DB_PATH and
+// re-imports the modules fresh (the same isolation pattern admin-session.test.ts uses).
+let access: typeof import("../access-entries.js");
+let dedup: typeof import("../dedup.js");
+let dbPath: string;
+
+beforeEach(async () => {
+  vi.resetModules();
+  dbPath = path.join(os.tmpdir(), `access-entries-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
+  process.env.DEDUP_DB_PATH = dbPath;
+  access = await import("../access-entries.js");
+  dedup = await import("../dedup.js");
+  access.initAccessEntriesTable();
+});
+
+afterEach(() => {
+  dedup.closeDb();
+  try {
+    fs.unlinkSync(dbPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+function rawRow(kind: string, value: string) {
+  return dedup
+    .getDb()
+    .prepare("SELECT kind, value, role, provider, subject, added_at, added_by FROM access_entries WHERE kind = ? AND value = ?")
+    .get(kind, value) as
+    | { kind: string; value: string; role: string; provider: string | null; subject: string | null; added_at: number; added_by: string | null }
+    | undefined;
+}
+
+describe("listAccessEntries", () => {
+  it("returns an empty list before anything is stored — the signal that the env list still applies", () => {
+    expect(access.listAccessEntries()).toEqual([]);
+  });
+
+  it("orders by kind then value, so the page renders deterministically", () => {
+    access.saveAccessEntries(
+      [
+        { kind: "address", value: "zoe@eudoxus.ai", role: "admin" },
+        { kind: "domain", value: "eudoxus.ai", role: "user" },
+        { kind: "address", value: "ada@eudoxus.ai", role: "user" },
+      ],
+      "ricardo@eudoxus.ai",
+    );
+    expect(access.listAccessEntries().map((e) => `${e.kind}:${e.value}`)).toEqual([
+      "address:ada@eudoxus.ai",
+      "address:zoe@eudoxus.ai",
+      "domain:eudoxus.ai",
+    ]);
+  });
+
+  it("narrows an unreadable row toward less access rather than more", () => {
+    const now = Date.now();
+    dedup
+      .getDb()
+      .prepare("INSERT INTO access_entries (kind, value, role, provider, subject, added_at, added_by) VALUES (?, ?, ?, NULL, NULL, ?, NULL)")
+      .run("Domain", "eudoxus.ai", "Admin", now);
+
+    const [entry] = access.listAccessEntries();
+    // 'Domain' would have admitted everyone at the company; 'Admin' would have granted management.
+    expect(entry.kind).toBe("address");
+    expect(entry.role).toBe("user");
+  });
+});
+
+describe("saveAccessEntries", () => {
+  it("stores entries with their provenance and no binding", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], "ricardo@eudoxus.ai");
+    const [entry] = access.listAccessEntries();
+    expect(entry).toMatchObject({
+      kind: "address",
+      value: "ada@eudoxus.ai",
+      role: "admin",
+      provider: null,
+      subject: null,
+      addedBy: "ricardo@eudoxus.ai",
+    });
+    expect(entry.addedAt).toBeGreaterThan(0);
+  });
+
+  it("trims and lowercases the value, so matching is case-insensitive", () => {
+    access.saveAccessEntries([{ kind: "address", value: "  Ada@Eudoxus.AI  ", role: "user" }], null);
+    expect(access.listAccessEntries()[0].value).toBe("ada@eudoxus.ai");
+  });
+
+  it("removes entries absent from the next list", () => {
+    access.saveAccessEntries(
+      [
+        { kind: "address", value: "ada@eudoxus.ai", role: "admin" },
+        { kind: "address", value: "zoe@eudoxus.ai", role: "user" },
+      ],
+      null,
+    );
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    expect(access.listAccessEntries().map((e) => e.value)).toEqual(["ada@eudoxus.ai"]);
+  });
+
+  it("keeps a surviving entry's binding and provenance while updating its role", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "user" }], "first@eudoxus.ai");
+    access.bindAccessEntry("ada@eudoxus.ai", "google", "google|123");
+    dedup.getDb().prepare("UPDATE access_entries SET added_at = ? WHERE value = ?").run(1000, "ada@eudoxus.ai");
+
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], "second@eudoxus.ai");
+
+    const row = rawRow("address", "ada@eudoxus.ai")!;
+    expect(row.role).toBe("admin");
+    // A save must not unbind or re-attribute someone who has already signed in.
+    expect(row.provider).toBe("google");
+    expect(row.subject).toBe("google|123");
+    expect(row.added_at).toBe(1000);
+    expect(row.added_by).toBe("first@eudoxus.ai");
+  });
+
+  it("refuses a domain carrying the admin role", () => {
+    expect(() => access.saveAccessEntries([{ kind: "domain", value: "eudoxus.ai", role: "admin" }], null)).toThrow(
+      /domain entry cannot carry the admin role/,
+    );
+  });
+
+  it("refuses an entry that is empty once trimmed", () => {
+    expect(() => access.saveAccessEntries([{ kind: "address", value: "   ", role: "user" }], null)).toThrow(
+      /cannot be empty/,
+    );
+  });
+
+  it("writes nothing at all when one entry in the batch is invalid", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    expect(() =>
+      access.saveAccessEntries(
+        [
+          { kind: "address", value: "zoe@eudoxus.ai", role: "user" },
+          { kind: "domain", value: "eudoxus.ai", role: "admin" },
+        ],
+        null,
+      ),
+    ).toThrow();
+    // Validation runs before the transaction, so the previous list is untouched.
+    expect(access.listAccessEntries().map((e) => e.value)).toEqual(["ada@eudoxus.ai"]);
+  });
+});
+
+describe("bindAccessEntry", () => {
+  it("records the provider identity an address resolved to", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    access.bindAccessEntry("Ada@Eudoxus.ai", "google", "google|123");
+
+    const row = rawRow("address", "ada@eudoxus.ai")!;
+    expect(row.provider).toBe("google");
+    expect(row.subject).toBe("google|123");
+  });
+
+  it("binds once — a later sign-in cannot re-point an entry at another subject", () => {
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    access.bindAccessEntry("ada@eudoxus.ai", "google", "google|123");
+    access.bindAccessEntry("ada@eudoxus.ai", "microsoft", "ms|999");
+
+    const row = rawRow("address", "ada@eudoxus.ai")!;
+    expect(row.provider).toBe("google");
+    expect(row.subject).toBe("google|123");
+  });
+
+  it("ignores domain entries, which admit many identities and bind to none", () => {
+    access.saveAccessEntries([{ kind: "domain", value: "eudoxus.ai", role: "user" }], null);
+    access.bindAccessEntry("eudoxus.ai", "google", "google|123");
+
+    const row = rawRow("domain", "eudoxus.ai")!;
+    expect(row.provider).toBeNull();
+    expect(row.subject).toBeNull();
+  });
+});
+
+describe("matchAccessEntry", () => {
+  const entry = (over: Partial<import("../access-entries.js").AccessEntry> = {}) => ({
+    kind: "address" as const,
+    value: "ada@eudoxus.ai",
+    role: "admin" as const,
+    provider: null as string | null,
+    subject: null as string | null,
+    addedAt: 0,
+    addedBy: null as string | null,
+    ...over,
+  });
+
+  const ada = { provider: "google", sub: "google|123", email: "ada@eudoxus.ai" };
+
+  it("prefers an address over a domain, so the more specific grant carries the role", () => {
+    const domain = entry({ kind: "domain", value: "eudoxus.ai", role: "user" });
+    const address = entry({ value: "ada@eudoxus.ai", role: "admin" });
+    expect(access.matchAccessEntry(ada, [domain, address])).toBe(address);
+  });
+
+  it("matches an unbound address on the email", () => {
+    const address = entry();
+    expect(access.matchAccessEntry(ada, [address])).toBe(address);
+  });
+
+  it("keeps matching a bound entry after the address changes — a rename does not cost the role", () => {
+    const address = entry({ provider: "google", subject: "google|123" });
+    const renamed = { provider: "google", sub: "google|123", email: "a.lovelace@eudoxus.ai" };
+    expect(access.matchAccessEntry(renamed, [address])).toBe(address);
+  });
+
+  it("refuses a bound entry to a different subject, so a reassigned address inherits nothing", () => {
+    const domain = entry({ kind: "domain", value: "eudoxus.ai", role: "user" });
+    const address = entry({ provider: "google", subject: "google|123", role: "admin" });
+    const newHolder = { provider: "google", sub: "google|999", email: "ada@eudoxus.ai" };
+
+    // Falls through to ordinary domain admission rather than inheriting admin.
+    expect(access.matchAccessEntry(newHolder, [domain, address])).toBe(domain);
+  });
+
+  it("does not match a bound entry through a second provider — the known cost of binding", () => {
+    const address = entry({ provider: "google", subject: "google|123" });
+    const viaMicrosoft = { provider: "microsoft", sub: "ms|123", email: "ada@eudoxus.ai" };
+    expect(access.matchAccessEntry(viaMicrosoft, [address])).toBeNull();
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(access.matchAccessEntry({ provider: "google", sub: "x", email: "stranger@evil.com" }, [entry()])).toBeNull();
+  });
+});
+
+describe("getEffectiveAllowlist", () => {
+  beforeEach(() => {
+    // An ambient value would otherwise decide these tests — the same leak that makes
+    // the step suites fail inside a dev-run container.
+    delete process.env.OAUTH_ALLOWED_DOMAINS;
+    delete process.env.OAUTH_ALLOWED_EMAILS;
+  });
+
+  it("serves the env list while nothing is stored, admitting domains as user and addresses as admin", () => {
+    process.env.OAUTH_ALLOWED_DOMAINS = "Eudoxus.AI, ";
+    process.env.OAUTH_ALLOWED_EMAILS = " cameron@theaboutbox.com ,john@oolidata.ai";
+
+    const effective = access.getEffectiveAllowlist()!;
+    expect(effective.source).toBe("env");
+    expect(effective.entries).toEqual([
+      { kind: "domain", value: "eudoxus.ai", role: "user", provider: null, subject: null, addedAt: 0, addedBy: null },
+      { kind: "address", value: "cameron@theaboutbox.com", role: "admin", provider: null, subject: null, addedAt: 0, addedBy: null },
+      { kind: "address", value: "john@oolidata.ai", role: "admin", provider: null, subject: null, addedAt: 0, addedBy: null },
+    ]);
+  });
+
+  it("denies everyone when neither the env nor the stored list has anything", () => {
+    const effective = access.getEffectiveAllowlist()!;
+    expect(effective.source).toBe("env");
+    expect(effective.entries).toEqual([]);
+  });
+
+  it("hands authority to the stored list once a row exists, ignoring the env from then on", () => {
+    process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    access.refreshEffectiveAllowlist();
+
+    const effective = access.getEffectiveAllowlist()!;
+    expect(effective.source).toBe("db");
+    expect(effective.entries.map((e) => e.value)).toEqual(["ada@eudoxus.ai"]);
+  });
+
+  it("falls back to the env list if the stored list ceases to exist", () => {
+    process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    access.refreshEffectiveAllowlist();
+    expect(access.getEffectiveAllowlist()!.source).toBe("db");
+
+    // A restored-from-empty volume must fall back rather than lock everyone out.
+    dedup.getDb().prepare("DELETE FROM access_entries").run();
+    access.refreshEffectiveAllowlist();
+    expect(access.getEffectiveAllowlist()!.source).toBe("env");
+  });
+
+  it("holds the list in memory until an explicit refresh, so the per-request check costs no query", () => {
+    process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+    expect(access.getEffectiveAllowlist()!.source).toBe("env");
+
+    access.saveAccessEntries([{ kind: "address", value: "ada@eudoxus.ai", role: "admin" }], null);
+    expect(access.getEffectiveAllowlist()!.source).toBe("env");
+
+    access.refreshEffectiveAllowlist();
+    expect(access.getEffectiveAllowlist()!.source).toBe("db");
+  });
+
+  it("keeps serving the last good list when a read fails", () => {
+    process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(access.getEffectiveAllowlist()!.entries).toHaveLength(1);
+
+    dedup.getDb().exec("DROP TABLE access_entries");
+    access.refreshEffectiveAllowlist();
+
+    // Nobody is ejected by a database problem.
+    expect(access.getEffectiveAllowlist()!.entries).toHaveLength(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns null when a read fails with nothing cached, and recovers on a later call", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    dedup.getDb().exec("DROP TABLE access_entries");
+    expect(access.getEffectiveAllowlist()).toBeNull();
+    expect(error).toHaveBeenCalled();
+
+    // The next call retries rather than staying disabled until a restart.
+    access.initAccessEntriesTable();
+    process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+    expect(access.getEffectiveAllowlist()!.source).toBe("env");
+    error.mockRestore();
+  });
+});

--- a/src/__tests__/access-recovery.test.ts
+++ b/src/__tests__/access-recovery.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from "vitest";
+import { runAccessRecovery, type AccessRecoveryDependencies } from "../access-recovery.js";
+import type { AccessEntry } from "../access-entries.js";
+
+/** A stored row, with the provenance fields the command never sets itself. */
+function entry(kind: "address" | "domain", value: string, role: "user" | "admin" = "user"): AccessEntry {
+  return { kind, value, role, provider: null, subject: null, addedAt: 0, addedBy: null };
+}
+
+/**
+ * Fake dependencies throughout: the storage behaviour is the access-entries suite's job, so these
+ * assert only what the command itself decides — which list it computes, and how it reports.
+ */
+function deps(overrides: Partial<AccessRecoveryDependencies> = {}) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const saved: Array<Parameters<AccessRecoveryDependencies["saveEntries"]>> = [];
+  const notified: Array<[string, string]> = [];
+
+  const base: AccessRecoveryDependencies = {
+    initTables: vi.fn(),
+    listEntries: () => [],
+    saveEntries: ((...args) => { saved.push(args); }) as AccessRecoveryDependencies["saveEntries"],
+    notify: async (url, message) => { notified.push([url, message]); },
+    writeStdout: (text) => { stdout.push(text); },
+    writeStderr: (text) => { stderr.push(text); },
+    notifyWebhookUrl: undefined,
+    appName: undefined,
+    ...overrides,
+  };
+  return { deps: base, stdout, stderr, saved, notified };
+}
+
+describe("runAccessRecovery arguments", () => {
+  it("prints usage and succeeds for --help, touching nothing", async () => {
+    const d = deps();
+    expect(await runAccessRecovery(["--help"], d.deps)).toBe(0);
+    expect(d.stdout.join("")).toContain("Usage: node dist/access-recovery.js");
+    expect(d.saved).toHaveLength(0);
+    expect(d.deps.initTables).not.toHaveBeenCalled();
+  });
+
+  it("refuses to run without --email", async () => {
+    const d = deps();
+    expect(await runAccessRecovery([], d.deps)).toBe(1);
+    expect(d.stderr.join("")).toContain("--email is required");
+    expect(d.saved).toHaveLength(0);
+  });
+
+  it("refuses an unknown argument rather than ignoring it", async () => {
+    const d = deps();
+    expect(await runAccessRecovery(["--email", "ada@example.com", "--wipe"], d.deps)).toBe(1);
+    expect(d.stderr.join("")).toContain("Unknown argument: --wipe");
+    expect(d.saved).toHaveLength(0);
+  });
+
+  it("rejects a malformed address with the validator's own message, and writes nothing", async () => {
+    const d = deps();
+    expect(await runAccessRecovery(["--email", "not-an-email"], d.deps)).toBe(1);
+    expect(d.stderr.join("")).toContain("is not an email address");
+    expect(d.saved).toHaveLength(0);
+  });
+});
+
+describe("runAccessRecovery list construction", () => {
+  it("initializes its tables — a separate process, where nothing else has", async () => {
+    const d = deps();
+    await runAccessRecovery(["--email", "ada@example.com"], d.deps);
+    expect(d.deps.initTables).toHaveBeenCalled();
+  });
+
+  it("adds to the existing list by default, leaving domain entries intact", async () => {
+    const d = deps({
+      listEntries: () => [entry("address", "cam@example.com", "admin"), entry("domain", "example.com")],
+    });
+    expect(await runAccessRecovery(["--email", "ada@example.com"], d.deps)).toBe(0);
+
+    expect(d.saved[0]![0]).toEqual([
+      { kind: "address", value: "cam@example.com", role: "admin" },
+      { kind: "domain", value: "example.com", role: "user" },
+      { kind: "address", value: "ada@example.com", role: "admin" },
+    ]);
+  });
+
+  it("promotes an address already listed instead of failing as a duplicate", async () => {
+    const d = deps({ listEntries: () => [entry("address", "ada@example.com", "user")] });
+    expect(await runAccessRecovery(["--email", "ADA@Example.com"], d.deps)).toBe(0);
+
+    // One entry, now admin — the demotion that could have caused the lockout is undone.
+    expect(d.saved[0]![0]).toEqual([{ kind: "address", value: "ada@example.com", role: "admin" }]);
+  });
+
+  it("replaces the whole list under --only", async () => {
+    const d = deps({
+      listEntries: () => [entry("address", "cam@example.com", "admin"), entry("domain", "example.com")],
+    });
+    expect(await runAccessRecovery(["--email", "ada@example.com", "--only"], d.deps)).toBe(0);
+
+    expect(d.saved[0]![0]).toEqual([{ kind: "address", value: "ada@example.com", role: "admin" }]);
+    expect(d.stdout.join("")).toContain("replacing the previous list");
+  });
+
+  it("records the change as a recovery by nobody", async () => {
+    const d = deps();
+    await runAccessRecovery(["--email", "ada@example.com"], d.deps);
+
+    const [, actor, opts] = d.saved[0]!;
+    expect(actor).toBeNull();
+    expect(opts).toEqual({ action: "recover" });
+  });
+
+  it("returns a failure code when the save is refused", async () => {
+    const d = deps({
+      saveEntries: () => { throw new Error("database is locked"); },
+    });
+    expect(await runAccessRecovery(["--email", "ada@example.com"], d.deps)).toBe(1);
+    expect(d.stderr.join("")).toContain("Recovery failed: database is locked");
+  });
+
+  it("returns a failure code when the tables cannot be created", async () => {
+    // Same path as a save failure: one try covers every step that touches the database.
+    const d = deps({ initTables: () => { throw new Error("unable to open database file"); } });
+    expect(await runAccessRecovery(["--email", "ada@example.com"], d.deps)).toBe(1);
+    expect(d.stderr.join("")).toContain("Recovery failed: unable to open database file");
+  });
+});
+
+describe("runAccessRecovery notification", () => {
+  it("announces the recovery when a webhook is configured", async () => {
+    const d = deps({ notifyWebhookUrl: "https://hooks.example.com/abc", appName: "orchestrator-prod" });
+    await runAccessRecovery(["--email", "ada@example.com"], d.deps);
+
+    expect(d.notified).toHaveLength(1);
+    const [url, message] = d.notified[0]!;
+    expect(url).toBe("https://hooks.example.com/abc");
+    expect(message).toContain("orchestrator-prod");
+    expect(message).toContain("ada@example.com");
+    expect(message).toContain("no authenticated user");
+  });
+
+  it("stays silent when no webhook is configured", async () => {
+    const d = deps();
+    await runAccessRecovery(["--email", "ada@example.com"], d.deps);
+    expect(d.notified).toHaveLength(0);
+  });
+
+  it("still succeeds when the webhook is down — the access change is what mattered", async () => {
+    const d = deps({
+      notifyWebhookUrl: "https://hooks.example.com/abc",
+      notify: async () => { throw new Error("503"); },
+    });
+    expect(await runAccessRecovery(["--email", "ada@example.com"], d.deps)).toBe(0);
+    expect(d.stderr.join("")).toContain("Notification failed");
+  });
+});

--- a/src/__tests__/admin-session.test.ts
+++ b/src/__tests__/admin-session.test.ts
@@ -8,8 +8,16 @@ import { SESSION_COOKIE_NAME } from "../cookies.js";
 // dedup.ts freezes its DB path at import time, so each test sets a unique DEDUP_DB_PATH and
 // re-imports the modules fresh (the same isolation pattern admin.test.ts uses).
 let session: typeof import("../admin-session.js");
+let access: typeof import("../access-entries.js");
 let dedup: typeof import("../dedup.js");
 let dbPath: string;
+
+/** Seed the list in force the way a pre-handover deployment does — from the env. */
+function allow(domains: string, emails = ""): void {
+  process.env.OAUTH_ALLOWED_DOMAINS = domains;
+  process.env.OAUTH_ALLOWED_EMAILS = emails;
+  access.refreshEffectiveAllowlist();
+}
 
 const mkReq = (headers: Record<string, string>) => ({ headers }) as unknown as http.IncomingMessage;
 
@@ -27,7 +35,9 @@ beforeEach(async () => {
   dbPath = path.join(os.tmpdir(), `admin-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`);
   process.env.DEDUP_DB_PATH = dbPath;
   session = await import("../admin-session.js");
+  access = await import("../access-entries.js");
   dedup = await import("../dedup.js");
+  access.initAccessEntriesTable();
 });
 
 afterEach(() => {
@@ -73,31 +83,45 @@ describe("createSession", () => {
   });
 });
 
-describe("isValidSession", () => {
-  it("returns false for an undefined or unknown token", () => {
-    expect(session.isValidSession(undefined)).toBe(false);
-    expect(session.isValidSession("not-a-real-token")).toBe(false);
+describe("resolveSession", () => {
+  it("returns null for an undefined or unknown token", () => {
+    expect(session.resolveSession(undefined)).toBeNull();
+    expect(session.resolveSession("not-a-real-token")).toBeNull();
   });
 
-  it("returns true for a fresh session", () => {
-    const token = session.createSession();
-    expect(session.isValidSession(token)).toBe(true);
+  it("returns the identity for a session minted through SSO", () => {
+    const token = session.createSession({ email: "ada@eudoxus.ai", sub: "google|123", provider: "google", name: "Ada" });
+    expect(session.resolveSession(token)).toEqual({
+      identity: { email: "ada@eudoxus.ai", sub: "google|123", provider: "google", name: "Ada" },
+    });
   });
 
-  it("returns false and lazily deletes the row when the session has expired", () => {
+  it("distinguishes a live access-code session from no session at all", () => {
     const token = session.createSession();
+    expect(session.resolveSession(token)).toEqual({ identity: null });
+    expect(session.resolveSession("not-a-real-token")).toBeNull();
+  });
+
+  it("returns null and lazily deletes the row when the session has expired", () => {
+    const token = session.createSession({ email: "ada@eudoxus.ai", sub: "google|123", provider: "google" });
     dedup.getDb().prepare("UPDATE admin_sessions SET expires_at = ? WHERE token = ?").run(Date.now() - 1, token);
-    expect(session.isValidSession(token)).toBe(false);
+    expect(session.resolveSession(token)).toBeNull();
     expect(sessionRow(token)).toBeUndefined();
+  });
+
+  it("reports no identity when a row carries only some of the identity columns", () => {
+    const token = session.createSession({ email: "ada@eudoxus.ai", sub: "google|123", provider: "google" });
+    dedup.getDb().prepare("UPDATE admin_sessions SET provider = NULL WHERE token = ?").run(token);
+    expect(session.resolveSession(token)).toEqual({ identity: null });
   });
 });
 
 describe("revokeSession", () => {
   it("drops the row so the token no longer validates (server-side logout)", () => {
     const token = session.createSession();
-    expect(session.isValidSession(token)).toBe(true);
+    expect(session.resolveSession(token)).not.toBeNull();
     session.revokeSession(token);
-    expect(session.isValidSession(token)).toBe(false);
+    expect(session.resolveSession(token)).toBeNull();
     expect(sessionRow(token)).toBeUndefined();
   });
 });
@@ -125,6 +149,57 @@ describe("getRequestToken", () => {
 
   it("ignores a non-Bearer authorization header", () => {
     expect(session.getRequestToken(mkReq({ authorization: "Basic abc123" }))).toBeUndefined();
+  });
+});
+
+describe("authenticateAdminRequest", () => {
+  const withToken = (token: string) => mkReq({ authorization: `Bearer ${token}` });
+  const ada = { email: "ada@eudoxus.ai", sub: "google|123", provider: "google" };
+
+  it("refuses a request carrying no token, and one carrying an unknown token", () => {
+    allow("eudoxus.ai");
+    expect(session.authenticateAdminRequest(mkReq({}))).toEqual({ ok: false, status: 401, error: "Unauthorized" });
+    expect(session.authenticateAdminRequest(withToken("nope"))).toMatchObject({ ok: false, status: 401 });
+  });
+
+  it("admits an access-code session without consulting the list, since it carries no address", () => {
+    allow("");
+    const token = session.createSession();
+    expect(session.authenticateAdminRequest(withToken(token))).toEqual({ ok: true, identity: null, entry: null });
+  });
+
+  it("admits an allowed identity and hands back the entry that matched", () => {
+    allow("eudoxus.ai");
+    const token = session.createSession(ada);
+    const gate = session.authenticateAdminRequest(withToken(token));
+    expect(gate.ok).toBe(true);
+    if (gate.ok) {
+      expect(gate.identity?.email).toBe("ada@eudoxus.ai");
+      // The entry is what carries the role once roles land.
+      expect(gate.entry).toMatchObject({ kind: "domain", value: "eudoxus.ai" });
+    }
+  });
+
+  it("revokes the session when the identity is no longer admitted, so a removal takes effect at once", () => {
+    allow("eudoxus.ai");
+    const token = session.createSession(ada);
+    expect(session.authenticateAdminRequest(withToken(token)).ok).toBe(true);
+
+    allow("");
+    expect(session.authenticateAdminRequest(withToken(token))).toMatchObject({ ok: false, status: 401 });
+    // The row is gone, so re-adding them requires a fresh sign-in.
+    expect(sessionRow(token)).toBeUndefined();
+  });
+
+  it("answers 503 and keeps the session when the list cannot be read", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const token = session.createSession(ada);
+    dedup.getDb().exec("DROP TABLE access_entries");
+
+    // A 401 would log every operator out of the SPA over a transient database problem.
+    expect(session.authenticateAdminRequest(withToken(token))).toMatchObject({ ok: false, status: 503 });
+    expect(sessionRow(token)).toBeDefined();
+    error.mockRestore();
   });
 });
 

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -101,6 +101,7 @@ let installState: typeof InstallStateModule;
 let queue: typeof WorkflowSyncQueueModule;
 let adminSession: typeof AdminSessionModule;
 let accessEntries: typeof AccessEntriesModule;
+let accessAudit: typeof import("../access-audit.js");
 let provider: FakeProvider;
 
 beforeEach(async () => {
@@ -111,6 +112,7 @@ beforeEach(async () => {
   admin = await import("../admin.js");
   adminSession = await import("../admin-session.js");
   accessEntries = await import("../access-entries.js");
+  accessAudit = await import("../access-audit.js");
   config = await import("../config.js");
   dedup = await import("../dedup.js");
   runnerMode = await import("../runner-mode.js");
@@ -123,6 +125,7 @@ beforeEach(async () => {
   stepLog.initStepLogTable();
   runnerMode.initSettingsTable();
   accessEntries.initAccessEntriesTable();
+  accessAudit.initAccessAuditTable();
   // Every /api/* request now re-checks the signed-in identity, so the suite needs a list in force.
   process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
   process.env.OAUTH_ALLOWED_EMAILS = "";
@@ -257,6 +260,93 @@ describe("admin auth", () => {
     // Row should be deleted from DB
     const row = getDb().prepare("SELECT * FROM admin_sessions WHERE token = ?").get(token);
     expect(row).toBeUndefined();
+  });
+});
+
+describe("admin access endpoint", () => {
+  const ada = { email: "ada@eudoxus.ai", sub: "google|123", provider: "google" };
+  const body = (entries: unknown) => ({ entries });
+
+  it("returns 401 without a session", async () => {
+    expect((await request("/api/access", "GET", "secret")).statusCode).toBe(401);
+  });
+
+  it("reports the env list as the one in force before any save", async () => {
+    const token = adminSession.createSession(ada);
+    const res = await request("/api/access", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body);
+    expect(payload.source).toBe("env");
+    expect(payload.stored).toEqual([]);
+    expect(payload.env.map((e: { value: string }) => e.value)).toEqual(["eudoxus.ai"]);
+    expect(payload.changes).toEqual([]);
+  });
+
+  it("tells the page whether the caller may edit, so it never has to infer identity", async () => {
+    const sso = await request("/api/access", "GET", "secret", undefined, adminSession.createSession(ada));
+    expect(JSON.parse(sso.body)).toMatchObject({ canEdit: true, you: "ada@eudoxus.ai" });
+
+    const code = await request("/api/access", "GET", "secret", undefined, await login("secret"));
+    expect(JSON.parse(code.body)).toMatchObject({ canEdit: false, you: null });
+  });
+
+  it("refuses a save from an access-code session, which cannot attribute the change", async () => {
+    const token = await login("secret");
+    const res = await request("/api/access", "POST", "secret", body([]), token);
+    expect(res.statusCode).toBe(403);
+    expect(accessEntries.listAccessEntries()).toEqual([]);
+  });
+
+  it("saves, hands authority to the stored list, and returns the new state", async () => {
+    const token = adminSession.createSession(ada);
+    const res = await request(
+      "/api/access",
+      "POST",
+      "secret",
+      body([
+        { kind: "domain", value: "eudoxus.ai", role: "user" },
+        { kind: "address", value: "ada@eudoxus.ai", role: "admin" },
+      ]),
+      token,
+    );
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body);
+    // The first save is the handover, and the response is what makes that visible.
+    expect(payload.source).toBe("db");
+    expect(payload.stored).toHaveLength(2);
+    expect(payload.changes[0].actor).toBe("ada@eudoxus.ai");
+  });
+
+  it("applies immediately, without waiting for a restart", async () => {
+    const token = adminSession.createSession(ada);
+    await request("/api/access", "POST", "secret", body([{ kind: "domain", value: "eudoxus.ai", role: "user" }]), token);
+    expect(accessEntries.getEffectiveAllowlist()?.source).toBe("db");
+  });
+
+  it("rejects malformed input without touching the stored list", async () => {
+    const token = adminSession.createSession(ada);
+    const res = await request("/api/access", "POST", "secret", body([{ kind: "domain", value: "ada@eudoxus.ai", role: "user" }]), token);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/not a domain/);
+    expect(accessEntries.listAccessEntries()).toEqual([]);
+  });
+
+  it("refuses a save that would remove the saver's own access, leaving no trace of the attempt", async () => {
+    const token = adminSession.createSession(ada);
+    const res = await request(
+      "/api/access",
+      "POST",
+      "secret",
+      body([{ kind: "address", value: "someone-else@eudoxus.ai", role: "admin" }]),
+      token,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/remove your own access/);
+    // Rolled back whole: no entries, and no audit row for a change that did not happen.
+    expect(accessEntries.listAccessEntries()).toEqual([]);
+    expect(accessAudit.listAccessChanges()).toEqual([]);
   });
 });
 

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type * as AdminModule from "../admin.js";
+import type * as AdminSessionModule from "../admin-session.js";
+import type * as AccessEntriesModule from "../access-entries.js";
 import type * as ConfigModule from "../config.js";
 import type * as DedupModule from "../dedup.js";
 import type * as RunnerModeModule from "../runner-mode.js";
@@ -97,6 +99,8 @@ let log: typeof LogModule;
 let stepLog: typeof StepLogModule;
 let installState: typeof InstallStateModule;
 let queue: typeof WorkflowSyncQueueModule;
+let adminSession: typeof AdminSessionModule;
+let accessEntries: typeof AccessEntriesModule;
 let provider: FakeProvider;
 
 beforeEach(async () => {
@@ -105,6 +109,8 @@ beforeEach(async () => {
   process.env.DEDUP_DB_PATH = dbPath;
   provider = new FakeProvider();
   admin = await import("../admin.js");
+  adminSession = await import("../admin-session.js");
+  accessEntries = await import("../access-entries.js");
   config = await import("../config.js");
   dedup = await import("../dedup.js");
   runnerMode = await import("../runner-mode.js");
@@ -116,6 +122,11 @@ beforeEach(async () => {
   log.initLogTable();
   stepLog.initStepLogTable();
   runnerMode.initSettingsTable();
+  accessEntries.initAccessEntriesTable();
+  // Every /api/* request now re-checks the signed-in identity, so the suite needs a list in force.
+  process.env.OAUTH_ALLOWED_DOMAINS = "eudoxus.ai";
+  process.env.OAUTH_ALLOWED_EMAILS = "";
+  accessEntries.refreshEffectiveAllowlist();
 });
 
 afterEach(() => {
@@ -246,6 +257,49 @@ describe("admin auth", () => {
     // Row should be deleted from DB
     const row = getDb().prepare("SELECT * FROM admin_sessions WHERE token = ?").get(token);
     expect(row).toBeUndefined();
+  });
+});
+
+describe("admin session-identity endpoint", () => {
+  it("returns 401 without a session", async () => {
+    const res = await request("/api/session-identity", "GET", "secret");
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("reports an access-code session as unattributed", async () => {
+    const token = await login("secret");
+    const res = await request("/api/session-identity", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      email: null,
+      name: null,
+      provider: null,
+      authMethod: "access-code",
+    });
+  });
+
+  it("returns the signed-in identity for an SSO session", async () => {
+    const token = adminSession.createSession({
+      email: "ada@eudoxus.ai",
+      sub: "google|123",
+      provider: "google",
+      name: "Ada",
+    });
+    const res = await request("/api/session-identity", "GET", "secret", undefined, token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      email: "ada@eudoxus.ai",
+      name: "Ada",
+      provider: "google",
+      authMethod: "sso",
+    });
+  });
+
+  it("stays reachable when access-code login is disabled, so an SSO-only deployment can probe it", async () => {
+    const token = adminSession.createSession({ email: "ada@eudoxus.ai", sub: "google|123", provider: "google" });
+    const res = await requestRaw("/api/session-identity", "GET", null, undefined, token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).email).toBe("ada@eudoxus.ai");
   });
 });
 

--- a/src/__tests__/authorize.test.ts
+++ b/src/__tests__/authorize.test.ts
@@ -1,13 +1,24 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import {
-  configureAuthorizationPolicy,
-  authorize,
-  getAuthorizationPolicy,
-  __resetAuthorizationPolicyForTest,
-} from "../oauth/authorize.js";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
 import type { VerifiedIdentity } from "../oauth/oidc.js";
+import type { AccessEntry } from "../access-entries.js";
 
-const identity = (over: Partial<VerifiedIdentity>): VerifiedIdentity => ({
+// authorize.ts imports access-entries.ts, which imports dedup.ts — and dedup resolves (and
+// creates) its directory at module load. Setting the path before the dynamic import keeps this
+// suite off /data. Nothing here calls getDb(), so no database file is ever opened.
+let authz: typeof import("../oauth/authorize.js");
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.DEDUP_DB_PATH = path.join(
+    os.tmpdir(),
+    `authorize-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  authz = await import("../oauth/authorize.js");
+});
+
+const identity = (over: Partial<VerifiedIdentity> = {}): VerifiedIdentity => ({
   provider: "google",
   sub: "google|1",
   email: "ada@eudoxus.ai",
@@ -19,58 +30,68 @@ const identity = (over: Partial<VerifiedIdentity>): VerifiedIdentity => ({
   ...over,
 });
 
-beforeEach(() => __resetAuthorizationPolicyForTest());
+const entry = (over: Partial<AccessEntry> = {}): AccessEntry => ({
+  kind: "address",
+  value: "ada@eudoxus.ai",
+  role: "admin",
+  provider: null,
+  subject: null,
+  addedAt: 0,
+  addedBy: null,
+  ...over,
+});
 
 describe("authorize", () => {
-  it("denies everyone when the policy is empty (fail-closed)", () => {
-    expect(authorize(identity({})).ok).toBe(false);
+  it("denies everyone when the list is empty (fail-closed)", () => {
+    expect(authz.authorize(identity(), []).ok).toBe(false);
   });
 
-  it("allows a verified email whose domain is on the allowlist", () => {
-    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
-    expect(authorize(identity({ email: "ada@eudoxus.ai" }))).toEqual({ ok: true });
+  it("allows a verified email whose domain is listed", () => {
+    const domain = entry({ kind: "domain", value: "eudoxus.ai", role: "user" });
+    const result = authz.authorize(identity({ email: "ada@eudoxus.ai" }), [domain]);
+    expect(result).toEqual({ ok: true, entry: domain });
   });
 
-  it("allows a verified email listed explicitly, even off an allowed domain", () => {
-    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: ["contractor@gmail.com"] });
-    expect(authorize(identity({ email: "contractor@gmail.com" }))).toEqual({ ok: true });
+  it("allows an address listed explicitly, even off any listed domain", () => {
+    const listed = entry({ value: "contractor@gmail.com" });
+    const result = authz.authorize(identity({ email: "contractor@gmail.com" }), [listed]);
+    expect(result).toEqual({ ok: true, entry: listed });
   });
 
-  it("denies an unverified email regardless of the allowlist", () => {
-    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
-    const result = authorize(identity({ email: "ada@eudoxus.ai", emailVerified: false }));
+  it("returns the matching entry, which is what carries the role and the binding target", () => {
+    const listed = entry({ value: "ada@eudoxus.ai", role: "admin" });
+    const result = authz.authorize(identity(), [listed]);
+    expect(result.ok && result.entry.role).toBe("admin");
+  });
+
+  it("denies an unverified email regardless of the list", () => {
+    const result = authz.authorize(identity({ emailVerified: false }), [entry()]);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toMatch(/not verified/);
   });
 
   it("denies when the provider returned no email", () => {
-    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
-    const result = authorize(identity({ email: null }));
+    const result = authz.authorize(identity({ email: null }), [entry()]);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toMatch(/no email/);
   });
 
-  it("denies a verified email that is neither listed nor on an allowed domain", () => {
-    configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
-    expect(authorize(identity({ email: "someone@evil.com" })).ok).toBe(false);
+  it("denies a verified email that is neither listed nor on a listed domain", () => {
+    const result = authz.authorize(identity({ email: "someone@evil.com" }), [
+      entry({ kind: "domain", value: "eudoxus.ai", role: "user" }),
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/not on the access allowlist/);
   });
 
-  it("matches case-insensitively on email and domain, trimming/dropping empty config entries", () => {
-    configureAuthorizationPolicy({ allowedDomains: [" Eudoxus.AI ", ""], allowedEmails: [] });
-    expect(authorize(identity({ email: "Ada@EUDOXUS.ai" }))).toEqual({ ok: true });
+  it("folds the identity's email before matching, so provider casing does not matter", () => {
+    const domain = entry({ kind: "domain", value: "eudoxus.ai", role: "user" });
+    expect(authz.authorize(identity({ email: " Ada@EUDOXUS.ai " }), [domain]).ok).toBe(true);
   });
 
-  it("does not treat a malformed, @-less identifier as a domain", () => {
+  it("does not treat a malformed, @-less identifier as its own domain", () => {
     // "noatsign".split("@").pop() === "noatsign" === email → the domain check must be skipped
-    configureAuthorizationPolicy({ allowedDomains: ["noatsign"], allowedEmails: [] });
-    expect(authorize(identity({ email: "noatsign" })).ok).toBe(false);
-  });
-
-  it("stores the normalized (lowercased, trimmed, compacted) policy", () => {
-    configureAuthorizationPolicy({ allowedDomains: ["Eudoxus.AI"], allowedEmails: ["Ada@Eudoxus.ai", "  "] });
-    expect(getAuthorizationPolicy()).toEqual({
-      allowedDomains: ["eudoxus.ai"],
-      allowedEmails: ["ada@eudoxus.ai"],
-    });
+    const domain = entry({ kind: "domain", value: "noatsign", role: "user" });
+    expect(authz.authorize(identity({ email: "noatsign" }), [domain]).ok).toBe(false);
   });
 });

--- a/src/__tests__/mcp-oauth.test.ts
+++ b/src/__tests__/mcp-oauth.test.ts
@@ -83,10 +83,17 @@ const asRes = (res: MockResponse) => res as unknown as http.ServerResponse;
 // Modules reloaded per test to get fresh DB state
 let mcpOauth: typeof import("../mcp-oauth.js");
 let providers: typeof import("../oauth/providers.js");
-let authz: typeof import("../oauth/authorize.js");
+let access: typeof import("../access-entries.js");
 let oidc: typeof import("../oauth/oidc.js");
 let dedup: typeof import("../dedup.js");
 let dbPath: string;
+
+/** Seed the list in force the way a pre-handover deployment does — from the env. */
+function setAllowedDomains(domains: string): void {
+  process.env.OAUTH_ALLOWED_DOMAINS = domains;
+  process.env.OAUTH_ALLOWED_EMAILS = "";
+  access.refreshEffectiveAllowlist();
+}
 
 beforeEach(async () => {
   vi.resetModules();
@@ -96,13 +103,14 @@ beforeEach(async () => {
 
   mcpOauth = await import("../mcp-oauth.js");
   providers = await import("../oauth/providers.js");
-  authz = await import("../oauth/authorize.js");
+  access = await import("../access-entries.js");
   oidc = await import("../oauth/oidc.js");
   dedup = await import("../dedup.js");
 
   mcpOauth.initMcpOAuthTables();
+  access.initAccessEntriesTable();
   providers.configureOAuthProviders([googleProvider]);
-  authz.configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+  setAllowedDomains("eudoxus.ai");
   (oidc.buildAuthUrl as ReturnType<typeof vi.fn>).mockResolvedValue(OIDC_START);
 });
 
@@ -720,7 +728,7 @@ describe("handleMcpTokenRequest — refresh_token grant", () => {
   it("re-checks the allowlist and refuses if user is removed", async () => {
     const { refreshToken, clientId } = await getTokens();
     // Remove user from allowlist
-    authz.configureAuthorizationPolicy({ allowedDomains: [], allowedEmails: [] });
+    setAllowedDomains("");
     const res = new MockResponse();
     await mcpOauth.handleMcpTokenRequest(makeRefreshReq(refreshToken, clientId), asRes(res));
     expect(res.statusCode).toBe(400);

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -7,6 +7,10 @@ vi.mock("../mcp-oauth.js", () => ({
   verifyMcpToken: vi.fn(),
 }));
 
+vi.mock("../access-entries.js", () => ({
+  recheckIdentity: vi.fn(),
+}));
+
 vi.mock("../runner-mode.js", () => ({
   getRunnerMode: vi.fn(),
 }));
@@ -86,6 +90,7 @@ class MockResponse extends Writable {
 
 let mockHttpRequest: ReturnType<typeof vi.fn>;
 let mcpOauth: typeof import("../mcp-oauth.js");
+let accessMock: typeof import("../access-entries.js");
 let runnerModeMock: typeof import("../runner-mode.js");
 let configMock: typeof import("../config.js");
 let logMock: typeof import("../log.js");
@@ -97,6 +102,7 @@ beforeEach(async () => {
   vi.spyOn(http, "request").mockImplementation(mockHttpRequest as never);
 
   mcpOauth = await import("../mcp-oauth.js");
+  accessMock = await import("../access-entries.js");
   runnerModeMock = await import("../runner-mode.js");
   configMock = await import("../config.js");
   logMock = await import("../log.js");
@@ -116,6 +122,20 @@ beforeEach(async () => {
       get: vi.fn(() => ({ n: 0 })),
       all: vi.fn(() => []),
     })),
+  });
+
+  // The gate re-checks the token's identity on every request; allow it unless a test says otherwise.
+  (accessMock.recheckIdentity as ReturnType<typeof vi.fn>).mockReturnValue({
+    status: "ok",
+    entry: {
+      kind: "address",
+      value: "ada@eudoxus.ai",
+      role: "admin",
+      provider: null,
+      subject: null,
+      addedAt: 0,
+      addedBy: null,
+    },
   });
 });
 
@@ -224,6 +244,23 @@ describe("handleMcpRequest", () => {
     it("does not proxy on auth failure", async () => {
       await callMcp({ authorization: "Bearer invalid" }, false);
       expect(mockHttpRequest).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 for a valid token whose identity is no longer admitted", async () => {
+      (accessMock.recheckIdentity as ReturnType<typeof vi.fn>).mockReturnValue({ status: "denied" });
+      // The token itself is still valid — an access token would otherwise outlive a removal by an hour.
+      const result = await callMcp({ authorization: "Bearer tok" }, true);
+      expect(result.statusCode).toBe(401);
+      expect(result.responseHeaders["WWW-Authenticate"]).toContain("oauth-protected-resource");
+      expect(mockHttpRequest).not.toHaveBeenCalled();
+    });
+
+    it("returns 503 rather than 401 when the allowlist cannot be read", async () => {
+      (accessMock.recheckIdentity as ReturnType<typeof vi.fn>).mockReturnValue({ status: "unavailable" });
+      const result = await callMcp({ authorization: "Bearer tok" }, true);
+      expect(result.statusCode).toBe(503);
+      // Not an authentication failure, so no challenge to re-authenticate against.
+      expect(result.responseHeaders["WWW-Authenticate"]).toBeUndefined();
     });
   });
 

--- a/src/__tests__/oauth-routes.test.ts
+++ b/src/__tests__/oauth-routes.test.ts
@@ -55,7 +55,7 @@ const asRes = (res: MockResponse) => res as unknown as http.ServerResponse;
 
 let routes: typeof import("../oauth/routes.js");
 let providers: typeof import("../oauth/providers.js");
-let authz: typeof import("../oauth/authorize.js");
+let access: typeof import("../access-entries.js");
 let oidc: typeof import("../oauth/oidc.js");
 let store: typeof import("../oauth/state-store.js");
 let session: typeof import("../admin-session.js");
@@ -69,12 +69,20 @@ beforeEach(async () => {
   process.env.DEDUP_DB_PATH = dbPath;
   routes = await import("../oauth/routes.js");
   providers = await import("../oauth/providers.js");
-  authz = await import("../oauth/authorize.js");
+  access = await import("../access-entries.js");
   oidc = await import("../oauth/oidc.js");
   store = await import("../oauth/state-store.js");
   session = await import("../admin-session.js");
   dedup = await import("../dedup.js");
+  access.initAccessEntriesTable();
 });
+
+/** Seed the list in force the way a pre-handover deployment does — from the env. */
+function allowDomain(domain: string): void {
+  process.env.OAUTH_ALLOWED_DOMAINS = domain;
+  process.env.OAUTH_ALLOWED_EMAILS = "";
+  access.refreshEffectiveAllowlist();
+}
 
 afterEach(() => {
   dedup.closeDb();
@@ -172,7 +180,7 @@ describe("handleOAuthCallback", () => {
 
   it("redirects to auth_error=denied with no session when the identity is not allowed", async () => {
     providers.configureOAuthProviders([googleProvider]);
-    authz.configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    allowDomain("eudoxus.ai");
     store.putTransaction({ state: "dn", provider: "google", codeVerifier: "v", nonce: "n", redirectTo: "/admin" });
     vi.mocked(oidc.completeAuth).mockResolvedValue(identity({ email: "stranger@evil.com" }));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -189,7 +197,7 @@ describe("handleOAuthCallback", () => {
 
   it("on success sets a session cookie and 302-redirects to the stored path", async () => {
     providers.configureOAuthProviders([googleProvider]);
-    authz.configureAuthorizationPolicy({ allowedDomains: ["eudoxus.ai"], allowedEmails: [] });
+    allowDomain("eudoxus.ai");
     store.putTransaction({ state: "ok", provider: "google", codeVerifier: "v", nonce: "n", redirectTo: "/admin/pipelines" });
     vi.mocked(oidc.completeAuth).mockResolvedValue(identity({ email: "ada@eudoxus.ai" }));
 
@@ -201,20 +209,20 @@ describe("handleOAuthCallback", () => {
     const setCookie = res.headers["Set-Cookie"] as string;
     expect(setCookie).toContain("ai_admin_session=");
     const token = decodeURIComponent(setCookie.split(";")[0].split("=")[1]);
-    expect(session.isValidSession(token)).toBe(true);
+    expect(session.resolveSession(token)).not.toBeNull();
   });
 });
 
 describe("handleOAuthLogout", () => {
   it("revokes the session and clears the cookie", () => {
     const token = session.createSession({ email: "ada@eudoxus.ai", sub: "s", provider: "google", name: "Ada" });
-    expect(session.isValidSession(token)).toBe(true);
+    expect(session.resolveSession(token)).not.toBeNull();
 
     const res = new MockResponse();
     routes.handleOAuthLogout(mkReq("/api/auth/logout", { cookie: `ai_admin_session=${token}` }), asRes(res), false);
 
     expect(res.statusCode).toBe(200);
     expect(res.headers["Set-Cookie"] as string).toContain("Max-Age=0");
-    expect(session.isValidSession(token)).toBe(false);
+    expect(session.resolveSession(token)).toBeNull();
   });
 });

--- a/src/access-audit.ts
+++ b/src/access-audit.ts
@@ -1,0 +1,86 @@
+/**
+ * A record of every change to who may sign in.
+ * Append-only: it says what the list was, what it became, and who did it — 
+ * never why, and never anything the allowlist decides.
+ */
+
+import { getDb } from "./dedup.js";
+import type { AccessEntryInput } from "./access-entries.js";
+
+/** How the change was made. An access-code save and a host recovery both have no attributable person. */
+export type AccessAuditAction = "save" | "recover";
+
+export interface AccessChange {
+  id: number;
+  createdAt: number;
+  actor: string | null;
+  action: AccessAuditAction;
+  before: AccessEntryInput[];
+  after: AccessEntryInput[];
+}
+
+interface AccessChangeRow {
+  id: number;
+  created_at: number;
+  actor: string | null;
+  action: string;
+  before_json: string;
+  after_json: string;
+}
+
+/** An audit snapshot is what an operator edited — never the binding or provenance they didn't. */
+const snapshot = (entries: AccessEntryInput[]): AccessEntryInput[] =>
+  entries.map(({ kind, value, role }) => ({ kind, value, role }));
+
+export function initAccessAuditTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS access_audit (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      created_at  INTEGER NOT NULL,
+      actor       TEXT,
+      action      TEXT NOT NULL,
+      before_json TEXT NOT NULL,
+      after_json  TEXT NOT NULL
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_access_audit_created_at ON access_audit(created_at)");
+}
+
+export function recordAccessChange(change: Omit<AccessChange, "id" | "createdAt">): void {
+  getDb()
+    .prepare("INSERT INTO access_audit (created_at, actor, action, before_json, after_json) VALUES (?, ?, ?, ?, ?)")
+    .run(
+      Date.now(),
+      change.actor,
+      change.action,
+      JSON.stringify(snapshot(change.before)),
+      JSON.stringify(snapshot(change.after)),
+    );
+}
+
+export function listAccessChanges(limit = 20): AccessChange[] {
+  const rows = getDb()
+    .prepare(
+      "SELECT id, created_at, actor, action, before_json, after_json FROM access_audit ORDER BY created_at DESC, id DESC LIMIT ?",
+    )
+    .all(limit) as AccessChangeRow[];
+  return rows.map((r) => ({
+    id: r.id,
+    createdAt: r.created_at,
+    actor: r.actor,
+    action: r.action === "recover" ? "recover" : "save",
+    before: parseSnapshot(r.before_json),
+    after: parseSnapshot(r.after_json),
+  }));
+}
+
+function parseSnapshot(raw: string): AccessEntryInput[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as AccessEntryInput[]) : [];
+  } catch {
+    // A row we cannot read is still evidence a change happened — keep it, show it empty.
+    return [];
+  }
+}

--- a/src/access-entries.ts
+++ b/src/access-entries.ts
@@ -243,15 +243,21 @@ export function saveAccessEntries(
     }
     recordAccessChange({ actor, action: "save", before, after: normalized });
   })();
+  // After the transaction, never inside it — the lockout guard above rolls the save back by
+  // throwing, and a refresh from within would cache what was rolled back.
+  refreshEffectiveAllowlist();
 }
 
 /** Record the provider identity an address resolved to, the first time it signs in. */
 export function bindAccessEntry(value: string, provider: string, subject: string): void {
-  getDb()
+  const result = getDb()
     .prepare(
       "UPDATE access_entries SET provider = ?, subject = ? WHERE kind = 'address' AND value = ? AND provider IS NULL",
     )
     .run(provider, subject, value.trim().toLowerCase());
+  // Without this the binding is written but never consulted: the cache still holds the entry as
+  // unbound, so matching keeps taking the address branch and admits whoever holds it.
+  if (result.changes > 0) refreshEffectiveAllowlist();
 }
 
 /** Test hook: drop the cached list. */

--- a/src/access-entries.ts
+++ b/src/access-entries.ts
@@ -1,0 +1,203 @@
+/**
+ * The sign-in allowlist: who may authenticate, and as what.
+ *
+ * One row per entry — a whole email domain, or one address.
+ * - A domain admits as`user`; only a listed address may carry `admin`
+ * - `provider`/`subject` bind on first successful sign-in and match from then on, so a rename keeps its role
+ * and a reassigned address inherits nothing.
+ */
+
+import { getDb } from "./dedup.js";
+
+export type AccessEntryKind = "domain" | "address";
+export type AccessRole = "user" | "admin";
+export type RecheckResult =
+  | { status: "ok"; entry: AccessEntry }
+  | { status: "unavailable" }
+  | { status: "denied" };
+
+export interface EffectiveAllowlist {
+  entries: AccessEntry[];
+  source: "env" | "db";
+}
+
+export interface AccessEntry {
+  kind: AccessEntryKind;
+  value: string;
+  role: AccessRole;
+  provider: string | null;
+  subject: string | null;
+  addedAt: number;
+  addedBy: string | null;
+}
+
+export interface AccessEntryInput {
+  kind: AccessEntryKind;
+  value: string;
+  role: AccessRole;
+}
+
+interface AccessEntryRow {
+  kind: string;
+  value: string;
+  role: string;
+  provider: string | null;
+  subject: string | null;
+  added_at: number;
+  added_by: string | null;
+}
+
+let cached: EffectiveAllowlist | null = null;
+
+export function initAccessEntriesTable(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS access_entries (
+      kind     TEXT NOT NULL,
+      value    TEXT NOT NULL,
+      role     TEXT NOT NULL,
+      provider TEXT,
+      subject  TEXT,
+      added_at INTEGER NOT NULL,
+      added_by TEXT,
+      PRIMARY KEY (kind, value)
+    )
+  `);
+}
+
+/** Re-check a persisted identity against the list in force. */
+export function recheckIdentity(identity: { provider: string; sub: string; email: string | null }): RecheckResult {
+  const allowlist = getEffectiveAllowlist();
+  if (!allowlist) return { status: "unavailable" };
+  const entry = matchAccessEntry(identity, allowlist.entries);
+  return entry ? { status: "ok", entry } : { status: "denied" };
+}
+
+/**
+ * The entry admitting this identity, or null. Takes the three fields every identity shape
+ * in the codebase carries, so a session row and an MCP token row both fit without adapting.
+ */
+export function matchAccessEntry(
+  identity: { provider: string; sub: string; email: string | null },
+  entries: AccessEntry[],
+): AccessEntry | null {
+  const email = (identity.email ?? "").trim().toLowerCase();
+  const domain = email.split("@").pop() ?? "";
+
+  // An address outranks a domain: it is the more specific grant and the only one carrying a role.
+  for (const entry of entries) {
+    if (entry.kind !== "address") continue;
+    if (entry.provider && entry.subject) {
+      // Bound entries match on the provider identity alone, so a reassigned address inherits nothing.
+      if (entry.provider === identity.provider && entry.subject === identity.sub) return entry;
+    } else if (entry.value === email) {
+      return entry;
+    }
+  }
+
+  // A malformed, @-less identifier has domain === email and must not match a domain entry.
+  if (domain && domain !== email) {
+    for (const entry of entries) {
+      if (entry.kind === "domain" && entry.value === domain) return entry;
+    }
+  }
+  return null;
+}
+
+/** The list in force. Null only when no list has ever loaded — callers must deny. */
+export function getEffectiveAllowlist(): EffectiveAllowlist | null {
+  if (!cached) refreshEffectiveAllowlist();
+  return cached;
+}
+
+/** Re-read after a write, so a change applies without a restart. */
+export function refreshEffectiveAllowlist(): void {
+  try {
+    const stored = listAccessEntries();
+    cached = stored.length > 0
+      ? { entries: stored, source: "db" }
+      : { entries: allowlistFromEnv(process.env), source: "env" };
+  } catch (err) {
+    if (cached) {
+      console.warn("[access] allowlist read failed; serving the last good list, will retry on the next request:", err);
+    } else {
+      console.error("[access] allowlist unreadable with none cached. admin and MCP denied, will retry on the next request:", err);
+    }
+  }
+}
+
+/** The env values, which apply until the first save hands authority to the stored list. */
+function allowlistFromEnv(env: NodeJS.ProcessEnv): AccessEntry[] {
+  const split = (raw: string | undefined) =>
+    (raw || "").split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+  // addedAt 0: env entries are synthesized per read and carry no provenance.
+  return [
+    ...split(env.OAUTH_ALLOWED_DOMAINS).map((value): AccessEntry => ({
+      kind: "domain", value, role: "user", provider: null, subject: null, addedAt: 0, addedBy: null,
+    })),
+    ...split(env.OAUTH_ALLOWED_EMAILS).map((value): AccessEntry => ({
+      kind: "address", value, role: "admin", provider: null, subject: null, addedAt: 0, addedBy: null,
+    })),
+  ];
+}
+
+/** Every stored entry. Zero rows means the env->DB handover has not happened and the env list still applies. */
+export function listAccessEntries(): AccessEntry[] {
+  const rows = getDb()
+    .prepare("SELECT kind, value, role, provider, subject, added_at, added_by FROM access_entries ORDER BY kind, value")
+    .all() as AccessEntryRow[];
+  // Both checks name the permissive value, so an unreadable row falls back to the restrictive one
+  // ('domain' admits a whole company, 'address' admits one person)
+  return rows.map((r) => ({
+    kind: r.kind === "domain" ? "domain" : "address",
+    value: r.value,
+    role: r.role === "admin" ? "admin" : "user",
+    provider: r.provider,
+    subject: r.subject,
+    addedAt: r.added_at,
+    addedBy: r.added_by,
+  }));
+}
+
+/** Replace the stored list. Surviving entries keep their binding and provenance. */
+export function saveAccessEntries(next: AccessEntryInput[], actor: string | null): void {
+  const normalized = next.map((e) => ({ ...e, value: e.value.trim().toLowerCase() }));
+
+  for (const e of normalized) {
+    if (!e.value) throw new Error("an access entry cannot be empty");
+    if (e.kind === "domain" && e.role === "admin") {
+      throw new Error("a domain entry cannot carry the admin role");
+    }
+  }
+
+  const db = getDb();
+  const now = Date.now();
+  const keep = new Set(normalized.map((e) => `${e.kind}:${e.value}`));
+
+  db.transaction(() => {
+    for (const existing of listAccessEntries()) {
+      if (!keep.has(`${existing.kind}:${existing.value}`)) {
+        db.prepare("DELETE FROM access_entries WHERE kind = ? AND value = ?").run(existing.kind, existing.value);
+      }
+    }
+    const upsert = db.prepare(
+      `INSERT INTO access_entries (kind, value, role, provider, subject, added_at, added_by)
+       VALUES (?, ?, ?, NULL, NULL, ?, ?)
+       ON CONFLICT(kind, value) DO UPDATE SET role = excluded.role`,
+    );
+    for (const e of normalized) upsert.run(e.kind, e.value, e.role, now, actor);
+  })();
+}
+
+/** Record the provider identity an address resolved to, the first time it signs in. */
+export function bindAccessEntry(value: string, provider: string, subject: string): void {
+  getDb()
+    .prepare(
+      "UPDATE access_entries SET provider = ?, subject = ? WHERE kind = 'address' AND value = ? AND provider IS NULL",
+    )
+    .run(provider, subject, value.trim().toLowerCase());
+}
+
+/** Test hook: drop the cached list. */
+export function __resetAllowlistCacheForTest(): void {
+  cached = null;
+}

--- a/src/access-entries.ts
+++ b/src/access-entries.ts
@@ -7,7 +7,15 @@
  * and a reassigned address inherits nothing.
  */
 
+import { recordAccessChange } from "./access-audit.js";
 import { getDb } from "./dedup.js";
+
+/**
+ * The identity fields a decision needs. Deliberately not exported and deliberately not a fourth
+ * identity type — VerifiedIdentity, SessionIdentity and McpTokenIdentity all satisfy it
+ * structurally, and its `email: string | null` is wider than the two persisted shapes.
+ */
+type MatchableIdentity = { provider: string; sub: string; email: string | null };
 
 export type AccessEntryKind = "domain" | "address";
 export type AccessRole = "user" | "admin";
@@ -15,6 +23,9 @@ export type RecheckResult =
   | { status: "ok"; entry: AccessEntry }
   | { status: "unavailable" }
   | { status: "denied" };
+type ParsedAccess =
+  | { ok: true; entries: AccessEntryInput[] }
+  | { ok: false; error: string };
 
 export interface EffectiveAllowlist {
   entries: AccessEntry[];
@@ -47,6 +58,10 @@ interface AccessEntryRow {
   added_by: string | null;
 }
 
+const MAX_ACCESS_ENTRIES = 200;
+const ADDRESS_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const DOMAIN_SHAPE = /^[^\s@.]+(\.[^\s@.]+)+$/;
+
 let cached: EffectiveAllowlist | null = null;
 
 export function initAccessEntriesTable(): void {
@@ -65,21 +80,15 @@ export function initAccessEntriesTable(): void {
 }
 
 /** Re-check a persisted identity against the list in force. */
-export function recheckIdentity(identity: { provider: string; sub: string; email: string | null }): RecheckResult {
+export function recheckIdentity(identity: MatchableIdentity): RecheckResult {
   const allowlist = getEffectiveAllowlist();
   if (!allowlist) return { status: "unavailable" };
   const entry = matchAccessEntry(identity, allowlist.entries);
   return entry ? { status: "ok", entry } : { status: "denied" };
 }
 
-/**
- * The entry admitting this identity, or null. Takes the three fields every identity shape
- * in the codebase carries, so a session row and an MCP token row both fit without adapting.
- */
-export function matchAccessEntry(
-  identity: { provider: string; sub: string; email: string | null },
-  entries: AccessEntry[],
-): AccessEntry | null {
+/** The entry admitting this identity, or null. Entries arrive normalized; only the identity is folded here. */
+export function matchAccessEntry(identity: MatchableIdentity, entries: AccessEntry[]): AccessEntry | null {
   const email = (identity.email ?? "").trim().toLowerCase();
   const domain = email.split("@").pop() ?? "";
 
@@ -140,6 +149,11 @@ function allowlistFromEnv(env: NodeJS.ProcessEnv): AccessEntry[] {
   ];
 }
 
+/** What the env supplies, whether or not it is still in force. The page shows it as stale after handover. */
+export function getEnvAllowlist(): AccessEntry[] {
+  return allowlistFromEnv(process.env);
+}
+
 /** Every stored entry. Zero rows means the env->DB handover has not happened and the env list still applies. */
 export function listAccessEntries(): AccessEntry[] {
   const rows = getDb()
@@ -158,8 +172,44 @@ export function listAccessEntries(): AccessEntry[] {
   }));
 }
 
+export function parseAccessEntries(raw: unknown): ParsedAccess {
+  if (!Array.isArray(raw)) return { ok: false, error: "entries must be an array" };
+  if (raw.length > MAX_ACCESS_ENTRIES) {
+    // The list is scanned on every authenticated request, so its length is bounded.
+    return { ok: false, error: `at most ${MAX_ACCESS_ENTRIES} entries` };
+  }
+
+  const entries: AccessEntryInput[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (typeof item !== "object" || item === null) return { ok: false, error: "each entry must be an object" };
+    const { kind, value, role } = item as Record<string, unknown>;
+    if (kind !== "domain" && kind !== "address") return { ok: false, error: "kind must be 'domain' or 'address'" };
+    if (role !== "user" && role !== "admin") return { ok: false, error: "role must be 'user' or 'admin'" };
+    if (typeof value !== "string" || !value.trim()) return { ok: false, error: "value must be a non-empty string" };
+
+    const normalized = value.trim().toLowerCase();
+    // A shape mismatch would save cleanly and then match nobody — an entry that looks right and is inert.
+    if (kind === "address" && !ADDRESS_SHAPE.test(normalized)) {
+      return { ok: false, error: `"${normalized}" is not an email address` };
+    }
+    if (kind === "domain" && !DOMAIN_SHAPE.test(normalized)) {
+      return { ok: false, error: `"${normalized}" is not a domain` };
+    }
+    if (seen.has(`${kind}:${normalized}`)) return { ok: false, error: `"${normalized}" is listed twice` };
+
+    seen.add(`${kind}:${normalized}`);
+    entries.push({ kind, value: normalized, role });
+  }
+  return { ok: true, entries };
+}
+
 /** Replace the stored list. Surviving entries keep their binding and provenance. */
-export function saveAccessEntries(next: AccessEntryInput[], actor: string | null): void {
+export function saveAccessEntries(
+  next: AccessEntryInput[],
+  actor: string | null,
+  mustAdmit?: MatchableIdentity | null,
+): void {
   const normalized = next.map((e) => ({ ...e, value: e.value.trim().toLowerCase() }));
 
   for (const e of normalized) {
@@ -174,9 +224,10 @@ export function saveAccessEntries(next: AccessEntryInput[], actor: string | null
   const keep = new Set(normalized.map((e) => `${e.kind}:${e.value}`));
 
   db.transaction(() => {
-    for (const existing of listAccessEntries()) {
-      if (!keep.has(`${existing.kind}:${existing.value}`)) {
-        db.prepare("DELETE FROM access_entries WHERE kind = ? AND value = ?").run(existing.kind, existing.value);
+    const before = listAccessEntries();
+    for (const entry of before) {
+      if (!keep.has(`${entry.kind}:${entry.value}`)) {
+        db.prepare("DELETE FROM access_entries WHERE kind = ? AND value = ?").run(entry.kind, entry.value);
       }
     }
     const upsert = db.prepare(
@@ -185,6 +236,12 @@ export function saveAccessEntries(next: AccessEntryInput[], actor: string | null
        ON CONFLICT(kind, value) DO UPDATE SET role = excluded.role`,
     );
     for (const e of normalized) upsert.run(e.kind, e.value, e.role, now, actor);
+
+    // Evaluated against the real result, and a throw rolls the whole save back.
+    if (mustAdmit && !matchAccessEntry(mustAdmit, listAccessEntries())) {
+      throw new Error("this change would remove your own access");
+    }
+    recordAccessChange({ actor, action: "save", before, after: normalized });
   })();
 }
 

--- a/src/access-entries.ts
+++ b/src/access-entries.ts
@@ -7,7 +7,7 @@
  * and a reassigned address inherits nothing.
  */
 
-import { recordAccessChange } from "./access-audit.js";
+import { recordAccessChange, type AccessAuditAction } from "./access-audit.js";
 import { getDb } from "./dedup.js";
 
 /**
@@ -63,6 +63,18 @@ const ADDRESS_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const DOMAIN_SHAPE = /^[^\s@.]+(\.[^\s@.]+)+$/;
 
 let cached: EffectiveAllowlist | null = null;
+let cachedAt = 0;
+
+/**
+ * How long a cached list serves before it is re-read: one poll interval, so a write from another
+ * process — the recovery command — takes effect without a restart. Writes made in this process
+ * refresh immediately, so removing someone still takes effect on their next request.
+ *
+ * Parsed strictly: a NaN would make every freshness comparison false and silently stop the re-read.
+ */
+const CONFIGURED_POLL_MS = parseInt(process.env.POLL_INTERVAL_MS || "", 10);
+const ALLOWLIST_TTL_MS =
+  Number.isFinite(CONFIGURED_POLL_MS) && CONFIGURED_POLL_MS > 0 ? CONFIGURED_POLL_MS : 60_000;
 
 export function initAccessEntriesTable(): void {
   getDb().exec(`
@@ -114,21 +126,26 @@ export function matchAccessEntry(identity: MatchableIdentity, entries: AccessEnt
 
 /** The list in force. Null only when no list has ever loaded — callers must deny. */
 export function getEffectiveAllowlist(): EffectiveAllowlist | null {
-  if (!cached) refreshEffectiveAllowlist();
+  if (!cached || Date.now() - cachedAt >= ALLOWLIST_TTL_MS) refreshEffectiveAllowlist();
   return cached;
 }
 
-/** Re-read after a write, so a change applies without a restart. */
+/** Re-read after a write, or once the cached list has aged out. */
 export function refreshEffectiveAllowlist(): void {
   try {
     const stored = listAccessEntries();
     cached = stored.length > 0
       ? { entries: stored, source: "db" }
       : { entries: allowlistFromEnv(process.env), source: "env" };
+    cachedAt = Date.now();
   } catch (err) {
     if (cached) {
-      console.warn("[access] allowlist read failed; serving the last good list, will retry on the next request:", err);
+      // Back off to one attempt per window: the last good list serves correctly meanwhile, and
+      // retrying per request would warn on every one.
+      cachedAt = Date.now();
+      console.warn("[access] allowlist read failed; serving the last good list, will retry shortly:", err);
     } else {
+      // cachedAt stays 0 so the next request retries — nothing is being served yet.
       console.error("[access] allowlist unreadable with none cached. admin and MCP denied, will retry on the next request:", err);
     }
   }
@@ -208,7 +225,7 @@ export function parseAccessEntries(raw: unknown): ParsedAccess {
 export function saveAccessEntries(
   next: AccessEntryInput[],
   actor: string | null,
-  mustAdmit?: MatchableIdentity | null,
+  opts: { mustAdmit?: MatchableIdentity | null; action?: AccessAuditAction } = {},
 ): void {
   const normalized = next.map((e) => ({ ...e, value: e.value.trim().toLowerCase() }));
 
@@ -238,10 +255,10 @@ export function saveAccessEntries(
     for (const e of normalized) upsert.run(e.kind, e.value, e.role, now, actor);
 
     // Evaluated against the real result, and a throw rolls the whole save back.
-    if (mustAdmit && !matchAccessEntry(mustAdmit, listAccessEntries())) {
+    if (opts.mustAdmit && !matchAccessEntry(opts.mustAdmit, listAccessEntries())) {
       throw new Error("this change would remove your own access");
     }
-    recordAccessChange({ actor, action: "save", before, after: normalized });
+    recordAccessChange({ actor, action: opts.action ?? "save", before, after: normalized });
   })();
   // After the transaction, never inside it — the lockout guard above rolls the save back by
   // throwing, and a refresh from within would cache what was rolled back.
@@ -263,4 +280,5 @@ export function bindAccessEntry(value: string, provider: string, subject: string
 /** Test hook: drop the cached list. */
 export function __resetAllowlistCacheForTest(): void {
   cached = null;
+  cachedAt = 0;
 }

--- a/src/access-recovery.ts
+++ b/src/access-recovery.ts
@@ -1,0 +1,132 @@
+/**
+ * Break-glass access recovery, run on the host when nobody can sign in.
+ *
+ *   node dist/access-recovery.js --email you@example.com [--only]
+ *
+ * There is no standing credential: the authority is shell access, which already implies reading
+ * the database and every secret. The change is audited with a null actor, because nobody
+ * authenticated for it.
+ */
+
+import { initAccessAuditTable } from "./access-audit.js";
+import { initAccessEntriesTable, listAccessEntries, parseAccessEntries, saveAccessEntries } from "./access-entries.js";
+import { notifyText } from "./notify.js";
+
+export interface AccessRecoveryDependencies {
+  initTables: () => void;
+  listEntries: typeof listAccessEntries;
+  saveEntries: typeof saveAccessEntries;
+  notify: typeof notifyText;
+  writeStdout: (text: string) => void;
+  writeStderr: (text: string) => void;
+  /** The only two environment values this command reads. */
+  notifyWebhookUrl: string | undefined;
+  appName: string | undefined;
+}
+
+const DEFAULT_DEPENDENCIES: AccessRecoveryDependencies = {
+  initTables: () => {
+    // A separate process from the orchestrator, so neither table exists here until asked for.
+    initAccessEntriesTable();
+    initAccessAuditTable();
+  },
+  listEntries: listAccessEntries,
+  saveEntries: saveAccessEntries,
+  notify: notifyText,
+  writeStdout: (text) => process.stdout.write(text),
+  writeStderr: (text) => process.stderr.write(text),
+  notifyWebhookUrl: process.env.NOTIFY_WEBHOOK_URL,
+  appName: process.env.FLY_APP_NAME,
+};
+
+const USAGE = `Usage: node dist/access-recovery.js --email <address> [--only]
+
+  --email <address>  the address to grant admin
+  --only             replace the whole list with this address, rather than adding to it
+`;
+
+export async function runAccessRecovery(
+  args: string[],
+  deps: AccessRecoveryDependencies = DEFAULT_DEPENDENCIES,
+): Promise<number> {
+  let email = "";
+  let only = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--email" && args[i + 1]) email = args[++i] as string;
+    else if (arg === "--only") only = true;
+    else if (arg === "--help" || arg === "-h") {
+      deps.writeStdout(USAGE);
+      return 0;
+    } else {
+      deps.writeStderr(`Unknown argument: ${arg}\n\n${USAGE}`);
+      return 1;
+    }
+  }
+
+  if (!email) {
+    deps.writeStderr(`--email is required\n\n${USAGE}`);
+    return 1;
+  }
+
+  const address = email.trim().toLowerCase();
+
+  // One try around every step that touches the database, so opening it, reading it and writing to
+  // it all fail the same way. The guard at the bottom of the file is then a last resort for a bug,
+  // not a second error path.
+  try {
+    deps.initTables();
+
+    // Dropping any existing row for this address first makes recovery idempotent, and lets it
+    // promote someone whose role is what locked them out rather than refusing as a duplicate.
+    const kept = only
+      ? []
+      : deps.listEntries().filter((e) => !(e.kind === "address" && e.value === address));
+    const desired = [
+      ...kept.map(({ kind, value, role }) => ({ kind, value, role })),
+      { kind: "address", value: address, role: "admin" },
+    ];
+
+    // The same validator the admin route uses, so the command cannot write a shape the UI rejects.
+    const parsed = parseAccessEntries(desired);
+    if (!parsed.ok) {
+      deps.writeStderr(`${parsed.error}\n`);
+      return 1;
+    }
+
+    deps.saveEntries(parsed.entries, null, { action: "recover" });
+  } catch (err) {
+    deps.writeStderr(`Recovery failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  }
+
+  deps.writeStdout(
+    `Added ${address} as admin${only ? ", replacing the previous list" : ""}.\n` +
+      `Recorded in the access audit with no actor.\n` +
+      `In effect within one poll interval — no restart needed.\n`,
+  );
+
+  if (deps.notifyWebhookUrl) {
+    // Best-effort: a recovery that worked must not report failure because a webhook was down.
+    try {
+      await deps.notify(
+        deps.notifyWebhookUrl,
+        `Access recovery ran on ${deps.appName ?? "this orchestrator"}: ${address} granted admin` +
+          `${only ? " (list replaced)" : ""}. Performed on the host, with no authenticated user.`,
+      );
+    } catch (err) {
+      deps.writeStderr(`Notification failed: ${err instanceof Error ? err.message : String(err)}\n`);
+    }
+  }
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runAccessRecovery(process.argv.slice(2))
+    .then((exitCode) => process.exit(exitCode))
+    .catch((err) => {
+      process.stderr.write(`Recovery failed: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/src/admin-session.ts
+++ b/src/admin-session.ts
@@ -1,13 +1,15 @@
 /**
- * Admin session tokens — mint, validate, revoke, and resolve them from a request.
- * Extracted from admin.ts so the OAuth routes (and index.ts) can share the session layer without importing the heavy admin module.
- * Kept dependency-light: only the DB + cookie helper.
+ * Admin sessions — mint, validate, revoke, resolve them from a request, and gate a request
+ * on the identity still being allowed.
+ * Extracted from admin.ts so the OAuth routes (and index.ts) can share the session layer
+ * without importing the heavy admin module; the allowlist adds no dependency beyond the DB.
  */
 
 import crypto from "node:crypto";
 import type http from "node:http";
 import { getDb } from "./dedup.js";
 import { parseCookies, SESSION_COOKIE_NAME } from "./cookies.js";
+import { recheckIdentity, type AccessEntry } from "./access-entries.js";
 
 export const SESSION_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -17,6 +19,11 @@ export interface SessionIdentity {
   sub: string;
   provider: string;
   name?: string | null;
+}
+
+/** A live session. `identity` is null for the access-code path, which mints one without a user. */
+export interface ResolvedSession {
+  identity: SessionIdentity | null;
 }
 
 /** Mint a session token. SSO passes the verified identity; the access-code path passes nothing (identity columns stay NULL). */
@@ -37,17 +44,31 @@ export function createSession(identity?: SessionIdentity): string {
   return token;
 }
 
-export function isValidSession(token: string | undefined): boolean {
-  if (!token) return false;
+/** Validate a token and return who holds it — the identity columns ride along with the expiry check. */
+export function resolveSession(token: string | undefined): ResolvedSession | null {
+  if (!token) return null;
   const row = getDb()
-    .prepare("SELECT expires_at FROM admin_sessions WHERE token = ?")
-    .get(token) as { expires_at: number } | undefined;
-  if (!row) return false;
+    .prepare("SELECT expires_at, email, sub, provider, name FROM admin_sessions WHERE token = ?")
+    .get(token) as
+      | {
+          expires_at: number;
+          email: string | null;
+          sub: string | null;
+          provider: string | null;
+          name: string | null;
+        }
+      | undefined;
+  if (!row) return null;
   if (Date.now() > row.expires_at) {
     getDb().prepare("DELETE FROM admin_sessions WHERE token = ?").run(token);
-    return false;
+    return null;
   }
-  return true;
+  // SSO sets all three; the access-code path sets none.
+  const identity: SessionIdentity | null =
+    row.email && row.sub && row.provider
+      ? { email: row.email, sub: row.sub, provider: row.provider, name: row.name }
+      : null;
+  return { identity };
 }
 
 /** Server-side logout: drop the row so a replayed cookie or bearer token no longer validates. */
@@ -73,4 +94,29 @@ export function accessCodeMatches(submitted: string, configured: string): boolea
   const a = crypto.createHash("sha256").update(submitted).digest();
   const b = crypto.createHash("sha256").update(configured).digest();
   return crypto.timingSafeEqual(a, b);
+}
+
+export type AdminGate =
+  | { ok: true; identity: SessionIdentity | null; entry: AccessEntry | null }
+  | { ok: false; status: number; error: string };
+
+/** Authenticate a request and confirm the identity is still admitted. */
+export function authenticateAdminRequest(req: http.IncomingMessage): AdminGate {
+  const token = getRequestToken(req);
+  const session = resolveSession(token);
+  if (!session) return { ok: false, status: 401, error: "Unauthorized" };
+
+  // An access-code session carries no address to re-check against.
+  if (!session.identity) return { ok: true, identity: null, entry: null };
+
+  const recheck = recheckIdentity(session.identity);
+  if (recheck.status === "unavailable") {
+    // Not a 401: the SPA logs out on 401, and a database problem must not eject everyone.
+    return { ok: false, status: 503, error: "Access control is unavailable" };
+  }
+  if (recheck.status === "denied") {
+    if (token) revokeSession(token);
+    return { ok: false, status: 401, error: "Unauthorized" };
+  }
+  return { ok: true, identity: session.identity, entry: recheck.entry };
 }

--- a/src/admin-ui/auth.ts
+++ b/src/admin-ui/auth.ts
@@ -142,14 +142,34 @@ export const authJs = `
     history.replaceState(null, '', location.pathname + location.hash); // drop the query so a refresh won't re-show it
   }
 
-  // Ask the server whether we're authed. 200 => authed, 401 => not.
-  async function probeSession() {
+  let sessionIdentity = null;
+
+  // Doubles as the sign-in probe: a 200 means the session is live. 401 if not
+  async function loadSessionIdentity() {
     const headers = {};
     if (token) headers['Authorization'] = 'Bearer ' + token;
     try {
-      const res = await fetch(API + '/api/admin/config-status', { credentials: 'include', headers });
-      return res.ok;
-    } catch (e) { return false; }
+      const res = await fetch(API + '/api/session-identity', { credentials: 'include', headers });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (e) { return null; }
+  }
+  window.getSessionIdentity = function () { return sessionIdentity; };
+
+  function applySessionIdentity(s) {
+    // The bright slot always carries the most identifying value we have.
+    const primary = s.name || s.email || 'Access code';
+    const secondary = s.name ? (s.email || '') : '';
+    const nameEl = document.getElementById('session-name');
+    const emailEl = document.getElementById('session-email');
+    const avatarEl = document.getElementById('session-avatar');
+    if (nameEl) { nameEl.textContent = primary; nameEl.title = primary; }
+    if (emailEl) {
+      emailEl.textContent = secondary;
+      emailEl.hidden = !secondary;
+      emailEl.title = secondary;
+    }
+    if (avatarEl) avatarEl.textContent = primary.charAt(0).toUpperCase();
   }
 
   async function login() {
@@ -163,6 +183,8 @@ export const authJs = `
     if (data.token) {
       token = data.token;
       localStorage.setItem('admin_token', token);
+      sessionIdentity = await loadSessionIdentity();
+      if (sessionIdentity) applySessionIdentity(sessionIdentity);
       showAdmin();
     } else {
       const el = document.getElementById('login-error');
@@ -176,6 +198,7 @@ export const authJs = `
     try { await fetch(API + '/api/auth/logout', { method: 'POST', credentials: 'include' }); } catch (e) { /* ignore */ }
     localStorage.removeItem('admin_token');
     token = null;
+    sessionIdentity = null;
     await renderLogin(); // repaint the buttons — bootstrap skipped them when we were authed
     showLogin();
   }
@@ -187,7 +210,9 @@ export const authJs = `
     if (ac) ac.addEventListener('keydown', function (e) { if (e.key === 'Enter') login(); });
 
     showAuthError();
-    if (await probeSession()) {
+    sessionIdentity = await loadSessionIdentity();
+    if (sessionIdentity) {
+      applySessionIdentity(sessionIdentity);
       showAdmin();
     } else {
       await renderLogin();

--- a/src/admin-ui/components.ts
+++ b/src/admin-ui/components.ts
@@ -114,10 +114,20 @@ export const componentsCss = `
   align-items: center;
   gap: 10px;
   padding: 8px;
-  border-radius: var(--r-sm);
-  cursor: pointer;
 }
-.sidebar-user:hover { background: var(--bg-hover); }
+.sidebar-user-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 8px 8px;
+}
+/* Squared to the avatar above so the two column-align; the default icon padding insets the glyph. */
+.sidebar-user-actions .btn-icon {
+  width: 24px; height: 24px;
+  padding: 0;
+  justify-content: center;
+}
+.sidebar-user-actions .btn-danger { background: transparent; border-color: transparent; }
 .sidebar-user .avatar {
   width: 24px; height: 24px;
   border-radius: 6px;
@@ -134,7 +144,7 @@ export const componentsCss = `
 }
 .sidebar-user .user-email {
   font-size: 11px;
-  color: var(--fg-tertiary);
+  color: var(--fg-secondary);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 
@@ -410,6 +420,12 @@ export const componentsCss = `
 .tbl tbody tr.failed-row:hover td { background: rgba(220, 38, 38, 0.05); }
 .tbl tbody tr.redispatch-row td { background: var(--st-warn-bg); }
 .tbl tbody tr.redispatch-row:hover td { background: var(--bg-hover); }
+.tbl tbody tr.row-new td { background: var(--st-success-bg); }
+.tbl tbody tr.row-new td:first-child { box-shadow: inset 3px 0 0 var(--st-success-dot); }
+.tbl tbody tr.row-changed td { background: var(--st-warn-bg); }
+.tbl tbody tr.row-changed td:first-child { box-shadow: inset 3px 0 0 var(--st-warn-dot); }
+.tbl tbody tr.row-new:hover td,
+.tbl tbody tr.row-changed:hover td { background: var(--bg-hover); }
 
 .mono {
   font-family: var(--font-mono);

--- a/src/admin-ui/components.ts
+++ b/src/admin-ui/components.ts
@@ -130,10 +130,12 @@ export const componentsCss = `
   font-size: 12.5px;
   font-weight: 500;
   color: var(--fg-primary);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .sidebar-user .user-email {
   font-size: 11px;
   color: var(--fg-tertiary);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 
 /* ── Main content area ─────────────────────────────────────── */

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -4,6 +4,7 @@ import { sidebarHtml } from "./sidebar.js";
 import { themeJs } from "./theme.js";
 import { routerJs } from "./router.js";
 import { authJs } from "./auth.js";
+import { accessHtml, accessScript } from "./pages/access.js";
 import { overviewHtml, overviewScript } from "./pages/overview.js";
 import { settingsHtml, settingsScript } from "./pages/settings.js";
 import { projectsHtml, projectsScript } from "./pages/projects.js";
@@ -55,6 +56,7 @@ const shell = `<div id="admin-page" class="app-shell hidden">
     ${runnersHtml}
     ${reportsHtml}
     ${deploymentsHtml}
+    ${accessHtml}
     ${stubsHtml}
   </main>
 </div>`;
@@ -85,7 +87,7 @@ const body = `<body>
 ${shell}
 ${drawerHtml}
 ${stepperHtml}
-<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${blockersScript}${customizationsScript}${pipelinesAndStepsScript}${modelsAndProvidersScript}${runnersScript}${reportsScript}${deploymentsScript}${drawerScript}${stepperScript}</script>
+<script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${blockersScript}${customizationsScript}${pipelinesAndStepsScript}${modelsAndProvidersScript}${runnersScript}${reportsScript}${deploymentsScript}${accessScript}${drawerScript}${stepperScript}</script>
 </body></html>`;
 
 export const adminHtml = head + body;

--- a/src/admin-ui/pages/access.ts
+++ b/src/admin-ui/pages/access.ts
@@ -1,0 +1,343 @@
+export const accessHtml = `
+<section data-page="access" hidden>
+  <header class="page-header">
+    <div class="page-header-left">
+      <h1 class="page-title">Access</h1>
+      <div class="page-subtitle">Who may sign in to this orchestrator</div>
+    </div>
+    <div class="page-header-actions">
+      <span id="access-dirty" class="badge warn hidden" style="margin-right:8px"><span class="dot"></span>unsaved changes</span>
+      <button class="btn btn-accent btn-sm" id="access-save" onclick="saveAccess()" disabled>Save changes</button>
+    </div>
+  </header>
+  <div class="page-body">
+    <div id="access-unreadable" class="error hidden" style="margin-bottom:12px">
+      The allowlist could not be read, so sign-in is denied until it can be. Nothing here can be edited and no change has been lost.
+    </div>
+    <div id="access-readonly" class="warning hidden" style="margin-bottom:12px">
+      Signed in with an access code, so this list is read-only &#x2014; a change here could not be attributed to anyone. Sign in with SSO to edit it.
+    </div>
+    <div id="access-seed" class="warning hidden" style="margin-bottom:12px">
+      Nobody can sign in. Set <span class="mono">OAUTH_ALLOWED_DOMAINS</span> or <span class="mono">OAUTH_ALLOWED_EMAILS</span> on this app and restart &#x2014; once someone can sign in with SSO, this page takes over from there.
+    </div>
+
+    <div class="card">
+      <div class="card-header">
+        <h2 class="card-title">Sign-in allowlist</h2>
+      </div>
+      <div class="card-body">
+        <div class="field-hint" style="margin-bottom:8px">A domain admits everyone at that domain as a user. Only an email can be an admin.</div>
+        <table class="tbl">
+          <thead><tr><th>Type</th><th>Email / Domain</th><th>Role</th><th>Added</th><th></th></tr></thead>
+          <tbody id="access-body"></tbody>
+        </table>
+        <div id="access-empty" class="empty hidden">No entries.</div>
+
+        <div id="access-banner" class="alert hidden" style="margin-top:12px">
+          <span class="alert-icon">&#x25CF;</span>
+          <div>
+            <div class="alert-title" id="access-banner-title"></div>
+            <div class="alert-desc" id="access-banner-desc"></div>
+          </div>
+        </div>
+
+        <div id="access-editor" style="display:flex;gap:6px;align-items:flex-end;flex-wrap:wrap;margin-top:10px">
+          <div class="field" style="min-width:110px">
+            <label class="field-label">Type</label>
+            <select class="input" id="access-new-kind" onchange="onAccessKindChange()">
+              <option value="address">Email</option>
+              <option value="domain">Domain</option>
+            </select>
+          </div>
+          <div class="field" style="flex:1;min-width:220px">
+            <label class="field-label">Email / Domain</label>
+            <input class="input mono" id="access-new-value" placeholder="name@example.com">
+          </div>
+          <div class="field" style="min-width:110px">
+            <label class="field-label">Role</label>
+            <select class="input" id="access-new-role">
+              <option value="user">user</option>
+              <option value="admin">admin</option>
+            </select>
+          </div>
+          <button class="btn btn-accent btn-sm" onclick="addAccessEntry()" style="align-self:flex-end">+ Add</button>
+        </div>
+        <div class="field-hint">Roles are stored now and take effect when the Admin/User split ships.</div>
+        <div id="access-error" class="error hidden"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header"><h2 class="card-title">Recent access changes</h2></div>
+      <div class="card-body">
+        <table class="tbl">
+          <thead><tr><th>When</th><th>Who</th><th>Change</th></tr></thead>
+          <tbody id="access-changes-body"></tbody>
+        </table>
+        <div id="access-changes-empty" class="empty hidden">No changes recorded yet.</div>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+export const accessScript = `
+(function () {
+  // saved is slimmed for comparison against the draft; stored keeps the database rows whole,
+  // because only they carry addedAt.
+  var state = { source: null, env: [], saved: [], stored: [], changes: [], draft: [], canEdit: false, you: null };
+  // Stored kinds stay 'address'/'domain'; the page speaks the operator's words.
+  var TYPE_LABEL = { address: 'Email', domain: 'Domain' };
+
+  function slim(e) { return { kind: e.kind, value: e.value, role: e.role }; }
+
+  function signature(list) {
+    return list.map(function (e) { return e.kind + ':' + e.value + ':' + e.role; }).sort().join('|');
+  }
+
+  function isDirty() { return signature(state.draft) !== signature(state.saved); }
+
+  function addedLabel(e) {
+    var match = null;
+    for (var i = 0; i < state.stored.length; i++) {
+      if (state.stored[i].kind === e.kind && state.stored[i].value === e.value) match = state.stored[i];
+    }
+    if (!match || !match.addedAt) return '\\u2014';
+    return new Date(match.addedAt).toLocaleDateString();
+  }
+
+  function renderBanner(blocked) {
+    var banner = document.getElementById('access-banner');
+    var title = document.getElementById('access-banner-title');
+    var desc = document.getElementById('access-banner-desc');
+    if (blocked === 'unreadable') {
+      banner.classList.add('hidden');
+      return;
+    }
+    banner.classList.remove('hidden', 'warn', 'info');
+    if (state.source === 'env') {
+      banner.classList.add('warn');
+      title.textContent = 'Allowlist source: Environment variables';
+      desc.textContent = 'OAUTH_ALLOWED_DOMAINS and OAUTH_ALLOWED_EMAILS are in force. Saving hands control to this list \\u2014 the environment values stop being consulted while it has entries.';
+    } else if (state.env.length) {
+      banner.classList.add('warn');
+      title.textContent = 'Allowlist source: Database';
+      desc.textContent = 'OAUTH_ALLOWED_* are still set on this app and are no longer used. Clearing them removes a value that no longer reflects who can sign in.';
+    } else {
+      banner.classList.add('info');
+      title.textContent = 'Allowlist source: Database';
+      desc.textContent = 'This list is what decides who can sign in.';
+    }
+  }
+
+  /** 'new', 'changed', or null — how this row differs from what is stored. */
+  function pendingState(e) {
+    var saved = null;
+    for (var i = 0; i < state.saved.length; i++) {
+      if (state.saved[i].kind === e.kind && state.saved[i].value === e.value) saved = state.saved[i];
+    }
+    if (!saved) return 'new';
+    if (saved.role !== e.role) return 'changed';
+    return null;
+  }
+
+  var ROW_CLASS = { 'new': 'row-new', 'changed': 'row-changed' };
+
+  function renderRows(blocked) {
+    var body = document.getElementById('access-body');
+    document.getElementById('access-empty').classList.toggle('hidden', state.draft.length > 0);
+    var readOnly = blocked !== null;
+    body.innerHTML = state.draft.map(function (e, i) {
+      // A domain cannot carry admin, so the control does not exist for a value that cannot take it.
+      var role = (e.kind === 'domain' || readOnly)
+        ? '<span class="text-tertiary">' + window.esc(e.role) + '</span>'
+        : '<select class="input" onchange="setAccessRole(' + i + ', this.value)">'
+          + '<option value="user"' + (e.role === 'user' ? ' selected' : '') + '>user</option>'
+          + '<option value="admin"' + (e.role === 'admin' ? ' selected' : '') + '>admin</option>'
+          + '</select>';
+      var pending = pendingState(e);
+      return '<tr' + (pending ? ' class="' + ROW_CLASS[pending] + '"' : '') + '>'
+        + '<td>' + window.esc(TYPE_LABEL[e.kind] || e.kind) + '</td>'
+        + '<td class="mono">' + window.esc(e.value) + '</td>'
+        + '<td>' + role + '</td>'
+        + '<td class="text-tertiary">' + window.esc(addedLabel(e)) + '</td>'
+        + '<td style="text-align:right;white-space:nowrap">'
+        + (readOnly ? '' : '<button class="btn btn-sm btn-danger" onclick="removeAccessEntry(' + i + ')">Remove</button>')
+        + '</td>'
+        + '</tr>';
+    }).join('');
+  }
+
+  /** Returns markup, so the call site must not escape it \u2014 values are escaped here. */
+  function summarize(change) {
+    var before = {}, beforeRole = {}, after = {}, added = [], removed = [], roleChanges = [];
+    change.before.forEach(function (e) {
+      before[e.kind + ':' + e.value] = true;
+      beforeRole[e.kind + ':' + e.value] = e.role;
+    });
+    change.after.forEach(function (e) {
+      after[e.kind + ':' + e.value] = true;
+      if (!before[e.kind + ':' + e.value]) added.push(e.value);
+      var was = beforeRole[e.kind + ':' + e.value];
+      if (was && was !== e.role) roleChanges.push(e.value + ': ' + was + ' \\u2192 ' + e.role);
+    });
+    change.before.forEach(function (e) { if (!after[e.kind + ':' + e.value]) removed.push(e.value); });
+    var groups = [];
+    if (added.length) groups.push(['added', added]);
+    if (removed.length) groups.push(['removed', removed]);
+    if (roleChanges.length) groups.push(['role changed', roleChanges]);
+    if (!groups.length) return '<span class="text-tertiary">no effective change</span>';
+    return groups.map(function (g) {
+      return '<div style="display:flex;gap:10px;align-items:baseline;margin-top:2px">'
+        + '<span class="text-tertiary" style="flex:none;min-width:96px">' + g[0] + ' ' + g[1].length + '</span>'
+        + '<span>' + window.esc(g[1].join(', ')) + '</span>'
+        + '</div>';
+    }).join('');
+  }
+
+  function renderChanges() {
+    var body = document.getElementById('access-changes-body');
+    document.getElementById('access-changes-empty').classList.toggle('hidden', state.changes.length > 0);
+    body.innerHTML = state.changes.map(function (c) {
+      var who = c.actor || (c.action === 'recover' ? 'host recovery' : 'unattributed');
+      return '<tr>'
+        + '<td class="text-tertiary">' + window.esc(new Date(c.createdAt).toLocaleString()) + '</td>'
+        + '<td>' + window.esc(who) + '</td>'
+        + '<td>' + summarize(c) + '</td>'
+        + '</tr>';
+    }).join('');
+  }
+
+  /**
+   * Why editing is unavailable, or null. An empty list denies everyone, so the only session that
+   * can be looking at one is an access-code session — it is seeded from the environment, not here.
+   */
+  function blockedBecause() {
+    if (!state.source) return 'unreadable';
+    // Server-supplied rather than inferred: auth.ts populates the identity asynchronously, and
+    // the router can reach this page first.
+    if (!state.canEdit) return 'access-code';
+    if (!state.saved.length && !state.draft.length) return 'seed';
+    return null;
+  }
+
+  function render() {
+    var blocked = blockedBecause();
+    renderBanner(blocked);
+    renderRows(blocked);
+    renderChanges();
+    var dirty = isDirty();
+    document.getElementById('access-unreadable').classList.toggle('hidden', blocked !== 'unreadable');
+    document.getElementById('access-readonly').classList.toggle('hidden', blocked !== 'access-code');
+    document.getElementById('access-seed').classList.toggle('hidden', blocked !== 'seed');
+    document.getElementById('access-editor').classList.toggle('hidden', blocked !== null);
+    document.getElementById('access-save').disabled = blocked !== null || !dirty;
+    document.getElementById('access-dirty').classList.toggle('hidden', blocked !== null || !dirty);
+  }
+
+  function showError(message) {
+    var el = document.getElementById('access-error');
+    el.textContent = message || '';
+    el.classList.toggle('hidden', !message);
+  }
+
+  function apply(payload) {
+    state.source = payload.source;
+    state.env = payload.env || [];
+    state.saved = (payload.entries || []).map(slim);
+    state.stored = payload.stored || [];
+    state.changes = payload.changes || [];
+    state.canEdit = payload.canEdit === true;
+    state.you = payload.you || null;
+    // map(slim), not slice() — a shallow array copy would share the row objects, so editing a
+    // role in the draft would silently edit the saved copy it is compared against.
+    state.draft = state.saved.map(slim);
+    render();
+  }
+
+  function onAccessKindChange() {
+    var kind = document.getElementById('access-new-kind').value;
+    var role = document.getElementById('access-new-role');
+    // Keep the form from offering a combination the server will refuse.
+    role.value = kind === 'domain' ? 'user' : role.value;
+    role.disabled = kind === 'domain';
+    document.getElementById('access-new-value').placeholder = kind === 'domain' ? 'example.com' : 'name@example.com';
+  }
+  window.onAccessKindChange = onAccessKindChange;
+
+  function addAccessEntry() {
+    var kind = document.getElementById('access-new-kind').value;
+    var valueEl = document.getElementById('access-new-value');
+    var value = valueEl.value.trim().toLowerCase();
+    var role = kind === 'domain' ? 'user' : document.getElementById('access-new-role').value;
+    if (!value) return showError(kind === 'domain' ? 'Enter a domain.' : 'Enter an email address.');
+    // A hint, not the gate — the server re-checks with the stricter patterns and is authoritative.
+    if (kind === 'address' && !/^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/.test(value)) {
+      return showError('"' + value + '" is not an email address.');
+    }
+    if (kind === 'domain' && !/^[^\\s@.]+(\\.[^\\s@.]+)+$/.test(value)) {
+      return showError('"' + value + '" is not a domain.');
+    }
+    for (var i = 0; i < state.draft.length; i++) {
+      if (state.draft[i].kind === kind && state.draft[i].value === value) return showError(value + ' is already listed.');
+    }
+    state.draft.push({ kind: kind, value: value, role: role });
+    valueEl.value = '';
+    showError('');
+    render();
+  }
+  window.addAccessEntry = addAccessEntry;
+
+  function removeAccessEntry(index) {
+    state.draft.splice(index, 1);
+    render();
+  }
+  window.removeAccessEntry = removeAccessEntry;
+
+  function setAccessRole(index, role) {
+    state.draft[index].role = role;
+    render();
+  }
+  window.setAccessRole = setAccessRole;
+
+  function wouldDemoteMe() {
+    if (!state.you) return false;
+    var email = state.you.toLowerCase();
+    var isAdmin = function (list) {
+      return list.some(function (e) { return e.kind === 'address' && e.value === email && e.role === 'admin'; });
+    };
+    return isAdmin(state.saved) && !isAdmin(state.draft);
+  }
+
+  async function saveAccess() {
+    if (wouldDemoteMe() && !confirm("This removes your own admin access. You'll keep sign-in access but won't be able to edit this page after saving. Continue?")) return;
+    showError('');
+    var payload;
+    try {
+      var res = await window.api('/api/access', { method: 'POST', body: JSON.stringify({ entries: state.draft }) });
+      payload = await res.json();
+      if (!res.ok) return showError(payload.error || 'The list could not be saved.');
+    } catch (e) {
+      return showError('The list could not be saved.');
+    }
+    apply(payload);
+  }
+  window.saveAccess = saveAccess;
+
+  async function loadAccess() {
+    var payload;
+    try {
+      var res = await window.api('/api/access');
+      if (!res.ok) return showError('Could not load the access list.');
+      payload = await res.json();
+    } catch (e) {
+      return showError('Could not load the access list.');
+    }
+    // Outside the catch deliberately: a render fault is a bug, and reporting it as a failed
+    // request sends the reader to the network tab.
+    apply(payload);
+  }
+
+  window.registerPage('access', loadAccess);
+})();
+`;

--- a/src/admin-ui/sidebar.ts
+++ b/src/admin-ui/sidebar.ts
@@ -59,10 +59,10 @@ export function sidebarHtml(): string {
     </div>
     <div class="sidebar-footer">
       <div class="sidebar-user">
-        <div class="avatar">·</div>
+        <div class="avatar" id="session-avatar">·</div>
         <div style="min-width:0;flex:1">
-          <div class="user-name">Admin</div>
-          <div class="user-email">signed in</div>
+          <div class="user-name" id="session-name">Signed in</div>
+          <div class="user-email" id="session-email"></div>
         </div>
         <button class="btn btn-ghost btn-icon" onclick="window.toggleTheme()" title="Toggle theme">
           <span class="theme-icon-sun">${icon("sun", 14)}</span>

--- a/src/admin-ui/sidebar.ts
+++ b/src/admin-ui/sidebar.ts
@@ -24,6 +24,7 @@ const groups: NavGroup[] = [
     { key: "sessions",    label: "Sessions",    icon: "server" },
     { key: "deployments", label: "Deployments", icon: "rocket", count: "deploy-available" },
     { key: "reaper",      label: "Reaper",      icon: "broom" },
+    { key: "access",      label: "Access",      icon: "shield" },
     { key: "secrets",     label: "Secrets",     icon: "key" },
     { key: "settings",    label: "Settings",    icon: "settings" },
   ]},
@@ -64,11 +65,13 @@ export function sidebarHtml(): string {
           <div class="user-name" id="session-name">Signed in</div>
           <div class="user-email" id="session-email"></div>
         </div>
+      </div>
+      <div class="sidebar-user-actions">
         <button class="btn btn-ghost btn-icon" onclick="window.toggleTheme()" title="Toggle theme">
           <span class="theme-icon-sun">${icon("sun", 14)}</span>
           <span class="theme-icon-moon">${icon("moon", 14)}</span>
         </button>
-        <button class="btn btn-ghost btn-icon" onclick="logout()" title="Log out">${icon("x", 12)}</button>
+        <button class="btn btn-sm btn-danger" onclick="logout()">${icon("x", 12)}Log out</button>
       </div>
     </div>
   `;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -27,7 +27,7 @@ import {
 } from "./runner-mode.js";
 import { listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
 import { listParked, unpark } from "./dispatch-breaker.js";
-import { createSession, isValidSession, getRequestToken, accessCodeMatches } from "./admin-session.js";
+import { createSession, accessCodeMatches, authenticateAdminRequest } from "./admin-session.js";
 import type { DeployStart } from "./deploy.js";
 import { getDeployOutcome } from "./deploy-notify.js";
 import { getAvailability, type SelfDeployTarget } from "./deploy-availability.js";
@@ -217,8 +217,20 @@ export function handleAdminRequest(
 
   // All other /api routes require auth
   if (url.startsWith("/api/")) {
-    if (!isValidSession(getRequestToken(req))) {
-      json(res, 401, { error: "Unauthorized" });
+    const gate = authenticateAdminRequest(req);
+    if (!gate.ok) {
+      json(res, gate.status, { error: gate.error });
+      return true;
+    }
+
+    // Must stay reachable by every authenticated session — the SPA probes it to decide it is signed in.
+    if (url === "/api/session-identity" && method === "GET") {
+      json(res, 200, {
+        email: gate.identity?.email ?? null,
+        name: gate.identity?.name ?? null,
+        provider: gate.identity?.provider ?? null,
+        authMethod: gate.identity ? "sso" : "access-code",
+      });
       return true;
     }
 

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -28,7 +28,7 @@ import {
 import { listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
 import { listParked, unpark } from "./dispatch-breaker.js";
 import { createSession, accessCodeMatches, authenticateAdminRequest, type SessionIdentity } from "./admin-session.js";
-import { getEffectiveAllowlist, getEnvAllowlist, listAccessEntries, parseAccessEntries, refreshEffectiveAllowlist, saveAccessEntries } from "./access-entries.js";
+import { getEffectiveAllowlist, getEnvAllowlist, listAccessEntries, parseAccessEntries, saveAccessEntries } from "./access-entries.js";
 import { listAccessChanges } from "./access-audit.js";
 import type { DeployStart } from "./deploy.js";
 import { getDeployOutcome } from "./deploy-notify.js";
@@ -1177,7 +1177,6 @@ async function handlePostAccess(
     return;
   }
 
-  refreshEffectiveAllowlist();
   handleGetAccess(res, identity);
 }
 

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -1171,7 +1171,7 @@ async function handlePostAccess(
   }
 
   try {
-    saveAccessEntries(parsed.entries, identity.email, identity);
+    saveAccessEntries(parsed.entries, identity.email, { mustAdmit: identity });
   } catch (err) {
     json(res, 400, { error: err instanceof Error ? err.message : "the access list could not be saved" });
     return;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -27,7 +27,9 @@ import {
 } from "./runner-mode.js";
 import { listDispatched, deleteDispatched, getReaperSummary, listReaperActions, getDispatchedIds } from "./dedup.js";
 import { listParked, unpark } from "./dispatch-breaker.js";
-import { createSession, accessCodeMatches, authenticateAdminRequest } from "./admin-session.js";
+import { createSession, accessCodeMatches, authenticateAdminRequest, type SessionIdentity } from "./admin-session.js";
+import { getEffectiveAllowlist, getEnvAllowlist, listAccessEntries, parseAccessEntries, refreshEffectiveAllowlist, saveAccessEntries } from "./access-entries.js";
+import { listAccessChanges } from "./access-audit.js";
 import type { DeployStart } from "./deploy.js";
 import { getDeployOutcome } from "./deploy-notify.js";
 import { getAvailability, type SelfDeployTarget } from "./deploy-availability.js";
@@ -456,6 +458,16 @@ export function handleAdminRequest(
 
     if (url === "/api/settings" && method === "POST") {
       handlePostSettings(req, res, config);
+      return true;
+    }
+
+    if (url === "/api/access" && method === "GET") {
+      handleGetAccess(res, gate.identity);
+      return true;
+    }
+
+    if (url === "/api/access" && method === "POST") {
+      handlePostAccess(req, res, gate.identity);
       return true;
     }
 
@@ -1106,6 +1118,67 @@ async function handlePostSettings(
     },
     restartRequired,
   });
+}
+
+function handleGetAccess(res: http.ServerResponse, identity: SessionIdentity | null): void {
+  const effective = getEffectiveAllowlist();
+  // getEffectiveAllowlist() is guarded; these two are not, and an access-code session is exempt
+  // from the re-check, so it reaches this route even when the tables are unreadable.
+  // An empty `stored` here can mean "unreadable", so read it only alongside a null `source`.
+  let stored: ReturnType<typeof listAccessEntries> = [];
+  let changes: ReturnType<typeof listAccessChanges> = [];
+  try {
+    stored = listAccessEntries();
+    changes = listAccessChanges(20);
+  } catch {
+    /* a null source tells the page what happened */
+  }
+  json(res, 200, {
+    source: effective?.source ?? null,
+    entries: effective?.entries ?? [],
+    stored,
+    env: getEnvAllowlist(),
+    changes,
+    // The same rule the POST enforces, so the page never has to infer it.
+    canEdit: identity !== null,
+    you: identity?.email ?? null,
+  });
+}
+
+async function handlePostAccess(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  identity: SessionIdentity | null,
+): Promise<void> {
+  // An anonymous session cannot make an attributable change to who gets in.
+  if (!identity) {
+    json(res, 403, { error: "Editing the access list requires a signed-in identity" });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(await readBody(req));
+  } catch {
+    json(res, 400, { error: "Invalid request body" });
+    return;
+  }
+
+  const parsed = parseAccessEntries((body as { entries?: unknown } | null)?.entries);
+  if (!parsed.ok) {
+    json(res, 400, { error: parsed.error });
+    return;
+  }
+
+  try {
+    saveAccessEntries(parsed.entries, identity.email, identity);
+  } catch (err) {
+    json(res, 400, { error: err instanceof Error ? err.message : "the access list could not be saved" });
+    return;
+  }
+
+  refreshEffectiveAllowlist();
+  handleGetAccess(res, identity);
 }
 
 async function handleListGlobalSecrets(

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { configureLinearAuth } from "./linear-app-auth.js";
 import { configureOAuthProviders, isOAuthConfigured, providersFromEnv } from "./oauth/providers.js";
 import { handleOAuthCallback, handleOAuthLogout, handleOAuthProviders, handleOAuthStart } from "./oauth/routes.js";
 import { initAccessEntriesTable } from "./access-entries.js";
+import { initAccessAuditTable } from "./access-audit.js";
 import { handleTokenRequest } from "./token-vending.js";
 import { handleDependencyTokenRequest } from "./dependency-token-vending.js";
 import { handlePublicationTokenRequest } from "./publication-token-vending.js";
@@ -3312,6 +3313,7 @@ async function main(): Promise<void> {
   initReconciliationTable();
   initStepLogTable();
   initMcpOAuthTables();
+  initAccessAuditTable();
 
   // A process that died mid-deploy must not leave dispatch paused forever.
   const holdWasSet = clearDeployHold();

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,8 @@ import type { Job, JobStatus } from "./log.js";
 import { getInstallationToken, getAppSlug } from "./github-app-auth.js";
 import { configureLinearAuth } from "./linear-app-auth.js";
 import { configureOAuthProviders, isOAuthConfigured, providersFromEnv } from "./oauth/providers.js";
-import { configureAuthorizationPolicy } from "./oauth/authorize.js";
 import { handleOAuthCallback, handleOAuthLogout, handleOAuthProviders, handleOAuthStart } from "./oauth/routes.js";
+import { initAccessEntriesTable } from "./access-entries.js";
 import { handleTokenRequest } from "./token-vending.js";
 import { handleDependencyTokenRequest } from "./dependency-token-vending.js";
 import { handlePublicationTokenRequest } from "./publication-token-vending.js";
@@ -147,10 +147,6 @@ function loadConfig(): AppConfig {
     const modes: string[] = [];
     if (oauthConfigured) {
       configureOAuthProviders(oauthProviders);
-      configureAuthorizationPolicy({
-        allowedDomains: (process.env.OAUTH_ALLOWED_DOMAINS || "").split(",").map((s) => s.trim()).filter(Boolean),
-        allowedEmails: (process.env.OAUTH_ALLOWED_EMAILS || "").split(",").map((s) => s.trim()).filter(Boolean),
-      });
 
       modes.push(`SSO (${oauthProviders.map((p) => p.id).join(", ")})`);
     }
@@ -3312,6 +3308,7 @@ async function main(): Promise<void> {
   initDispatchBreakerTable();
   sweepOrphanedGapfillRows(); // AII-279: heal rows wedged before the AII-277 terminal hook existed
   initSettingsTable();
+  initAccessEntriesTable();
   initReconciliationTable();
   initStepLogTable();
   initMcpOAuthTables();

--- a/src/mcp-oauth.ts
+++ b/src/mcp-oauth.ts
@@ -23,6 +23,7 @@ import { getDb } from "./dedup.js";
 import { getProvider, listConfiguredProviders } from "./oauth/providers.js";
 import { buildAuthUrl, completeAuth } from "./oauth/oidc.js";
 import { authorize } from "./oauth/authorize.js";
+import { bindAccessEntry, getEffectiveAllowlist, matchAccessEntry } from "./access-entries.js";
 
 // Token and state lifetimes
 export const MCP_TOKEN_TTL_MS: number = (() => {
@@ -418,10 +419,20 @@ export async function handleMcpOidcCallback(
   }
 
   // Fail-closed allowlist check
-  const decision = authorize(identity);
+  const allowlist = getEffectiveAllowlist();
+  if (!allowlist) {
+    console.error(`[mcp-oauth] ${providerId} sign-in denied: the access list could not be loaded`);
+    return redirectWithError(res, stateRow.redirect_uri, stateRow.client_state, "server_error");
+  }
+
+  const decision = authorize(identity, allowlist.entries);
   if (!decision.ok) {
     console.warn(`[mcp-oauth] denied ${identity.email ?? "?"} via ${providerId}: ${decision.reason}`);
     return redirectWithError(res, stateRow.redirect_uri, stateRow.client_state, "access_denied");
+  }
+
+  if (decision.entry.kind === "address") {
+    bindAccessEntry(decision.entry.value, identity.provider, identity.sub);
   }
 
   db.prepare("UPDATE mcp_clients SET used_at = ? WHERE client_id = ?").run(Date.now(), stateRow.client_id);
@@ -584,18 +595,14 @@ function handleRefreshTokenGrant(
     return json(res, 400, { error: "invalid_grant", error_description: "Refresh token already used" });
   }
 
-  // Allowlist re-check (fail-closed: user removed from allowlist must not outlive their access token)
-  const decision = authorize({
-    provider: row.provider,
-    sub: row.sub,
-    email: row.email,
-    emailVerified: true,
-    name: null,
-    hd: null,
-    tid: null,
-    rawClaims: {},
-  });
-  if (!decision.ok) {
+  // Allowlist re-check (fail-closed: a removed user must not outlive their access token)
+  const allowlist = getEffectiveAllowlist();
+  if (!allowlist) {
+    // Do NOT revoke the chain here — a transient read failure is not a removal.
+    console.error("[mcp-oauth] refresh deferred: the access list could not be loaded");
+    return json(res, 503, { error: "temporarily_unavailable", error_description: "Access control is unavailable" });
+  }
+  if (!matchAccessEntry(row, allowlist.entries)) {
     db.prepare("DELETE FROM mcp_refresh_tokens WHERE family_id = ?").run(row.family_id);
     console.warn(`[mcp-oauth] refresh denied: ${row.email} no longer on allowlist`);
     return json(res, 400, { error: "invalid_grant", error_description: "Identity no longer authorized" });

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -7,6 +7,7 @@ import { getInFlightJobs } from "./log.js";
 import { getDb } from "./dedup.js";
 import { getIssueReportCard, getFleetReport } from "./report-card.js";
 import { isKgDegraded } from "./deploy-notify.js";
+import { recheckIdentity } from "./access-entries.js";
 
 interface JsonRpcRequest {
   jsonrpc?: string;
@@ -383,14 +384,24 @@ export async function handleMcpRequest(
 
   const auth = req.headers.authorization;
   const submitted = auth?.startsWith("Bearer ") ? auth.slice(7) : "";
-  if (!verifyMcpToken(submitted)) {
+  const unauthorized = (): void => {
     res.writeHead(401, {
       "Content-Type": "application/json",
       "WWW-Authenticate": `Bearer realm="MCP", resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
     });
     res.end(JSON.stringify({ error: "unauthorized" }));
+  };
+
+  const identity = verifyMcpToken(submitted);
+  if (!identity) return unauthorized();
+
+  // An access token outlives a removal by up to an hour; re-checking closes that window.
+  const recheck = recheckIdentity(identity);
+  if (recheck.status === "unavailable") {
+    json(res, 503, { error: "access control is unavailable" });
     return;
   }
+  if (recheck.status === "denied") return unauthorized();
 
   let body: Buffer;
   try {

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -1,51 +1,24 @@
 /**
- * Authorization policy — decides whether an authenticated identity may access the admin UI.
- * Provider-agnostic so the same gate covers Google, Microsoft, and any future IdP.
- * Fail-closed: an empty allowlist denies everyone.
+ * Sign-in authorization — the OIDC preconditions that must hold before an identity is
+ * matched against the allowlist. Provider-agnostic: the same gate covers Google,
+ * Microsoft, and any future IdP.
  */
 
 import type { VerifiedIdentity } from "./oidc.js";
+import { matchAccessEntry, type AccessEntry } from "../access-entries.js";
 
-/** Who may access the admin UI. Empty lists deny everyone. */
-export interface AuthorizationPolicy {
-  allowedDomains: string[]; // email domains, e.g. ["eudoxus.ai"]
-  allowedEmails: string[]; // explicit individual emails
-}
-
-// Singleton state: the normalized (lowercased) policy, empty until configured.
-let policy: AuthorizationPolicy = { allowedDomains: [], allowedEmails: [] };
-
-/** Seed the allowlist once at startup. Values are lowercased so matching is case-insensitive. */
-export function configureAuthorizationPolicy(p: AuthorizationPolicy): void {
-  policy = {
-    allowedDomains: p.allowedDomains.map((d) => d.trim().toLowerCase()).filter(Boolean),
-    allowedEmails: p.allowedEmails.map((e) => e.trim().toLowerCase()).filter(Boolean),
-  };
-}
-
-export function getAuthorizationPolicy(): AuthorizationPolicy {
-  return policy;
-}
-
-/** Decide whether a verified identity is allowed in. reason is for server-side logging, not the end user. */
-export function authorize(identity: VerifiedIdentity): { ok: true } | { ok: false; reason: string } {
+/** Decide whether a freshly-authenticated identity may in. reason is for server-side logging, not the end user. */
+export function authorize(
+  identity: VerifiedIdentity,
+  entries: AccessEntry[],
+): { ok: true; entry: AccessEntry } | { ok: false; reason: string } {
   if (!identity.emailVerified) {
     return { ok: false, reason: `email address is not verified by the ${identity.provider}` };
   }
   if (!identity.email) {
     return { ok: false, reason: `${identity.provider} returned no email address` };
   }
-
-  const email = identity.email.trim().toLowerCase();
-  const domain = email.split("@").pop() ?? "";
-
-  if (policy.allowedEmails.includes(email)) return { ok: true };
-  if (domain !== email && policy.allowedDomains.includes(domain)) return { ok: true };
-
-  return { ok: false, reason: `${identity.email} is not on the access allowlist` };
-}
-
-/** Test hook: clear the policy back to the empty (deny-all) state. */
-export function __resetAuthorizationPolicyForTest(): void {
-  policy = { allowedDomains: [], allowedEmails: [] };
+  const entry = matchAccessEntry(identity, entries);
+  if (!entry) return { ok: false, reason: `${identity.email} is not on the access allowlist` };
+  return { ok: true, entry };
 }

--- a/src/oauth/routes.ts
+++ b/src/oauth/routes.ts
@@ -10,6 +10,7 @@ import { authorize } from "./authorize.js";
 import { putTransaction, takeTransaction } from "./state-store.js";
 import { createSession, revokeSession, getRequestToken, SESSION_TTL_MS } from "../admin-session.js";
 import { serializeSessionCookie, clearSessionCookie } from "../cookies.js";
+import { bindAccessEntry, getEffectiveAllowlist } from "../access-entries.js";
 
 function json(res: http.ServerResponse, status: number, data: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });
@@ -90,10 +91,21 @@ export async function handleOAuthCallback(
     return redirect(res, "/admin?auth_error=failed");
   }
 
-  const decision = authorize(identity);
+  const allowlist = getEffectiveAllowlist();
+  if (!allowlist) {
+    console.error(`[oauth] ${providerId} sign-in denied: the access list could not be loaded`);
+    return redirect(res, "/admin?auth_error=failed");
+  }
+
+  const decision = authorize(identity, allowlist.entries);
   if (!decision.ok) {
     console.warn(`[oauth] denied ${identity.email ?? "?"} via ${providerId}: ${decision.reason}`);
     return redirect(res, "/admin?auth_error=denied");
+  }
+
+  // First sign-in binds the entry; the provider identity is what matches from then on.
+  if (decision.entry.kind === "address") {
+    bindAccessEntry(decision.entry.value, identity.provider, identity.sub);
   }
 
   const token = createSession({


### PR DESCRIPTION
Moves the admin sign-in allowlist out of `OAUTH_ALLOWED_DOMAINS` / `OAUTH_ALLOWED_EMAILS` and into the database, editable from a new Access page, with every change recorded against the person who made it. Closes AII-339 along with its three prerequisites — AII-427, AII-428 and AII-429.

**This is behaviourally inert until someone saves.** With no stored rows the environment list serves exactly as it does today, so an existing deployment that never opens the page sees no change at all. The first save is what hands authority to the stored list, and it does so permanently — there is no boot-time migration.

## What changed

**Session identity (AII-427)** — `admin_sessions` has stored `email`, `sub`, `provider` and `name` since SSO landed and nothing ever read them. Adds a resolver that returns the identity alongside the session in the same primary-key lookup, a `GET /api/session-identity` endpoint, and real identity in the sidebar footer in place of the hardcoded "Admin / signed in".

**Access-change audit trail (AII-428)** — a new append-only `access_audit` table following the existing `reaper_actions` shape, recording actor, action, and before/after snapshots. Deliberately no retention: the table only grows when a human changes who can sign in, and pruning is the anti-goal for an audit trail. Scoped to access changes only — the general facility across all mutating admin routes is a separate piece of work.

**Allowlist storage and enforcement (AII-339)** — a new `access_entries` table, a resolver with the environment-until-first-save precedence rule, and a per-request re-check so removing someone ends their session on their next request rather than at token expiry. `authorize()` stays pure and takes a policy; the resolver owns where that policy comes from, preserving the existing test seam.

**The Access page** — effective list with its source, add/remove/role editing, the change log, and the states around them (environment in force, database in force with stale environment values still set, unreadable, access-code, and nothing-configured).

**Host recovery command (AII-429)** — `node dist/access-recovery.js --email you@example.com [--only]`, run over `fly ssh console` when nobody can sign in. No standing credential exists to steal: the authority is shell access, which already implies reading the database and every secret. The change is audited with a null actor, announced on the notification webhook if one is configured, and takes effect without a restart. Adding an address already listed promotes it rather than failing as a duplicate, since a mangled role is one of the ways to get locked out.

**Documentation** — a new `docs/access-model.md` carries the depth. `CLAUDE.md`, `.env.example`, `SECURITY.md` and `docs/kg-sidecar.md` are corrected where they described the previous auth surface; the last two were stale in ways that predate this work.

## Design decisions worth knowing at review time

- **Domains admit as User; Admin is only ever conferred on a listed address.** Enforced at write, and a domain row cannot carry admin by construction. This is what makes AII-340's "seed existing identities as admin" instruction coherent — a domain admits an unbounded set with no identities to enumerate.
- **Address is the declared key; provider + subject bind on first sign-in** and match thereafter. This finally uses the `sub` claim the system has stored and ignored. A rename keeps its role; a reassigned address does not inherit one. Known cost: the same person arriving via a second provider presents a different subject and will not match their bound entry.
- **The self-lockout guard runs inside the transaction**, evaluated against the real post-save result rather than a prediction, and a throw rolls the whole save back.
- **A failed read never becomes an empty list.** The last good policy is kept; at boot with none, the admin UI and `/mcp` deny while polling and dispatch continue. An unreadable allowlist returns 503, not 401, so a database problem does not silently sign everyone out.
- **The re-check costs no query per request** (~675ns against a cached list). Writes made by this process refresh the cache immediately, so revocation is never delayed; a write from *another* process — only the recovery command — is picked up within one poll interval. That window is what lets recovery work without a restart, and it means a hand-edited database converges rather than being ignored until the next deploy.

## Not in this PR

Both belong to AII-340, in a follow-up PR:

- **Roles do nothing.** The Role column persists a value and the page says so in-line. Admin/User enforcement, per-page grants, and MCP-only defaults are all AII-340.
- **No last-admin guard.** A save can currently leave zero admins. Since roles are not enforced anywhere yet this has no effect on access today; the guard lands with enforcement.

One current behaviour that looks like a gap and is not: **access-code sessions are read-only on the Access page.** They carry no address, so a change could not be attributed to anyone; the page says so and `POST /api/access` returns 403 regardless of what the UI shows.

## Acceptance criteria (AII-339)

| Criterion | How it's met |
|---|---|
| Effective list visible with its source | Access page states Environment or Database, and flags environment values left set but no longer used |
| Add/remove applies without a redeploy | Saves write to the database and refresh the in-memory list; no restart |
| Env-only deployments unchanged, fail-closed preserved | Environment serves until the first save; fail-closed is strengthened by the last-good-policy rule |
| Admin UI and MCP enforce the same list | Both gates call the same matcher and re-check |
| Every change audit-logged with actor | `access_audit` row per save, actor recorded; recovery records a null actor deliberately |

## Verification

```bash
npm run typecheck   # clean
npm run build       # clean
npm test            # 3336 passing across 172 files
```

The recovery command was also exercised end to end against a real database using the compiled artifact — recovering into an empty list, adding alongside an existing one, promoting an already-listed address, `--only` replacing the list, and the exit codes for each failure path.

Test-file types were checked separately with a throwaway config, since `tsconfig.json` excludes `src/__tests__` and vitest strips types without checking them (AII-215). Six errors surface, all pre-existing and identical on `origin/testing`; the new test files are clean.

If you run the suite locally and see a single failure in `src/__tests__/executor.test.ts`, that is the known intermittent stdin EPIPE flake (AII-214), not this branch — it appeared in two of eight consecutive runs here, in two *different* tests within that one file, which is its documented signature.

## Notes

- An earlier review of this branch caught a real defect: `bindAccessEntry` wrote the provider binding to the database without refreshing the in-memory list, so the binding had no effect until an unrelated save or a restart. Fixed inside `bindAccessEntry` rather than at its two call sites, so a future caller cannot forget it, with a regression test that fails without the fix.
- `access_entries` and `access_audit` are proper tables rather than settings keys, so AII-338's typed-accessor work does not grow because of this change.
