### PR TITLE
fix(jira): render comments as real ADF, and stop the reader dropping markdown markers

### DIFF
--- a/src/__tests__/providers/adf-round-trip.test.ts
+++ b/src/__tests__/providers/adf-round-trip.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { markdownToAdf } from "../../providers/markdown-to-adf.js";
+import { adfToPlainText } from "../../providers/jira.js";
+import { parsePlanningBlock } from "../../planning-block.js";
+import { parseDeclaredFiles } from "../../poll-selection.js";
+
+// Jira comments are written as structured ADF (markdownToAdf) so they render as
+// headings/lists/code rather than literal markdown characters. Every reader downstream
+// matches on MARKDOWN syntax after converting ADF back to text, and ADF is structural —
+// headings, list markers and inline code carry no literal characters — so a lossy
+// adfToPlainText returns nothing useful for every Jira project, with no error anywhere.
+//
+// These guard the round trip against the REAL adfToPlainText. A local copy of its logic
+// would make them vacuous, since a regression in jira.ts could not affect the copy.
+function roundTrip(markdown: string): string {
+  return adfToPlainText(markdownToAdf(markdown));
+}
+
+describe("markdown -> ADF -> text round trip", () => {
+  it("preserves the ## heading that fetchPlanningContext prefix matching needs", () => {
+    // JIRA_V2_PREFIXES entries are matched with startsWith, so losing "## " loses the block.
+    const text = roundTrip("## 🗺 AI Planning: Implementation Map\n\nSome prose.");
+    expect(text.startsWith("## 🗺 AI Planning: Implementation Map")).toBe(true);
+  });
+
+  it("preserves bullet markers and inline-code backticks for parseDeclaredFiles", () => {
+    // FILE_LINE_RE is /^\s*[-*]\s*(?:Create|Modify|Test|Delete):\s*`([^`\s:]+)/gim — it needs
+    // the bullet marker AND the backticks, both of which ADF stores structurally.
+    const md = "## Files\n\n- Modify: `src/index.ts` — the poll loop\n- Create: `src/github.ts` — dispatch\n";
+    const files = parseDeclaredFiles(roundTrip(md));
+    expect(files).toContain("src/index.ts");
+    expect(files).toContain("src/github.ts");
+  });
+
+  it("preserves the inline `Files:` form the planning template emits", () => {
+    const md = "- Wire the poll loop. Files: `src/index.ts`, `src/github.ts`. Depends on: WU-1.";
+    const files = parseDeclaredFiles(roundTrip(md));
+    expect(files).toContain("src/index.ts");
+    expect(files).toContain("src/github.ts");
+  });
+
+  it("keeps the ai-implement-planning machine block parseable across lines", () => {
+    const md = [
+      "## 🗺 AI Planning: Implementation Map",
+      "",
+      "Prose that soft-wraps",
+      "across two lines.",
+      "",
+      "<!-- ai-implement-planning",
+      "v: 1",
+      'files: ["src/a.ts","src/b.ts"]',
+      "risk: low",
+      "-->",
+    ].join("\n");
+    expect(parsePlanningBlock(roundTrip(md))).toEqual({ v: 1, files: ["src/a.ts", "src/b.ts"], risk: "low" });
+  });
+
+  it("still folds ordinary soft-wrapped prose into one paragraph", () => {
+    // The machine-block handling must not turn every newline into a hard break.
+    expect(roundTrip("one\ntwo")).toBe("one two");
+  });
+
+  it("preserves ordered-list content without inventing bullet markers", () => {
+    const text = roundTrip("1. first\n2. second");
+    expect(text).toContain("first");
+    expect(text).toContain("second");
+    expect(text).not.toContain("- first");
+  });
+});

