### PR TITLE
AII-450: Explicit permission-* inputs on the runner token mint (loud mint, both sites)

### DIFF
--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -189,6 +189,16 @@ jobs:
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
+          # Explicit permissions (AII-450). Implicit mode inherits "all installation
+          # permissions", which made a missing scope a push-time mystery — two runs
+          # died pushing a workflow file with a buried remote-rejected error while
+          # every permission surface CLAIMED workflows:write. Explicit scopes make
+          # the mint fail loudly, by name, at mint time instead.
+          permission-contents: write
+          permission-workflows: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-metadata: read
 
       - name: Validate Bedrock inputs
         if: inputs.provider == 'bedrock'

--- a/workflows/claude-implement.yml
+++ b/workflows/claude-implement.yml
@@ -189,6 +189,16 @@ jobs:
         with:
           app-id: ${{ secrets.AI_IMPLEMENT_APP_ID }}
           private-key: ${{ secrets.AI_IMPLEMENT_PRIVATE_KEY }}
+          # Explicit permissions (AII-450). Implicit mode inherits "all installation
+          # permissions", which made a missing scope a push-time mystery — two runs
+          # died pushing a workflow file with a buried remote-rejected error while
+          # every permission surface CLAIMED workflows:write. Explicit scopes make
+          # the mint fail loudly, by name, at mint time instead.
+          permission-contents: write
+          permission-workflows: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-metadata: read
 
       - name: Validate Bedrock inputs
         if: inputs.provider == 'bedrock'


### PR DESCRIPTION
Operator-landed — the pipeline run for this very issue was rejected at push (it edits workflow files; the self-referential case the issue body predicted).

## Investigation record (task 6)
- The original hypothesis (mint narrows and drops the permission) is **falsified**: the mint step uses no narrowing, and it is byte-identical between the template and this repo's copy.
- Every permission surface CLAIMS `workflows: write`: both candidate runner Apps (`ai-implement-bot` 2971252, `ai-implement-orchestrator-bot` 4080959) at **app level** and at the **accepted BuildDownAI installation**. Yet three runs died with `refusing … without workflows permission`, while `contents` pushes on the same path work.
- The decisive mint-response experiment needs an org App private key (only the runner holds one), so this PR converts the pipeline itself into the experiment: **explicit `permission-*` inputs** mean the next pipeline run either works, or fails AT MINT TIME with the missing scope named — ending the mystery either way.
- Pinned action SHA verified to support `permission-*` inputs (checked `action.yml` at `fee1f7d`).
- Timeline anchor for the asymmetry: the same pipeline pushed KGB-6's workflow file on the base repo 2026-08-19.

## Changes
- `.github/workflows/claude-implement.yml` + `workflows/claude-implement.yml` (template — reaches newly-onboarded repos per seed-once): the mint declares `contents/workflows/pull-requests/issues: write`, `metadata: read`.

## Smoke
- workflow-sync tests 21/21; both files YAML-valid; the PR's `unit-tests` check exercises the suite.

## Post-merge regression (task 5 — needs one pipeline run)
Re-run an AII-450-shaped scratch issue (workflow-file-only change) through the pipeline: green push = fixed; a named mint-time permission error = the investigation's definitive answer, fix then targeted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)