### PR TITLE
AII-449: Add unit-test CI to AI-Implement PRs (vitest + typecheck as a required check)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,5 +27,14 @@ jobs:
       # vitest exits non-zero on test failures AND on unhandled errors
       # (verified on AII-448: 28 unhandled rejections alone produced exit 1
       # while all tests passed — the exact signal this gate exists to catch).
-      - run: npm test
+      #
+      # Ambient Actions vars are scrubbed for the test step: orchestrator code
+      # branches on GITHUB_RUN_ID / GITHUB_ENV / etc., and the suite asserts
+      # the non-CI defaults (first run of this gate proved it: reporter tests
+      # picked up the job's own run id). The suite must see the same env shape
+      # locally and here.
+      - name: npm test (ambient CI vars scrubbed)
+        run: |
+          unset GITHUB_RUN_ID GITHUB_ENV GITHUB_REPOSITORY GITHUB_REF_NAME                 GITHUB_EVENT_NAME GITHUB_SHA GITHUB_ACTIONS GITHUB_ACTION
+          npm test
       - run: npm run typecheck

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,31 @@
+# Unit-test gate for AI-Implement PRs (AII-449).
+#
+# Named unit-tests.yml deliberately: the claude-*.yml files here are TEMPLATES
+# synced to target repos, and sync-workflow.yml is the sync fallback — this file
+# is neither, and must never be distributed by sync.
+#
+# Operator step after first merge: mark the "unit-tests" check REQUIRED on the
+# testing branch (Settings → Branches). The branch is unprotected today, so the
+# check is advisory until that click.
+name: unit-tests
+
+on:
+  pull_request:
+    branches: [testing, main]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      # vitest exits non-zero on test failures AND on unhandled errors
+      # (verified on AII-448: 28 unhandled rejections alone produced exit 1
+      # while all tests passed — the exact signal this gate exists to catch).
+      - run: npm test
+      - run: npm run typecheck

--- a/src/__tests__/kg-refresh.test.ts
+++ b/src/__tests__/kg-refresh.test.ts
@@ -15,7 +15,9 @@ function makeTarball(dir: string): Buffer {
   const wrap = mkdtempSync(join(tmpdir(), "kgtar-"));
   const top = join(wrap, "repo");
   mkdirSync(top, { recursive: true });
-  execSync(`cp -R ${dir}/ ${top}/`);
+  // `dir/.` copies CONTENTS on both BSD (macOS) and GNU (Linux) cp — a bare
+  // trailing slash nests the directory on GNU, which broke this fixture in CI.
+  execSync(`cp -R ${dir}/. ${top}/`);
   const out = join(wrap, "src.tar.gz");
   execSync(`tar -czf ${out} -C ${wrap} repo`);
   return readFileSync(out) as Buffer;


### PR DESCRIPTION
Operator-landed (bd-build-down local-fix loop): the pipeline's two implementation attempts were rejected at push — the runner's GitHub App token lacks the `workflows` permission for `.github/workflows/` writes on this repo (dispatches 527/528, `remote rejected`). Token-scope gap filed separately.

## The gate
- `unit-tests.yml`: on `pull_request` to `testing`/`main` — `npm ci`, `npm test`, `npm run typecheck`; Node 24 per the repo pin; npm cache; 10-min timeout.
- **Named to stay out of sync's hands**: the `claude-*.yml` files are templates distributed to target repos; this file is repo-local CI and sync never touches it.
- **Unhandled-error acceptance**: vitest's exit code already fails on unhandled errors — proven empirically on AII-448, where 28 unhandled rejections alone produced exit 1 with all 3,453 tests passing. That live evidence replaces the spec's inject-and-remove step.

## The smoke IS this PR
The `unit-tests` check runs on this very PR from the merge ref — a green check here is the workflow executing itself against the suite AII-448 just made reliably green.

## Operator step after merge (John)
Mark the `unit-tests` check **required** on `testing` (Settings → Branches — the branch is unprotected today, so until that click the gate is advisory).

Rationale trail: AII-449 ← mega-grill of AII-448 (Option A split) ← PR #346's "tests: failed in prose" incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)