### PR TITLE
feat: reference repositories on the project mapping (AII-506)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,3 +71,9 @@ A test target is the deployed environment a recipe runs against. The first test 
 A preview environment is a deployment of one PR branch, reachable before merge, used as a test target and torn down after use. In AI-Implement a preview environment is one Fly machine in the standing previews app (ADR 012).
 
 **Not to be confused with:** The testing orchestrator, which is the standing post-merge environment.
+
+## Reference repository
+
+A reference repository is a second repository that a run clones read-only at dispatch, so the agent can check a claim against real source. A project mapping declares each one with a workspace path and an optional ref.
+
+**Not to be confused with:** The knowledge graph, which serves prose — issues, decisions, and documentation — and holds no source code. Also not a sibling repository, which Dependency Token Scope makes readable so a dependency install can resolve private packages.

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1008,6 +1008,85 @@ describe("admin mappings", () => {
     expect(JSON.parse(create.body).skillsRepo).toBe("https://GitHub.com/acme/skills.git");
   });
 
+  it("persists referenceRepos and expands shorthand at storage time", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "RR1", owner: "org", repo: "app",
+      referenceRepos: [
+        { repo: "acme/docs", path: "docs-source", ref: "v1.1.0" },
+        { repo: "https://github.com/acme/api", path: "api-source" },
+      ],
+    }, token);
+    expect(create.statusCode).toBe(202);
+
+    const list = await request("/api/mappings", "GET", "secret", undefined, token);
+    expect(JSON.parse(list.body).RR1.referenceRepos).toEqual([
+      { repo: "https://github.com/acme/docs", path: "docs-source", ref: "v1.1.0" },
+      { repo: "https://github.com/acme/api", path: "api-source" },
+    ]);
+  });
+
+  it("stores an entry with no ref and reads it back without one", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "RR2", owner: "org", repo: "app",
+      referenceRepos: [{ repo: "acme/docs", path: "docs-source" }],
+    }, token);
+    expect(create.statusCode).toBe(202);
+    expect(JSON.parse(create.body).referenceRepos[0]).not.toHaveProperty("ref");
+  });
+
+  it("treats an empty referenceRepos list as null", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "RR3", owner: "org", repo: "app", referenceRepos: [],
+    }, token);
+    expect(create.statusCode).toBe(202);
+    expect(JSON.parse(create.body).referenceRepos).toBeNull();
+  });
+
+  // Regression guard: an absent field must store null, not undefined. A mapping saved
+  // before this setting existed is the same case, and every downstream consumer
+  // conditionally spreads on it.
+  it("stores null when referenceRepos is absent from the request", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "RR4", owner: "org", repo: "app",
+    }, token);
+    expect(create.statusCode).toBe(202);
+    expect(JSON.parse(create.body).referenceRepos).toBeNull();
+  });
+
+  it.each([
+    ["a non-array", "RRBAD1", "acme/docs"],
+    ["a non-GitHub host", "RRBAD2", [{ repo: "https://gitlab.com/acme/docs", path: "x" }]],
+    ["an absolute path", "RRBAD3", [{ repo: "acme/docs", path: "/etc" }]],
+    ["a traversal path", "RRBAD4", [{ repo: "acme/docs", path: "../outside" }]],
+    ["a path inside .git", "RRBAD5", [{ repo: "acme/docs", path: ".git/hooks" }]],
+    ["two entries sharing a path", "RRBAD6", [
+      { repo: "acme/a", path: "same" },
+      { repo: "acme/b", path: "same" },
+    ]],
+    ["an entry missing its path", "RRBAD7", [{ repo: "acme/docs" }]],
+  ])("rejects referenceRepos with %s", async (_label, teamKey, value) => {
+    const token = await login("secret");
+    const res = await request("/api/mappings", "POST", "secret", {
+      teamKey, owner: "org", repo: "app", referenceRepos: value,
+    }, token);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("referenceRepos");
+  });
+
+  it("rejects more than ten referenceRepos entries", async () => {
+    const token = await login("secret");
+    const res = await request("/api/mappings", "POST", "secret", {
+      teamKey: "RRMANY", owner: "org", repo: "app",
+      referenceRepos: Array.from({ length: 11 }, (_, i) => ({ repo: "acme/docs", path: `p${i}` })),
+    }, token);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("referenceRepos");
+  });
+
   it("clears skillsRepo when an existing mapping is updated to null", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", {

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1008,6 +1008,18 @@ describe("admin mappings", () => {
     expect(JSON.parse(create.body).skillsRepo).toBe("https://GitHub.com/acme/skills.git");
   });
 
+  // Previously accepted, then broken at clone time: install-skills injects its own token by
+  // replacing the https:// prefix, which on a value already carrying userinfo yields a
+  // malformed remote and a silent no-op.
+  it("rejects a skillsRepo URL that embeds a credential", async () => {
+    const token = await login("secret");
+    const create = await request("/api/mappings", "POST", "secret", {
+      teamKey: "SR9", owner: "org", repo: "app", skillsRepo: "https://user:tok@github.com/acme/skills",
+    }, token);
+    expect(create.statusCode).toBe(400);
+    expect(JSON.parse(create.body).error).toContain("skillsRepo");
+  });
+
   it("persists referenceRepos and expands shorthand at storage time", async () => {
     const token = await login("secret");
     const create = await request("/api/mappings", "POST", "secret", {
@@ -1068,6 +1080,8 @@ describe("admin mappings", () => {
       { repo: "acme/b", path: "same" },
     ]],
     ["an entry missing its path", "RRBAD7", [{ repo: "acme/docs" }]],
+    ["a credential embedded in the URL", "RRBAD8", [{ repo: "https://user:tok@github.com/acme/docs", path: "x" }]],
+    ["a backslash path separator", "RRBAD9", [{ repo: "acme/docs", path: "vendor\\upstream" }]],
   ])("rejects referenceRepos with %s", async (_label, teamKey, value) => {
     const token = await login("secret");
     const res = await request("/api/mappings", "POST", "secret", {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -39,6 +39,8 @@ function mapping(overrides: Partial<RepoMapping> & Pick<RepoMapping, "owner" | "
     sensitiveAddPatterns: null,
     sensitiveAllowPatterns: null,
     dependencyTokenScope: null,
+    memoryProviderId: null,
+    referenceRepos: null,
     ...overrides,
   };
 }
@@ -594,6 +596,65 @@ describe("config", () => {
     expect(all.SAP.sensitiveAllowPatterns).toEqual([".env", ".env.*"]);
     expect(all.SAP_NULL.sensitiveAddPatterns).toBeNull();
     expect(all.SAP_NULL.sensitiveAllowPatterns).toBeNull();
+  });
+
+  it("round-trips referenceRepos, preserving order and the optional ref", () => {
+    config.initMappingsTable();
+    config.upsertMapping("RR", mapping({
+      owner: "org", repo: "repo",
+      referenceRepos: [
+        { repo: "https://github.com/acme/docs", path: "docs-source", ref: "v1.1.0" },
+        { repo: "https://github.com/acme/api", path: "api-source" },
+      ],
+    }));
+    config.upsertMapping("RR_NULL", mapping({ owner: "org", repo: "repo", referenceRepos: null }));
+
+    const all = config.getMappings();
+    expect(all.RR.referenceRepos).toEqual([
+      { repo: "https://github.com/acme/docs", path: "docs-source", ref: "v1.1.0" },
+      { repo: "https://github.com/acme/api", path: "api-source" },
+    ]);
+    expect(all.RR_NULL.referenceRepos).toBeNull();
+  });
+
+  it("reads referenceRepos as null when the stored JSON is malformed", () => {
+    config.initMappingsTable();
+    config.upsertMapping("RR_BAD", mapping({ owner: "org", repo: "repo" }));
+
+    const db = new Database(dbPath);
+    db.prepare("UPDATE mappings SET reference_repos = ? WHERE team_key = ?").run("{not json", "RR_BAD");
+    db.close();
+
+    // A malformed value must not take down every mapping read — the parse is guarded
+    // per field, so the row still loads with that one field unset.
+    expect(config.getMappings().RR_BAD.referenceRepos).toBeNull();
+    expect(config.getMappings().RR_BAD.owner).toBe("org");
+  });
+
+  it("migrates a pre-existing mappings table to include the reference_repos column (default null)", () => {
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE mappings (
+        team_key TEXT PRIMARY KEY,
+        owner TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        workflow_file TEXT NOT NULL,
+        default_branch TEXT NOT NULL
+      )
+    `);
+    db.prepare("INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch) VALUES (?, ?, ?, ?, ?)")
+      .run("LEG_RR", "org", "legacy", "claude-implement.yml", "main");
+    db.close();
+
+    config.initMappingsTable();
+    // null, never undefined — a caller that spreads the mapping into an envelope must
+    // see an explicit absence rather than a missing key.
+    expect(config.getMappings().LEG_RR.referenceRepos).toBeNull();
+
+    const reopened = new Database(dbPath);
+    const info = reopened.prepare("PRAGMA table_info(mappings)").all() as Array<{ name: string }>;
+    reopened.close();
+    expect(info.map((c) => c.name)).toContain("reference_repos");
   });
 
   it("migrates a pre-existing mappings table to include sensitive glob columns (default null)", () => {

--- a/src/__tests__/reference-repos.test.ts
+++ b/src/__tests__/reference-repos.test.ts
@@ -24,12 +24,38 @@ describe("normalizeGitHubRepo", () => {
     ["an unparseable URL", "https://"],
     ["a bare word", "docs"],
     ["three path segments", "acme/docs/extra"],
+    ["a URL embedding a token", "https://x-access-token:ghs_SECRET@github.com/acme/docs"],
+    ["a URL embedding a bare username", "https://someone@github.com/acme/docs"],
   ])("rejects %s", (_label, value) => {
     expect(() => normalizeGitHubRepo(value, "referenceRepos")).toThrow(/referenceRepos/);
   });
 
   it("names the caller's field in the error, so one function serves two settings", () => {
     expect(() => normalizeGitHubRepo("git@github.com:a/b.git", "skillsRepo")).toThrow(/skillsRepo/);
+  });
+
+  it("distinguishes an embedded credential from a bad host", () => {
+    expect(() => normalizeGitHubRepo("https://user:tok@github.com/acme/docs", "referenceRepos"))
+      .toThrow(/must not embed a username or token/);
+  });
+
+  // The message reaches an admin API response and the logs behind it.
+  it("does not echo the credential back in the error", () => {
+    let message = "";
+    try {
+      normalizeGitHubRepo("https://x-access-token:ghs_SUPERSECRET@github.com/acme/docs", "referenceRepos");
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toMatch(/must not embed/);
+    expect(message).not.toContain("ghs_SUPERSECRET");
+  });
+
+  // Userinfo precedes the host, so an @ later in the URL is not a credential.
+  it("accepts an @ in the path", () => {
+    expect(normalizeGitHubRepo("https://github.com/acme/docs@v1", "referenceRepos")).toBe(
+      "https://github.com/acme/docs@v1",
+    );
   });
 });
 
@@ -126,8 +152,16 @@ describe("normalizeReferenceRepos path rules", () => {
     ["whitespace only", "   "],
     ["the git directory", ".git"],
     ["a path inside the git directory", ".git/hooks"],
+    ["a backslash separator", "vendor\\upstream"],
+    ["a backslash traversal attempt", "vendor\\..\\..\\etc"],
   ])("rejects %s", (_label, value) => {
     expect(withPath(value)).toThrow();
+  });
+
+  // Backslash cannot traverse on the runner, so this is a typo guard rather than a
+  // security control — the message should say so.
+  it("tells the operator to use forward slashes", () => {
+    expect(withPath("vendor\\upstream")).toThrow(/must use forward slashes/);
   });
 
   it("rejects a path over 256 characters", () => {

--- a/src/__tests__/reference-repos.test.ts
+++ b/src/__tests__/reference-repos.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { normalizeGitHubRepo, normalizeReferenceRepos } from "../reference-repos.js";
+
+describe("normalizeGitHubRepo", () => {
+  it("expands owner/repo shorthand", () => {
+    expect(normalizeGitHubRepo("acme/docs", "referenceRepos")).toBe("https://github.com/acme/docs");
+  });
+
+  it("passes through an https://github.com URL unchanged", () => {
+    expect(normalizeGitHubRepo("https://github.com/acme/docs", "referenceRepos")).toBe(
+      "https://github.com/acme/docs",
+    );
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(normalizeGitHubRepo("  acme/docs  ", "referenceRepos")).toBe("https://github.com/acme/docs");
+  });
+
+  it.each([
+    ["an SSH remote", "git@github.com:acme/docs.git"],
+    ["a non-GitHub host", "https://gitlab.com/acme/docs"],
+    ["the www subdomain", "https://www.github.com/acme/docs"],
+    ["a plain http URL", "http://github.com/acme/docs"],
+    ["an unparseable URL", "https://"],
+    ["a bare word", "docs"],
+    ["three path segments", "acme/docs/extra"],
+  ])("rejects %s", (_label, value) => {
+    expect(() => normalizeGitHubRepo(value, "referenceRepos")).toThrow(/referenceRepos/);
+  });
+
+  it("names the caller's field in the error, so one function serves two settings", () => {
+    expect(() => normalizeGitHubRepo("git@github.com:a/b.git", "skillsRepo")).toThrow(/skillsRepo/);
+  });
+});
+
+describe("normalizeReferenceRepos", () => {
+  const entry = { repo: "acme/docs", path: "docs-source" };
+
+  it("returns null for absent and for empty, so the column stores one unset value", () => {
+    expect(normalizeReferenceRepos(null)).toBeNull();
+    expect(normalizeReferenceRepos(undefined)).toBeNull();
+    expect(normalizeReferenceRepos([])).toBeNull();
+  });
+
+  it("normalizes the repo and keeps the path", () => {
+    expect(normalizeReferenceRepos([entry])).toEqual([
+      { repo: "https://github.com/acme/docs", path: "docs-source" },
+    ]);
+  });
+
+  it("omits ref entirely when absent rather than storing undefined", () => {
+    const [only] = normalizeReferenceRepos([entry])!;
+    expect(only).not.toHaveProperty("ref");
+  });
+
+  it("keeps and trims a ref when present", () => {
+    expect(normalizeReferenceRepos([{ ...entry, ref: "  v1.1.0  " }])).toEqual([
+      { repo: "https://github.com/acme/docs", path: "docs-source", ref: "v1.1.0" },
+    ]);
+  });
+
+  it("accepts the same repository twice at two paths on two refs", () => {
+    const entries = normalizeReferenceRepos([
+      { repo: "acme/docs", path: "stable-source", ref: "v1.1.0" },
+      { repo: "acme/docs", path: "latest-source", ref: "testing" },
+    ]);
+    expect(entries).toHaveLength(2);
+    expect(entries![0].repo).toBe(entries![1].repo);
+  });
+
+  it("preserves declaration order", () => {
+    const entries = normalizeReferenceRepos([
+      { repo: "acme/a", path: "a" },
+      { repo: "acme/b", path: "b" },
+      { repo: "acme/c", path: "c" },
+    ]);
+    expect(entries!.map((e) => e.path)).toEqual(["a", "b", "c"]);
+  });
+
+  it.each([
+    ["a non-array", { repo: "acme/docs", path: "x" }],
+    ["a non-object entry", ["acme/docs"]],
+    ["a null entry", [null]],
+    ["an array entry", [[]]],
+    ["a missing repo", [{ path: "x" }]],
+    ["a blank repo", [{ repo: "   ", path: "x" }]],
+    ["a missing path", [{ repo: "acme/docs" }]],
+    ["a non-string path", [{ repo: "acme/docs", path: 7 }]],
+    ["a blank ref", [{ repo: "acme/docs", path: "x", ref: "  " }]],
+    ["a non-string ref", [{ repo: "acme/docs", path: "x", ref: 7 }]],
+  ])("rejects %s", (_label, value) => {
+    expect(() => normalizeReferenceRepos(value)).toThrow();
+  });
+
+  it("rejects more than ten entries", () => {
+    const many = Array.from({ length: 11 }, (_, i) => ({ repo: "acme/docs", path: `p${i}` }));
+    expect(() => normalizeReferenceRepos(many)).toThrow(/too many entries \(11\)/);
+  });
+
+  it("accepts exactly ten", () => {
+    const ten = Array.from({ length: 10 }, (_, i) => ({ repo: "acme/docs", path: `p${i}` }));
+    expect(normalizeReferenceRepos(ten)).toHaveLength(10);
+  });
+
+  it("rejects two entries sharing a path, comparing the normalized form", () => {
+    expect(() =>
+      normalizeReferenceRepos([
+        { repo: "acme/a", path: "shared" },
+        { repo: "acme/b", path: "./shared/" },
+      ]),
+    ).toThrow(/share the path/);
+  });
+});
+
+describe("normalizeReferenceRepos path rules", () => {
+  const withPath = (p: unknown) => () => normalizeReferenceRepos([{ repo: "acme/docs", path: p }]);
+
+  it.each([
+    ["an absolute posix path", "/etc/passwd"],
+    ["a Windows drive path", "C:\\Windows"],
+    ["a parent traversal", "../outside"],
+    ["a traversal in the middle", "docs/../../outside"],
+    ["a path that normalizes to the workspace root", "docs/.."],
+    ["a bare dot", "."],
+    ["an empty string", ""],
+    ["whitespace only", "   "],
+    ["the git directory", ".git"],
+    ["a path inside the git directory", ".git/hooks"],
+  ])("rejects %s", (_label, value) => {
+    expect(withPath(value)).toThrow();
+  });
+
+  it("rejects a path over 256 characters", () => {
+    expect(withPath("a".repeat(257))).toThrow(/path too long \(257 chars\)/);
+  });
+
+  it("allows a dot-prefixed directory that is not .git", () => {
+    const entries = normalizeReferenceRepos([{ repo: "acme/docs", path: ".github-source" }]);
+    expect(entries![0].path).toBe(".github-source");
+  });
+
+  it("allows a nested path and strips a trailing slash", () => {
+    const entries = normalizeReferenceRepos([{ repo: "acme/docs", path: "vendor/upstream/" }]);
+    expect(entries![0].path).toBe("vendor/upstream");
+  });
+
+  it("collapses a redundant segment rather than rejecting it", () => {
+    const entries = normalizeReferenceRepos([{ repo: "acme/docs", path: "vendor/./upstream" }]);
+    expect(entries![0].path).toBe("vendor/upstream");
+  });
+});

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -62,37 +62,15 @@ import { JiraClient, JiraFieldNotSelectError } from "./providers/jira-client.js"
 import { enqueueWorkflowSync, runWorkflowSync, getWorkflowSyncById } from "./workflow-sync-queue.js";
 import type { KgRefreshStatus } from "./kg-refresh.js";
 import { normalizeBranchPrefix } from "./pipeline/branch-name.js";
+import { normalizeGitHubRepo, normalizeReferenceRepos, type ReferenceRepo } from "./reference-repos.js";
 import picomatch from "picomatch";
 
-const SKILLS_REPO_SHORTHAND = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
-// NOTE: skillsRepo is syntax- and host-validated only — it is NOT sanitised. Any code that
-// later feeds this value to a subprocess (e.g. the `git clone` in the runner) MUST
-// pass it as a separate argv element, never interpolated into a shell string, to
-// avoid command injection.
 function normalizeSkillsRepo(raw: unknown): string | null {
   if (raw == null) return null;
   if (typeof raw !== "string") throw new Error("skillsRepo must be a string");
   const v = raw.trim();
   if (v === "") return null;
-  if (SKILLS_REPO_SHORTHAND.test(v)) return `https://github.com/${v}`;
-  // Only https://github.com remotes (and the owner/repo shorthand handled above, which
-  // implies github.com) are usable on the runner: clone auth is the orchestrator-minted
-  // GitHub App installation token embedded in the URL, and that credential must never
-  // be sent to any other host. An SSH (git@…) URL would need keys the runner doesn't
-  // have, so the install step just warns and installs nothing — a silent no-op. Reject
-  // both here rather than storing a value that looks accepted but does nothing (or
-  // worse) at dispatch. Exact host match, case-insensitive; www.github.com excluded —
-  // git remotes live on the apex host.
-  let host: string | null = null;
-  if (/^https:\/\/[^\s]+$/.test(v)) {
-    try {
-      host = new URL(v).hostname.toLowerCase();
-    } catch {
-      host = null;
-    }
-  }
-  if (host !== "github.com") throw new Error("skillsRepo must be 'owner/repo' shorthand or an https://github.com/... URL (the runner clones with a GitHub token, so other hosts and SSH git@ URLs are not supported)");
-  return v;
+  return normalizeGitHubRepo(v, "skillsRepo");
 }
 
 function normalizeSensitiveGlobs(raw: unknown): string[] | null {
@@ -1581,6 +1559,7 @@ async function handleUpsertMapping(
       maxJobMinutes?: number | null;
       branchPrefix?: string | null;
       skillsRepo?: string | null;
+      referenceRepos?: unknown;
       sensitiveAddPatterns?: string | string[] | null;
       sensitiveAllowPatterns?: string | string[] | null;
       dependencyTokenScope?: string | null;
@@ -1723,6 +1702,14 @@ async function handleUpsertMapping(
       return;
     }
 
+    let referenceRepos: ReferenceRepo[] | null;
+    try {
+      referenceRepos = normalizeReferenceRepos(body.referenceRepos);
+    } catch (err) {
+      json(res, 400, { error: `referenceRepos invalid: ${err instanceof Error ? err.message : String(err)}` });
+      return;
+    }
+
     let sensitiveAddPatterns: string[] | null;
     try {
       sensitiveAddPatterns = normalizeSensitiveGlobs(body.sensitiveAddPatterns);
@@ -1782,6 +1769,7 @@ async function handleUpsertMapping(
       maxJobMinutes,
       branchPrefix,
       skillsRepo,
+      referenceRepos,
       sensitiveAddPatterns,
       sensitiveAllowPatterns,
       dependencyTokenScope,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { getDb } from "./dedup.js";
 import type { ProviderId } from "./providers/types.js";
+import type { ReferenceRepo } from "./reference-repos.js";
 import {
   type TicketingMappingConfig,
   validateTicketingConfig,
@@ -65,6 +66,8 @@ export interface RepoMapping {
   branchPrefix: string | null;
   /** Optional skills repo (owner/repo shorthand or git URL) to clone for per-project skills. NULL means no skills repo. */
   skillsRepo: string | null;
+  /** Repositories cloned read-only into the workspace as reference source. NULL means none. */
+  referenceRepos: ReferenceRepo[] | null;
   /** Glob patterns to add to the sensitive-files list for this project. NULL means unset. */
   sensitiveAddPatterns: string[] | null;
   /** Glob patterns that are explicitly allowed (not sensitive) for this project. NULL means unset. */
@@ -153,6 +156,9 @@ function ensureMappingsColumns(): void {
   if (!names.has("skills_repo")) {
     db.exec(`ALTER TABLE mappings ADD COLUMN skills_repo TEXT`);
   }
+  if (!names.has("reference_repos")) {
+    db.exec(`ALTER TABLE mappings ADD COLUMN reference_repos TEXT`);
+  }
   if (!names.has("sensitive_add_patterns")) {
     db.exec(`ALTER TABLE mappings ADD COLUMN sensitive_add_patterns TEXT`);
   }
@@ -196,6 +202,7 @@ export function initMappingsTable(): void {
       max_job_minutes INTEGER,
       branch_prefix TEXT,
       skills_repo TEXT,
+      reference_repos TEXT,
       sensitive_add_patterns TEXT,
       sensitive_allow_patterns TEXT,
       dependency_token_scope TEXT,
@@ -208,10 +215,10 @@ export function initMappingsTable(): void {
   const count = db.prepare("SELECT COUNT(*) as n FROM mappings").get() as { n: number };
   if (count.n === 0 && Object.keys(SEED_MAPPINGS).length > 0) {
     const insert = db.prepare(
-      "INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, auto_merge, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix, skills_repo, sensitive_add_patterns, sensitive_allow_patterns, dependency_token_scope, memory_provider_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, auto_merge, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix, skills_repo, reference_repos, sensitive_add_patterns, sensitive_allow_patterns, dependency_token_scope, memory_provider_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     for (const [key, m] of Object.entries(SEED_MAPPINGS)) {
-      insert.run(key, m.owner, m.repo, m.workflowFile, m.defaultBranch, m.maxInProgressAiIssues, m.executionMode, m.sessionMode, m.machineCpus, m.machineMemoryMb, m.planningEnabled ? 1 : 0, m.planningWorkflowFile, m.autoApprovePlans ? 1 : 0, m.autoMerge ? 1 : 0, Object.keys(m.extraEnv).length > 0 ? JSON.stringify(m.extraEnv) : null, m.provider, m.ticketingProvider, JSON.stringify(m.ticketingConfig), m.awsRegion, m.paused ? 1 : 0, m.maxTurns, m.maxIterations, m.maxJobMinutes, m.branchPrefix, m.skillsRepo, m.sensitiveAddPatterns ? JSON.stringify(m.sensitiveAddPatterns) : null, m.sensitiveAllowPatterns ? JSON.stringify(m.sensitiveAllowPatterns) : null, m.dependencyTokenScope, m.memoryProviderId);
+      insert.run(key, m.owner, m.repo, m.workflowFile, m.defaultBranch, m.maxInProgressAiIssues, m.executionMode, m.sessionMode, m.machineCpus, m.machineMemoryMb, m.planningEnabled ? 1 : 0, m.planningWorkflowFile, m.autoApprovePlans ? 1 : 0, m.autoMerge ? 1 : 0, Object.keys(m.extraEnv).length > 0 ? JSON.stringify(m.extraEnv) : null, m.provider, m.ticketingProvider, JSON.stringify(m.ticketingConfig), m.awsRegion, m.paused ? 1 : 0, m.maxTurns, m.maxIterations, m.maxJobMinutes, m.branchPrefix, m.skillsRepo, m.referenceRepos ? JSON.stringify(m.referenceRepos) : null, m.sensitiveAddPatterns ? JSON.stringify(m.sensitiveAddPatterns) : null, m.sensitiveAllowPatterns ? JSON.stringify(m.sensitiveAllowPatterns) : null, m.dependencyTokenScope, m.memoryProviderId);
     }
     console.log(`[config] Seeded ${Object.keys(SEED_MAPPINGS).length} default mappings`);
   }
@@ -220,7 +227,7 @@ export function initMappingsTable(): void {
 export function getMappings(): Record<string, RepoMapping> {
   const rows = getDb()
     .prepare(
-      "SELECT team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, auto_merge, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix, skills_repo, sensitive_add_patterns, sensitive_allow_patterns, dependency_token_scope, memory_provider_id FROM mappings",
+      "SELECT team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, auto_merge, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix, skills_repo, reference_repos, sensitive_add_patterns, sensitive_allow_patterns, dependency_token_scope, memory_provider_id FROM mappings",
     )
     .all() as Array<{
       team_key: string;
@@ -248,6 +255,7 @@ export function getMappings(): Record<string, RepoMapping> {
       max_job_minutes: number | null;
       branch_prefix: string | null;
       skills_repo: string | null;
+      reference_repos: string | null;
       sensitive_add_patterns: string | null;
       sensitive_allow_patterns: string | null;
       dependency_token_scope: string | null;
@@ -291,6 +299,7 @@ export function getMappings(): Record<string, RepoMapping> {
       maxJobMinutes: row.max_job_minutes,
       branchPrefix: row.branch_prefix,
       skillsRepo: row.skills_repo,
+      referenceRepos: (() => { try { return row.reference_repos ? JSON.parse(row.reference_repos) as ReferenceRepo[] : null; } catch { return null; } })(),
       sensitiveAddPatterns: (() => { try { return row.sensitive_add_patterns ? JSON.parse(row.sensitive_add_patterns) as string[] : null; } catch { return null; } })(),
       sensitiveAllowPatterns: (() => { try { return row.sensitive_allow_patterns ? JSON.parse(row.sensitive_allow_patterns) as string[] : null; } catch { return null; } })(),
       dependencyTokenScope: row.dependency_token_scope as "installation" | null,
@@ -303,7 +312,7 @@ export function getMappings(): Record<string, RepoMapping> {
 export function upsertMapping(teamKey: string, mapping: RepoMapping): void {
   getDb()
     .prepare(
-      "INSERT OR REPLACE INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, auto_merge, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix, skills_repo, sensitive_add_patterns, sensitive_allow_patterns, dependency_token_scope, memory_provider_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT OR REPLACE INTO mappings (team_key, owner, repo, workflow_file, default_branch, max_in_progress_ai_issues, execution_mode, session_mode, machine_cpus, machine_memory_mb, planning_enabled, planning_workflow_file, auto_approve_plans, auto_merge, extra_env, provider, ticketing_provider, ticketing_config, aws_region, paused, max_turns, max_iterations, max_job_minutes, branch_prefix, skills_repo, reference_repos, sensitive_add_patterns, sensitive_allow_patterns, dependency_token_scope, memory_provider_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     )
     .run(
       teamKey,
@@ -331,6 +340,7 @@ export function upsertMapping(teamKey: string, mapping: RepoMapping): void {
       mapping.maxJobMinutes,
       mapping.branchPrefix,
       mapping.skillsRepo,
+      mapping.referenceRepos ? JSON.stringify(mapping.referenceRepos) : null,
       mapping.sensitiveAddPatterns ? JSON.stringify(mapping.sensitiveAddPatterns) : null,
       mapping.sensitiveAllowPatterns ? JSON.stringify(mapping.sensitiveAllowPatterns) : null,
       mapping.dependencyTokenScope,

--- a/src/reference-repos.ts
+++ b/src/reference-repos.ts
@@ -73,15 +73,22 @@ export function normalizeGitHubRepo(raw: string, field: string): string {
   const v = raw.trim();
   if (REPO_SHORTHAND.test(v)) return `https://github.com/${v}`;
   let host: string | null = null;
+  let hasUserinfo = false;
   if (/^https:\/\/[^\s]+$/.test(v)) {
     try {
-      host = new URL(v).hostname.toLowerCase();
+      const parsed = new URL(v);
+      host = parsed.hostname.toLowerCase();
+      hasUserinfo = parsed.username !== "" || parsed.password !== "";
     } catch {
       host = null;
     }
   }
   if (host !== "github.com") {
     throw new Error(`${field} must be 'owner/repo' shorthand or an https://github.com/... URL (the runner clones with a GitHub token, so other hosts and SSH git@ URLs are not supported)`);
+  }
+  // A token here would survive into the clone's remote.origin.url, in a directory that persists for the whole run and that the agent is pointed at.
+  if (hasUserinfo) {
+    throw new Error(`${field} must not embed a username or token in the URL; the runner supplies its own credential at clone time`);
   }
   return v;
 }
@@ -95,6 +102,10 @@ function normalizePath(raw: string): string {
   }
   if (path.posix.isAbsolute(v) || /^[A-Za-z]:/.test(v)) {
     throw new Error(`path "${v}" must be relative to the workspace`);
+  }
+  // Not a traversal vector here — backslash is a literal filename character on the runner.
+  if (v.includes("\\")) {
+    throw new Error(`path "${v}" must use forward slashes`);
   }
 
   const normalized = path.posix.normalize(v).replace(/\/+$/, "");

--- a/src/reference-repos.ts
+++ b/src/reference-repos.ts
@@ -1,0 +1,108 @@
+import path from "node:path";
+
+/** One repository a project's runs clone read-only into the workspace. */
+export interface ReferenceRepo {
+  /** Normalized `https://github.com/owner/repo`. */
+  repo: string;
+  /** Workspace-relative directory the clone lands in. */
+  path: string;
+  /** Branch, tag, or full commit hash. Absent means the default branch. */
+  ref?: string;
+}
+
+const REPO_SHORTHAND = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const MAX_ENTRIES = 10;
+const MAX_PATH_LENGTH = 256;
+
+/** Returns null for both absent and empty, so the column stores one "unset" value. */
+export function normalizeReferenceRepos(raw: unknown): ReferenceRepo[] | null {
+  if (raw == null) return null;
+  if (!Array.isArray(raw)) throw new Error("referenceRepos must be an array of entries");
+  if (raw.length === 0) return null;
+  if (raw.length > MAX_ENTRIES) {
+    throw new Error(`too many entries (${raw.length}); maximum is ${MAX_ENTRIES}`);
+  }
+
+  const entries: ReferenceRepo[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const item of raw) {
+    if (item == null || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error("each entry must be an object with repo and path");
+    }
+    const { repo, path: rawPath, ref } = item as Record<string, unknown>;
+    if (typeof repo !== "string" || repo.trim() === "") {
+      throw new Error("each entry needs a repo");
+    }
+    if (typeof rawPath !== "string") {
+      throw new Error("each entry needs a path");
+    }
+    if (ref != null && (typeof ref !== "string" || ref.trim() === "")) {
+      throw new Error("ref must be a non-empty string when present");
+    }
+
+    const normalizedPath = normalizePath(rawPath);
+    if (seenPaths.has(normalizedPath)) {
+      throw new Error(`two entries share the path "${normalizedPath}"; each entry needs its own directory`);
+    }
+    seenPaths.add(normalizedPath);
+
+    entries.push({
+      repo: normalizeGitHubRepo(repo, "referenceRepos"),
+      path: normalizedPath,
+      ...(ref != null ? { ref: (ref as string).trim() } : {}),
+    });
+  }
+
+  return entries;
+}
+
+/** 
+ * Exact host match, case-insensitive
+ * 
+ * www.github.com excluded — git remotes live on the apex host.
+ * Other hosts and SSH URLs are rejected rather than stored: the runner's only
+ * clone credential is a GitHub App token that must never be sent elsewhere, and an SSH
+ * URL would store as valid and then silently no-op at clone time.
+ * 
+ * NOTE: the result is syntax- and host-validated only — it is NOT sanitized. Any code
+ * that feeds it to a subprocess MUST pass it as a separate argv element, never
+ * interpolated into a shell string, to avoid command injection.
+*/
+export function normalizeGitHubRepo(raw: string, field: string): string {
+  const v = raw.trim();
+  if (REPO_SHORTHAND.test(v)) return `https://github.com/${v}`;
+  let host: string | null = null;
+  if (/^https:\/\/[^\s]+$/.test(v)) {
+    try {
+      host = new URL(v).hostname.toLowerCase();
+    } catch {
+      host = null;
+    }
+  }
+  if (host !== "github.com") {
+    throw new Error(`${field} must be 'owner/repo' shorthand or an https://github.com/... URL (the runner clones with a GitHub token, so other hosts and SSH git@ URLs are not supported)`);
+  }
+  return v;
+}
+
+/** Checks the normalized form as well as the raw one: a path can look contained and normalize outward. */
+function normalizePath(raw: string): string {
+  const v = raw.trim();
+  if (v === "") throw new Error("each entry needs a non-empty path");
+  if (v.length > MAX_PATH_LENGTH) {
+    throw new Error(`path too long (${v.length} chars): "${v.slice(0, 30)}..."; maximum is ${MAX_PATH_LENGTH}`);
+  }
+  if (path.posix.isAbsolute(v) || /^[A-Za-z]:/.test(v)) {
+    throw new Error(`path "${v}" must be relative to the workspace`);
+  }
+
+  const normalized = path.posix.normalize(v).replace(/\/+$/, "");
+  if (normalized === "." || normalized === "" || normalized.split("/").includes("..")) {
+    throw new Error(`path "${v}" must stay inside the workspace and name a directory`);
+  }
+  if (normalized.split("/")[0] === ".git") {
+    throw new Error(`path "${v}" must not write into the repository's own .git directory`);
+  }
+  return normalized;
+}


### PR DESCRIPTION
First of five issues under [AII-178](https://linear.app/eudoxus/issue/AII-178). A project mapping can now declare repositories that its runs read as reference source, so an agent can check a claim against real code instead of trusting what an issue asserts.

## In progress — what this PR deliberately does not do

**Nothing reads the new field yet, and that is the intended end state of this PR.** The setting is stored and validated; the envelope, the clone step, the prompt block and the operator interface land in AII-508 through AII-511. An operator who sets this today gets a value that does nothing, which is the same staging the dependency-token and skills-repository settings went through.

**No `docs/` reference page is added here.** `CLAUDE.md` asks that a change adding an architectural feature updates its matching reference in the same change. Reference repositories are not their own subsystem — they are one of a set of per-project settings that provision something into a run, alongside the skills repository and dependency token scope, and that set has no page today either. AII-525 writes `docs/runner-context.md` covering the two shipped settings, and AII-510 adds this feature's section once the rail is complete. A page written here would describe a mechanism that does not exist, in a place we have decided it does not belong.

Please review this diff as the storage and validation layer it is, rather than against the feature it is the first fifth of.

## What changed

**`src/reference-repos.ts` is new** and owns the entry type and every rule that governs it. An entry names a repository, a workspace-relative path, and an optional ref; omitting the ref means the repository's default branch.

The module exists rather than another private function in `admin.ts` because the rules have two consumers. The admin API validates on save, and the clone step will re-validate on the runner before a path becomes a filesystem operation — a value written before a rule tightened is still in the database. `admin.ts` keeps only the wiring that calls in.

**`normalizeSkillsRepo` now shares the repository rule.** The shorthand expansion and the exact-host check moved into the new module and `normalizeSkillsRepo` calls them, which removes a duplicate rather than adding a third copy. Its error message for the host rule is byte-identical to before.

It does gain one behavior change, deliberately: a URL embedding a username or token is now rejected, where previously it was stored. That is the second commit responding to the first review round, and it is a fix rather than a tightening — such a value never worked, because `install-skills.ts` injects its own token by replacing the `https://` prefix, which on a value already carrying userinfo produces a malformed remote and a silent no-op at clone time. No mapping currently sets the field.

The same rule exists a third time on the runner in `install-skills.ts` and does **not** yet have the credential check. Unreachable today, since the orchestrator rejects at save; tracked to be closed when the runner adopts the shared module.


**Path validation is the security-relevant part.** An operator supplies the value and the runner will turn it into a directory it writes into, so the check runs against the normalized form as well as the raw one — a path can look contained and normalize outward. Absolute paths, traversal, and the repository's own git directory are all rejected, along with duplicate paths within a mapping.

One narrowing worth calling out: the rule rejects a path whose **first segment** is `.git`, rather than any path starting with those characters. The broader reading would also reject a legitimate `.github-source`.

**`CONTEXT.md` gains a glossary entry.** The concept was called a knowledge repository during design and was renamed before it reached a schema, because "knowledge" already means the knowledge graph across this codebase and a reader meeting `knowledgeRepos` would reasonably think it configured one. The entry names both neighbors it must not be confused with.

## Note on a fixture outside this issue's scope

`config.test.ts`'s mapping helper was missing `memoryProviderId` as well as the new field, so it has been completed rather than only extended. Without it the round-trip test would assert against an `undefined` that collapses to `null` on the way into SQLite, and would pass for the wrong reason.

## Follow-ups

The rest of the feature is filed and sequenced: AII-508 carries the field in the run envelope, AII-509 vends a scoped read token and clones, AII-510 reports to the agent and the operator, and AII-511 adds the editor. AII-507 regroups the mapping surfaces that editor lands in, and AII-525 writes the reference page all three settings share.
