### PR TITLE
fix(jira): normalize blank ticketingConfig field overrides to null

### DIFF
--- a/src/__tests__/providers/ticketing-config.test.ts
+++ b/src/__tests__/providers/ticketing-config.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { validateTicketingConfig, DEFAULT_TICKETING_CONFIG } from "../../providers/ticketing-config.js";
+import { resolveCustomFieldIds } from "../../providers/jira-fields.js";
+import type { JiraMappingConfig } from "../../providers/ticketing-config.js";
+
+const jiraBase = { kind: "jira", jql: "project = ENG", repoFieldValue: "owner/repo" };
+
+describe("validateTicketingConfig", () => {
+  it("returns the linear default for a null config on the linear provider", () => {
+    expect(validateTicketingConfig("linear", null)).toEqual(DEFAULT_TICKETING_CONFIG);
+  });
+
+  it("throws when kind does not match the provider", () => {
+    expect(() => validateTicketingConfig("jira", { kind: "linear" })).toThrow(/must match ticketingProvider/);
+  });
+
+  it("requires a non-empty jql and repoFieldValue for jira", () => {
+    expect(() => validateTicketingConfig("jira", { kind: "jira", repoFieldValue: "owner/repo" })).toThrow(/jql/);
+    expect(() => validateTicketingConfig("jira", { kind: "jira", jql: "project = ENG" })).toThrow(/repoFieldValue/);
+  });
+
+  it("keeps a valid field override, trimmed", () => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: "  customfield_10042  ",
+    }) as JiraMappingConfig;
+    expect(cfg.statusFieldOverride).toBe("customfield_10042");
+  });
+
+  // The bug this file exists for: a blank-but-present override used to survive
+  // validation and reach jira-fields.ts as a literal field id.
+  it.each([
+    ["empty string", ""],
+    ["whitespace only", "   "],
+    ["a non-string", 42],
+    ["null", null],
+    ["undefined", undefined],
+  ])("normalizes a %s field override to null", (_label, value) => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: value,
+      repoFieldOverride: value,
+      profilesFieldOverride: value,
+    }) as JiraMappingConfig;
+    expect(cfg.statusFieldOverride).toBeNull();
+    expect(cfg.repoFieldOverride).toBeNull();
+    expect(cfg.profilesFieldOverride).toBeNull();
+  });
+});
+
+describe("blank overrides no longer reach jira-fields as field ids", () => {
+  const fields = [
+    { id: "customfield_10042", name: "AI-Implement Status", custom: true },
+    { id: "customfield_10043", name: "AI-Implement Repo", custom: true },
+  ];
+
+  const overridesFrom = (cfg: JiraMappingConfig) => ({
+    statusOverride: cfg.statusFieldOverride ?? null,
+    repoOverride: cfg.repoFieldOverride ?? null,
+    profilesOverride: cfg.profilesFieldOverride ?? null,
+  });
+
+  it('falls back to discovery by name for an "" override rather than using it as an id', async () => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: "",
+      repoFieldOverride: "",
+    }) as JiraMappingConfig;
+    const client = { listFields: vi.fn().mockResolvedValue(fields) };
+
+    const ids = await resolveCustomFieldIds(client as any, overridesFrom(cfg));
+
+    expect(ids.statusFieldId).toBe("customfield_10042");
+    expect(ids.repoFieldId).toBe("customfield_10043");
+  });
+
+  it("still calls listFields when every override is whitespace-only", async () => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: "   ",
+      repoFieldOverride: "   ",
+      profilesFieldOverride: "   ",
+    }) as JiraMappingConfig;
+    const client = { listFields: vi.fn().mockResolvedValue(fields) };
+
+    const ids = await resolveCustomFieldIds(client as any, overridesFrom(cfg));
+
+    // Before the fix these were truthy, so the all-overrides-set short-circuit
+    // returned "   " for all three and listFields was never called.
+    expect(client.listFields).toHaveBeenCalled();
+    expect(ids.statusFieldId).toBe("customfield_10042");
+    expect(ids.repoFieldId).toBe("customfield_10043");
+  });
+});

