### PR TITLE
fix(admin-ui): unescaped quote in the machine-logs dialog kills the inline bundle (admin UI lockout) + bundle-parse guard

### DIFF
--- a/src/admin-ui/__tests__/bundle-syntax.test.ts
+++ b/src/admin-ui/__tests__/bundle-syntax.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import vm from "node:vm";
+import { adminHtml } from "../index.js";
+
+/**
+ * Every page's client script is a TypeScript string template concatenated into one inline
+ * <script> at module load. tsc never parses the contents of those strings, so a syntax error
+ * inside one — a stray quote, an unescaped backtick, a template-literal escape consumed one
+ * level too early — ships silently and kills the ENTIRE bundle in the browser, including the
+ * login page. Observed live 2026-09-05: `this.closest(\'dialog\')` inside a template literal
+ * reached the browser as `'dialog'` inside a single-quoted string; every admin user was
+ * locked out with no SSO tile and a dead access-code form. This test parses the served
+ * bundle exactly as a browser would, so that class of defect fails here instead of in prod.
+ */
+describe("admin UI inline bundle", () => {
+  const scripts = [...adminHtml.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+
+  it("contains at least one inline script", () => {
+    expect(scripts.length).toBeGreaterThan(0);
+  });
+
+  it("parses as valid JavaScript (a syntax error anywhere kills the whole admin UI)", () => {
+    for (const [i, src] of scripts.entries()) {
+      expect(() => new vm.Script(src, { filename: `admin-inline-${i}.js` }), `inline script ${i}`).not.toThrow();
+    }
+  });
+});

--- a/src/admin-ui/pages/pipelines.ts
+++ b/src/admin-ui/pages/pipelines.ts
@@ -272,7 +272,7 @@ export const pipelinesScript = `
     dialog.style.cssText = 'width:80vw;max-width:900px;max-height:80vh;overflow:auto;padding:0;border:1px solid var(--border-default);border-radius:8px;background:var(--bg-elev)';
     dialog.innerHTML = '<div style="padding:16px 20px;border-bottom:1px solid var(--border-default);display:flex;justify-content:space-between;align-items:center">'
       + '<strong>Machine Logs \u2014 ' + window.esc(machineId) + '</strong>'
-      + '<button onclick="this.closest(\'dialog\').close()" style="background:none;border:none;cursor:pointer;font-size:1.2em;color:var(--fg-secondary)">\u00d7</button>'
+      + '<button onclick="this.closest(&quot;dialog&quot;).close()" style="background:none;border:none;cursor:pointer;font-size:1.2em;color:var(--fg-secondary)">\u00d7</button>'
       + '</div>'
       + '<pre class="ml-content" style="margin:0;padding:16px;font-size:0.8em;white-space:pre-wrap;word-break:break-all;color:var(--fg-primary)">Loading\u2026</pre>';
     document.body.appendChild(dialog);


### PR DESCRIPTION
## What broke
The AII-519 machine-logs modal wrote `this.closest(\'dialog\')` inside a **template literal**. The template consumed the backslashes, so the browser received a raw `'dialog'` inside a single-quoted string → `SyntaxError: Unexpected identifier 'dialog'`. The admin SPA is one concatenated inline script, so that error aborted **everything**: no SSO tile rendered and the access-code form never bound. Every admin user was locked out (live, 2026-09-05).

## Why nothing caught it
Page scripts are string templates — `tsc` never parses their contents, and no test parsed the concatenated bundle. It passed unit tests, typecheck, review, and the #411 smoke (which booted the orchestrator and hit endpoints but never loaded the page in a browser).

## Fix
One line: `&quot;dialog&quot;` in the onclick attribute — an HTML entity, so there is no template-literal escaping hazard at all.

## Guard (prevents the whole class)
`src/admin-ui/__tests__/bundle-syntax.test.ts` parses every inline `<script>` of the served `adminHtml` with `vm.Script`. It **reproduced the live failure red before the fix** and is green after. A syntax error in any page template now fails in CI instead of in prod.

## Verification
- admin-ui suite: 22 files / 279 tests green (guard included)
- `tsc --noEmit` clean (admin-ui tests are type-checked)
- Re-parsed the built bundle: OK

Surfaced from the live lockout report. Related: AII-519, AII-521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)