### PR TITLE
AII-507: Group the runner-context settings on both project-mapping surfaces

### DIFF
--- a/src/__tests__/projects-page.test.ts
+++ b/src/__tests__/projects-page.test.ts
@@ -67,6 +67,19 @@ describe("mapping dialog — tabbed layout", () => {
   });
 });
 
+describe("mapping dialog — cap validation", () => {
+  it("applies the same rule the server does, and routes the error to the Capacity tab", () => {
+    expect(projectsScript).toContain("value !== null && (!Number.isInteger(value) || value < 1)");
+    expect(projectsScript).toMatch(/showMappingError\(cap\[0\][^;]*'capacity'\)/);
+  });
+
+  // parseInt("1.5") is 1, so a decimal would become a different valid number silently.
+  it("parses caps with Number rather than parseInt", () => {
+    expect(projectsScript).toContain("v === '' ? null : Number(v)");
+    expect(projectsScript).not.toContain("parseInt(v, 10)");
+  });
+});
+
 describe("mapping dialog — field placement", () => {
   function panelOf(id: string): string | undefined {
     const at = projectsHtml.indexOf(`id="${id}"`);

--- a/src/__tests__/projects-page.test.ts
+++ b/src/__tests__/projects-page.test.ts
@@ -2,54 +2,182 @@ import { describe, expect, it } from "vitest";
 import { projectsHtml, projectsScript } from "../admin-ui/pages/projects.js";
 import { stepperHtml } from "../admin-ui/stepper.js";
 
-describe("projects page — sensitive-files glob fields", () => {
-  it("projectsHtml contains 'Additional sensitive patterns' label", () => {
-    expect(projectsHtml).toContain("Additional sensitive patterns");
+/** Tab keys in the order the strip presents them. */
+const TABS = ["ticketing", "source", "context", "execution", "capacity", "guardrails", "provider"];
+
+/** The edit dialog alone. The page also carries the stepper, which it owns. */
+const dialogHtml = projectsHtml.slice(
+  projectsHtml.indexOf('<dialog id="mapping-dialog">'),
+  projectsHtml.indexOf("</dialog>"),
+);
+
+/**
+ * The `.field` wrapper enclosing a control, so a test can assert on a control together with
+ * the label and hint that belong to it rather than against the whole document.
+ */
+function fieldBlockFor(html: string, id: string): string {
+  const at = html.indexOf(`id="${id}"`);
+  expect(at, `no element carries id="${id}"`).toBeGreaterThan(-1);
+  const start = html.lastIndexOf('<div class="field"', at);
+  const next = html.indexOf('<div class="field"', at);
+  return html.slice(start, next === -1 ? start + 1200 : next);
+}
+
+describe("mapping dialog — tabbed layout", () => {
+  it("declares a panel for every tab and a tab for every panel", () => {
+    const tabs = [...projectsHtml.matchAll(/data-md-tab="([a-z]+)"/g)].map((m) => m[1]);
+    const panels = [...projectsHtml.matchAll(/data-md-panel="([a-z]+)"/g)].map((m) => m[1]);
+    expect(tabs).toEqual(TABS);
+    expect(panels).toEqual(TABS);
   });
 
-  it("projectsHtml contains 'Allowed exceptions' label", () => {
-    expect(projectsHtml).toContain("Allowed exceptions");
+  // Two visible panels would stack two sections; none visible would render an empty dialog.
+  // Both fail silently, so the count is worth pinning.
+  it("ships exactly one panel visible, and it is the one whose tab is active", () => {
+    const panels = [...projectsHtml.matchAll(/data-md-panel="([a-z]+)"( hidden)?/g)];
+    expect(panels.filter((m) => !m[2]).map((m) => m[1])).toEqual(["ticketing"]);
+    expect(projectsHtml).toContain('class="btn btn-sm active" data-md-tab="ticketing"');
   });
 
-  it("projectsHtml has both textareas with placeholder 'one glob per line'", () => {
-    const matches = (projectsHtml.match(/placeholder="one glob per line"/g) || []).length;
-    expect(matches).toBeGreaterThanOrEqual(2);
+  it("reuses the existing segmented control rather than a new tab component", () => {
+    expect(projectsHtml).toContain('<span class="seg" id="md-tabs">');
   });
 
-  it("projectsHtml Allowed-exceptions block contains guardrail-bypass warning", () => {
-    expect(projectsHtml).toContain("bypass the sensitive-files guardrail");
+  // The strip must sit outside .md-body, the scrolling container — inside it, the tabs
+  // scroll out of reach exactly when a long panel needs them.
+  it("puts the tab strip ahead of the scrolling body", () => {
+    expect(projectsHtml.indexOf('id="md-tabs"')).toBeLessThan(projectsHtml.indexOf('class="md-body"'));
   });
 
-  it("projectsHtml contains textarea id md-sensitive-add", () => {
+  it("exposes the tab switcher and a tab-aware error reporter", () => {
+    expect(projectsScript).toContain("window.switchMappingTab = switchMappingTab");
+    expect(projectsScript).toContain("function showMappingError(message, tab)");
+  });
+
+  // Three save rules span two panels, so the offending field can be on a panel the operator
+  // cannot see. Every rejection must name the tab that holds it.
+  it("routes every save rejection to a tab", () => {
+    const calls = [...projectsScript.matchAll(/showMappingError\('[^;]*?\);/g)].map((m) => m[0]);
+    expect(calls.length).toBeGreaterThanOrEqual(6);
+    for (const call of calls) {
+      expect(call, `no tab argument in ${call}`).toMatch(
+        /,\s*'(ticketing|source|context|execution|capacity|guardrails|provider)'\s*\)/,
+      );
+    }
+  });
+});
+
+describe("mapping dialog — field placement", () => {
+  function panelOf(id: string): string | undefined {
+    const at = projectsHtml.indexOf(`id="${id}"`);
+    return [...projectsHtml.slice(0, at).matchAll(/data-md-panel="([a-z]+)"/g)].pop()?.[1];
+  }
+
+  it.each([
+    ["md-ticketing-provider", "ticketing"],
+    ["md-team-key", "ticketing"],
+    ["md-owner", "source"],
+    ["md-repo", "source"],
+    ["md-branch", "source"],
+    ["md-branch-prefix", "source"],
+    ["md-skills-repo", "context"],
+    ["md-dep-token-scope", "context"],
+    ["md-exec-mode", "execution"],
+    ["md-env", "execution"],
+    ["md-max-turns", "capacity"],
+    ["md-max-job-min", "capacity"],
+    ["md-sensitive-add", "guardrails"],
+    ["md-sensitive-allow", "guardrails"],
+    ["md-provider", "provider"],
+    ["md-planning", "provider"],
+  ])("%s sits on the %s panel", (id, panel) => {
+    expect(panelOf(id)).toBe(panel);
+  });
+
+  // Every field is read by id at save time whether or not its panel is showing, so a
+  // duplicated id silently sends the wrong value.
+  it("declares no id twice", () => {
+    const ids = [...projectsHtml.matchAll(/id="([a-z0-9-]+)"/g)].map((m) => m[1]);
+    expect(ids.length).toBe(new Set(ids).size);
+  });
+});
+
+describe("mapping dialog — retired legacy vocabulary", () => {
+  it.each([["md-field"], ["md-cols"], ["<fieldset>"], ["<legend>"]])("no longer emits %s", (token) => {
+    expect(projectsHtml).not.toContain(token);
+  });
+
+  it("titles its sections in sentence case, not the uppercase page-section header", () => {
+    expect(projectsHtml).not.toContain('class="section-h"');
+    expect(projectsHtml).toContain('<h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Guardrails</h3>');
+  });
+});
+
+describe("mapping dialog — guardrails", () => {
+  it("keeps both glob fields", () => {
     expect(projectsHtml).toContain('id="md-sensitive-add"');
-  });
-
-  it("projectsHtml contains textarea id md-sensitive-allow", () => {
     expect(projectsHtml).toContain('id="md-sensitive-allow"');
   });
 
-  it("projectsScript includes sensitiveAddPatterns payload field", () => {
-    expect(projectsScript).toContain("sensitiveAddPatterns");
+  it.each([["md-sensitive-add"], ["md-sensitive-allow"]])(
+    "%s carries a non-empty label and a non-empty placeholder",
+    (id) => {
+      const block = fieldBlockFor(projectsHtml, id);
+      expect(block).toMatch(/<label class="field-label">\s*\S[^<]*<\/label>/);
+      expect(block).toMatch(new RegExp(`id="${id}"[^>]*placeholder="[^"]+"`));
+    },
+  );
+
+  it("labels the two fields differently", () => {
+    const labelIn = (id: string) => fieldBlockFor(projectsHtml, id).match(/<label class="field-label">([^<]+)</)?.[1];
+    expect(labelIn("md-sensitive-add")).not.toBe(labelIn("md-sensitive-allow"));
   });
 
-  it("projectsScript includes sensitiveAllowPatterns payload field", () => {
+  it("warns, as an alert, that exceptions override the guardrail", () => {
+    expect(projectsHtml).toContain('class="alert warn"');
+    expect(projectsHtml).toContain("Exceptions win over every other rule");
+  });
+
+  // "glob" is jargon an operator may not carry; the placeholder is what teaches the syntax.
+  it("shows worked pattern examples rather than naming the format", () => {
+    expect(dialogHtml).toContain("infra/**");
+    expect(dialogHtml).not.toContain("one glob per line");
+  });
+
+  it("still sends both payload fields", () => {
+    expect(projectsScript).toContain("sensitiveAddPatterns");
     expect(projectsScript).toContain("sensitiveAllowPatterns");
   });
+});
 
-  it("stepperHtml contains textarea id np-sensitive-add", () => {
-    expect(stepperHtml).toContain('id="np-sensitive-add"');
+describe("projects page — owns the surfaces only it opens", () => {
+  it("carries the new-project stepper, which nothing else opens", () => {
+    expect(projectsHtml).toContain('id="np-stepper-wrap"');
+    expect(projectsHtml).toContain('onclick="openNewProjectStepper()"');
   });
 
-  it("stepperHtml contains textarea id np-sensitive-allow", () => {
+  it("mounts the stepper exactly once, inside its own page section", () => {
+    expect(projectsHtml.split('id="np-stepper-wrap"').length - 1).toBe(1);
+    expect(projectsHtml.indexOf('<section data-page="projects"')).toBeLessThan(
+      projectsHtml.indexOf('id="np-stepper-wrap"'),
+    );
+    expect(projectsHtml.indexOf('id="np-stepper-wrap"')).toBeLessThan(projectsHtml.lastIndexOf("</section>"));
+  });
+});
+
+describe("new-project stepper — sensitive-files glob fields", () => {
+  it("contains both textareas", () => {
+    expect(stepperHtml).toContain('id="np-sensitive-add"');
     expect(stepperHtml).toContain('id="np-sensitive-allow"');
   });
 
-  it("stepperHtml contains 'one glob per line' placeholder", () => {
-    const matches = (stepperHtml.match(/one glob per line/g) || []).length;
-    expect(matches).toBeGreaterThanOrEqual(2);
+  it.each([["np-sensitive-add"], ["np-sensitive-allow"]])("%s carries a non-empty placeholder", (id) => {
+    expect(stepperHtml).toMatch(new RegExp(`id="${id}"[^>]*placeholder="[^"]+"`));
   });
 
-  it("stepperHtml contains guardrail-bypass warning", () => {
-    expect(stepperHtml).toContain("bypass the sensitive-files guardrail");
+  // Both surfaces now carry the same warning, as the same component.
+  it("warns, as an alert, that exceptions override the guardrail", () => {
+    expect(stepperHtml).toContain('class="alert warn"');
+    expect(stepperHtml).toContain("Exceptions win over every other rule");
   });
 });

--- a/src/admin-ui/__tests__/stepper.test.ts
+++ b/src/admin-ui/__tests__/stepper.test.ts
@@ -1,9 +1,36 @@
 import { describe, expect, it } from "vitest";
 import { stepperHtml, stepperScript } from "../stepper.js";
 
+/** Rail order. Inserting a step renumbers every later one, so this is the spine of the file. */
+const STEPS = ["Ticketing", "Config", "Source", "Context", "Execution", "Provider", "Capacity", "Secrets", "Review"];
+
+describe("new-project stepper — step numbering", () => {
+  it("declares one block per step and no more", () => {
+    for (let i = 0; i < STEPS.length; i++) expect(stepperHtml).toContain(`data-step="${i}"`);
+    expect(stepperHtml).not.toContain(`data-step="${STEPS.length}"`);
+    const blocks = [...stepperHtml.matchAll(/data-step="(\d)"/g)].map((m) => m[1]);
+    expect(blocks.length).toBe(new Set(blocks).size);
+  });
+
+  it("keeps LAST_STEP, STEP_LABELS and the markup in agreement", () => {
+    expect(stepperScript).toContain(`const LAST_STEP = ${STEPS.length - 1};`);
+    const labels = stepperScript.match(/STEP_LABELS = \[(.*?)\]/)?.[1] ?? "";
+    expect(labels.split(",").map((s) => s.trim().replace(/'/g, ""))).toEqual(STEPS);
+  });
+
+  // Every step must be reachable by collectStep, or its fields are silently dropped when
+  // the operator moves past it. Review (the last) collects nothing.
+  it("collects every step except Review", () => {
+    const body = stepperScript.slice(stepperScript.indexOf("function collectStep"));
+    for (let i = 0; i < STEPS.length - 1; i++) {
+      expect(body, `collectStep has no branch for step ${i} (${STEPS[i]})`).toContain(`n === ${i}`);
+    }
+  });
+});
+
 describe("new-project stepper", () => {
-  it("declares all eight step blocks", () => {
-    for (let i = 0; i < 8; i++) expect(stepperHtml).toContain(`data-step="${i}"`);
+  it("declares all nine step blocks", () => {
+    for (let i = 0; i < STEPS.length; i++) expect(stepperHtml).toContain(`data-step="${i}"`);
   });
 
   it("splits Ticketing into a system-select step and a provider-specific config step", () => {
@@ -60,5 +87,120 @@ describe("new-project stepper", () => {
 
   it("uses const/let, not var", () => {
     expect(stepperScript).not.toMatch(/\bvar\s+\w/);
+  });
+});
+
+describe("new-project stepper — the four touch points a new field needs", () => {
+  // The initializer and the reset inside openNewProjectStepper are two separate lists.
+  // A field added to one and not the other keeps its previous value across a reopen.
+  it("resets every field the initializer declares", () => {
+    const init = stepperScript.slice(
+      stepperScript.indexOf("const data = {"),
+      stepperScript.indexOf("let jiraFieldsLoaded"),
+    );
+    const fields = [...init.matchAll(/(\w+):/g)].map((m) => m[1]);
+    expect(fields.length).toBeGreaterThan(20);
+    const reset = stepperScript.slice(
+      stepperScript.indexOf("function openNewProjectStepper"),
+      stepperScript.indexOf("// Clear inputs"),
+    );
+    for (const field of fields) {
+      expect(reset, `data.${field} is declared but never reset on reopen`).toContain(`data.${field} =`);
+    }
+  });
+
+  it("clears only inputs that exist in the markup", () => {
+    const list = stepperScript.match(/const toClear = \[(.*?)\]/s)?.[1] ?? "";
+    const ids = [...list.matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    expect(ids.length).toBeGreaterThan(8);
+    for (const id of ids) {
+      expect(stepperHtml, `toClear names ${id}, which no element declares`).toContain(`id="${id}"`);
+    }
+  });
+
+  it.each([
+    ["branchPrefix", "np-branch-prefix"],
+    ["maxTurns", "np-maxTurns"],
+    ["maxIterations", "np-maxIterations"],
+    ["maxJobMinutes", "np-maxJobMinutes"],
+  ])("%s is declared, reset, collected and submitted", (field, id) => {
+    expect(stepperHtml).toContain(`id="${id}"`);
+    expect(stepperScript).toContain(`data.${field} =`);
+    expect(stepperScript).toContain(`'${id}'`);
+    expect(stepperScript).toMatch(new RegExp(`${field}: data\\.${field}`));
+  });
+});
+
+describe("new-project stepper — field placement", () => {
+  const stepOf = (id: string): number => {
+    const at = stepperHtml.indexOf(`id="${id}"`);
+    const before = [...stepperHtml.slice(0, at).matchAll(/data-step="(\d)"/g)];
+    return Number(before[before.length - 1][1]);
+  };
+
+  it.each([
+    ["np-owner", 2],
+    ["np-defaultBranch", 2],
+    ["np-branch-prefix", 2],
+    ["np-sensitive-add", 2],
+    ["np-sensitive-allow", 2],
+    ["np-skills-repo", 3],
+    ["np-dep-token-scope", 3],
+    ["np-sessionMode", 4],
+    ["np-maxAi", 6],
+    ["np-maxTurns", 6],
+    ["np-maxJobMinutes", 6],
+  ])("%s sits on step %i", (id, step) => {
+    expect(stepOf(id)).toBe(step);
+  });
+
+  it("gives the Context step its own heading rather than folding it into Source", () => {
+    expect(stepperHtml).toContain('<h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Context</h3>');
+  });
+
+  it("renames the Runner step to Execution, so it does not collide with Runner context", () => {
+    expect(stepperHtml).toContain('<h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Execution</h3>');
+    expect(stepperHtml).not.toContain(">Runner</h3>");
+  });
+});
+
+describe("new-project stepper — review step", () => {
+  it.each([["branchPrefix"], ["caps"]])("has a review row for %s", (key) => {
+    expect(stepperHtml).toContain(`data-review="${key}"`);
+  });
+
+  // The review mirrors the rail so a wrong value tells you which step to go back to.
+  it("groups its rows under the step each value was set on", () => {
+    const headings = [...stepperHtml.matchAll(/np-review-h">([A-Za-z ]+?)(?: <span|<\/div>)/g)].map((m) => m[1].trim());
+    expect(headings).toEqual([
+      "Ticketing",
+      "Source",
+      "Context",
+      "Execution",
+      "Provider",
+      "Capacity",
+      "Secrets",
+      "Pinned defaults",
+    ]);
+  });
+
+  it("puts every review row under a heading", () => {
+    const body = stepperHtml.slice(stepperHtml.indexOf('data-step="8"'));
+    expect(body.indexOf('class="np-review-h"')).toBeLessThan(body.indexOf('class="np-review-row"'));
+  });
+
+  it("populates every review slot the markup declares", () => {
+    const keys = [...stepperHtml.matchAll(/data-review="(\w+)"/g)].map((m) => m[1]);
+    for (const key of keys) {
+      expect(stepperScript, `no set('${key}', …) in populateReview`).toContain(`set('${key}'`);
+    }
+  });
+
+  // Constants, so they live in the markup rather than being written by populateReview.
+  it("names the three values the stepper pins and the dialog can change later", () => {
+    const pinned = stepperHtml.slice(stepperHtml.indexOf("Pinned defaults"));
+    expect(pinned).toContain("claude-implement.yml");
+    expect(pinned).toContain("claude-plan.yml");
+    expect(pinned).toContain("Extra env");
   });
 });

--- a/src/admin-ui/__tests__/stepper.test.ts
+++ b/src/admin-ui/__tests__/stepper.test.ts
@@ -131,6 +131,29 @@ describe("new-project stepper — the four touch points a new field needs", () =
   });
 });
 
+describe("new-project stepper — cap validation", () => {
+  // Mirrors resolveCap on the server: integer, at least 1, or null for the default. The
+  // point of checking here is to name the field rather than round-trip a 400.
+  it("rejects a cap that is not a positive integer, and allows a blank one", () => {
+    expect(stepperScript).toContain("function badCap(value)");
+    expect(stepperScript).toContain("value !== null && (!Number.isInteger(value) || value < 1)");
+  });
+
+  it("checks all three optional caps, not only the required one", () => {
+    for (const field of ["maxTurns", "maxIterations", "maxJobMinutes"]) {
+      expect(stepperScript).toContain(`'${field}'`);
+    }
+    expect(stepperScript).toContain("for (const cap of CAP_FIELDS)");
+  });
+
+  // parseInt("1.5") is 1, so a decimal would become a different valid number instead of
+  // an error. Number() keeps it non-integer so badCap can reject it.
+  it("parses with Number rather than parseInt, so a decimal cannot truncate silently", () => {
+    expect(stepperScript).not.toContain("parseInt(v, 10)");
+    expect(stepperScript).toContain("v === '' ? null : Number(v)");
+  });
+});
+
 describe("new-project stepper — field placement", () => {
   const stepOf = (id: string): number => {
     const at = stepperHtml.indexOf(`id="${id}"`);

--- a/src/admin-ui/components.ts
+++ b/src/admin-ui/components.ts
@@ -534,6 +534,37 @@ export const componentsCss = `
   color: var(--fg-tertiary);
   line-height: 1.45;
 }
+
+/* The marker is drawn here because the native one cannot be styled across browsers. */
+.explain { margin-top: 2px; }
+.explain > summary {
+  cursor: pointer;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent);
+}
+.explain > summary::-webkit-details-marker { display: none; }
+.explain > summary::before {
+  content: "›";
+  font-size: 15px;
+  line-height: 1;
+  transition: transform 120ms ease;
+}
+.explain[open] > summary::before { transform: rotate(90deg); }
+.explain > summary:hover { color: var(--accent-hover); }
+.explain-body {
+  font-size: 12px;
+  color: var(--fg-secondary);
+  line-height: 1.6;
+  margin-top: 8px;
+  padding-left: 12px;
+  border-left: 2px solid var(--border-subtle);
+}
+.explain-body + .explain-body { margin-top: 10px; }
 .input, .select, .textarea {
   width: 100%;
   background: var(--bg-elev);
@@ -842,17 +873,21 @@ export const componentsCss = `
 /* ── Stepper (new project flow) ────────────────────────────── */
 .stepper {
   display: flex;
-  align-items: center;
-  gap: 0;
-  padding: 16px 24px;
-  border-bottom: 1px solid var(--border-subtle);
+  flex-direction: column;
+  gap: 2px;
+  padding: 16px 12px;
+  border-right: 1px solid var(--border-subtle);
+  overflow-y: auto;
 }
 .stepper-step {
-  display: flex; align-items: center; gap: 8px;
-  padding: 4px 0;
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 10px;
+  border-radius: var(--r-sm);
   color: var(--fg-tertiary);
   font-size: 12px;
   font-weight: 500;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 .stepper-step .num {
   width: 20px; height: 20px;
@@ -864,7 +899,7 @@ export const componentsCss = `
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }
-.stepper-step.active { color: var(--fg-primary); }
+.stepper-step.active { color: var(--fg-primary); background: var(--bg-hover); }
 .stepper-step.active .num {
   background: var(--accent);
   border-color: var(--accent);
@@ -874,12 +909,6 @@ export const componentsCss = `
   background: var(--accent-soft);
   border-color: var(--accent-soft);
   color: var(--accent-soft-fg);
-}
-.stepper-divider {
-  flex: 1;
-  height: 1px;
-  background: var(--border-subtle);
-  margin: 0 14px;
 }
 
 /* ── Misc ──────────────────────────────────────────────────── */
@@ -1009,7 +1038,7 @@ deck-stage, .dc-artboard { background: var(--bg-app); }
 .ac-row { display: flex; gap: 8px; }
 .ac-row .input { flex: 1; min-width: 0; }
 
-/* ── Native <dialog> for legacy mapping form ─────────────────────────── */
+/* ── Native <dialog> shell for the project mapping form ──────────────── */
 dialog {
   border: none;
   border-radius: var(--r-md);
@@ -1019,6 +1048,15 @@ dialog {
   background: var(--bg-elev);
   color: var(--fg-primary);
   box-shadow: var(--shadow-lg);
+  /* Top-pinned rather than UA-centred, so a content height change cannot shift it. */
+  margin-top: 7vh;
+  margin-bottom: auto;
+  max-height: 86vh;
+}
+/* Scoped to [open]: a bare display here beats the UA rule that hides a closed dialog. */
+dialog[open] {
+  display: flex;
+  flex-direction: column;
 }
 dialog::backdrop { background: rgba(0,0,0,0.5); }
 .md-header {
@@ -1035,13 +1073,9 @@ dialog::backdrop { background: rgba(0,0,0,0.5); }
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-height: 70vh;
+  flex: 0 1 auto;
+  min-height: 0;
   overflow-y: auto;
-}
-.md-cols {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
 }
 .md-footer {
   padding: 12px 20px;
@@ -1049,42 +1083,6 @@ dialog::backdrop { background: rgba(0,0,0,0.5); }
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-}
-.md-field {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  margin-bottom: 8px;
-}
-.md-field:last-child { margin-bottom: 0; }
-.md-field label {
-  font-size: 11px;
-  color: var(--fg-secondary);
-  font-weight: 500;
-}
-.md-field input,
-.md-field select,
-.md-field textarea {
-  width: 100%;
-  background: var(--bg-elev);
-  border: 1px solid var(--border-default);
-  border-radius: var(--r-sm);
-  padding: 7px 10px;
-  font-size: 12.5px;
-  color: var(--fg-primary);
-  transition: border-color 80ms ease, box-shadow 80ms ease;
-}
-.md-field input:focus,
-.md-field select:focus,
-.md-field textarea:focus {
-  outline: none;
-  border-color: var(--border-focus);
-  box-shadow: var(--shadow-focus);
-}
-.md-field textarea {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  resize: vertical;
 }
 
 /* ── Legacy button class aliases (preserved during ported-page migration) */
@@ -1136,4 +1134,11 @@ button.secondary,
   color: var(--fg-tertiary);
   font-weight: 500;
 }
+.np-review-h {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-secondary);
+  margin: 18px 0 4px;
+}
+.np-review-h:first-child { margin-top: 0; }
 `;

--- a/src/admin-ui/index.ts
+++ b/src/admin-ui/index.ts
@@ -24,7 +24,7 @@ import { deploymentsHtml, deploymentsScript } from "./pages/deployments.js";
 import { stubsHtml } from "./pages/stubs.js";
 import { noAccessHtml } from "./pages/no-access.js";
 import { drawerHtml, drawerScript } from "./drawer.js";
-import { stepperHtml, stepperScript } from "./stepper.js";
+import { stepperScript } from "./stepper.js";
 
 const head = `<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -93,7 +93,6 @@ const body = `<body>
 </div>
 ${shell}
 ${drawerHtml}
-${stepperHtml}
 <script>${themeJs}${authJs}${routerJs}${overviewScript}${settingsScript}${projectsScript}${pipelinesScript}${reaperScript}${sessionsScript}${auditScript}${issuesScript}${pullsScript}${blockersScript}${customizationsScript}${pipelinesAndStepsScript}${modelsAndProvidersScript}${runnersScript}${reportsScript}${deploymentsScript}${accessScript}${drawerScript}${stepperScript}</script>
 </body></html>`;
 

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -509,6 +509,23 @@ export const projectsScript = `
   }
   window.switchMappingTab = switchMappingTab;
 
+  // Blank means "use the built-in default", which the payload carries as null. Number()
+  // rather than parseInt so "1.5" fails validation instead of truncating to 1.
+  function optionalCap(id) {
+    const v = document.getElementById(id).value.trim();
+    return v === '' ? null : Number(v);
+  }
+
+  const CAP_FIELDS = [
+    ['Max Turns', 'maxTurns'],
+    ['Max Iterations', 'maxIterations'],
+    ['Job Timeout', 'maxJobMinutes'],
+  ];
+
+  function badCap(value) {
+    return value !== null && (!Number.isInteger(value) || value < 1);
+  }
+
   // Several save rules span two tabs, so the offending field may be on a hidden panel.
   function showMappingError(message, tab) {
     if (tab) switchMappingTab(tab);
@@ -778,7 +795,7 @@ export const projectsScript = `
       repo: document.getElementById('md-repo').value.trim(),
       workflowFile: document.getElementById('md-wf').value.trim(),
       defaultBranch,
-      maxInProgressAiIssues: parseInt(document.getElementById('md-max-ai').value, 10),
+      maxInProgressAiIssues: Number(document.getElementById('md-max-ai').value.trim() || NaN),
       executionMode: document.getElementById('md-exec-mode').value,
       sessionMode: document.getElementById('md-session-mode').value,
       machineCpus: parseInt(document.getElementById('md-cpus').value, 10),
@@ -790,9 +807,9 @@ export const projectsScript = `
       extraEnv: parseEnvText(document.getElementById('md-env').value),
       provider: document.getElementById('md-provider').value,
       awsRegion: document.getElementById('md-aws-region').value.trim() || null,
-      maxTurns: (function(){ var v = document.getElementById('md-max-turns').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
-      maxIterations: (function(){ var v = document.getElementById('md-max-iter').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
-      maxJobMinutes: (function(){ var v = document.getElementById('md-max-job-min').value.trim(); return v === '' ? null : parseInt(v, 10); })(),
+      maxTurns: optionalCap('md-max-turns'),
+      maxIterations: optionalCap('md-max-iter'),
+      maxJobMinutes: optionalCap('md-max-job-min'),
       branchPrefix: (function(){ var v = document.getElementById('md-branch-prefix').value.trim(); return v === '' ? null : v; })(),
       skillsRepo: (function(){ var v = document.getElementById('md-skills-repo').value.trim(); return v === '' ? null : v; })(),
       sensitiveAddPatterns: (function(){ var v = document.getElementById('md-sensitive-add').value.trim(); return v === '' ? null : v; })(),
@@ -830,9 +847,15 @@ export const projectsScript = `
       showMappingError('Owner and Repo are required.', 'source');
       return;
     }
-    if (!Number.isFinite(body.maxInProgressAiIssues) || body.maxInProgressAiIssues < 1) {
+    if (!Number.isInteger(body.maxInProgressAiIssues) || body.maxInProgressAiIssues < 1) {
       showMappingError('Max AI Issues must be a positive integer.', 'capacity');
       return;
+    }
+    for (const cap of CAP_FIELDS) {
+      if (badCap(body[cap[1]])) {
+        showMappingError(cap[0] + ' must be a positive integer, or blank for the default.', 'capacity');
+        return;
+      }
     }
     if (body.provider === 'bedrock' && body.executionMode === 'fly-machines') {
       showMappingError('Bedrock is not supported with the fly-machines execution mode. Change one of them.', 'provider');

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -1,3 +1,5 @@
+import { stepperHtml } from "../stepper.js";
+
 export const projectsHtml = `
 <section data-page="projects" hidden>
   <header class="page-header">
@@ -12,7 +14,7 @@ export const projectsHtml = `
   <div class="page-body">
     <div class="card">
       <div class="card-body tight">
-        <table class="tbl" id="mappings-table">
+        <table class="tbl">
           <thead>
             <tr>
               <th>Team</th><th>Repo</th><th>Runner</th><th>Session</th>
@@ -61,168 +63,268 @@ export const projectsHtml = `
       <button class="btn btn-ghost btn-icon" onclick="closeMappingDialog()">&#215;</button>
     </div>
     <input type="hidden" id="md-team-key-orig">
+    <div style="padding:12px 20px 0">
+      <span class="seg" id="md-tabs">
+        <button type="button" class="btn btn-sm active" data-md-tab="ticketing" onclick="switchMappingTab('ticketing')">Ticketing</button>
+        <button type="button" class="btn btn-sm" data-md-tab="source" onclick="switchMappingTab('source')">Source</button>
+        <button type="button" class="btn btn-sm" data-md-tab="context" onclick="switchMappingTab('context')">Context</button>
+        <button type="button" class="btn btn-sm" data-md-tab="execution" onclick="switchMappingTab('execution')">Execution</button>
+        <button type="button" class="btn btn-sm" data-md-tab="capacity" onclick="switchMappingTab('capacity')">Capacity</button>
+        <button type="button" class="btn btn-sm" data-md-tab="guardrails" onclick="switchMappingTab('guardrails')">Guardrails</button>
+        <button type="button" class="btn btn-sm" data-md-tab="provider" onclick="switchMappingTab('provider')">Provider</button>
+      </span>
+    </div>
     <div class="md-body">
-      <fieldset>
-        <legend>Ticketing Provider</legend>
-        <div style="display:flex;gap:20px;align-items:flex-start;flex-wrap:wrap">
-          <div class="md-field" style="margin-bottom:0;min-width:140px">
-            <label>Provider</label>
-            <select id="md-ticketing-provider" onchange="onTicketingProviderChange()">
-              <option value="linear">Linear</option>
-              <option value="jira">Jira</option>
-            </select>
+      <div data-md-panel="ticketing">
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Ticketing</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 18px">Where this project&rsquo;s issues come from, and how the orchestrator recognises them.</p>
+        <div style="display:grid;gap:12px">
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+            <div class="field">
+              <label class="field-label">Provider</label>
+              <select class="select" id="md-ticketing-provider" onchange="onTicketingProviderChange()">
+                <option value="linear">Linear</option>
+                <option value="jira">Jira</option>
+              </select>
+            </div>
+            <div class="field">
+              <label class="field-label">Team Key</label>
+              <input class="input mono" id="md-team-key" placeholder="MY_TEAM">
+              <div class="field-hint">The tracker team this mapping serves, e.g. ENG. Cannot be changed after creation.</div>
+            </div>
+          </div>
+          <div id="md-jira-fields" class="hidden" style="display:grid;gap:12px">
+            <div class="field">
+              <label class="field-label">Mapping ID</label>
+              <input class="input mono" id="md-jira-mapping-id" placeholder="acme/billing">
+            </div>
+            <div class="field">
+              <label class="field-label">JQL</label>
+              <textarea class="textarea" id="md-jira-jql" rows="3" placeholder="project = TEST"></textarea>
+              <div style="display:flex;gap:8px;align-items:center;margin-top:2px">
+                <button type="button" class="btn btn-sm" onclick="validateJqlButton()">Validate</button>
+                <span id="md-jira-jql-status" class="field-hint"></span>
+              </div>
+              <div class="field-hint">The orchestrator wraps this with its own status filter at query time. Don't include status filters here.</div>
+            </div>
+            <div class="field">
+              <label class="field-label">Status Field</label>
+              <select class="select" id="md-jira-status-field">
+                <option value="">(auto-discover by name "AI-Implement Status")</option>
+              </select>
+              <div class="field-hint">Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Status&rdquo;. Otherwise pick the field that holds the workflow status (Ready, Planning, Implementing, etc.).</div>
+            </div>
+            <div class="field">
+              <label class="field-label">Repo Field</label>
+              <select class="select" id="md-jira-repo-field" onchange="onRepoFieldChange()">
+                <option value="">(auto-discover by name "AI-Implement Repo")</option>
+              </select>
+              <div class="field-hint">Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Repo&rdquo;. Otherwise pick the field that identifies which GitHub repo an issue belongs to.</div>
+            </div>
+            <div class="field">
+              <label class="field-label">Profiles Field</label>
+              <select class="select" id="md-jira-profiles-field">
+                <option value="">(auto-discover by name "AI-Implement Profiles")</option>
+              </select>
+              <div class="field-hint">Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Profiles&rdquo;. Otherwise pick the multi-select field that holds the implementation profiles for an issue.</div>
+            </div>
+            <div class="field">
+              <label class="field-label">Repo Field Value</label>
+              <select class="select" id="md-jira-repo-value">
+                <option value="">Select a Repo Field first</option>
+              </select>
+              <input class="input mono hidden" id="md-jira-repo-value-text" type="text" placeholder="owner/repo">
+            </div>
           </div>
         </div>
-        <div id="md-jira-fields" class="hidden" style="margin-top:12px">
-          <div class="md-field">
-            <label>Mapping ID</label>
-            <input id="md-jira-mapping-id" placeholder="acme/billing">
+      </div>
+      <div data-md-panel="source" hidden>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Source</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 18px">The GitHub repository this mapping dispatches against, and how its branches are named.</p>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+          <div class="field">
+            <label class="field-label">Owner</label>
+            <input class="input mono" id="md-owner" placeholder="acme-corp">
+            <div class="field-hint">Org or user that owns the repo.</div>
           </div>
-          <div class="md-field">
-            <label>JQL</label>
-            <textarea id="md-jira-jql" rows="3" placeholder="project = TEST"></textarea>
-            <div style="display:flex;gap:8px;align-items:center;margin-top:4px">
-              <button type="button" class="btn btn-ghost" onclick="validateJqlButton()">Validate</button>
-              <span id="md-jira-jql-status" class="text-tertiary" style="font-size:0.85em"></span>
-            </div>
+          <div class="field">
+            <label class="field-label">Repo</label>
+            <input class="input mono" id="md-repo" placeholder="backend">
+            <div class="field-hint">Repository name only, no owner prefix.</div>
           </div>
-          <div class="md-field">
-            <label>Status Field</label>
-            <select id="md-jira-status-field">
-              <option value="">(auto-discover by name "AI-Implement Status")</option>
-            </select>
-            <div class="text-tertiary" style="font-size:0.85em;margin-top:4px">
-              Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Status&rdquo;. Otherwise pick the field that holds the workflow status (Ready, Planning, Implementing, etc.).
-            </div>
+          <div class="field">
+            <label class="field-label">Default Branch</label>
+            <input class="input mono" id="md-branch" placeholder="development">
+            <div class="field-hint">Base for runner clones and implementation PRs.</div>
           </div>
-          <div class="md-field">
-            <label>Repo Field</label>
-            <select id="md-jira-repo-field" onchange="onRepoFieldChange()">
-              <option value="">(auto-discover by name "AI-Implement Repo")</option>
-            </select>
-            <div class="text-tertiary" style="font-size:0.85em;margin-top:4px">
-              Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Repo&rdquo;. Otherwise pick the field that identifies which GitHub repo an issue belongs to.
-            </div>
+          <div class="field">
+            <label class="field-label">Workflow File</label>
+            <input class="input mono" id="md-wf" value="claude-implement.yml">
+            <div class="field-hint">Synced into the target repo under .github/workflows/.</div>
           </div>
-          <div class="md-field">
-            <label>Profiles Field</label>
-            <select id="md-jira-profiles-field">
-              <option value="">(auto-discover by name "AI-Implement Profiles")</option>
-            </select>
-            <div class="text-tertiary" style="font-size:0.85em;margin-top:4px">
-              Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Profiles&rdquo;. Otherwise pick the multi-select field that holds the implementation profiles for an issue.
-            </div>
-          </div>
-          <div class="md-field">
-            <label>Repo Field Value</label>
-            <select id="md-jira-repo-value">
-              <option value="">Select a Repo Field first</option>
-            </select>
-            <input id="md-jira-repo-value-text" type="text" class="hidden" placeholder="owner/repo">
+          <div class="field" style="grid-column:1 / -1">
+            <label class="field-label">Branch Prefix</label>
+            <input class="input mono" id="md-branch-prefix" placeholder="pr">
+            <div class="field-hint">Blank = none.</div>
+            <details class="explain">
+              <summary>What a prefix changes</summary>
+              <div class="explain-body">A run names its branch <span class="mono">ai-implement/&lt;issue-key&gt;-&lt;title-slug&gt;</span>. The prefix is joined in front of that as a leading path segment, so <span class="mono">pr</span> turns <span class="mono">ai-implement/aii-42-add-search</span> into <span class="mono">pr/ai-implement/aii-42-add-search</span>. It may contain <span class="mono">/</span> itself to nest several segments deep.</div>
+              <div class="explain-body">Only the first run of an issue is affected. A gap-fill run commits to the pull-request branch that already exists, so setting this later does not rename anything already created.</div>
+            </details>
           </div>
         </div>
-      </fieldset>
-      <div class="md-cols">
-        <fieldset>
-          <legend>Basic</legend>
-          <div class="md-field"><label>Team Key</label><input id="md-team-key" placeholder="MY_TEAM"></div>
-          <div class="md-field"><label>Owner</label><input id="md-owner" placeholder="acme-corp"></div>
-          <div class="md-field"><label>Repo</label><input id="md-repo" placeholder="backend"></div>
-          <div class="md-field"><label>Workflow File</label><input id="md-wf" value="claude-implement.yml"></div>
-          <div class="md-field"><label>Default Branch</label><input id="md-branch" placeholder="development"></div>
-          <div class="md-field"><label>Max AI Issues</label><input id="md-max-ai" type="number" min="1" value="3"></div>
-          <div class="md-field"><label>Max Turns <span class="text-tertiary" style="font-size:0.85em">(blank = 50)</span></label><input id="md-max-turns" type="number" min="1" step="1" placeholder="50"></div>
-          <div class="md-field"><label>Max Iterations <span class="text-tertiary" style="font-size:0.85em">(blank = bedrock 2 / anthropic 3)</span></label><input id="md-max-iter" type="number" min="1" step="1" placeholder="3"></div>
-          <div class="md-field"><label>Job Timeout (min) <span class="text-tertiary" style="font-size:0.85em">(blank = 90)</span></label><input id="md-max-job-min" type="number" min="1" step="1" placeholder="90"></div>
-          <div class="md-field"><label>Branch Prefix <span class="text-tertiary" style="font-size:0.85em">(blank = none)</span></label><input id="md-branch-prefix" placeholder="pr"></div>
-          <div class="md-field">
-            <label>Skills Repo <span class="text-tertiary" style="font-size:0.85em">(optional)</span></label>
-            <input id="md-skills-repo" placeholder="owner/skills-repo or https://github.com/owner/skills.git">
+      </div>
+      <div data-md-panel="context" hidden>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Context</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 18px">What a run can reach beyond the target repository.</p>
+        <div style="display:grid;gap:12px">
+          <div class="field">
+            <label class="field-label">Skills Repo</label>
+            <input class="input mono" id="md-skills-repo" placeholder="owner/skills-repo or https://github.com/owner/skills.git">
             <div class="field-hint">Cloned at dispatch and installed into the runner's ~/.claude/skills. Blank = none. Requires the target repo to re-sync claude-implement.yml.</div>
           </div>
-          <div class="md-field">
-            <label>Additional sensitive patterns <span class="text-tertiary" style="font-size:0.85em">(optional)</span></label>
-            <textarea id="md-sensitive-add" rows="3" placeholder="one glob per line"></textarea>
-            <div class="field-hint">Extra file globs to protect in addition to the built-in sensitive-files list. One glob per line. Blank = none.</div>
-          </div>
-          <div class="md-field">
-            <label>Allowed exceptions <span class="text-tertiary" style="font-size:0.85em">(optional)</span></label>
-            <textarea id="md-sensitive-allow" rows="3" placeholder="one glob per line"></textarea>
-            <div class="field-hint" style="color:var(--st-warn-fg,#c80)">Files matching these globs bypass the sensitive-files guardrail for this project.</div>
-          </div>
-          <div class="md-field">
-            <label>Dependency Token Scope <span class="text-tertiary" style="font-size:0.85em">(optional)</span></label>
-            <select id="md-dep-token-scope">
+          <div class="field">
+            <label class="field-label">Dependency Token Scope</label>
+            <select class="select" id="md-dep-token-scope">
               <option value="">Off (default)</option>
               <option value="installation">All repos the App can access (read-only)</option>
             </select>
-            <div class="field-hint">Grants the implementer read access to every repository this GitHub App installation can see. The run can read those repos but never write to them. Leave off unless builds fetch private dependencies from sibling repos. When enabled, the runner mounts a scoped installation token as a git credential helper and sets <code>COMPOSER_AUTH</code>, so private dependencies resolve automatically during the install step.</div>
+            <div class="field-hint">Lets the run read private sibling repos while installing dependencies. It can never write to them. Leave off unless builds need it.</div>
+            <details class="explain">
+              <summary>How the token is scoped</summary>
+              <div class="explain-body">The run receives a second token, installation-wide but strictly read-only, fetched over the runner callback and installed as a git credential helper for github.com and as <span class="mono">COMPOSER_AUTH</span>. So private dependencies resolve during the install step, and the run still cannot push anywhere but its own target repository.</div>
+              <div class="explain-body">The scope is all-or-nothing: it reads every repository the App installation covers, not a chosen subset. It also needs a publicly reachable orchestrator &mdash; a run dispatched without a progress token skips the fetch and proceeds without private-dependency access rather than failing.</div>
+            </details>
           </div>
-        </fieldset>
-        <fieldset>
-          <legend>Execution</legend>
-          <div class="md-field">
-            <label>Mode</label>
-            <select id="md-exec-mode" onchange="onExecModeChange()">
-              <option value="github-actions">github-actions</option>
-              <option value="fly-machines">fly-machines</option>
-            </select>
-          </div>
-          <div class="md-field">
-            <label>Session Mode</label>
-            <select id="md-session-mode">
-              <option value="autonomous">autonomous</option>
-              <option value="interactive">interactive</option>
-              <option value="hybrid">hybrid</option>
-            </select>
-          </div>
-          <div id="md-fly-fields" class="hidden">
-            <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px">
-              <div class="md-field" style="margin-bottom:0"><label>CPUs</label><input id="md-cpus" type="number" min="1" value="2"></div>
-              <div class="md-field" style="margin-bottom:0"><label>Memory (MB)</label><input id="md-mem" type="number" min="256" step="256" value="4096"></div>
+        </div>
+      </div>
+      <div data-md-panel="execution" hidden>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Execution</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 18px">Where runs execute, and what the runner process receives.</p>
+        <div style="display:grid;gap:12px">
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+            <div class="field">
+              <label class="field-label">Mode</label>
+              <select class="select" id="md-exec-mode" onchange="onExecModeChange()">
+                <option value="github-actions">github-actions</option>
+                <option value="fly-machines">fly-machines</option>
+              </select>
+            </div>
+            <div class="field">
+              <label class="field-label">Session Mode</label>
+              <select class="select" id="md-session-mode">
+                <option value="autonomous">autonomous</option>
+                <option value="interactive">interactive</option>
+                <option value="hybrid">hybrid</option>
+              </select>
             </div>
           </div>
-          <div class="md-field">
-            <label>Extra Env (KEY=VALUE, one per line)</label>
-            <textarea id="md-env" rows="4" placeholder="KEY=VALUE&#10;ANOTHER=value"></textarea>
+          <div id="md-fly-fields" class="hidden" style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+            <div class="field">
+              <label class="field-label">CPUs</label>
+              <input class="input" id="md-cpus" type="number" min="1" value="2">
+            </div>
+            <div class="field">
+              <label class="field-label">Memory (MB)</label>
+              <input class="input" id="md-mem" type="number" min="256" step="256" value="4096">
+            </div>
           </div>
-        </fieldset>
+          <div class="field">
+            <label class="field-label">Extra Env</label>
+            <textarea class="textarea" id="md-env" rows="4" placeholder="LOG_LEVEL=debug&#10;FEATURE_FLAG=on"></textarea>
+            <div class="field-hint">One KEY=VALUE per line. Unlike secrets, these reach the model process and are visible to the agent.</div>
+          </div>
+        </div>
       </div>
-      <fieldset>
-        <legend>Planning</legend>
-        <div style="display:flex;gap:20px;align-items:center;flex-wrap:wrap">
-          <label style="font-size:0.85em;display:flex;align-items:center;gap:6px;white-space:nowrap"><input id="md-planning" type="checkbox" style="width:auto" onchange="onPlanningChange()"> Enabled</label>
-          <label style="font-size:0.85em;display:flex;align-items:center;gap:6px;white-space:nowrap"><input id="md-auto-approve" type="checkbox" style="width:auto" checked> Auto-approve</label>
-          <label style="font-size:0.85em;display:flex;align-items:center;gap:6px;white-space:nowrap"><input id="md-auto-merge" type="checkbox" style="width:auto"> Auto-merge child PRs</label>
-          <div id="md-planning-wf-wrap" class="md-field hidden" style="flex:1;min-width:160px;margin-bottom:0">
-            <label>Planning Workflow File</label><input id="md-planning-wf" value="claude-plan.yml">
+      <div data-md-panel="capacity" hidden>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Capacity</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 18px">How much work this project may have running, and how long each run may take. Every cap applies to re-dispatches as well as initial runs.</p>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+          <div class="field">
+            <label class="field-label">Max AI Issues</label>
+            <input class="input" id="md-max-ai" type="number" min="1" value="3">
+            <div class="field-hint">Issues in flight at once for this project. Required.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Max Turns</label>
+            <input class="input" id="md-max-turns" type="number" min="1" step="1" placeholder="50">
+            <div class="field-hint">Claude turns per implement pass. Blank = 50.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Max Iterations</label>
+            <input class="input" id="md-max-iter" type="number" min="1" step="1" placeholder="3">
+            <div class="field-hint">Implement/review cycles. Blank = 2 on bedrock, 3 on anthropic.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Job Timeout (min)</label>
+            <input class="input" id="md-max-job-min" type="number" min="1" step="1" placeholder="90">
+            <div class="field-hint">GitHub Actions only. Blank = 90.</div>
           </div>
         </div>
-      </fieldset>
-      <fieldset>
-        <legend>Claude Provider</legend>
-        <div style="display:flex;gap:20px;align-items:flex-end;flex-wrap:wrap">
-          <div class="md-field" style="margin-bottom:0;min-width:140px">
-            <label>Provider</label>
-            <select id="md-provider" onchange="onProviderChange()">
-              <option value="anthropic">anthropic</option>
-              <option value="bedrock">bedrock</option>
-            </select>
+      </div>
+      <div data-md-panel="guardrails" hidden>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Guardrails</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 18px">Files a run is refused permission to push. AI-Implement already blocks a built-in list; these two settings extend it and carve holes in it.</p>
+        <div style="display:grid;gap:12px">
+          <div class="field">
+            <label class="field-label">Additional protected files</label>
+            <textarea class="textarea" id="md-sensitive-add" rows="3" placeholder="infra/**&#10;*.pem&#10;deploy/production.yml"></textarea>
+            <div class="field-hint">One file pattern per line, on top of the built-in list. <span class="mono">*</span> matches within one path segment, <span class="mono">**</span> matches across segments. Blank = none.</div>
           </div>
-          <div id="md-aws-region-wrap" class="md-field hidden" style="flex:1;min-width:180px;margin-bottom:0">
-            <label>AWS Region</label><input id="md-aws-region" placeholder="us-west-2">
+          <div class="field">
+            <label class="field-label">Exceptions to those rules</label>
+            <textarea class="textarea" id="md-sensitive-allow" rows="3" placeholder="infra/README.md&#10;deploy/example.yml"></textarea>
+            <div class="field-hint">One file pattern per line. Same syntax as above.</div>
+          </div>
+          <div class="alert warn">
+            <div class="alert-icon">&#9888;</div>
+            <div>
+              <div class="alert-title">Exceptions win over every other rule</div>
+              <div class="alert-desc">A file matching an exception is pushed even when it also matches the built-in list or a pattern added above.</div>
+            </div>
           </div>
         </div>
-      </fieldset>
+      </div>
+      <div data-md-panel="provider" hidden>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Provider</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 18px">Which Claude backend runs this project, and whether it plans before implementing.</p>
+        <div style="display:grid;gap:18px">
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+            <div class="field">
+              <label class="field-label">Provider</label>
+              <select class="select" id="md-provider" onchange="onProviderChange()">
+                <option value="anthropic">anthropic</option>
+                <option value="bedrock">bedrock</option>
+              </select>
+              <div class="field-hint">Bedrock requires the GitHub Actions execution mode.</div>
+            </div>
+            <div id="md-aws-region-wrap" class="field hidden">
+              <label class="field-label">AWS Region</label>
+              <input class="input mono" id="md-aws-region" placeholder="us-west-2">
+              <div class="field-hint">Where your Bedrock inference profile is deployed.</div>
+            </div>
+          </div>
+          <div>
+            <div style="font-size:12px;font-weight:500;color:var(--fg-secondary);margin-bottom:10px">Planning</div>
+            <label class="checkbox-row"><input id="md-planning" type="checkbox" onchange="onPlanningChange()"> Enabled &mdash; Claude posts a plan to the ticket before implementing</label>
+            <label class="checkbox-row"><input id="md-auto-approve" type="checkbox" checked> Auto-approve plans</label>
+            <label class="checkbox-row"><input id="md-auto-merge" type="checkbox"> Auto-merge child PRs into their grouping branch</label>
+            <div id="md-planning-wf-wrap" class="field hidden" style="max-width:260px;margin-top:10px">
+              <label class="field-label">Planning Workflow File</label>
+              <input class="input mono" id="md-planning-wf" value="claude-plan.yml">
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+    <div id="md-error" class="error hidden" style="margin:0 20px"></div>
     <div class="md-footer">
-      <div id="md-error" class="error hidden" style="margin-bottom:8px"></div>
-      <div style="display:flex;gap:8px;justify-content:flex-end">
-        <button class="btn btn-ghost" onclick="closeMappingDialog()">Cancel</button>
-        <button id="md-save" class="btn btn-accent" onclick="saveMappingDialog()">Save Mapping</button>
-      </div>
+      <button class="btn btn-ghost" onclick="closeMappingDialog()">Cancel</button>
+      <button id="md-save" class="btn btn-accent" onclick="saveMappingDialog()">Save Mapping</button>
     </div>
   </dialog>
+
+  ${stepperHtml}
 </section>
 `;
 
@@ -388,10 +490,32 @@ export const projectsScript = `
     onProviderChange();
     onPlanningChange();
     onTicketingProviderChange();
+    switchMappingTab('ticketing');
 
     document.getElementById('mapping-dialog').showModal();
   }
   window.openMappingDialog = openMappingDialog;
+
+  function switchMappingTab(name) {
+    for (const panel of document.querySelectorAll('[data-md-panel]')) {
+      panel.hidden = panel.dataset.mdPanel !== name;
+    }
+    for (const btn of document.querySelectorAll('#md-tabs [data-md-tab]')) {
+      btn.classList.toggle('active', btn.dataset.mdTab === name);
+    }
+    // a tall panel leaves the body scrolled; the next one would open part-way down
+    const body = document.querySelector('#mapping-dialog .md-body');
+    if (body) body.scrollTop = 0;
+  }
+  window.switchMappingTab = switchMappingTab;
+
+  // Several save rules span two tabs, so the offending field may be on a hidden panel.
+  function showMappingError(message, tab) {
+    if (tab) switchMappingTab(tab);
+    const errEl = document.getElementById('md-error');
+    errEl.textContent = message;
+    errEl.classList.remove('hidden');
+  }
 
   function closeMappingDialog() {
     document.getElementById('mapping-dialog').close();
@@ -644,8 +768,7 @@ export const projectsScript = `
     const teamKey = isNew ? document.getElementById('md-team-key').value.trim() : origKey;
     const defaultBranch = document.getElementById('md-branch').value.trim();
     if (!defaultBranch) {
-      errEl.textContent = 'Default Branch is required.';
-      errEl.classList.remove('hidden');
+      showMappingError('Default Branch is required.', 'source');
       return;
     }
 
@@ -699,29 +822,28 @@ export const projectsScript = `
       };
     }
 
-    if (!body.teamKey || !body.owner || !body.repo) {
-      errEl.textContent = 'Team Key, Owner, and Repo are required.';
-      errEl.classList.remove('hidden');
+    if (!body.teamKey) {
+      showMappingError('Team Key is required.', 'ticketing');
+      return;
+    }
+    if (!body.owner || !body.repo) {
+      showMappingError('Owner and Repo are required.', 'source');
       return;
     }
     if (!Number.isFinite(body.maxInProgressAiIssues) || body.maxInProgressAiIssues < 1) {
-      errEl.textContent = 'Max AI Issues must be a positive integer.';
-      errEl.classList.remove('hidden');
+      showMappingError('Max AI Issues must be a positive integer.', 'capacity');
       return;
     }
     if (body.provider === 'bedrock' && body.executionMode === 'fly-machines') {
-      errEl.textContent = 'Bedrock provider is not supported with fly-machines execution mode.';
-      errEl.classList.remove('hidden');
+      showMappingError('Bedrock is not supported with the fly-machines execution mode. Change one of them.', 'provider');
       return;
     }
     if (body.provider === 'bedrock' && !body.awsRegion) {
-      errEl.textContent = 'AWS Region is required when provider is bedrock.';
-      errEl.classList.remove('hidden');
+      showMappingError('AWS Region is required when provider is bedrock.', 'provider');
       return;
     }
     if (body.planningEnabled && !body.planningWorkflowFile) {
-      errEl.textContent = 'Planning Workflow File is required when planning is enabled.';
-      errEl.classList.remove('hidden');
+      showMappingError('Planning Workflow File is required when planning is enabled.', 'provider');
       return;
     }
 

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -1,7 +1,7 @@
 export const stepperHtml = `
 <div id="np-stepper-wrap" class="modal" hidden>
   <div class="modal-backdrop" onclick="closeNewProjectStepper()"></div>
-  <div class="modal-card" style="display:flex;flex-direction:column;max-height:90vh">
+  <div class="modal-card" style="display:flex;flex-direction:column;max-height:90vh;width:860px">
     <div style="padding:18px 24px 14px;border-bottom:1px solid var(--border-subtle);display:flex;justify-content:space-between;align-items:center">
       <div>
         <h2 style="font-size:15px;font-weight:600;margin:0">New project</h2>
@@ -10,9 +10,10 @@ export const stepperHtml = `
       <button class="btn btn-ghost btn-icon" onclick="closeNewProjectStepper()" title="Close">&times;</button>
     </div>
 
+    <div style="display:grid;grid-template-columns:186px 1fr;flex:1;min-height:0">
     <div class="stepper" id="np-stepper-rail"></div>
 
-    <div id="np-step-body" style="padding:24px;flex:1;overflow-y:auto;min-height:360px">
+    <div id="np-step-body" style="padding:24px;overflow-y:auto;min-height:360px">
       <div data-step="0">
         <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Ticketing System</h3>
         <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">Choose where this mapping&rsquo;s issues come from. Each ticketing system has different config requirements on the next step.</p>
@@ -111,33 +112,65 @@ export const stepperHtml = `
             <div class="field-hint">Branch used for workflow dispatches, runner clones, and implementation PR bases.</div>
           </div>
           <div class="field" style="grid-column:1 / -1">
-            <label class="field-label">Skills Repo <span style="font-weight:400;color:var(--text-tertiary)">(optional)</span></label>
-            <input class="input mono" id="np-skills-repo" placeholder="owner/skills-repo or https://github.com/owner/skills.git" autocomplete="off">
-            <div class="field-hint">Cloned at dispatch and installed into the runner's ~/.claude/skills. Blank = none. Requires the target repo to re-sync claude-implement.yml.</div>
+            <label class="field-label">Branch Prefix <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <input class="input mono" id="np-branch-prefix" placeholder="pr" autocomplete="off">
+            <div class="field-hint">Blank = none.</div>
+            <details class="explain">
+              <summary>What a prefix changes</summary>
+              <div class="explain-body">A run names its branch <span class="mono">ai-implement/&lt;issue-key&gt;-&lt;title-slug&gt;</span>. The prefix is joined in front of that as a leading path segment, so <span class="mono">pr</span> turns <span class="mono">ai-implement/aii-42-add-search</span> into <span class="mono">pr/ai-implement/aii-42-add-search</span>. It may contain <span class="mono">/</span> itself to nest several segments deep.</div>
+              <div class="explain-body">The branch name is computed at dispatch, so this only affects the first run of an issue &mdash; and a project created without a prefix has already produced that branch by the time one is added.</div>
+            </details>
           </div>
-          <div class="field" style="grid-column:1 / -1">
-            <label class="field-label">Additional sensitive patterns <span style="font-weight:400;color:var(--text-tertiary)">(optional)</span></label>
-            <textarea class="input mono" id="np-sensitive-add" rows="3" placeholder="one glob per line" autocomplete="off"></textarea>
-            <div class="field-hint">Extra file globs to protect in addition to the built-in sensitive-files list. One glob per line. Blank = none.</div>
+        </div>
+        <div style="font-size:12px;font-weight:500;color:var(--fg-secondary);margin:22px 0 10px">Guardrails</div>
+        <div style="display:grid;gap:12px">
+          <div class="field">
+            <label class="field-label">Additional protected files <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <textarea class="input mono" id="np-sensitive-add" rows="3" placeholder="infra/**&#10;*.pem&#10;deploy/production.yml" autocomplete="off"></textarea>
+            <div class="field-hint">One file pattern per line, on top of the built-in sensitive-files list. <span class="mono">*</span> matches within one path segment, <span class="mono">**</span> matches across segments. Blank = none.</div>
           </div>
-          <div class="field" style="grid-column:1 / -1">
-            <label class="field-label">Allowed exceptions <span style="font-weight:400;color:var(--text-tertiary)">(optional)</span></label>
-            <textarea class="input mono" id="np-sensitive-allow" rows="3" placeholder="one glob per line" autocomplete="off"></textarea>
-            <div class="field-hint" style="color:var(--st-warn-fg,#c80)">Files matching these globs bypass the sensitive-files guardrail for this project.</div>
+          <div class="field">
+            <label class="field-label">Exceptions to those rules <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <textarea class="input mono" id="np-sensitive-allow" rows="3" placeholder="infra/README.md&#10;deploy/example.yml" autocomplete="off"></textarea>
+            <div class="field-hint">One file pattern per line. Same syntax as above.</div>
           </div>
-          <div class="field" style="grid-column:1 / -1">
-            <label class="field-label">Dependency Token Scope <span style="font-weight:400;color:var(--text-tertiary)">(optional)</span></label>
-            <select class="input" id="np-dep-token-scope">
-              <option value="">Off (default)</option>
-              <option value="installation">All repos the App can access (read-only)</option>
-            </select>
-            <div class="field-hint">Grants the implementer read access to every repository this GitHub App installation can see. The run can read those repos but never write to them. Leave off unless builds fetch private dependencies from sibling repos. When enabled, the runner mounts a scoped installation token as a git credential helper and sets <code>COMPOSER_AUTH</code>, so private dependencies resolve automatically during the install step.</div>
+          <div class="alert warn">
+            <div class="alert-icon">&#9888;</div>
+            <div>
+              <div class="alert-title">Exceptions win over every other rule</div>
+              <div class="alert-desc">A file matching an exception is pushed even when it also matches the built-in sensitive-files list or a pattern added above.</div>
+            </div>
           </div>
         </div>
       </div>
 
       <div data-step="3" hidden>
-        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Runner</h3>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Context</h3>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">What a run can reach beyond the target repository.</p>
+        <div style="display:grid;gap:12px">
+          <div class="field">
+            <label class="field-label">Skills Repo <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <input class="input mono" id="np-skills-repo" placeholder="owner/skills-repo or https://github.com/owner/skills.git" autocomplete="off">
+            <div class="field-hint">Cloned at dispatch and installed into the runner's ~/.claude/skills. Blank = none. Requires the target repo to re-sync claude-implement.yml.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Dependency Token Scope <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <select class="input" id="np-dep-token-scope">
+              <option value="">Off (default)</option>
+              <option value="installation">All repos the App can access (read-only)</option>
+            </select>
+            <div class="field-hint">Lets the run read private sibling repos while installing dependencies. It can never write to them. Leave off unless builds need it.</div>
+            <details class="explain">
+              <summary>How the token is scoped</summary>
+              <div class="explain-body">The run receives a second token, installation-wide but strictly read-only, fetched over the runner callback and installed as a git credential helper for github.com and as <span class="mono">COMPOSER_AUTH</span>. So private dependencies resolve during the install step, and the run still cannot push anywhere but its own target repository.</div>
+              <div class="explain-body">The scope is all-or-nothing: it reads every repository the App installation covers, not a chosen subset. It also needs a publicly reachable orchestrator &mdash; a run dispatched without a progress token skips the fetch and proceeds without private-dependency access rather than failing.</div>
+            </details>
+          </div>
+        </div>
+      </div>
+
+      <div data-step="4" hidden>
+        <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Execution</h3>
         <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">Choose where AI-Implement executes implementation runs.</p>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:18px">
           <div class="runner-card active" data-runner="github-actions" onclick="selectExecutionMode('github-actions')">
@@ -171,7 +204,7 @@ export const stepperHtml = `
         </div>
       </div>
 
-      <div data-step="4" hidden>
+      <div data-step="5" hidden>
         <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Provider</h3>
         <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">Select the AI provider and configure planning behaviour.</p>
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:18px">
@@ -215,9 +248,9 @@ export const stepperHtml = `
         </div>
       </div>
 
-      <div data-step="5" hidden>
+      <div data-step="6" hidden>
         <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Capacity</h3>
-        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">Limit how many AI issues run concurrently for this project.</p>
+        <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">How much work this project may have running, and how long each run may take. Every cap applies to re-dispatches as well as initial runs.</p>
         <div class="alert warn" style="margin-bottom:18px">
           <div class="alert-icon">&#9888;</div>
           <div style="flex:1">
@@ -225,14 +258,31 @@ export const stepperHtml = `
             <div class="alert-desc">Each in-progress issue consumes API quota and spawns at least one GitHub Actions run or Fly Machine. Keep low (1&ndash;3) while evaluating.</div>
           </div>
         </div>
-        <div class="field" style="max-width:180px">
-          <label class="field-label">Max parallel AI issues</label>
-          <input class="input" type="number" id="np-maxAi" min="1" value="3">
-          <div class="field-hint">Must be a positive integer.</div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+          <div class="field">
+            <label class="field-label">Max parallel AI issues</label>
+            <input class="input" type="number" id="np-maxAi" min="1" value="3">
+            <div class="field-hint">Issues in flight at once for this project. Must be a positive integer.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Max Turns <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <input class="input" type="number" id="np-maxTurns" min="1" step="1" placeholder="50">
+            <div class="field-hint">Claude turns per implement pass. Blank = 50.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Max Iterations <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <input class="input" type="number" id="np-maxIterations" min="1" step="1" placeholder="3">
+            <div class="field-hint">Implement/review cycles. Blank = 2 on bedrock, 3 on anthropic.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Job Timeout (min) <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <input class="input" type="number" id="np-maxJobMinutes" min="1" step="1" placeholder="90">
+            <div class="field-hint">GitHub Actions only. Blank = 90.</div>
+          </div>
         </div>
       </div>
 
-      <div data-step="6" hidden>
+      <div data-step="7" hidden>
         <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Secrets</h3>
         <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">Optionally seed one or more secrets for this project now. You can always add or update secrets later via the Secrets button on the Projects page.</p>
         <div class="alert info" style="margin-bottom:18px">
@@ -246,72 +296,109 @@ export const stepperHtml = `
         <button class="btn btn-sm" onclick="addSecretRow()">+ Add secret</button>
       </div>
 
-      <div data-step="7" hidden>
+      <div data-step="8" hidden>
         <h3 style="font-size:13px;font-weight:600;margin:0 0 4px">Review</h3>
         <p style="font-size:12px;color:var(--fg-tertiary);margin:0 0 20px">Confirm your settings before creating the project.</p>
         <div style="display:flex;flex-direction:column">
+          <div class="np-review-h">Ticketing</div>
           <div class="np-review-row">
-            <div class="np-review-label">Ticketing</div>
+            <div class="np-review-label">System</div>
             <div data-review="ticketing"></div>
           </div>
           <div class="np-review-row">
-            <div class="np-review-label">Ticketing Config</div>
+            <div class="np-review-label">Config</div>
             <div data-review="ticketingConfig"></div>
           </div>
           <div class="np-review-row">
-            <div class="np-review-label">Team Key</div>
-            <div data-review="teamKey" class="mono"></div>
+            <div class="np-review-label">Team key</div>
+            <div data-review="teamKey"></div>
           </div>
+
+          <div class="np-review-h">Source</div>
           <div class="np-review-row">
             <div class="np-review-label">Repository</div>
-            <div data-review="repo" class="mono"></div>
+            <div data-review="repo"></div>
           </div>
           <div class="np-review-row">
             <div class="np-review-label">Default branch</div>
-            <div data-review="defaultBranch" class="mono"></div>
+            <div data-review="defaultBranch"></div>
           </div>
           <div class="np-review-row">
-            <div class="np-review-label">Skills Repo</div>
-            <div data-review="skillsRepo" class="mono"></div>
+            <div class="np-review-label">Branch prefix</div>
+            <div data-review="branchPrefix"></div>
           </div>
           <div class="np-review-row">
-            <div class="np-review-label">Sensitive add patterns</div>
+            <div class="np-review-label">Protected files</div>
             <div data-review="sensitiveAddPatterns"></div>
           </div>
           <div class="np-review-row">
-            <div class="np-review-label">Allowed exceptions</div>
+            <div class="np-review-label">Exceptions</div>
             <div data-review="sensitiveAllowPatterns"></div>
           </div>
+
+          <div class="np-review-h">Context</div>
           <div class="np-review-row">
-            <div class="np-review-label">Dep. Token Scope</div>
-            <div data-review="dependencyTokenScope"></div>
+            <div class="np-review-label">Skills repo</div>
+            <div data-review="skillsRepo"></div>
           </div>
           <div class="np-review-row">
-            <div class="np-review-label">Runner</div>
+            <div class="np-review-label">Dependency token scope</div>
+            <div data-review="dependencyTokenScope"></div>
+          </div>
+
+          <div class="np-review-h">Execution</div>
+          <div class="np-review-row">
+            <div class="np-review-label">Mode</div>
             <div data-review="runner"></div>
           </div>
           <div class="np-review-row">
             <div class="np-review-label">Session mode</div>
             <div data-review="session"></div>
           </div>
+
+          <div class="np-review-h">Provider</div>
           <div class="np-review-row">
-            <div class="np-review-label">Provider</div>
+            <div class="np-review-label">Claude provider</div>
             <div data-review="provider"></div>
           </div>
           <div class="np-review-row">
             <div class="np-review-label">Planning</div>
             <div data-review="planning"></div>
           </div>
+
+          <div class="np-review-h">Capacity</div>
           <div class="np-review-row">
-            <div class="np-review-label">Capacity</div>
+            <div class="np-review-label">Parallel issues</div>
             <div data-review="cap"></div>
           </div>
           <div class="np-review-row">
-            <div class="np-review-label">Secrets</div>
+            <div class="np-review-label">Run caps</div>
+            <div data-review="caps"></div>
+          </div>
+
+          <div class="np-review-h">Secrets</div>
+          <div class="np-review-row">
+            <div class="np-review-label">Seeded</div>
             <div data-review="secrets"></div>
+          </div>
+
+          <div class="np-review-h">Pinned defaults <span style="font-weight:400;color:var(--fg-tertiary)">&mdash; most projects keep these; the Edit dialog can change them if yours needs to</span></div>
+          <div class="np-review-row">
+            <div class="np-review-label">Workflow file</div>
+            <div><span class="mono">claude-implement.yml</span></div>
+          </div>
+          <div class="np-review-row">
+            <div class="np-review-label">Planning workflow</div>
+            <div><span class="mono">claude-plan.yml</span></div>
+          </div>
+          <div class="np-review-row">
+            <div class="np-review-label">Extra env</div>
+            <div>none</div>
           </div>
         </div>
       </div>
+    </div>
+
     </div>
 
     <div id="np-error" class="error hidden" style="margin:0 24px"></div>
@@ -331,8 +418,8 @@ export const stepperHtml = `
 export const stepperScript = `
 (function () {
   let step = 0;
-  const LAST_STEP = 7;
-  const STEP_LABELS = ['Ticketing', 'Config', 'Source', 'Runner', 'Provider', 'Capacity', 'Secrets', 'Review'];
+  const LAST_STEP = 8;
+  const STEP_LABELS = ['Ticketing', 'Config', 'Source', 'Context', 'Execution', 'Provider', 'Capacity', 'Secrets', 'Review'];
   const data = {
     ticketingProvider: 'linear',
     jiraJql: '',
@@ -340,11 +427,12 @@ export const stepperScript = `
     jiraStatusFieldOverride: '',
     jiraRepoFieldOverride: '',
     jiraProfilesFieldOverride: '',
-    teamKey: '', owner: '', repo: '', defaultBranch: '', skillsRepo: '', sensitiveAddPatterns: '', sensitiveAllowPatterns: '', dependencyTokenScope: null,
+    teamKey: '', owner: '', repo: '', defaultBranch: '', branchPrefix: '', sensitiveAddPatterns: '', sensitiveAllowPatterns: '',
+    skillsRepo: '', dependencyTokenScope: null,
     executionMode: 'github-actions', machineCpus: 2, machineMemoryMb: 4096, sessionMode: 'autonomous',
     provider: 'anthropic', awsRegion: '',
     planningEnabled: true, autoApprovePlans: true, autoMerge: false,
-    maxInProgressAiIssues: 3,
+    maxInProgressAiIssues: 3, maxTurns: null, maxIterations: null, maxJobMinutes: null,
     secrets: [],
   };
   let jiraFieldsLoaded = false;
@@ -362,6 +450,7 @@ export const stepperScript = `
     data.owner = '';
     data.repo = '';
     data.defaultBranch = '';
+    data.branchPrefix = '';
     data.skillsRepo = '';
     data.sensitiveAddPatterns = '';
     data.sensitiveAllowPatterns = '';
@@ -376,10 +465,13 @@ export const stepperScript = `
     data.autoApprovePlans = true;
     data.autoMerge = false;
     data.maxInProgressAiIssues = 3;
+    data.maxTurns = null;
+    data.maxIterations = null;
+    data.maxJobMinutes = null;
     data.secrets = [];
 
-    // Clear inputs
-    const toClear = ['np-teamKey', 'np-owner', 'np-repo', 'np-defaultBranch', 'np-skills-repo', 'np-sensitive-add', 'np-sensitive-allow', 'np-awsRegion'];
+    // Clear inputs. Not derived from the initializer above — a new field needs both.
+    const toClear = ['np-teamKey', 'np-owner', 'np-repo', 'np-defaultBranch', 'np-branch-prefix', 'np-skills-repo', 'np-sensitive-add', 'np-sensitive-allow', 'np-awsRegion', 'np-maxTurns', 'np-maxIterations', 'np-maxJobMinutes'];
     const depScopeEl = document.getElementById('np-dep-token-scope');
     if (depScopeEl) depScopeEl.value = '';
     for (const id of toClear) {
@@ -473,9 +565,6 @@ export const stepperScript = `
       const cls = i === step ? 'active' : i < step ? 'done' : '';
       const numContent = i < step ? '&#10003;' : String(i + 1);
       html += '<div class="stepper-step ' + cls + '"><div class="num">' + numContent + '</div>' + STEP_LABELS[i] + '</div>';
-      if (i < STEP_LABELS.length - 1) {
-        html += '<div class="stepper-divider"></div>';
-      }
     }
     rail.innerHTML = html;
   }
@@ -623,6 +712,13 @@ export const stepperScript = `
     }
   }
 
+  // Blank means "use the built-in default", which the payload carries as null.
+  function optionalCap(id) {
+    const el = document.getElementById(id);
+    const v = el ? el.value.trim() : '';
+    return v === '' ? null : parseInt(v, 10);
+  }
+
   function collectStep(n) {
     if (n === 0) {
       const provEl = document.getElementById('np-ticketing-provider');
@@ -649,25 +745,28 @@ export const stepperScript = `
       const owEl = document.getElementById('np-owner');
       const reEl = document.getElementById('np-repo');
       const brEl = document.getElementById('np-defaultBranch');
-      const srEl = document.getElementById('np-skills-repo');
+      const bpEl = document.getElementById('np-branch-prefix');
       const saEl = document.getElementById('np-sensitive-add');
       const salEl = document.getElementById('np-sensitive-allow');
       if (owEl) data.owner = owEl.value.trim();
       if (reEl) data.repo = reEl.value.trim();
       if (brEl) data.defaultBranch = brEl.value.trim();
-      if (srEl) data.skillsRepo = srEl.value.trim();
+      if (bpEl) data.branchPrefix = bpEl.value.trim();
       if (saEl) data.sensitiveAddPatterns = saEl.value.trim();
       if (salEl) data.sensitiveAllowPatterns = salEl.value.trim();
-      const dtsEl = document.getElementById('np-dep-token-scope');
-      if (dtsEl) data.dependencyTokenScope = dtsEl.value || null;
     } else if (n === 3) {
+      const srEl = document.getElementById('np-skills-repo');
+      const dtsEl = document.getElementById('np-dep-token-scope');
+      if (srEl) data.skillsRepo = srEl.value.trim();
+      if (dtsEl) data.dependencyTokenScope = dtsEl.value || null;
+    } else if (n === 4) {
       const smEl = document.getElementById('np-sessionMode');
       const cpEl = document.getElementById('np-cpus');
       const memEl = document.getElementById('np-mem');
       if (smEl) data.sessionMode = smEl.value;
       if (cpEl) data.machineCpus = parseInt(cpEl.value, 10) || 2;
       if (memEl) data.machineMemoryMb = parseInt(memEl.value, 10) || 4096;
-    } else if (n === 4) {
+    } else if (n === 5) {
       const arEl = document.getElementById('np-awsRegion');
       const plEl = document.getElementById('np-planning');
       const aaEl = document.getElementById('np-autoApprove');
@@ -676,10 +775,13 @@ export const stepperScript = `
       if (plEl) data.planningEnabled = plEl.checked;
       if (aaEl) data.autoApprovePlans = aaEl.checked;
       if (amEl) data.autoMerge = amEl.checked;
-    } else if (n === 5) {
+    } else if (n === 6) {
       const maxEl = document.getElementById('np-maxAi');
       if (maxEl) data.maxInProgressAiIssues = parseInt(maxEl.value, 10);
-    } else if (n === 6) {
+      data.maxTurns = optionalCap('np-maxTurns');
+      data.maxIterations = optionalCap('np-maxIterations');
+      data.maxJobMinutes = optionalCap('np-maxJobMinutes');
+    } else if (n === 7) {
       const secrets = [];
       const list = document.getElementById('np-secrets-list');
       if (list) {
@@ -723,8 +825,10 @@ export const stepperScript = `
       if (!data.repo) { showError('Repository Name is required.'); return false; }
       if (!data.defaultBranch) { showError('Default Branch is required.'); return false; }
     } else if (n === 3) {
-      // executionMode is set via card selection — always valid
+      // Both Context fields are optional — always valid
     } else if (n === 4) {
+      // executionMode is set via card selection — always valid
+    } else if (n === 5) {
       if (data.provider === 'bedrock' && data.executionMode === 'fly-machines') {
         showError('AWS Bedrock cannot be used with the Fly Machines runner. Please change the runner or provider.');
         return false;
@@ -733,7 +837,7 @@ export const stepperScript = `
         showError('AWS Region is required when using the Bedrock provider.');
         return false;
       }
-    } else if (n === 5) {
+    } else if (n === 6) {
       if (!Number.isFinite(data.maxInProgressAiIssues) || data.maxInProgressAiIssues < 1) {
         showError('Max parallel AI issues must be a positive integer.');
         return false;
@@ -755,6 +859,11 @@ export const stepperScript = `
       if (el) el.innerHTML = html;
     };
 
+    // The mono face goes on the value, never the slot, so a placeholder never inherits it.
+    const monoOr = function (value) {
+      return value ? '<span class="mono">' + window.esc(value) + '</span>' : '&mdash;';
+    };
+
     set('ticketing', window.esc(data.ticketingProvider));
 
     let cfgText;
@@ -769,10 +878,11 @@ export const stepperScript = `
     }
     set('ticketingConfig', cfgText);
 
-    set('teamKey', window.esc(effectiveTeamKey()) || '&mdash;');
-    set('repo', window.esc(data.owner) + '/' + window.esc(data.repo));
-    set('defaultBranch', window.esc(data.defaultBranch) || '&mdash;');
-    set('skillsRepo', data.skillsRepo ? window.esc(data.skillsRepo) : '&mdash;');
+    set('teamKey', monoOr(effectiveTeamKey()));
+    set('repo', monoOr(data.owner && data.repo ? data.owner + '/' + data.repo : ''));
+    set('defaultBranch', monoOr(data.defaultBranch));
+    set('branchPrefix', monoOr(data.branchPrefix));
+    set('skillsRepo', monoOr(data.skillsRepo));
     set('sensitiveAddPatterns', data.sensitiveAddPatterns ? (data.sensitiveAddPatterns.split('\\n').filter(function(l){return l.trim();}).length + ' pattern(s)') : '&mdash;');
     set('sensitiveAllowPatterns', data.sensitiveAllowPatterns ? (data.sensitiveAllowPatterns.split('\\n').filter(function(l){return l.trim();}).length + ' exception(s)') : '&mdash;');
     set('dependencyTokenScope', data.dependencyTokenScope ? window.esc(data.dependencyTokenScope) : '&mdash;');
@@ -797,10 +907,15 @@ export const stepperScript = `
     }
     set('planning', planningText);
 
-    set('cap', data.maxInProgressAiIssues + ' parallel');
+    set('cap', String(data.maxInProgressAiIssues));
+
+    const capText = function (value, unit) { return value == null ? 'default' : value + (unit || ''); };
+    set('caps', 'turns ' + capText(data.maxTurns)
+      + ' &middot; iterations ' + capText(data.maxIterations)
+      + ' &middot; timeout ' + capText(data.maxJobMinutes, ' min'));
 
     const validSecrets = data.secrets.filter(function (s) { return s.name && s.value; });
-    set('secrets', validSecrets.length + ' configured');
+    set('secrets', String(validSecrets.length));
   }
 
   function selectExecutionMode(mode) {
@@ -1076,10 +1191,10 @@ export const stepperScript = `
 
   async function stepperSubmit() {
     // Collect any final values from secrets step
-    collectStep(6);
+    collectStep(7);
 
-    // Validate all non-secret/non-review steps (0..5)
-    for (let i = 0; i < 6; i++) {
+    // Validate all non-secret/non-review steps (0..6)
+    for (let i = 0; i < 7; i++) {
       collectStep(i);
       if (!validateStep(i)) return;
     }
@@ -1104,6 +1219,10 @@ export const stepperScript = `
       extraEnv: {},
       provider: data.provider,
       awsRegion: data.provider === 'bedrock' ? (data.awsRegion || null) : null,
+      branchPrefix: data.branchPrefix || null,
+      maxTurns: data.maxTurns,
+      maxIterations: data.maxIterations,
+      maxJobMinutes: data.maxJobMinutes,
       skillsRepo: data.skillsRepo || null,
       sensitiveAddPatterns: data.sensitiveAddPatterns || null,
       sensitiveAllowPatterns: data.sensitiveAllowPatterns || null,

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -712,11 +712,22 @@ export const stepperScript = `
     }
   }
 
-  // Blank means "use the built-in default", which the payload carries as null.
+  // Blank means "use the built-in default", which the payload carries as null. Number()
+  // rather than parseInt so "1.5" fails validation instead of truncating to 1.
   function optionalCap(id) {
     const el = document.getElementById(id);
     const v = el ? el.value.trim() : '';
-    return v === '' ? null : parseInt(v, 10);
+    return v === '' ? null : Number(v);
+  }
+
+  const CAP_FIELDS = [
+    ['Max Turns', 'maxTurns'],
+    ['Max Iterations', 'maxIterations'],
+    ['Job Timeout', 'maxJobMinutes'],
+  ];
+
+  function badCap(value) {
+    return value !== null && (!Number.isInteger(value) || value < 1);
   }
 
   function collectStep(n) {
@@ -777,7 +788,7 @@ export const stepperScript = `
       if (amEl) data.autoMerge = amEl.checked;
     } else if (n === 6) {
       const maxEl = document.getElementById('np-maxAi');
-      if (maxEl) data.maxInProgressAiIssues = parseInt(maxEl.value, 10);
+      if (maxEl) data.maxInProgressAiIssues = maxEl.value.trim() === '' ? NaN : Number(maxEl.value);
       data.maxTurns = optionalCap('np-maxTurns');
       data.maxIterations = optionalCap('np-maxIterations');
       data.maxJobMinutes = optionalCap('np-maxJobMinutes');
@@ -838,9 +849,15 @@ export const stepperScript = `
         return false;
       }
     } else if (n === 6) {
-      if (!Number.isFinite(data.maxInProgressAiIssues) || data.maxInProgressAiIssues < 1) {
+      if (!Number.isInteger(data.maxInProgressAiIssues) || data.maxInProgressAiIssues < 1) {
         showError('Max parallel AI issues must be a positive integer.');
         return false;
+      }
+      for (const cap of CAP_FIELDS) {
+        if (badCap(data[cap[1]])) {
+          showError(cap[0] + ' must be a positive integer, or blank for the default.');
+          return false;
+        }
       }
     }
     return true;


### PR DESCRIPTION
Groups the settings that describe what a runner receives — the skills repository and the dependency token scope — into a `Context` grouping on both surfaces that configure a project mapping, and closes the gap where the New project stepper could not set four fields the edit dialog offers.

> **Interim.** This is the second of several changes under AII-178. The `Context` tab and step created here are where the reference-repositories editor lands in AII-511; they hold two fields today and will hold three. Nothing here is incomplete on its own terms, but a control that looks under-populated is expected.

## Edit dialog

The dialog held fourteen fields in one `Basic` group and required scrolling two to three modal heights to reach everything. It is now seven tabs — `Ticketing`, `Source`, `Context`, `Execution`, `Capacity`, `Guardrails`, `Provider` — built from the existing `.seg` segmented control, with the strip outside the scrolling body so it stays reachable.

Three save validations pair fields that now sit on different tabs (bedrock against fly-machines, bedrock against its region, planning against its workflow file). A rejection switches to the tab holding the offending field before showing the message, and a test requires every rejection to name a tab.

The dialog was also the last consumer of a parallel form vocabulary. `.md-field` and `.md-cols` existed only here and duplicated `.field` / `.input` / `.select` / `.textarea`; both are deleted. `<fieldset><legend>` has no rule anywhere in `components.ts`, so those group borders were browser defaults rendering inside a design system that never styled them — replaced with the same heading shape the stepper uses. Two long hints moved behind `<details>`, following the call sites in `access.ts` and `pipelines-and-steps.ts`.

Field ids are unchanged throughout, which is why `openMappingDialog` and `saveMappingDialog` needed no edits: hidden panels stay in the DOM, so save still reads every field regardless of the visible tab.

## New project stepper

A `Context` step is inserted after `Source`, which renumbers five later steps across their `data-step` attributes, `collectStep`, `validateStep`, and the submit loop. The `Runner` step is renamed `Execution` so it no longer collides with "runner context".

`branchPrefix` becomes settable on `Source` and the three per-run caps on `Capacity`; `Review` names `workflowFile`, `planningWorkflowFile` and `extraEnv` as pinned defaults the dialog can change later. `Review` is also grouped by the step each value came from, so a wrong value says which step to go back to.

The stepper's markup moves from a body-level mount into the Projects page section — it is the only thing that opens it. The job drawer stays global; two pages share that one.

## Two pre-existing defects fixed in passing

Both sit inside lines this change already rewrites, so separating them would have meant touching the same regions twice.

The step rail has overflowed since the `Ticketing` and `Config` steps were added in `7ad7177` (2026-05-11). `.stepper` declared no `overflow`, so the last step painted past the card edge with no scrollbar and nothing to signal it. A ninth label makes it worse, so the rail is now vertical, where a step costs column height instead of row width.

`var(--text-tertiary)` is not a defined token. Its only four uses were the optional-field markers on the fields being moved, which rendered in the label's color rather than muted.

## Worth a closer look

- The renumber is the highest-risk part and nothing type-checks it — the branches are numeric comparisons inside a template literal. Tests pin that `LAST_STEP`, `STEP_LABELS` and the markup agree, and that every step but `Review` has a `collectStep` branch.
- Every stepper field needs four touch points, and the reset list is not derived from the initializer. A test now requires every declared field to appear in both.
- `dialog[open]` rather than `dialog` carries the flex display: a bare `display` there overrides the user-agent rule that hides a closed dialog.
