### PR TITLE
legal(cla): exempt core team from the CLA gate (allowlist)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,7 +37,7 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/BuildDownAI/AI-Implement/blob/main/legal/ICLA.md
           branch: cla-signatures
-          allowlist: bot*,dependabot[bot],github-actions[bot]
+          allowlist: bot*,dependabot[bot],github-actions[bot],jodwyer,theaboutbox,rigonzal530
           custom-notsigned-prcomment: >
             Thanks for the contribution. Before we can merge, please sign our
             Contributor License Agreement — it is a one-time signature that


### PR DESCRIPTION
Exempts the BuildDown core team from the CLA gate by adding their GitHub usernames to the CLA Assistant allowlist:

- `jodwyer` (John O'Dwyer)
- `theaboutbox` (Cameron Pope)
- `rigonzal530` (Ricardo Gonzalez)

The CLA gate stays in force for **outside** contributors — this only exempts the internal team.

**Note on where this takes effect:** the CLA workflow runs from the repository **default branch (`main`)**, so the exemption only becomes active once the matching change is on `main` (companion PR). This PR keeps `testing` in sync so a future `testing → main` promotion doesn't revert the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)