### PR TITLE
chore: adopt mise.toml for local env loading

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+# Local development toolchain and environment, for https://mise.jdx.dev
+#
+# Node is pinned in .tool-versions (mise reads it natively, as asdf did), so
+# this file only carries the environment loading that .envrc used to do under
+# direnv. Both tools stay usable side by side.
+[env]
+_.file = ".env"


### PR DESCRIPTION
## What

Commits `mise.toml`, which has been sitting untracked in my working copy since the asdf/direnv → mise migration, and deletes the leftover `.envrc.pre-mise` backup.

```toml
[env]
_.file = ".env"
```

That is the whole behaviour change: it does under mise what the old `.envrc`'s `dotenv_if_exists` did under direnv.

## Notes

- **Node stays in `.tool-versions`** (`nodejs 24.15.0`). mise reads that file natively, so pinning the version a second time here would just be a place for the two to drift. asdf users are unaffected.
- **`.envrc` stays in `.gitignore`** despite no `.envrc` remaining in the tree. It costs one line, and anyone still using direnv would otherwise be one `git add` away from committing a file that customarily holds secrets.
- Nothing in the repo referenced `direnv` or `.envrc` outside `.gitignore` — no docs or scripts to update.