### PR TITLE
AII-426: Refresh the graph on a running orchestrator from an authenticated trigger

### DIFF
--- a/docs/kg-architecture.md
+++ b/docs/kg-architecture.md
@@ -191,9 +191,25 @@ read with `kg_neighbors`. Compare it against the ingest date. An unchanged stamp
 the build served the old snapshot — usually because the push had not landed, or because the remote
 builder's git cache served a stale `--depth 1` clone. Both are benign. Wait, redeploy, re-verify.
 
-## Process: refresh is redeploy
+## Process: refreshing the graph
 
-Run `bd-kg-refresh`, or these steps by hand.
+With the refresh rail (AII-426), publishing data no longer rides a release. Run `bd-kg-refresh`,
+or these steps by hand.
+
+1. Reconcile scope, ingest, and commit + push the snapshot — steps 1–5 below, unchanged.
+2. **Trigger the refresh**: `POST /api/kg/refresh` with an admin session token (or the
+   Deployments page's "Refresh graph now"). `202` = accepted; `409` = a refresh or a deploy is
+   already in progress — the trigger refuses while the deploy hold is set. The orchestrator
+   fetches the configured `KG_SOURCE_REPO`, stages under `/data/kg/staging` (materialize with
+   the image's venv — nothing embeds), writes the completion marker last, swaps by rename, and
+   restarts the sidecar.
+3. **The four gates run on the serving graph**: the sidecar answers; the vectors are present;
+   a canary query returns non-empty with `degraded: false`; and the served age stamp is
+   strictly newer than before the swap. Any failure reverts to the previous overlay and
+   restarts again. `GET /api/kg/status` reports the outcome and the gate that fired.
+
+**Redeploy remains the fallback** — an orchestrator predating the rail (the route answers 404),
+or a change that touches the sidecar's code rather than its data, still refreshes by deploy:
 
 1. **Reconcile scope.** Call `list_projects` on the orchestrator MCP, diff against `sources.yml`, and
    commit the manifest before ingesting.

--- a/src/__tests__/kg-refresh.test.ts
+++ b/src/__tests__/kg-refresh.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { makeKgRefresh, MATERIALIZE_ARGS, type KgRefreshHandle } from "../kg-refresh.js";
+import { COMPLETION_MARKER } from "../kg-sidecar.js";
+
+const NAMESPACE = "https://kg.test.example/";
+const OLD_STAMP = "2026-08-20T00:10:10+00:00";
+const NEW_STAMP = "2026-08-24T12:00:00+00:00";
+
+function makeTarball(dir: string): Buffer {
+  // extractSource strips one leading component, so wrap in a top-level dir.
+  const wrap = mkdtempSync(join(tmpdir(), "kgtar-"));
+  const top = join(wrap, "repo");
+  mkdirSync(top, { recursive: true });
+  execSync(`cp -R ${dir}/ ${top}/`);
+  const out = join(wrap, "src.tar.gz");
+  execSync(`tar -czf ${out} -C ${wrap} repo`);
+  return readFileSync(out) as Buffer;
+}
+
+describe("kg-refresh", () => {
+  let dataRoot: string;
+  let fixtureRepo: string;
+  let tarball: Buffer;
+  let servedStamp: string;
+  let canary: { count: number; degraded: boolean };
+  let sidecarUp: boolean;
+  let restart: ReturnType<typeof vi.fn>;
+  let materialize: ReturnType<typeof vi.fn>;
+  let handle: KgRefreshHandle;
+  let deployHeld: boolean;
+  let free: number;
+
+  const mcpToolCall = vi.fn(async (_url: string, tool: string) => {
+    if (!sidecarUp) throw new Error("ECONNREFUSED");
+    if (tool === "kg_neighbors") {
+      return {
+        edges: [
+          { predicate_iri: "http://purl.org/dc/terms/modified", neighbor: servedStamp },
+        ],
+      };
+    }
+    if (tool === "kg_hybrid_search") return { count: canary.count, degraded: canary.degraded, results: [] };
+    throw new Error(`unexpected tool ${tool}`);
+  });
+
+  function build(overrides: Record<string, unknown> = {}) {
+    handle = makeKgRefresh({
+      sidecar: { restart: restart as unknown as () => Promise<void> },
+      githubAppId: "1",
+      githubAppPrivateKey: "key",
+      kgSourceRepo: "TestOrg/test-kg",
+      dataRoot,
+      kgDir: "/nonexistent-kg",
+      sidecarMcpUrl: "http://127.0.0.1:1/mcp",
+      minFreeBytes: 1000,
+      deployHeld: () => deployHeld,
+      freeBytes: () => free,
+      mintToken: vi.fn(async () => ({ token: "tok", expiresAt: "" })) as never,
+      fetchTarball: vi.fn(async () => tarball) as never,
+      fetchDefaultBranch: vi.fn(async () => "main") as never,
+      materialize: materialize as never,
+      mcpToolCall: mcpToolCall as never,
+      ...overrides,
+    });
+  }
+
+  async function waitDone(): Promise<void> {
+    for (let i = 0; i < 200; i++) {
+      if (!(await handle.status()).running) return;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error("refresh did not finish");
+  }
+
+  beforeEach(() => {
+    dataRoot = mkdtempSync(join(tmpdir(), "kgroot-"));
+    fixtureRepo = mkdtempSync(join(tmpdir(), "kgrepo-"));
+    writeFileSync(join(fixtureRepo, "sources.yml"), `namespace: ${NAMESPACE}\n`);
+    mkdirSync(join(fixtureRepo, "snapshot"), { recursive: true });
+    tarball = makeTarball(fixtureRepo);
+
+    servedStamp = OLD_STAMP;
+    canary = { count: 3, degraded: false };
+    sidecarUp = true;
+    deployHeld = false;
+    free = 10_000;
+    process.env.KG_SIDECAR_URL = "http://127.0.0.1:1/mcp";
+
+    // A successful restart serves the new graph: stamp flips to the staged one.
+    restart = vi.fn(async () => {
+      servedStamp = NEW_STAMP;
+    });
+    // Materialize produces the loadable form inside the fetched tree (KGB-9 contract).
+    materialize = vi.fn(async (_python: string, cwd: string) => {
+      mkdirSync(join(cwd, "out"), { recursive: true });
+      writeFileSync(join(cwd, "out", "graph.trig"), "@prefix kg: <x> .");
+      writeFileSync(join(cwd, "out", "embeddings.npz"), "vectors");
+    });
+    build();
+  });
+
+  afterEach(() => {
+    rmSync(dataRoot, { recursive: true, force: true });
+    rmSync(fixtureRepo, { recursive: true, force: true });
+    delete process.env.KG_SIDECAR_URL;
+    vi.clearAllMocks();
+  });
+
+  it("returns 202, refreshes, and records the stamp movement", async () => {
+    const r = await handle.trigger();
+    expect(r.status).toBe(202);
+    await waitDone();
+
+    const s = await handle.status();
+    expect(s.lastRefresh?.ok).toBe(true);
+    expect(s.lastRefresh?.stampBefore).toBe(OLD_STAMP);
+    expect(s.lastRefresh?.stampAfter).toBe(NEW_STAMP);
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    const current = join(dataRoot, "current");
+    expect(existsSync(join(current, "graph.trig"))).toBe(true);
+    expect(existsSync(join(current, "embeddings.npz"))).toBe(true);
+    expect(existsSync(join(current, COMPLETION_MARKER))).toBe(true);
+    expect(existsSync(join(dataRoot, "fetch"))).toBe(false);
+  });
+
+  it("refuses with 409 while a refresh is running", async () => {
+    let release: (() => void) | undefined;
+    materialize.mockImplementationOnce(async (_p: string, cwd: string) => {
+      mkdirSync(join(cwd, "out"), { recursive: true });
+      writeFileSync(join(cwd, "out", "graph.trig"), "x");
+      writeFileSync(join(cwd, "out", "embeddings.npz"), "y");
+      await new Promise<void>((r) => {
+        release = r;
+      });
+    });
+    const first = await handle.trigger();
+    expect(first.status).toBe(202);
+    const second = await handle.trigger();
+    expect(second.status).toBe(409);
+    expect(second.body.error).toBe("refresh-in-progress");
+    // The blocking materialize starts a few awaits into the async run.
+    for (let i = 0; i < 200 && !release; i++) await new Promise((r) => setTimeout(r, 10));
+    release!();
+    await waitDone();
+  });
+
+  it("refuses with 409 while the deploy hold is set, and does not run", async () => {
+    deployHeld = true;
+    const r = await handle.trigger();
+    expect(r.status).toBe(409);
+    expect(r.body.error).toBe("deploy-in-progress");
+    expect(materialize).not.toHaveBeenCalled();
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it("refuses with 507 below the free-space threshold", async () => {
+    free = 10;
+    const r = await handle.trigger();
+    expect(r.status).toBe(507);
+    expect(materialize).not.toHaveBeenCalled();
+  });
+
+  it("returns 501 with no configured KG source repo", async () => {
+    build({ kgSourceRepo: null });
+    const r = await handle.trigger();
+    expect(r.status).toBe(501);
+  });
+
+  it("a crash during staging leaves current untouched and never restarts", async () => {
+    const current = join(dataRoot, "current");
+    mkdirSync(current, { recursive: true });
+    writeFileSync(join(current, "graph.trig"), "SERVING");
+    writeFileSync(join(current, COMPLETION_MARKER), "ok");
+
+    materialize.mockImplementationOnce(async () => {
+      throw new Error("OOM-killed");
+    });
+    await handle.trigger();
+    await waitDone();
+
+    const s = await handle.status();
+    expect(s.lastRefresh?.ok).toBe(false);
+    expect(s.lastRefresh?.gate).toBe("staging");
+    expect(readFileSync(join(current, "graph.trig"), "utf8")).toBe("SERVING");
+    expect(existsSync(join(dataRoot, "staging"))).toBe(false);
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it("a failed canary gate reverts to the previous overlay and restarts again", async () => {
+    const current = join(dataRoot, "current");
+    mkdirSync(current, { recursive: true });
+    writeFileSync(join(current, "graph.trig"), "OLD-OVERLAY");
+    writeFileSync(join(current, COMPLETION_MARKER), "ok");
+
+    restart.mockImplementation(async () => {
+      // After the failed swap the canary reports degraded; after revert it recovers.
+      canary = restart.mock.calls.length === 1 ? { count: 0, degraded: true } : { count: 3, degraded: false };
+    });
+    await handle.trigger();
+    await waitDone();
+
+    const s = await handle.status();
+    expect(s.lastRefresh?.ok).toBe(false);
+    expect(s.lastRefresh?.gate).toBe("canary");
+    expect(restart).toHaveBeenCalledTimes(2);
+    expect(readFileSync(join(current, "graph.trig"), "utf8")).toBe("OLD-OVERLAY");
+    expect(existsSync(join(dataRoot, "previous"))).toBe(false);
+  });
+
+  it("a stamp that did not move fails the stamp gate and reverts", async () => {
+    restart.mockImplementation(async () => {
+      /* served stamp stays OLD_STAMP */
+    });
+    await handle.trigger();
+    await waitDone();
+
+    const s = await handle.status();
+    expect(s.lastRefresh?.ok).toBe(false);
+    expect(s.lastRefresh?.gate).toBe("stamp");
+    // No previous existed: the failed overlay is withdrawn, baked graph serves.
+    expect(existsSync(join(dataRoot, "current"))).toBe(false);
+  });
+
+  it("a sidecar that never comes back fails the answers gate", async () => {
+    restart.mockImplementation(async () => {
+      delete process.env.KG_SIDECAR_URL;
+      sidecarUp = false;
+    });
+    await handle.trigger();
+    await waitDone();
+    const s = await handle.status();
+    expect(s.lastRefresh?.ok).toBe(false);
+    expect(s.lastRefresh?.gate).toBe("answers");
+  });
+
+  it("retains exactly one previous overlay across successive refreshes", async () => {
+    await handle.trigger();
+    await waitDone();
+    servedStamp = NEW_STAMP;
+    const newer = "2026-08-25T00:00:00+00:00";
+    restart.mockImplementation(async () => {
+      servedStamp = newer;
+    });
+    await handle.trigger();
+    await waitDone();
+
+    const s = await handle.status();
+    expect(s.lastRefresh?.ok).toBe(true);
+    expect(s.lastRefresh?.stampAfter).toBe(newer);
+    expect(existsSync(join(dataRoot, "previous"))).toBe(true);
+    expect(existsSync(join(dataRoot, "staging"))).toBe(false);
+  });
+
+  it("never reaches an embedding path: the staging command is materialize, full pass", () => {
+    expect([...MATERIALIZE_ARGS]).toEqual(["-m", "kg_ingest.materialize"]);
+    expect(MATERIALIZE_ARGS.join(" ")).not.toMatch(/embed|cli/);
+  });
+});

--- a/src/admin-ui/pages/deployments.ts
+++ b/src/admin-ui/pages/deployments.ts
@@ -60,6 +60,18 @@ export const deploymentsHtml = `
       </div>
     </div>
 
+    <div class="card" id="kg-refresh-card" hidden>
+      <div class="card-header"><h2 class="card-title">Knowledge graph <span class="badge neutral" id="kg-refresh-badge">—</span></h2></div>
+      <div class="card-body">
+        <div class="kpi-trend" id="kg-refresh-stamp">Served graph stamp: —</div>
+        <div class="kpi-trend text-secondary" id="kg-refresh-last"></div>
+        <div style="margin-top: 12px">
+          <button class="btn btn-sm" id="kg-refresh-btn" onclick="window.triggerKgRefresh()">Refresh graph now</button>
+          <span class="kpi-trend text-secondary" style="margin-left: 8px">Fetches the KG source repo's committed snapshot and restarts the sidecar — no deploy, no dispatch pause.</span>
+        </div>
+      </div>
+    </div>
+
     <div id="deployments-not-configured" class="alert warn" hidden>
       <div style="flex:1">
         <div class="alert-title">Self-deploy not configured</div>
@@ -419,6 +431,38 @@ export const deploymentsScript = `
   window.triggerDeploy = triggerDeploy;
   window.saveDeployPolicy = saveDeployPolicy;
   window.refreshPolicyDirty = refreshPolicyDirty;
-  window.registerPage('deployments', function () { loadDeployments(); setInterval(loadDeployments, 30000); });
+  async function loadKgStatus() {
+    const card = document.getElementById('kg-refresh-card');
+    try {
+      const res = await window.api('/api/kg/status');
+      if (!res.ok) { card.hidden = true; return; }
+      const data = await res.json();
+      card.hidden = false;
+      const badge = document.getElementById('kg-refresh-badge');
+      if (data.running) setBadge(badge, 'info', 'refreshing');
+      else if (data.kgDegraded) setBadge(badge, 'warn', 'degraded');
+      else setBadge(badge, 'ok', 'serving');
+      document.getElementById('kg-refresh-stamp').textContent =
+        'Served graph stamp: ' + (data.servedStamp || 'baked image graph');
+      const last = data.lastRefresh;
+      document.getElementById('kg-refresh-last').textContent = last
+        ? 'Last refresh: ' + (last.ok ? 'ok' : 'failed at gate "' + (last.gate || '?') + '"') + ' — ' + last.detail
+        : 'No refresh has run since boot.';
+      document.getElementById('kg-refresh-btn').disabled = !!data.running || !!data.deployHeld;
+    } catch (e) { card.hidden = true; }
+  }
+
+  window.triggerKgRefresh = async function () {
+    const btn = document.getElementById('kg-refresh-btn');
+    btn.disabled = true;
+    try {
+      const res = await window.api('/api/kg/refresh', { method: 'POST' });
+      const body = await res.json();
+      if (!res.ok) { showMessage('warning', 'Refresh refused — ' + (body.error || res.status)); }
+    } catch (err) { showMessage('warning', 'Refresh failed — ' + String(err)); }
+    setTimeout(loadKgStatus, 1000);
+  };
+
+  window.registerPage('deployments', function () { loadDeployments(); loadKgStatus(); setInterval(loadDeployments, 30000); setInterval(loadKgStatus, 15000); });
 })();
 `;

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -192,6 +192,11 @@ export interface AdminDeps {
   /** Starts a self-deploy. Absent when the orchestrator is not configured to deploy itself. */
   startDeploy?: () => Promise<DeployStart>;
   selfDeployTarget?: SelfDeployTarget | null;
+  /** The KG refresh rail (AII-426). Absent when no KG source repo is configured. */
+  kgRefresh?: {
+    trigger(): Promise<{ status: number; body: Record<string, unknown> }>;
+    status(): Promise<unknown>;
+  };
 }
 
 export function handleAdminRequest(
@@ -248,6 +253,30 @@ export function handleAdminRequest(
 
     if (url === "/api/deploy" && method === "POST") {
       handleDeployTrigger(res, deps);
+      return true;
+    }
+
+    if (url === "/api/kg/refresh" && method === "POST") {
+      if (!deps.kgRefresh) {
+        json(res, 501, { error: "KG refresh is not configured" });
+        return true;
+      }
+      deps.kgRefresh.trigger().then(
+        (r) => json(res, r.status, r.body),
+        (err) => json(res, 500, { error: String(err) }),
+      );
+      return true;
+    }
+
+    if (url === "/api/kg/status" && method === "GET") {
+      if (!deps.kgRefresh) {
+        json(res, 501, { error: "KG refresh is not configured" });
+        return true;
+      }
+      deps.kgRefresh.status().then(
+        (body) => json(res, 200, body as Record<string, unknown>),
+        (err) => json(res, 500, { error: String(err) }),
+      );
       return true;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ import { listOpenReviewFindings } from "./review-ledger-store.js";
 import { detectMergedPrs, prNumberFromUrl } from "./poll-merged-prs.js";
 import { githubActionsWatchdogDecision } from "./github-actions-watchdog.js";
 import { KgSidecar } from "./kg-sidecar.js";
+import { makeKgRefresh } from "./kg-refresh.js";
 
 // ---------- Configuration ----------
 
@@ -2862,8 +2863,9 @@ function onDeployBuildFailure(commit: string, err: unknown): void {
   recordDeployOutcome({ kind: "build-failed", commit, timestamp: Date.now(), detail: String(err) });
 }
 
-function startServer(config: AppConfig, registry: ProviderRegistry): http.Server {
+function startServer(config: AppConfig, registry: ProviderRegistry, sidecar: KgSidecar): http.Server {
   const startDeploy = makeStartDeploy({ ...config, onBuildFailure: onDeployBuildFailure });
+  const kgRefresh = makeKgRefresh({ sidecar, githubAppId: config.githubAppId, githubAppPrivateKey: config.githubAppPrivateKey, kgSourceRepo: config.kgSourceRepo });
 
   const handleRequest: http.RequestListener = (req, res) => {
     const url = req.url || "/";
@@ -3283,7 +3285,7 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
         githubAppId: config.githubAppId,
         githubAppPrivateKey: config.githubAppPrivateKey,
         notifyWebhookUrl: config.notifyWebhookUrl,
-      }, registry, { startDeploy, selfDeployTarget: config.selfDeployTarget })) return;
+      }, registry, { startDeploy, selfDeployTarget: config.selfDeployTarget, kgRefresh })) return;
     }
 
     res.writeHead(404, { "Content-Type": "application/json" });
@@ -3373,7 +3375,7 @@ async function main(): Promise<void> {
     }
   }
 
-  const server = startServer(config, registry);
+  const server = startServer(config, registry, sidecar);
 
   // Fire-and-forget: a hanging webhook must not delay reconciliation or the first poll.
   // Every write postBootNotice makes — LAST_IMAGE_REF_KEY, LAST_SHUTDOWN_AT_KEY and

--- a/src/kg-refresh.ts
+++ b/src/kg-refresh.ts
@@ -1,0 +1,407 @@
+import { mkdir, rm, rename, writeFile, copyFile, readFile } from "node:fs/promises";
+import { existsSync, statfsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import http from "node:http";
+import { getScopedInstallationToken } from "./github-app-auth.js";
+import { fetchRepoTarball } from "./github.js";
+import { extractSource, parseKgSourceRepo } from "./deploy.js";
+import { isDeployHeld } from "./deploy-hold.js";
+import { COMPLETION_MARKER, KG_DIR } from "./kg-sidecar.js";
+import { isKgDegraded } from "./deploy-notify.js";
+import { parseSidecarRpcResponse } from "./mcp.js";
+
+const execFile = promisify(execFileCb);
+
+/** Root of the runtime graph overlay. `current/` under it is what the sidecar serves. */
+const DATA_ROOT = "/data/kg";
+const SIDECAR_MCP_URL = "http://127.0.0.1:8765/mcp";
+
+/**
+ * Refuse to stage below this much free space on the volume. The volume also
+ * holds the SQLite database; a full disk corrupts more than a failed refresh.
+ */
+const MIN_FREE_BYTES = 200 * 1024 * 1024;
+
+/** Gates evaluated on the serving graph after the swap + restart. */
+export type RefreshGate = "staging" | "answers" | "vectors" | "canary" | "stamp";
+
+export interface RefreshOutcome {
+  ok: boolean;
+  at: number;
+  /** Which gate fired on failure; absent on success. `staging` = failed before any swap. */
+  gate?: RefreshGate;
+  detail: string;
+  stampBefore: string | null;
+  stampAfter: string | null;
+}
+
+export interface KgRefreshStatus {
+  running: boolean;
+  deployHeld: boolean;
+  kgDegraded: boolean;
+  servedStamp: string | null;
+  lastRefresh: RefreshOutcome | null;
+}
+
+export interface KgRefreshHandle {
+  /** POST /api/kg/refresh behind admin auth. Returns the HTTP status + body to send. */
+  trigger(): Promise<{ status: number; body: Record<string, unknown> }>;
+  /** GET /api/kg/status behind admin auth. */
+  status(): Promise<KgRefreshStatus>;
+}
+
+interface KgRefreshInput {
+  /** The supervised sidecar from AII-425; restart() is the reload mechanism. */
+  sidecar: { restart(): Promise<void> };
+  githubAppId: string;
+  githubAppPrivateKey: string;
+  /** owner/repo of the KG source (config.kgSourceRepo — never hard-code the slug). */
+  kgSourceRepo: string | null;
+  /** Overrides for tests. */
+  dataRoot?: string;
+  kgDir?: string;
+  sidecarMcpUrl?: string;
+  minFreeBytes?: number;
+  deployHeld?: () => boolean;
+  freeBytes?: (path: string) => number;
+  mintToken?: typeof getScopedInstallationToken;
+  fetchTarball?: typeof fetchRepoTarball;
+  fetchDefaultBranch?: (token: string, owner: string, repo: string) => Promise<string>;
+  materialize?: (python: string, cwd: string) => Promise<void>;
+  mcpToolCall?: (url: string, tool: string, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+/**
+ * The KG refresh rail (AII-426): fetch the configured KG source repo's committed
+ * snapshot, stage it on the volume, swap atomically, restart the sidecar, and
+ * verify the SERVING graph with four gates — reverting to the previous overlay
+ * on any failure. Never touches the deploy hold; refuses while one is set.
+ *
+ * Memory discipline: the graph is never parsed in this process. Staging runs the
+ * image's own materialize (venv, no fastembed import per KGB-9), and validation
+ * queries the sidecar over loopback — the process that already holds the graph.
+ *
+ * Partial-write invariant: `current/` is only ever created by renaming a fully
+ * staged directory whose COMPLETION_MARKER was written last. A crash at any point
+ * during staging leaves the serving graph untouched; the sidecar (AII-425)
+ * ignores a marker-less `current/` at boot.
+ */
+export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
+  const dataRoot = input.dataRoot ?? DATA_ROOT;
+  const kgDir = input.kgDir ?? KG_DIR;
+  const mcpUrl = input.sidecarMcpUrl ?? SIDECAR_MCP_URL;
+  const minFree = input.minFreeBytes ?? MIN_FREE_BYTES;
+  const deployHeld = input.deployHeld ?? isDeployHeld;
+  const freeBytes = input.freeBytes ?? defaultFreeBytes;
+  const mintToken = input.mintToken ?? getScopedInstallationToken;
+  const fetchTarball = input.fetchTarball ?? fetchRepoTarball;
+  const fetchDefaultBranch = input.fetchDefaultBranch ?? defaultFetchDefaultBranch;
+  const materialize = input.materialize ?? defaultMaterialize;
+  const mcpToolCall = input.mcpToolCall ?? defaultMcpToolCall;
+
+  let running = false;
+  let lastRefresh: RefreshOutcome | null = null;
+
+  const currentDir = join(dataRoot, "current");
+  const previousDir = join(dataRoot, "previous");
+  const stagingDir = join(dataRoot, "staging");
+  const fetchDir = join(dataRoot, "fetch");
+
+  async function readServedStamp(namespace: string | null): Promise<string | null> {
+    if (!namespace) return null;
+    try {
+      const spineIri = `${namespace.replace(/\/?$/, "/")}resource/graph/spine`;
+      const result = (await mcpToolCall(mcpUrl, "kg_neighbors", { iri: spineIri, limit: 30 })) as {
+        edges?: Array<{ predicate_iri?: string; neighbor?: string }>;
+      };
+      const edge = result?.edges?.find((e) => e.predicate_iri === "http://purl.org/dc/terms/modified");
+      return edge?.neighbor ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function readNamespace(sourceDir: string): Promise<string | null> {
+    try {
+      const raw = await readFile(join(sourceDir, "sources.yml"), "utf8");
+      const match = raw.match(/^namespace:\s*(\S+)\s*$/m);
+      return match ? match[1] : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function revert(namespace: string | null, gate: RefreshGate, detail: string, stampBefore: string | null): Promise<RefreshOutcome> {
+    // The failed overlay must stop serving before this reports. With no previous
+    // overlay, deleting current falls back to the baked graph — today's behaviour.
+    const rejected = join(dataRoot, "rejected");
+    await rm(rejected, { recursive: true, force: true });
+    if (existsSync(currentDir)) await rename(currentDir, rejected);
+    if (existsSync(previousDir)) await rename(previousDir, currentDir);
+    await input.sidecar.restart();
+    const servedNow = await readServedStamp(namespace);
+    const outcome: RefreshOutcome = {
+      ok: false,
+      at: Date.now(),
+      gate,
+      detail: `${detail}; reverted, serving stamp ${servedNow ?? "unknown"}`,
+      stampBefore,
+      stampAfter: servedNow,
+    };
+    console.error(`[kg-refresh] gate '${gate}' failed: ${outcome.detail}`);
+    return outcome;
+  }
+
+  async function runRefresh(): Promise<RefreshOutcome> {
+    const repo = parseKgSourceRepo(input.kgSourceRepo);
+    let stampBefore: string | null = null;
+    let namespace: string | null = null;
+
+    // ---- fetch (no swap yet; any failure here leaves current untouched) ----
+    try {
+      const { token } = await mintToken(input.githubAppId, input.githubAppPrivateKey, repo.owner, {
+        permissions: { contents: "read" },
+        repositories: [repo.repo],
+      });
+      const branch = await fetchDefaultBranch(token, repo.owner, repo.repo);
+      await rm(fetchDir, { recursive: true, force: true });
+      await mkdir(fetchDir, { recursive: true });
+      const source = await extractSource(await fetchTarball(token, repo.owner, repo.repo, branch), fetchDir);
+
+      namespace = await readNamespace(source);
+      stampBefore = await readServedStamp(namespace);
+
+      // ---- stage: materialize in the fetched tree with the image's venv.
+      // KGB-9's contract: this copies committed vectors and hard-fails on a
+      // stamp mismatch or missing artifact. Nothing embeds — ever.
+      await materialize(join(kgDir, ".venv", "bin", "python"), source);
+
+      await rm(stagingDir, { recursive: true, force: true });
+      await mkdir(stagingDir, { recursive: true });
+      await copyFile(join(source, "out", "graph.trig"), join(stagingDir, "graph.trig"));
+      await copyFile(join(source, "out", "embeddings.npz"), join(stagingDir, "embeddings.npz"));
+      // The marker is written LAST — the atomic-overlay invariant.
+      await writeFile(join(stagingDir, COMPLETION_MARKER), new Date().toISOString());
+    } catch (err) {
+      const outcome: RefreshOutcome = {
+        ok: false,
+        at: Date.now(),
+        gate: "staging",
+        detail: `staging failed before any swap: ${String(err)}`,
+        stampBefore,
+        stampAfter: stampBefore,
+      };
+      console.error(`[kg-refresh] ${outcome.detail}`);
+      await rm(stagingDir, { recursive: true, force: true });
+      return outcome;
+    }
+
+    // ---- swap: current only ever changes by rename of a fully staged dir ----
+    await rm(previousDir, { recursive: true, force: true });
+    if (existsSync(currentDir)) await rename(currentDir, previousDir);
+    await rename(stagingDir, currentDir);
+
+    await input.sidecar.restart();
+
+    // ---- gates, on the graph that is actually serving ----
+    if (!process.env.KG_SIDECAR_URL) {
+      return revert(namespace, "answers", "sidecar did not come back after restart", stampBefore);
+    }
+
+    if (!existsSync(join(currentDir, "embeddings.npz"))) {
+      return revert(namespace, "vectors", "no vectors in the serving overlay", stampBefore);
+    }
+
+    try {
+      const canary = (await mcpToolCall(mcpUrl, "kg_hybrid_search", { query: "knowledge graph", limit: 3 })) as {
+        count?: number;
+        degraded?: boolean;
+      };
+      if (!canary || canary.degraded !== false || (canary.count ?? 0) < 1) {
+        return revert(
+          namespace,
+          "canary",
+          `canary query degraded=${String(canary?.degraded)} count=${String(canary?.count)}`,
+          stampBefore,
+        );
+      }
+    } catch (err) {
+      return revert(namespace, "canary", `canary query failed: ${String(err)}`, stampBefore);
+    }
+
+    const stampAfter = await readServedStamp(namespace);
+    if (!stampAfter || (stampBefore !== null && stampAfter <= stampBefore)) {
+      return revert(
+        namespace,
+        "stamp",
+        `served stamp ${stampAfter ?? "unknown"} is not newer than ${stampBefore ?? "unknown"}`,
+        stampBefore,
+      );
+    }
+
+    await rm(fetchDir, { recursive: true, force: true });
+    const outcome: RefreshOutcome = {
+      ok: true,
+      at: Date.now(),
+      detail: `refreshed: ${stampBefore ?? "baked"} -> ${stampAfter}`,
+      stampBefore,
+      stampAfter,
+    };
+    console.log(`[kg-refresh] ${outcome.detail}`);
+    return outcome;
+  }
+
+  return {
+    async trigger() {
+      if (running) return { status: 409, body: { error: "refresh-in-progress" } };
+      if (deployHeld()) {
+        return { status: 409, body: { error: "deploy-in-progress", detail: "a deploy holds the machine; refresh refused" } };
+      }
+      if (input.kgSourceRepo === null) {
+        return { status: 501, body: { error: "kg-source-repo-not-configured" } };
+      }
+      try {
+        if (freeBytes(dataRoot) < minFree) {
+          return { status: 507, body: { error: "insufficient-storage", detail: `less than ${minFree} bytes free on the volume` } };
+        }
+      } catch {
+        // statfs failing is not a reason to refuse; disk pressure will surface in staging.
+      }
+
+      running = true;
+      void runRefresh()
+        .catch((err): RefreshOutcome => ({
+          ok: false,
+          at: Date.now(),
+          gate: "staging",
+          detail: `unexpected: ${String(err)}`,
+          stampBefore: null,
+          stampAfter: null,
+        }))
+        .then((outcome) => {
+          lastRefresh = outcome;
+          running = false;
+        });
+      return { status: 202, body: { refreshing: true } };
+    },
+
+    async status() {
+      return {
+        running,
+        deployHeld: deployHeld(),
+        kgDegraded: isKgDegraded(),
+        servedStamp: lastRefresh?.stampAfter ?? null,
+        lastRefresh,
+      };
+    },
+  };
+}
+
+function defaultFreeBytes(path: string): number {
+  const target = existsSync(path) ? path : tmpdir();
+  const s = statfsSync(target);
+  return s.bavail * s.bsize;
+}
+
+async function defaultFetchDefaultBranch(token: string, owner: string, repo: string): Promise<string> {
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}`, {
+    headers: { Authorization: `Bearer ${token}`, Accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) throw new Error(`repo metadata fetch failed: HTTP ${res.status}`);
+  const data = (await res.json()) as { default_branch?: string };
+  return data.default_branch || "main";
+}
+
+/**
+ * The staging command, exactly. The full materialize pass copies the committed
+ * vectors (KGB-9) and never imports fastembed — a refresh that would compute
+ * embeddings on this machine is a bug, not a slow path (KGB-8's OOM).
+ */
+export const MATERIALIZE_ARGS = ["-m", "kg_ingest.materialize"] as const;
+
+async function defaultMaterialize(python: string, cwd: string): Promise<void> {
+  await execFile(python, [...MATERIALIZE_ARGS], {
+    cwd,
+    env: { ...process.env, PYTHONPATH: cwd },
+    timeout: 5 * 60 * 1000,
+  });
+}
+
+/**
+ * Minimal streamable-HTTP MCP client for loopback gate checks: initialize,
+ * notifications/initialized, then one tools/call. FastMCP frames responses as
+ * SSE; parseSidecarRpcResponse handles both encodings. Tool results arrive as
+ * JSON text in content[0].text.
+ */
+async function defaultMcpToolCall(url: string, tool: string, args: Record<string, unknown>): Promise<unknown> {
+  const init = await mcpPost(url, null, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "kg-refresh-gate", version: "1.0" },
+    },
+  });
+  if (!init.parsed) throw new Error(`initialize failed (HTTP ${init.status})`);
+  const session = init.sessionId;
+
+  await mcpPost(url, session, { jsonrpc: "2.0", method: "notifications/initialized" });
+
+  const call = await mcpPost(url, session, {
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: tool, arguments: args },
+  });
+  const parsed = call.parsed as { result?: { content?: Array<{ type?: string; text?: string }> }; error?: unknown } | null;
+  if (!parsed || parsed.error) throw new Error(`tools/call ${tool} failed: ${JSON.stringify(parsed?.error ?? "no response")}`);
+  const text = parsed.result?.content?.find((c) => c.type === "text")?.text;
+  if (!text) throw new Error(`tools/call ${tool}: no text content`);
+  return JSON.parse(text);
+}
+
+function mcpPost(
+  url: string,
+  sessionId: string | null,
+  payload: Record<string, unknown>,
+): Promise<{ status: number; parsed: unknown; sessionId: string | null }> {
+  return new Promise((resolve, reject) => {
+    const body = Buffer.from(JSON.stringify(payload));
+    const req = http.request(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "content-length": String(body.length),
+          ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+        },
+        timeout: 10_000,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf8");
+          resolve({
+            status: res.statusCode ?? 0,
+            parsed: parseSidecarRpcResponse(raw, res.headers["content-type"]),
+            sessionId: (res.headers["mcp-session-id"] as string | undefined) ?? sessionId,
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("mcp request timeout"));
+    });
+    req.end(body);
+  });
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -234,7 +234,7 @@ interface SidecarRpcResponse {
  * the first event carrying a `result` (falling back to one carrying an
  * `error`), or null if nothing in the reply is a JSON-RPC response.
  */
-function parseSidecarRpcResponse(raw: string, contentType: string | undefined): SidecarRpcResponse | null {
+export function parseSidecarRpcResponse(raw: string, contentType: string | undefined): SidecarRpcResponse | null {
   if (contentType?.includes("text/event-stream")) {
     let errorReply: SidecarRpcResponse | null = null;
     // Events are separated by blank lines; one event's data may span several


### PR DESCRIPTION
Supersedes #329, which GitHub closed unrecoverably when its stacked base branch was deleted by #320's merge (a closed PR's base cannot be edited or reopened once the ref is gone). Same single commit, cherry-picked onto current `testing` — clean, no conflicts.

All content, design, and verification detail: see #329's description and [AII-426](https://linear.app/eudoxus/issue/AII-426/refresh-the-graph-on-a-running-orchestrator-from-an-authenticated). Summary: `POST /api/kg/refresh` fetches the configured `KG_SOURCE_REPO` snapshot with a read-only single-repo token, stages via the image's own `materialize` (nothing embeds), marker-last atomic swap, sidecar restart, four gates on the serving graph with revert. Refuses during deploys, under low disk, or unconfigured. `GET /api/kg/status` + Deployments-page panel. `index.ts` budget: one construction, one AdminDeps entry, one threaded parameter.

Fresh smoke-jumper run on this head follows as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)