### PR TITLE
AII-450: Publication token grants workflows:write — the actual mint that pushes

### DIFF
--- a/src/__tests__/publication-token-vending.test.ts
+++ b/src/__tests__/publication-token-vending.test.ts
@@ -86,7 +86,7 @@ describe("handlePublicationTokenRequest", () => {
       "fake-key",
       "original-owner",
       {
-        permissions: { contents: "write", pull_requests: "write" },
+        permissions: { contents: "write", pull_requests: "write", workflows: "write" },
         repositories: ["original-repo"],
         forceRefresh: true,
       },

--- a/src/publication-token-vending.ts
+++ b/src/publication-token-vending.ts
@@ -65,7 +65,12 @@ export async function handlePublicationTokenRequest(
       input.githubAppPrivateKey,
       owner,
       {
-        permissions: { contents: "write", pull_requests: "write" },
+        // workflows:write is load-bearing (AII-450): the push step refreshes to THIS
+        // credential immediately before pushing, so its permission set — not the
+        // workflow-side mint's — decides what the runner can push. Without it, any
+        // run touching .github/workflows/ dies at push with a buried remote-reject
+        // (three live occurrences before the omission was found).
+        permissions: { contents: "write", pull_requests: "write", workflows: "write" },
         repositories: [repo],
         forceRefresh: true,
       },


### PR DESCRIPTION
**Root cause, found by elimination through the AII-451 regression.** The push step refreshes to the PUBLICATION credential immediately before pushing (`src/pipeline/steps/push.ts` — the token-expiry refresh), and `src/publication-token-vending.ts` minted it with `{ contents: write, pull_requests: write }` — **no `workflows`**. That credential decides what the runner can push; the workflow-side mint never gets used for the push.

## How the regression proved it
- PR #349 gave the workflow-side mint explicit `permission-workflows: write`. The AII-451 regression run executed on the #349 merge commit; **the mint succeeded** (an explicit request for an ungranted scope fails at mint — it did not), and the push STILL died with the workflows rejection. Token provably fine → the push uses a different credential → one grep away.
- Every earlier observation now fits: contents pushes always worked; both Apps' installations correctly show `workflows: write` (irrelevant — the explicit narrow drops it); KGB-6's workflow push (2026-08-19) predates the publication-credential mechanism.

## Change
- One line: add `workflows: "write"` to the publication token's permission set, with the load-bearing comment.
- Test assertion updated in `publication-token-vending.test.ts`.

## Smoke
- Full suite 3,453/3,453; typecheck clean.
- **Live acceptance after merge + self-deploy**: AII-451 (the workflow-file-push regression issue, currently unlabeled to stop churn) gets relabeled — its pipeline run pushing `.github/workflows/unit-tests.yml` green is the definitive proof.

PR #349's explicit workflow-side permissions stay — right hardening, and it was the instrument that isolated this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)