### PR TITLE
legal: add Contributor License Agreement compliance

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,48 @@
+name: CLA Assistant
+
+# Blocks merge until a first-time contributor signs the Individual CLA.
+# Signatures are stored in this repository (branch: cla-signatures) rather than
+# in a third-party service — the cleaner position for a company that will be
+# diligenced later.
+#
+# VERIFY BEFORE MERGING: pin `contributor-assistant/github-action` to the latest
+# release. The version below was current at the time of writing but should be
+# checked against https://github.com/contributor-assistant/github-action/releases
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/BuildDownAI/AI-Implement/blob/main/legal/ICLA.md
+          branch: cla-signatures
+          allowlist: bot*,dependabot[bot],github-actions[bot]
+          custom-notsigned-prcomment: >
+            Thanks for the contribution. Before we can merge, please sign our
+            Contributor License Agreement — it is a one-time signature that
+            covers all your future contributions to BuildDown projects.
+            Read it at [legal/ICLA.md](legal/ICLA.md), then comment below with
+            exactly:
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: All contributors have signed the CLA. Thanks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,25 @@
 
 Thanks for your interest. This is a small project; most contributions land via PRs against `main`.
 
+## Contributor License Agreement — required
+
+**Before we can merge your pull request, you need to sign a Contributor License Agreement.** It's a one-time signature that covers everything you contribute to BuildDown projects in future.
+
+| You are… | Sign this |
+|---|---|
+| An individual contributing your own work | [Individual CLA](legal/ICLA.md) |
+| Contributing on behalf of an employer, or using employer time or equipment | Your employer signs the [Corporate CLA](legal/CCLA.md), **and** you sign the Individual CLA |
+
+When you open your first PR, the CLA bot will comment with a link. The status check blocks merge until it's signed.
+
+**You keep ownership of your code.** The CLA is a licence, not an assignment — you can keep using, licensing and distributing your contribution however you like, including in competing projects.
+
+**BuildDown gets a broad licence, including the right to relicense.** Section 4 is the part worth reading. It lets us distribute your contribution under a commercial or proprietary licence, change the project's licence in future, offer the project under several licences at once, and include your contribution in paid products and hosted services — without asking again and without paying you. If that's not acceptable, please don't sign and don't contribute.
+
+**Check your employment agreement first.** If you're employed as a developer, it may assign to your employer everything you write — including on your own time and equipment. Section 5.2 of the Individual CLA asks you to represent that you're entitled to grant the licence. If your employer owns your work, we need a Corporate CLA from them instead.
+
+Questions: **[PLACEHOLDER: cla@builddown.ai]**
+
 ## Setting up
 
 ```bash
@@ -32,6 +51,7 @@ Local implementation jobs still create real GitHub branches and PRs.
 2. **New functionality has tests** — most modules in `src/` have a sibling `__tests__/` directory; follow that pattern.
 3. **Workflow templates aren't broken** — if you change anything in `workflows/` or `.github/workflows/`, lint with `actionlint` if you have it installed.
 4. **No secrets, no client-specific data** — the `.gitignore` covers the obvious cases (`.env`, `*.pem`, `*.sqlite`), but double-check before pushing.
+5. **Disclose third-party and AI-generated material** — if your contribution includes code under a third-party licence, or was generated in substantial part by an AI system, mark it in the code and say so in the PR description. Sections 5.4 and 5.5 of the CLA. This is a disclosure requirement, not a prohibition.
 
 ## The `custom/` extension model
 
@@ -55,4 +75,6 @@ See [SECURITY.md](SECURITY.md). Do not file public issues for security reports.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the Apache License, Version 2.0 (the project's license). No CLA is required.
+The project is licensed under the **Apache License, Version 2.0** — see [LICENSE](LICENSE).
+
+By contributing, you agree that your contributions are licensed under Apache 2.0, and that BuildDown AI LLC additionally receives the rights set out in the CLA you signed.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Build Down AI
+   Copyright 2026 BuildDown AI LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,10 +1,14 @@
 AI-Implement
-Copyright 2026 Build Down AI
-
-This product includes software developed by Build Down AI and contributors.
+Copyright 2026 BuildDown AI LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/legal/CCLA.md
+++ b/legal/CCLA.md
@@ -1,0 +1,232 @@
+# BuildDown AI LLC
+## Corporate Contributor License Agreement ("CCLA")
+
+**Version 1.0**
+
+Thank you for your interest in contributing to software projects managed by
+**BuildDown AI LLC**, a Colorado limited liability company ("**BuildDown**").
+
+**Use this form when contributions are made by employees or contractors of a
+company, on that company's behalf or using that company's resources.** Where a
+corporate employer owns the intellectual property its employees create — which
+is the norm — an Individual CLA signed by the employee is not sufficient,
+because the employee does not own what they are purporting to license.
+
+This agreement must be signed by a person **authorized to bind the Corporation**.
+Please also have each contributing employee sign the **Individual CLA**, and list
+them on Schedule A.
+
+---
+
+## 1. Definitions
+
+**"Corporation"** means the entity identified in the signature block, together
+with all other entities that control, are controlled by, or are under common
+control with that entity. "Control" means (i) the power, direct or indirect, to
+cause the direction or management of such entity, whether by contract or
+otherwise, (ii) ownership of fifty percent (50%) or more of the outstanding
+shares, or (iii) beneficial ownership of such entity.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by the Corporation to BuildDown for inclusion in, or documentation of, any of the
+products owned or managed by BuildDown (the "**Work**"). "Submitted" means any
+form of electronic, verbal, or written communication sent to BuildDown or its
+representatives, including communication on electronic mailing lists, source code
+control systems, and issue tracking systems managed by or on behalf of BuildDown,
+but excluding communication conspicuously marked or otherwise designated in
+writing by the Corporation as **"Not a Contribution."**
+
+**"Project"** means any software project managed by BuildDown, including without
+limitation `github.com/BuildDownAI/AI-Implement` and
+`github.com/BuildDownAI/skills`, and any successor, renamed, forked, or
+additional repository under the `BuildDownAI` organization or otherwise
+designated by BuildDown.
+
+**"Designated Employees"** means the individuals listed on **Schedule A**, as
+updated from time to time in accordance with Section 8.
+
+---
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, **the Corporation hereby
+grants to BuildDown and to recipients of software distributed by BuildDown a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute the Corporation's Contributions and
+such derivative works.**
+
+---
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, **the Corporation hereby
+grants to BuildDown and to recipients of software distributed by BuildDown a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except
+as stated in this section) patent license to make, have made, use, offer to sell,
+sell, import, and otherwise transfer the Work**, where such license applies only
+to those patent claims licensable by the Corporation that are necessarily
+infringed by its Contributions alone or by combination of its Contributions with
+the Work to which such Contributions were submitted.
+
+If any entity institutes patent litigation against the Corporation or any other
+entity (including a cross-claim or counterclaim in a lawsuit) alleging that a
+Contribution, or the Work to which the Corporation has contributed, constitutes
+direct or contributory patent infringement, then any patent licenses granted to
+that entity under this Agreement for that Contribution or Work shall terminate as
+of the date such litigation is filed.
+
+---
+
+## 4. Right to Relicense and to Offer Under Multiple Licenses
+
+**4.1** The Corporation acknowledges and agrees that the sublicensing right
+granted in Section 2 expressly includes the right for BuildDown, in its sole
+discretion, to:
+
+&nbsp;&nbsp;**(a)** distribute Contributions under the Apache License,
+Version 2.0, or any other open source license;
+
+&nbsp;&nbsp;**(b)** distribute Contributions under one or more **commercial or
+proprietary licenses**, including on terms that do not require disclosure of
+source code;
+
+&nbsp;&nbsp;**(c)** **change the license** under which the Work, or any future
+version of the Work, is distributed;
+
+&nbsp;&nbsp;**(d)** offer the Work simultaneously under **multiple different
+licenses**; and
+
+&nbsp;&nbsp;**(e)** incorporate Contributions into proprietary products and
+hosted or managed services offered by BuildDown for a fee.
+
+**4.2** The Corporation will not be entitled to any compensation, royalty, or
+other consideration in respect of any license granted or revenue earned under
+Section 4.1, and waives any claim to an accounting of such revenue.
+
+**4.3 What the Corporation keeps.** Nothing in this Agreement transfers ownership
+of the Corporation's copyright. **The Corporation retains full ownership of its
+Contributions and may use, license, and distribute them however it wishes.** The
+license granted here is non-exclusive.
+
+---
+
+## 5. Representations
+
+The Corporation represents that:
+
+**5.1** Each Contribution is an original creation of the Corporation or its
+Designated Employees, or the Corporation otherwise has the right to submit it
+under the terms of this Agreement.
+
+**5.2** The person signing this Agreement is authorized to bind the Corporation,
+and the Corporation is legally entitled to grant the licenses in Sections 2, 3,
+and 4.
+
+**5.3** Each Designated Employee has been authorized by the Corporation to submit
+Contributions on its behalf.
+
+**5.4** Contributions do not include any material subject to a third-party
+license or other restriction (including related patents and trademarks) of which
+the Corporation is aware and which is not identified under Section 5.5.
+
+**5.5** The Corporation will identify the complete details of any third-party
+license or restriction of which it is aware and which is associated with any part
+of a Contribution, by conspicuously marking the affected material and noting it
+in the pull request description.
+
+**5.6** If any part of a Contribution was generated in whole or substantial part
+by an artificial intelligence system, the Corporation has the right to submit it
+under this Agreement and, to the best of its knowledge, doing so does not
+infringe the rights of any third party.
+
+**5.7** The Corporation is not expected to provide support for its Contributions.
+Unless required by applicable law or agreed to in writing, **Contributions are
+provided on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND**,
+either express or implied, including any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+---
+
+## 6. Notice of Change
+
+The Corporation agrees to notify BuildDown of any facts or circumstances of which
+it becomes aware that would make the representations in Section 5 inaccurate in
+any respect.
+
+---
+
+## 7. Scope
+
+This Agreement covers all Contributions submitted by the Corporation, whether by
+a Designated Employee or otherwise, and whether submitted before or after the
+date of signature.
+
+---
+
+## 8. Updating Schedule A
+
+The Corporation may add or remove Designated Employees by written notice to
+BuildDown, including by email to **[PLACEHOLDER: cla@builddown.ai]**, or by
+submitting an updated Schedule A. **Removal of an employee from Schedule A does
+not revoke any license already granted** in respect of Contributions made while
+that employee was designated.
+
+---
+
+## 9. Miscellaneous
+
+**9.1** BuildDown is under no obligation to accept, include, or use any
+Contribution.
+
+**9.2 Governing law.** This Agreement is governed by the laws of the State of
+Colorado, without regard to its conflict of laws provisions. The exclusive forum
+for any dispute is the state or federal courts located in Denver County,
+Colorado.
+
+**9.3 Assignment.** BuildDown may assign this Agreement, and the rights granted
+under it, in connection with a merger, reorganization, or sale of all or
+substantially all of its assets or of the Project.
+
+**9.4 Electronic signature.** This Agreement may be executed electronically and
+in counterparts.
+
+---
+
+## SIGNATURE
+
+| Field | Entry |
+|---|---|
+| Corporation name | |
+| Jurisdiction of organization | |
+| Mailing address | |
+| Signature | |
+| Printed name | |
+| Title | |
+| Date | |
+| Email address | |
+| Telephone | |
+| Point of contact for CLA matters | |
+
+---
+
+## SCHEDULE A — DESIGNATED EMPLOYEES
+
+*Individuals authorized to submit Contributions on behalf of the Corporation.*
+
+| # | Full name | GitHub username | Email | Date added | Date removed |
+|---|---|---|---|---|---|
+| 1 | | | | | |
+| 2 | | | | | |
+| 3 | | | | | |
+| 4 | | | | | |
+| 5 | | | | | |
+
+---
+
+*BuildDown AI LLC — Corporate Contributor License Agreement, Version 1.0.
+Adapted from the Apache Software Foundation Corporate Contributor License
+Agreement V2.0, which is licensed under the Apache License 2.0, with the addition
+of Section 4 (Right to Relicense), Section 5.6 (AI-generated content), and
+Colorado governing law.*

--- a/legal/ICLA.md
+++ b/legal/ICLA.md
@@ -1,0 +1,244 @@
+# BuildDown AI LLC
+## Individual Contributor License Agreement ("ICLA")
+
+**Version 1.0**
+
+Thank you for your interest in contributing to software projects managed by
+**BuildDown AI LLC**, a Colorado limited liability company ("**BuildDown**,"
+"**we**," or "**us**").
+
+This agreement clarifies the intellectual property license granted with
+Contributions from any person or entity. It protects **you** as a Contributor
+as well as BuildDown and its users. **It does not change your rights to use
+your own Contributions for any other purpose.**
+
+You accept and agree to the following terms for Your present and future
+Contributions submitted to BuildDown. Except for the license granted in this
+Agreement, **You reserve all right, title, and interest in and to Your
+Contributions.**
+
+---
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner, or the legal entity
+authorized by the copyright owner, that is entering into this Agreement with
+BuildDown. For legal entities, the entity making a Contribution and all other
+entities that control, are controlled by, or are under common control with that
+entity are considered to be a single Contributor. For the purposes of this
+definition, "control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or otherwise, or
+(ii) ownership of fifty percent (50%) or more of the outstanding shares, or
+(iii) beneficial ownership of such entity.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to BuildDown for inclusion in, or documentation of, any of the products
+owned or managed by BuildDown (the "**Work**"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written
+communication sent to BuildDown or its representatives, including but not
+limited to communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf of,
+BuildDown for the purpose of discussing and improving the Work, but excluding
+communication that is conspicuously marked or otherwise designated in writing by
+You as **"Not a Contribution."**
+
+**"Project"** means any software project managed by BuildDown, including without
+limitation:
+
+- `github.com/BuildDownAI/AI-Implement`
+- `github.com/BuildDownAI/skills`
+
+and any successor, renamed, forked, or additional repository under the
+`BuildDownAI` organization or otherwise designated by BuildDown.
+
+---
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, **You hereby grant to
+BuildDown and to recipients of software distributed by BuildDown a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license
+to reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contributions and such derivative works.**
+
+---
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, **You hereby grant to
+BuildDown and to recipients of software distributed by BuildDown a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated
+in this section) patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer the Work**, where such license applies only to
+those patent claims licensable by You that are necessarily infringed by Your
+Contribution alone or by combination of Your Contribution with the Work to which
+such Contribution was submitted.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
+
+---
+
+## 4. Right to Relicense and to Offer Under Multiple Licenses
+
+**This Section is the reason this Agreement exists in addition to the Project's
+open source license, and You should read it carefully before signing.**
+
+**4.1** You acknowledge and agree that the sublicensing right granted in
+Section 2 expressly includes the right for BuildDown, in its sole discretion, to:
+
+&nbsp;&nbsp;**(a)** distribute Your Contribution under the Apache License,
+Version 2.0, or under any other open source license;
+
+&nbsp;&nbsp;**(b)** distribute Your Contribution under one or more **commercial
+or proprietary licenses**, including on terms that do not require disclosure of
+source code;
+
+&nbsp;&nbsp;**(c)** **change the license** under which the Work, or any future
+version of the Work, is distributed;
+
+&nbsp;&nbsp;**(d)** offer the Work simultaneously under **multiple different
+licenses** ("dual licensing" or "multi-licensing"); and
+
+&nbsp;&nbsp;**(e)** incorporate Your Contribution into proprietary products and
+hosted or managed services offered by BuildDown for a fee.
+
+**4.2** You will **not** be entitled to any compensation, royalty, or other
+consideration in respect of any license granted or revenue earned under
+Section 4.1, and You waive any claim to an accounting of such revenue.
+
+**4.3 What You keep.** Nothing in this Agreement transfers ownership of Your
+copyright. **You retain full ownership of Your Contribution and may use,
+license, and distribute it however You wish, including in competing projects.**
+The license You grant here is non-exclusive.
+
+> **Plain-language summary of Section 4.** You keep owning your code. But
+> BuildDown can put it in a paid product, sell it under a closed-source licence,
+> or change the project's licence later — without asking you again and without
+> paying you. If that is not acceptable to you, do not sign this and do not
+> contribute.
+
+---
+
+## 5. Your Representations
+
+You represent that:
+
+**5.1 Original work.** Each of Your Contributions is Your original creation, or
+You have the right to submit it under the terms of this Agreement.
+
+**5.2 Authority.** You are legally entitled to grant the above licenses. If Your
+employer has rights to intellectual property that You create, You represent
+that:
+
+&nbsp;&nbsp;**(a)** You have received permission to make Contributions on behalf
+of that employer; **or**
+
+&nbsp;&nbsp;**(b)** Your employer has waived such rights for Your Contributions
+to BuildDown; **or**
+
+&nbsp;&nbsp;**(c)** Your employer has executed a **Corporate CLA** with
+BuildDown.
+
+> **This is the clause contributors most often get wrong.** If you are employed
+> as a software developer, your employment agreement may assign to your employer
+> everything you write, including on your own time and equipment. Check before
+> you sign.
+
+**5.3 Third-party materials.** Your Contribution does not include any material
+subject to a third-party license or other restriction (including but not limited
+to related patents and trademarks) of which You are personally aware and which
+is not identified under Section 5.4.
+
+**5.4 Disclosure of known third-party material.** You will identify the complete
+details of any third-party license or other restriction (including, without
+limitation, related patents, trademarks, and license agreements) of which You are
+personally aware and which is associated with any part of Your Contribution, by
+**conspicuously marking the affected material in the Contribution itself** and by
+noting it in the pull request description or the "Disclosures" field below.
+
+**5.5 AI-generated content.** If any part of Your Contribution was generated in
+whole or in substantial part by an artificial intelligence system, You represent
+that You have the right to submit it under this Agreement and that, to the best
+of Your knowledge, doing so does not infringe the rights of any third party. You
+will identify such material in the "Disclosures" field below where a reasonable
+contributor would consider the extent of generation material.
+
+**5.6 No obligation of support.** You are not expected to provide support for
+Your Contributions, except to the extent You desire to provide support. Unless
+required by applicable law or agreed to in writing, **You provide Your
+Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND**,
+either express or implied, including, without limitation, any warranties or
+conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+---
+
+## 6. Notice of Change
+
+You agree to notify BuildDown of any facts or circumstances of which You become
+aware that would make the representations in Section 5 inaccurate in any respect.
+
+---
+
+## 7. Miscellaneous
+
+**7.1 No obligation to use.** BuildDown is under no obligation to accept,
+include, or use any Contribution.
+
+**7.2 Governing law.** This Agreement is governed by the laws of the State of
+Colorado, without regard to its conflict of laws provisions. The exclusive forum
+for any dispute is the state or federal courts located in Denver County,
+Colorado.
+
+**7.3 Entire agreement.** This Agreement is the entire agreement between the
+parties regarding Contributions and supersedes any prior understanding on that
+subject.
+
+**7.4 Assignment.** BuildDown may assign this Agreement, and the rights granted
+under it, in connection with a merger, reorganization, or sale of all or
+substantially all of its assets or of the Project.
+
+**7.5 Electronic signature.** This Agreement may be executed electronically,
+including by an automated CLA workflow that records Your assent against Your
+verified account identity. Such assent has the same effect as a handwritten
+signature.
+
+---
+
+## SIGNATURE
+
+By signing below — or, where BuildDown uses an automated CLA workflow, by
+recording Your assent through that workflow — You accept and agree to the terms
+of this Individual Contributor License Agreement for Your present and future
+Contributions to BuildDown.
+
+| Field | Entry |
+|---|---|
+| Full legal name | |
+| Signature | |
+| Date | |
+| GitHub username | |
+| Email address | |
+| Mailing address | |
+| Country | |
+| Employer (if any) | |
+| Corporate CLA on file? | ☐ Yes ☐ No ☐ N/A |
+
+**Disclosures** *(Section 5.4 / 5.5 — write "None" if none):*
+
+<br>
+<br>
+
+---
+
+*BuildDown AI LLC — Individual Contributor License Agreement, Version 1.0.
+Adapted from the Apache Software Foundation Individual Contributor License
+Agreement V2.0, which is licensed under the Apache License 2.0, with the
+addition of Section 4 (Right to Relicense), Section 5.5 (AI-generated content),
+and Colorado governing law.*


### PR DESCRIPTION
Adds Contributor License Agreement (CLA) compliance to the repo.

## What this changes
- **New:** `legal/ICLA.md` + `legal/CCLA.md` (Individual / Corporate CLA v1.0), and `.github/workflows/cla.yml` — CLA Assistant, which blocks merge until a first-time contributor signs.
- **Replaced:** `CONTRIBUTING.md` (adds the CLA gate + keeps all existing dev content) and `NOTICE`.
- **LICENSE:** one line only — `Copyright 2026 Build Down AI` → `Copyright 2026 BuildDown AI LLC`. The Apache 2.0 text is untouched.
- `SECURITY.md` deliberately unchanged.

## Reviewer notes
- **This reverses the previous stance.** The prior `CONTRIBUTING.md` ended with *"No CLA is required"* — the new file requires a CLA before merge.
- **The CLA gate is forward-looking** — it applies to future contributions once the check is enabled; it does not retroactively require signatures for past work.
- ⚠️ **Placeholder to resolve before merge:** the `cla@builddown.ai` address appears in `CONTRIBUTING.md` and `CCLA` §8 as `[PLACEHOLDER: cla@builddown.ai]` — the alias needs to be set up (or replaced with a GitHub Discussions link) before this merges.

## Pre-merge checks already done
- `contributor-assistant/github-action@v2.6.1` confirmed as the latest release (no pin change needed).
- History scan: no `accelo` / `meQilibrium` / `Topia`; `Cloudshare` appears only in git history (commit messages + already-deleted docs), not the current tree — flagged separately, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)