--- a/src/providers/ticketing-config.ts
+++ b/src/providers/ticketing-config.ts
@@ -23,6 +23,29 @@ export type TicketingMappingConfig = LinearMappingConfig | JiraMappingConfig;
 export const DEFAULT_TICKETING_CONFIG: LinearMappingConfig = { kind: "linear" };
 
 /**
+ * Normalizes a `*FieldOverride` value from untrusted JSON: anything that is not a
+ * non-blank string becomes null, and a non-blank string is trimmed.
+ *
+ * Without this, a blank-but-present override survives validation and is then read
+ * as a literal Jira field id by resolveCustomFieldIds (src/providers/jira-fields.ts):
+ * - `""` is not nullish, so `overrides.statusOverride ?? lookup(STATUS_FIELD_NAME)`
+ *   yields `""` instead of falling back to discovery by name; profilesFieldId's
+ *   `=== null` guard is likewise skipped.
+ * - `"   "` is truthy, so the all-overrides-set short-circuit returns early and
+ *   listFields() is never called at all.
+ * Both leave the provider querying an empty or whitespace field id.
+ *
+ * The admin UI already normalizes with `|| null` at both call sites, so this closes
+ * the API path and puts the rule at the validation boundary rather than in two
+ * callers that have to remember it.
+ */
+function normalizeFieldOverride(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
  * Validates that the parsed JSON is a valid TicketingMappingConfig matching
  * the expected provider. Throws on mismatch.
  */
@@ -50,9 +73,9 @@ export function validateTicketingConfig(provider: ProviderId, value: unknown): T
       kind: "jira",
       jql: obj.jql,
       repoFieldValue: obj.repoFieldValue,
-      statusFieldOverride: typeof obj.statusFieldOverride === "string" ? obj.statusFieldOverride : null,
-      repoFieldOverride: typeof obj.repoFieldOverride === "string" ? obj.repoFieldOverride : null,
-      profilesFieldOverride: typeof obj.profilesFieldOverride === "string" ? obj.profilesFieldOverride : null,
+      statusFieldOverride: normalizeFieldOverride(obj.statusFieldOverride),
+      repoFieldOverride: normalizeFieldOverride(obj.repoFieldOverride),
+      profilesFieldOverride: normalizeFieldOverride(obj.profilesFieldOverride),
     };
   }
   throw new Error(`Unknown provider for ticketingConfig: ${provider}`);


### PR DESCRIPTION
## The defect

A `*FieldOverride` that is present but blank passes `validateTicketingConfig` unchanged, and `resolveCustomFieldIds` then treats it as a literal Jira field id. Two distinct failures, depending on the blank:

- **`""`** — not nullish, so `overrides.statusOverride ?? lookup(STATUS_FIELD_NAME)` (`jira-fields.ts:70-71`) yields `""` instead of falling back to discovery by name. `profilesFieldId`'s `=== null` guard (`jira-fields.ts:55`) is skipped for the same reason.
- **`"   "`** — truthy, so the all-overrides-set short-circuit at `jira-fields.ts:31` returns early and `listFields()` is never called at all.

Either way the provider ends up querying an empty or whitespace-only field id.

There is a smaller knock-on in `getCachedFieldIds`: the cache key uses `?? ""` (`jira-fields.ts:85`), so `null` and `""` collide on one entry while resolving differently.

## Reachability

Not reachable from the admin UI — it already normalizes with `|| null` at both call sites (`admin-ui/pages/projects.ts:689-691` and `admin-ui/stepper.ts:1117-1119`). The mappings API accepts the raw JSON, so that path is open.

Putting the rule at the validation boundary closes it, and stops correctness depending on two UI callers remembering to normalize.

## The change

`validateTicketingConfig` now routes all three overrides through a `normalizeFieldOverride` helper: non-strings and blank/whitespace-only strings become `null`, non-blank strings are trimmed.

## Tests

Adds `src/__tests__/providers/ticketing-config.test.ts` — this module had no test file before. Coverage includes the existing validator contract (provider/kind mismatch, required `jql` and `repoFieldValue`) plus the normalization cases, and two tests that drive the validated output through `resolveCustomFieldIds` to show the fallback-by-name now happens.

The five behaviour-pinning cases were mutation-checked: each fails against the unfixed validator, while the baseline contract tests still pass.

`npm test` (3621 passed, 180 files) and `npm run typecheck` are green.

## Disclosure

Per CONTRIBUTING.md and CLA sections 5.4/5.5: this contribution was generated in substantial part with Claude Code. The defect analysis, the reachability check, and the mutation testing were carried out against this repository at `6f755c2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcKEcso8JRQXq7FArrm3Gv