### PR TITLE
AII-441: ADR 012 (preview environments) + root CONTEXT.md glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,21 +1,73 @@
-# Glossary
+# AI-Implement Glossary
 
-Domain terms with one meaning each. Implementation detail stays out; that belongs in `docs/` and the ADRs.
+## Developer harness
+
+The developer harness runs AI-Implement against a live, bind-mounted checkout for maintainer testing. It can change that checkout and never publishes its changes.
+
+**Not to be confused with:** A local run, which uses an isolated copy and leaves the source checkout unchanged.
+
+## Local run
+
+A local run processes one Markdown task in an isolated copy of a clean local checkout. It returns local artifacts and does not require a tracker or GitHub App.
+
+**Not to be confused with:** The developer harness or GitHub publication.
+
+## Local artifact
+
+A local artifact is a reviewable result from a local run, including the patch, changed-file list, test summary, run summary, and logs.
+
+**Not to be confused with:** A GitHub branch or pull request.
+
+## Task document
+
+A task document is a Markdown file that states one product outcome, its acceptance criteria, and optional run limits. It contains no repository path, credential, publication setting, or queue dependency.
+
+**Not to be confused with:** A generated implementation plan or a tracker issue.
+
+## Demo run
+
+A demo run is a local run against the bundled disposable repository and task. It lets a user inspect AI-Implement without mounting a repository from the host.
+
+**Not to be confused with:** A local run against the user's own repository.
+
+## Managed run
+
+A managed run starts through the always-on orchestrator and reports its lifecycle through configured external services. It can publish a branch and pull request.
+
+**Not to be confused with:** A local run, which needs no orchestrator, tracker, or GitHub identity.
+
+## Selected repository
+
+The selected repository is the host Git repository that the user mounts read-only at `/repo` and names with `--repo /repo`. AI-Implement prints its resolved Git root before the run starts.
+
+**Not to be confused with:** The isolated working copy where the pipeline makes changes.
+
+## Local run success
+
+A local run succeeds only when the full plan, implement, test, review, and summary loop completes with approval. Starting or completing the Docker container is not enough.
+
+**Not to be confused with:** A partial run, which preserves artifacts but returns a nonzero exit code.
+
+## Trusted repository
+
+A trusted repository is source code that the user permits Claude Code to inspect, change in an isolated copy, and execute with network access. AI-Implement removes the model credential from setup and test processes that it starts, but commands started by Claude Code may inherit that credential.
+
+**Not to be confused with:** A sandbox for hostile code. The first local release does not provide that guarantee.
 
 ## Recipe
 
-A file in the target repository that describes one integration test in a form an agent can execute against a deployed environment. A recipe states the target, the steps, and the pass/fail assertions.
+A recipe is a file in the target repository that describes one integration test in a form an agent can execute against a deployed environment. A recipe states the target, the steps, and the pass/fail assertions.
 
-**Not to be confused with:** an in-repo test-suite test (vitest), which runs against code, not against a deployed environment.
+**Not to be confused with:** An in-repo test-suite test, which runs against code, not against a deployed environment.
 
 ## Test target
 
-The deployed environment a recipe runs against. The first test target is the AII testing orchestrator. A preview environment and an external system (for example Topia) are also test targets.
+A test target is the deployed environment a recipe runs against. The first test target is the AII testing orchestrator. A preview environment and an external system are also test targets.
 
-**Not to be confused with:** the target repository, which is the codebase a pipeline run implements issues in.
+**Not to be confused with:** The target repository, which is the codebase a pipeline run implements issues in.
 
 ## Preview environment
 
-A deployment of one PR branch, reachable before merge, used as a test target and torn down after use. In AI-Implement a preview environment is one Fly machine in the standing previews app (ADR 012).
+A preview environment is a deployment of one PR branch, reachable before merge, used as a test target and torn down after use. In AI-Implement a preview environment is one Fly machine in the standing previews app (ADR 012).
 
-**Not to be confused with:** the testing orchestrator, which is the standing post-merge environment.
+**Not to be confused with:** The testing orchestrator, which is the standing post-merge environment.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,55 +1,21 @@
-# AI-Implement Glossary
+# Glossary
 
-## Developer harness
+Domain terms with one meaning each. Implementation detail stays out; that belongs in `docs/` and the ADRs.
 
-The developer harness runs AI-Implement against a live, bind-mounted checkout for maintainer testing. It can change that checkout and never publishes its changes.
+## Recipe
 
-**Not to be confused with:** A local run, which uses an isolated copy and leaves the source checkout unchanged.
+A file in the target repository that describes one integration test in a form an agent can execute against a deployed environment. A recipe states the target, the steps, and the pass/fail assertions.
 
-## Local run
+**Not to be confused with:** an in-repo test-suite test (vitest), which runs against code, not against a deployed environment.
 
-A local run processes one Markdown task in an isolated copy of a clean local checkout. It returns local artifacts and does not require a tracker or GitHub App.
+## Test target
 
-**Not to be confused with:** The developer harness or GitHub publication.
+The deployed environment a recipe runs against. The first test target is the AII testing orchestrator. A preview environment and an external system (for example Topia) are also test targets.
 
-## Local artifact
+**Not to be confused with:** the target repository, which is the codebase a pipeline run implements issues in.
 
