### PR TITLE
legal(cla): allowlist the ai-implement[bot] pipeline committer

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,7 +37,7 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/BuildDownAI/AI-Implement/blob/main/legal/ICLA.md
           branch: cla-signatures
-          allowlist: bot*,dependabot[bot],github-actions[bot],jodwyer,theaboutbox,rigonzal530
+          allowlist: bot*,dependabot[bot],github-actions[bot],ai-implement[bot],jodwyer,theaboutbox,rigonzal530
           custom-notsigned-prcomment: >
             Thanks for the contribution. Before we can merge, please sign our
             Contributor License Agreement — it is a one-time signature that


### PR DESCRIPTION
Adds the pipeline bot **`ai-implement[bot]`** to the CLA Assistant allowlist.

**Why:** pipeline PRs (`ai-implement/*` branches) have their commits authored by `ai-implement[bot]`. The existing `bot*` glob does **not** match it (`bot*` matches names that *start* with "bot"; this one *ends* in `[bot]`), so the CLA gate was trying to make the pipeline bot sign the CLA — which it can't — and every pipeline PR's CLA check failed. This treats it exactly like the already-allowlisted `dependabot[bot]` / `github-actions[bot]`: org automation, not an outside contributor.

Companion fix: the missing `cla-signatures` branch was created on `BuildDownAI/skills` (AI-Implement already had it), which cleared the separate "Branch cla-signatures not found" hard error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)