--- a/src/__tests__/providers/jira-fields.test.ts
+++ b/src/__tests__/providers/jira-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { resolveCustomFieldIds, getCachedFieldIds, clearFieldCache, adfParagraph, adfWithLink, STATUS_VALUES } from "../../providers/jira-fields.js";
+import { resolveCustomFieldIds, getCachedFieldIds, clearFieldCache, adfWithLink, STATUS_VALUES } from "../../providers/jira-fields.js";
 
 const baseOverrides = { statusOverride: null, repoOverride: null, profilesOverride: null };
 const baseFields = [
@@ -214,12 +214,6 @@ describe("STATUS_VALUES", () => {
 });
 
 describe("ADF helpers", () => {
-  it("adfParagraph wraps text in a single-paragraph ADF doc", () => {
-    const doc = adfParagraph("hello") as any;
-    expect(doc.type).toBe("doc");
-    expect(doc.content[0].content[0]).toEqual({ type: "text", text: "hello" });
-  });
-
   it("adfWithLink includes a link mark on the label", () => {
     const doc = adfWithLink("PR opened: ", "PR-123", "https://example.com/pr/123") as any;
     const linkText = doc.content[0].content[1];

--- a/src/__tests__/providers/markdown-to-adf.test.ts
+++ b/src/__tests__/providers/markdown-to-adf.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { markdownToAdf } from "../../providers/markdown-to-adf.js";
+
+describe("markdownToAdf", () => {
+  it("wraps plain text in a single paragraph", () => {
+    const doc = markdownToAdf("Hello world") as any;
+    expect(doc).toEqual({
+      type: "doc",
+      version: 1,
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Hello world" }] }],
+    });
+  });
+
+  it("converts a heading", () => {
+    const doc = markdownToAdf("## Architecture Analysis") as any;
+    expect(doc.content[0]).toEqual({
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Architecture Analysis" }],
+    });
+  });
+
+  it("converts bold, italic, inline code, and link marks", () => {
+    const doc = markdownToAdf("**Next step:** run `npm test` and see [docs](https://example.com/x)") as any;
+    const runs = doc.content[0].content;
+    expect(runs[0]).toEqual({ type: "text", text: "Next step:", marks: [{ type: "strong" }] });
+    expect(runs).toContainEqual({ type: "text", text: "npm test", marks: [{ type: "code" }] });
+    expect(runs).toContainEqual({
+      type: "text",
+      text: "docs",
+      marks: [{ type: "link", attrs: { href: "https://example.com/x" } }],
+    });
+  });
+
+  it("groups consecutive bullet lines into a single bulletList", () => {
+    const doc = markdownToAdf("- **WU-1: Auth** — add login\n- **WU-2: Profile** — add page") as any;
+    expect(doc.content[0].type).toBe("bulletList");
+    expect(doc.content[0].content).toHaveLength(2);
+    expect(doc.content[0].content[0].type).toBe("listItem");
+  });
+
+  it("renders checklist items with a checkbox glyph", () => {
+    const doc = markdownToAdf("- [ ] Tests pass\n- [x] Lint clean") as any;
+    const items = doc.content[0].content;
+    expect(items[0].content[0].content[0].text).toBe("☐ Tests pass");
+    expect(items[1].content[0].content[0].text).toBe("☑ Lint clean");
+  });
+
+  it("groups consecutive numbered lines into a single orderedList", () => {
+    const doc = markdownToAdf("1. First step\n2. Second step") as any;
+    expect(doc.content[0].type).toBe("orderedList");
+    expect(doc.content[0].content).toHaveLength(2);
+  });
+
+  it("keeps indented (nested) bullet lines inside the bulletList", () => {
+    const doc = markdownToAdf("- a\n  - b\n- c") as any;
+    expect(doc.content).toHaveLength(1);
+    expect(doc.content[0].type).toBe("bulletList");
+    expect(doc.content[0].content).toHaveLength(3);
+    expect(doc.content[0].content.map((item: any) => item.content[0].content[0].text)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("keeps indented (nested) ordered lines inside the orderedList", () => {
+    const doc = markdownToAdf("1. a\n   1. b\n2. c") as any;
+    expect(doc.content).toHaveLength(1);
+    expect(doc.content[0].type).toBe("orderedList");
+    expect(doc.content[0].content).toHaveLength(3);
+  });
+
+  it("converts a fenced code block, preserving language and internal blank lines", () => {
+    const doc = markdownToAdf("```ts\nconst a = 1;\n\nconst b = 2;\n```") as any;
+    expect(doc.content[0]).toEqual({
+      type: "codeBlock",
+      attrs: { language: "ts" },
+      content: [{ type: "text", text: "const a = 1;\n\nconst b = 2;" }],
+    });
+  });
+
+  it("converts a fenced code block with no language", () => {
+    const doc = markdownToAdf("```\nplain log line\n```") as any;
+    expect(doc.content[0].attrs).toBeUndefined();
+    expect(doc.content[0].content[0].text).toBe("plain log line");
+  });
+
+  it("does not parse markdown syntax inside a code block", () => {
+    const doc = markdownToAdf("```\n**not bold** `not code`\n```") as any;
+    expect(doc.content[0].content[0].text).toBe("**not bold** `not code`");
+  });
+
+  it("converts a thematic break to a rule node", () => {
+    const doc = markdownToAdf("above\n\n---\n\nbelow") as any;
+    expect(doc.content.map((n: any) => n.type)).toEqual(["paragraph", "rule", "paragraph"]);
+  });
+
+  it("splits paragraphs on blank lines and joins wrapped lines within one", () => {
+    const doc = markdownToAdf("line one\nline two\n\nsecond paragraph") as any;
+    expect(doc.content).toHaveLength(2);
+    expect(doc.content[0].content[0].text).toBe("line one line two");
+    expect(doc.content[1].content[0].text).toBe("second paragraph");
+  });
+
+  it("renders a realistic gap-analysis style comment end to end", () => {
+    const md = [
+      "## 🏗️ AI Planning: Architecture Analysis",
+      "",
+      "**Approach**: Add a login form and wire it to the existing auth service.",
+      "",
+      "- **Files to Create/Modify**: `src/login.tsx`, `src/auth.ts`",
+      "- **Risks**: session expiry edge cases",
+      "",
+      "```ts",
+      "export function login() {}",
+      "```",
+    ].join("\n");
+    const doc = markdownToAdf(md) as any;
+    const types = doc.content.map((n: any) => n.type);
+    expect(types).toEqual(["heading", "paragraph", "bulletList", "codeBlock"]);
+  });
+});

--- a/src/providers/jira-fields.ts
+++ b/src/providers/jira-fields.ts
@@ -109,18 +109,6 @@ export const STATUS_VALUES = {
 
 export type StatusValue = (typeof STATUS_VALUES)[keyof typeof STATUS_VALUES];
 
-/** Build a minimal ADF document for a single paragraph. */
-export function adfParagraph(text: string): unknown {
-  return {
-    type: "doc",
-    version: 1,
-    content: [{
-      type: "paragraph",
-      content: [{ type: "text", text }],
-    }],
-  };
-}
-
 /** ADF for a paragraph with a hyperlink. */
 export function adfWithLink(prefix: string, label: string, url: string): unknown {
   return {

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -10,7 +10,6 @@ import type {
 import { MissingProviderConfigError } from "./types.js";
 import { JiraApiError, JiraClient } from "./jira-client.js";
 import {
-  adfParagraph,
   getCachedFieldIds,
   STATUS_VALUES,
   type ResolvedFieldIds,
@@ -18,16 +17,25 @@ import {
 import type { RepoMapping } from "../config.js";
 import { classifyByChildren, ancestorChain, type ChildState } from "./jira-hierarchy.js";
 import { parseIssueConfig } from "../issue-config.js";
+import { markdownToAdf } from "./markdown-to-adf.js";
 import type { FeatureBranchMode } from "../pipeline/branch-name.js";
 import { assemblePlanningContext } from "../planning-context-assembly.js";
 
-function adfToPlainText(adf: unknown): string {
+export function adfToPlainText(adf: unknown): string {
   const out: string[] = [];
-  function walk(node: unknown): void {
+  // ADF is structural: headings, list markers and inline code carry no literal characters.
+  // Every consumer downstream matches on markdown syntax — fetchPlanningContext
+  // prefix-matches JIRA_V2_PREFIXES ("## …"), parseDeclaredFiles needs a "- " bullet AND
+  // backticked paths, parseIssueConfig needs fences — so a reader that drops the markers
+  // silently returns nothing for any ADF that was authored structurally (i.e. anything
+  // written by markdownToAdf). Re-emit them.
+  function walk(node: unknown, inBulletList = false): void {
     if (!node || typeof node !== "object") return;
     const n = node as Record<string, unknown>;
     if (typeof n.text === "string") {
-      out.push(n.text);
+      const marks = Array.isArray(n.marks) ? n.marks as Array<Record<string, unknown>> : [];
+      const isCode = marks.some((m) => m && m.type === "code");
+      out.push(isCode ? `\`${n.text}\`` : n.text);
       return;
     }
     if (Array.isArray(n.content)) {
@@ -36,7 +44,14 @@ function adfToPlainText(adf: unknown): string {
       // markdown-shaped consumers (parseIssueConfig) see the same text a Linear
       // description would carry.
       if (t === "codeBlock") out.push("\n```\n");
-      for (const child of n.content) walk(child);
+      if (t === "heading") {
+        const attrs = n.attrs as Record<string, unknown> | undefined;
+        const level = typeof attrs?.level === "number" ? attrs.level : 1;
+        out.push("\n" + "#".repeat(Math.min(Math.max(level, 1), 6)) + " ");
+      }
+      if (t === "listItem" && inBulletList) out.push("- ");
+      const childInBullet = t === "bulletList" ? true : t === "orderedList" ? false : inBulletList;
+      for (const child of n.content) walk(child, childInBullet);
       if (t === "codeBlock") out.push("\n```\n");
       if (t === "paragraph" || t === "heading" || t === "listItem") {
         out.push("\n");
@@ -582,7 +597,7 @@ export class JiraProvider implements TicketingProvider {
     await this.setStatus(issueId, scopeKey, STATUS_VALUES.MERGED);
   }
   async postComment(issueId: string, body: string): Promise<void> {
-    await this.client.addComment(issueId, adfParagraph(body));
+    await this.client.addComment(issueId, markdownToAdf(body));
   }
 
   async fetchPlanningContext(issueId: string): Promise<string> {

--- a/src/providers/markdown-to-adf.ts
+++ b/src/providers/markdown-to-adf.ts
@@ -1,0 +1,175 @@
+// Converts the constrained markdown subset used in AI-Implement's generated
+// comments (implementation summaries, gap analysis, planning notes, status
+// updates) into Atlassian Document Format. Jira's comment API renders ADF
+// nodes/marks, not markdown syntax, so posting raw markdown text shows the
+// literal `**`/`#`/`` ` `` characters until a client re-parses it (e.g. on
+// paste). This is not a general-purpose markdown parser — it covers headings,
+// bold/italic, inline code, fenced code blocks, bullet/ordered lists, links,
+// and paragraphs, which is what these templates actually produce.
+
+interface AdfNode {
+  type: string;
+  [key: string]: unknown;
+}
+
+const INLINE_PATTERN =
+  /\*\*(.+?)\*\*|__(.+?)__|`([^`]+?)`|\*(.+?)\*|(?<![\w\\])_(?!\s)(.+?)(?<!\s)_(?!\w)|\[(.+?)\]\(([^)\s]+)\)/g;
+
+function parseInline(text: string): AdfNode[] {
+  const nodes: AdfNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  INLINE_PATTERN.lastIndex = 0;
+  while ((match = INLINE_PATTERN.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push({ type: "text", text: text.slice(lastIndex, match.index) });
+    }
+    const [, bold1, bold2, code, italic1, italic2, linkText, linkHref] = match;
+    if (bold1 !== undefined || bold2 !== undefined) {
+      nodes.push({ type: "text", text: bold1 ?? bold2, marks: [{ type: "strong" }] });
+    } else if (code !== undefined) {
+      nodes.push({ type: "text", text: code, marks: [{ type: "code" }] });
+    } else if (italic1 !== undefined || italic2 !== undefined) {
+      nodes.push({ type: "text", text: italic1 ?? italic2, marks: [{ type: "em" }] });
+    } else if (linkText !== undefined) {
+      nodes.push({
+        type: "text",
+        text: linkText,
+        marks: [{ type: "link", attrs: { href: linkHref } }],
+      });
+    }
+    lastIndex = INLINE_PATTERN.lastIndex;
+  }
+  if (lastIndex < text.length) {
+    nodes.push({ type: "text", text: text.slice(lastIndex) });
+  }
+  return nodes;
+}
+
+const HEADING_RE = /^(#{1,6})\s+(.*)$/;
+const RULE_RE = /^(?:-{3,}|\*{3,}|_{3,})$/;
+const BULLET_RE = /^\s*[-*]\s+(?:\[( |x|X)\]\s+)?(.*)$/;
+const ORDERED_RE = /^\s*\d+\.\s+(.*)$/;
+const FENCE_RE = /^```(\S*)\s*$/;
+
+export function markdownToAdf(markdown: string): unknown {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const content: AdfNode[] = [];
+  let i = 0;
+
+  let paragraphLines: string[] = [];
+  const flushParagraph = () => {
+    if (paragraphLines.length === 0) return;
+    content.push({ type: "paragraph", content: parseInline(paragraphLines.join(" ")) });
+    paragraphLines = [];
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // A multi-line HTML comment is a machine block, not prose: parsePlanningBlock matches
+    // `v:` / `files:` / `risk:` with line-anchored /m regexes, so folding it into a
+    // paragraph (which joins lines with a space) destroys it. Emit it as a codeBlock, whose
+    // text node preserves newlines verbatim and which adfToPlainText round-trips.
+    if (/^\s*<!--/.test(line) && !/-->/.test(line)) {
+      flushParagraph();
+      const commentLines: string[] = [line];
+      i++;
+      while (i < lines.length) {
+        commentLines.push(lines[i]);
+        if (/-->/.test(lines[i])) { i++; break; }
+        i++;
+      }
+      content.push({ type: "codeBlock", content: [{ type: "text", text: commentLines.join("\n") }] });
+      continue;
+    }
+
+    const fenceMatch = FENCE_RE.exec(line);
+    if (fenceMatch) {
+      flushParagraph();
+      const language = fenceMatch[1] || undefined;
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !FENCE_RE.test(lines[i])) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      i++; // skip closing fence (or EOF)
+      const codeText = codeLines.join("\n");
+      const codeBlock: AdfNode = {
+        type: "codeBlock",
+        content: codeText ? [{ type: "text", text: codeText }] : [],
+      };
+      if (language) codeBlock.attrs = { language };
+      content.push(codeBlock);
+      continue;
+    }
+
+    if (line.trim() === "") {
+      flushParagraph();
+      i++;
+      continue;
+    }
+
+    if (RULE_RE.test(line.trim())) {
+      flushParagraph();
+      content.push({ type: "rule" });
+      i++;
+      continue;
+    }
+
+    const headingMatch = HEADING_RE.exec(line);
+    if (headingMatch) {
+      flushParagraph();
+      content.push({
+        type: "heading",
+        attrs: { level: headingMatch[1].length },
+        content: parseInline(headingMatch[2]),
+      });
+      i++;
+      continue;
+    }
+
+    const bulletMatch = BULLET_RE.exec(line);
+    if (bulletMatch) {
+      flushParagraph();
+      const items: AdfNode[] = [];
+      while (i < lines.length) {
+        const m = BULLET_RE.exec(lines[i]);
+        if (!m) break;
+        const checkbox = m[1];
+        const text = checkbox !== undefined
+          ? `${checkbox.toLowerCase() === "x" ? "☑" : "☐"} ${m[2]}`
+          : m[2];
+        items.push({ type: "listItem", content: [{ type: "paragraph", content: parseInline(text) }] });
+        i++;
+      }
+      content.push({ type: "bulletList", content: items });
+      continue;
+    }
+
+    const orderedMatch = ORDERED_RE.exec(line);
+    if (orderedMatch) {
+      flushParagraph();
+      const items: AdfNode[] = [];
+      while (i < lines.length) {
+        const m = ORDERED_RE.exec(lines[i]);
+        if (!m) break;
+        items.push({ type: "listItem", content: [{ type: "paragraph", content: parseInline(m[1]) }] });
+        i++;
+      }
+      content.push({ type: "orderedList", content: items });
+      continue;
+    }
+
+    paragraphLines.push(line);
+    i++;
+  }
+  flushParagraph();
+
+  if (content.length === 0) {
+    content.push({ type: "paragraph", content: [] });
+  }
+
+  return { type: "doc", version: 1, content };
+}


### PR DESCRIPTION
Independent of #384 / #433. It touches `jira.ts` and `jira-fields.ts`, which #433 also touches, but in different regions — expect at most a trivial import-line conflict for whichever merges second.

## Two halves of one round trip

**Write.** `postComment` wraps the whole body in a single paragraph via `adfParagraph`, so every generated comment — implementation summaries, gap analysis, planning notes, status updates — renders in Jira as literal `**`, `#` and backtick characters until some client happens to re-parse it.

`markdownToAdf` converts the constrained markdown subset those templates actually emit (headings, bold/italic, inline code, fenced code blocks, bullet/ordered lists, links, paragraphs) into real ADF nodes. Deliberately not a general-purpose markdown parser.

**Read.** `adfToPlainText` walked ADF collecting only text nodes. ADF is structural, so headings, list markers and inline code carry no literal characters and were dropped. Every consumer downstream matches on markdown syntax:

| Consumer | Needs |
|---|---|
| `fetchPlanningContext` | prefix match on `JIRA_V2_PREFIXES` — `"## 🗺 AI Planning: …"` |
| `parseDeclaredFiles` | a `- ` bullet **and** backticked paths (`FILE_LINE_RE`) |
| `parseIssueConfig` | code fences |

A lossy read therefore returns nothing useful, for every Jira project, with no error anywhere. The walker now re-emits `## ` (honoring heading level), `- ` for bullet-list items only, and backticks for code-marked text.

## Why this is one PR and not two

Today the two bugs cancel out. `adfParagraph` stores the body as literal text, so `## ` survives as characters and prefix matching works.

Writing real ADF **without** fixing the reader turns those headings into structural nodes whose markers are gone — so `fetchPlanningContext` would silently start returning `""`. The orchestrator posts these planning comments and then reads its own comments back (`jira.ts` `adfToPlainText(c.body)` → `assemblePlanningContext(comments, JIRA_V2_PREFIXES)`), which is what closes the loop.

Shipping either half alone is a regression. Shipping both is a fix. Happy to split if you disagree, but the reader fix has to go first in that case.

## Compatibility

Backward compatible with comments already stored as a single literal-text paragraph — plain text still passes through unchanged, so existing tickets keep parsing.

## Also

Removes `adfParagraph`. Its only production caller was the `postComment` line this replaces (`adfWithLink` is independent). Its unit test goes with it.

`adfToPlainText` is now exported, so the round-trip guard can call the real implementation.

## Tests

14 cases for `markdownToAdf`, plus a round-trip suite that drives the **real** `adfToPlainText` — a local copy of its logic would be vacuous, since a regression in `jira.ts` could not affect the copy — asserting the specific thing each downstream parser needs, including that soft-wrapped prose still folds into one paragraph and that ordered lists do not gain invented `- ` markers.

Verified by mutation: with the old reader and the new writer, the heading guard and the `parseDeclaredFiles` guard both fail. That is exactly the silent regression described above.

`npm test` (4201 passed, 188 files) and `npm run typecheck` green. Note: I saw one intermittent unrelated failure across repeated runs — consistent with the known flakes tracked in AII-487 / AII-537 / AII-431. The tests added here passed 5/5 runs in isolation.

## Disclosure

Per CONTRIBUTING.md and CLA sections 5.4/5.5: this contribution was generated in substantial part with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcKEcso8JRQXq7FArrm3Gv