-A local artifact is a reviewable result from a local run, including the patch, changed-file list, test summary, run summary, and logs.
+## Preview environment
 
-**Not to be confused with:** A GitHub branch or pull request.
+A deployment of one PR branch, reachable before merge, used as a test target and torn down after use. In AI-Implement a preview environment is one Fly machine in the standing previews app (ADR 012).
 
-## Task document
-
-A task document is a Markdown file that states one product outcome, its acceptance criteria, and optional run limits. It contains no repository path, credential, publication setting, or queue dependency.
-
-**Not to be confused with:** A generated implementation plan or a tracker issue.
-
-## Demo run
-
-A demo run is a local run against the bundled disposable repository and task. It lets a user inspect AI-Implement without mounting a repository from the host.
-
-**Not to be confused with:** A local run against the user's own repository.
-
-## Managed run
-
-A managed run starts through the always-on orchestrator and reports its lifecycle through configured external services. It can publish a branch and pull request.
-
-**Not to be confused with:** A local run, which needs no orchestrator, tracker, or GitHub identity.
-
-## Selected repository
-
-The selected repository is the host Git repository that the user mounts read-only at `/repo` and names with `--repo /repo`. AI-Implement prints its resolved Git root before the run starts.
-
-**Not to be confused with:** The isolated working copy where the pipeline makes changes.
-
-## Local run success
-
-A local run succeeds only when the full plan, implement, test, review, and summary loop completes with approval. Starting or completing the Docker container is not enough.
-
-**Not to be confused with:** A partial run, which preserves artifacts but returns a nonzero exit code.
-
-## Trusted repository
-
-A trusted repository is source code that the user permits Claude Code to inspect, change in an isolated copy, and execute with network access. AI-Implement removes the model credential from setup and test processes that it starts, but commands started by Claude Code may inherit that credential.
-
-**Not to be confused with:** A sandbox for hostile code. The first local release does not provide that guarantee.
+**Not to be confused with:** the testing orchestrator, which is the standing post-merge environment.

--- a/docs/adr/012-preview-environments-as-machines-in-one-fly-app.md
+++ b/docs/adr/012-preview-environments-as-machines-in-one-fly-app.md
@@ -1,0 +1,51 @@
+# 012. Preview environments are machines in one standing Fly app
+
+**Status:** Accepted
+**Date:** 2026-09-01
+
+## Context
+
+Integration testing (AII-441) needs pre-merge environments: a PR branch of the
+orchestrator deployed somewhere a test run can reach, concurrently for several
+branches at once. Nothing in the codebase creates Fly *apps* programmatically —
+`src/fly-machines.ts` only manages *machines* inside an existing app, and the
+deploy credential contract (`FLY_DEPLOY_TOKEN`, ADR-relevant note in
+`docs/deployment.md`) deliberately scopes every Fly token to a single app. A
+per-branch *app* would require an org-scoped Fly token: a credential that can
+create and destroy any app in the organization.
+
+## Decision
+
+We run one standing "previews" Fly app, created once by an operator. Each PR
+branch under test becomes one **machine** inside that app, built from that
+branch's image, with its own volume and its own SQLite file. Multiple branches
+run concurrently as sibling machines. A test client reaches a specific branch
+with the `fly-force-instance` request header. Teardown destroys the machine and
+volume on PR close, with a TTL reaper for stragglers, mirroring the existing
+session-machine reaper pattern.
+
+## Alternatives considered
+
+- **One Fly app per PR branch** — clean URLs and full isolation, but requires an
+  org-scoped Fly token. A leak of that token exposes every app in the org, not
+  one. Rejected for blast radius, not for capability.
+- **ECS-per-PR (AII-140)** — already locked for the Cloudshare/AWS substrate. It
+  targets client repos on AWS, not the orchestrator's own Fly deployment.
+  Building it here would couple this feature to infrastructure AI-Implement
+  itself does not run on. The two previews share a recipe/target contract, not
+  an implementation.
+- **No pre-merge environments** — the status quo. Real behavior stays observable
+  only after merge, which is the gap AII-441 exists to close.
+
+## Consequences
+
+- Easier: no new credential class — the previews app gets its own app-scoped
+  token, the `FLY_SESSIONS_TOKEN` pattern exactly. Machine CRUD, wait, and
+  reaper code paths already exist and are reused.
+- Harder: all previews share one hostname, so addressing is by header rather
+  than by URL. Any client that cannot set headers cannot reach a specific
+  preview. Accepted: the test runner is the only intended client.
+- A concurrency cap on preview machines is required to bound cost; it is
+  configuration, not architecture.
+- Follow-on: the previews app must exist before the feature works; provisioning
+  is a one-time operator step documented with the feature.


### PR DESCRIPTION
Decision records from the AII-441 (Integration Testing) mega-build-up grill.

- **ADR 012** — preview environments are Fly machines in one standing previews app: no org-scoped token, reuse of machine CRUD and the reaper, concurrent branches, `fly-force-instance` addressing. Full alternatives and consequences in the ADR.
- **CONTEXT.md** (new, repo root) — glossary: Recipe, Test target, Preview environment.

Referenced by the filed issue tree AII-472..AII-477 and the Integration Testing project's Design Decisions document. Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)