### PR TITLE
AII-567: log every terminal result call so a refused report is attributable

### DIFF
--- a/src/__tests__/runner-callback.test.ts
+++ b/src/__tests__/runner-callback.test.ts
@@ -1389,3 +1389,115 @@ describe("handleRunnerResult — token replay", () => {
     expect(second.body.error).toBe("already_consumed");
   });
 });
+
+describe("handleRunnerResult — call attribution", () => {
+  it("logs the accepted call with its dispatch id, phase and outcome", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "planning",
+      ttlSeconds: runnerTokens.PLANNING_TTL_SECONDS,
+      secret: SECRET,
+    });
+
+    await runnerCallback.handleRunnerResult({
+      authorization: `Bearer ${token}`,
+      body: { phase: "planning", outcome: "success", comments: [] },
+      secret: SECRET,
+      resolveProvider: makeResolve(new FakeProvider()),
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`result accepted dispatch=${dispatchId} phase=planning outcome=success`),
+    );
+  });
+
+  it("names the dispatch when a replayed token is refused", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "planning",
+      ttlSeconds: runnerTokens.PLANNING_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const body = { phase: "planning" as const, outcome: "success" as const, comments: [] };
+    const resolveProvider = makeResolve(new FakeProvider());
+
+    await runnerCallback.handleRunnerResult({ authorization: `Bearer ${token}`, body, secret: SECRET, resolveProvider });
+    warnSpy.mockClear();
+    const second = await runnerCallback.handleRunnerResult({
+      authorization: `Bearer ${token}`, body, secret: SECRET, resolveProvider,
+    });
+
+    expect(second.status).toBe(409);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`result refused dispatch=${dispatchId}`),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("reason=already_consumed"));
+  });
+
+  it("reports an unknown dispatch rather than throwing when the token never parsed", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await runnerCallback.handleRunnerResult({
+      authorization: "Bearer garbage",
+      body: { phase: "planning", outcome: "success", comments: [] },
+      secret: SECRET,
+      resolveProvider: makeResolve(new FakeProvider()),
+    });
+
+    expect(res.status).toBe(401);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("result refused dispatch=unknown"));
+  });
+
+  // These two consume the token and then bail, so without a line the burn is invisible.
+  it("logs a burned token on phase_mismatch", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "planning",
+      ttlSeconds: runnerTokens.PLANNING_TTL_SECONDS,
+      secret: SECRET,
+    });
+
+    const res = await runnerCallback.handleRunnerResult({
+      authorization: `Bearer ${token}`,
+      body: { phase: "implementation", outcome: "success", prUrl: "https://github.com/o/r/pull/1", comments: [] },
+      secret: SECRET,
+      resolveProvider: makeResolve(new FakeProvider()),
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("phase_mismatch");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`result burned dispatch=${dispatchId} reason=phase_mismatch`),
+    );
+  });
+
+  it("logs a burned token on missing_prUrl", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "i",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+
+    const res = await runnerCallback.handleRunnerResult({
+      authorization: `Bearer ${token}`,
+      body: { phase: "implementation", outcome: "success", comments: [] },
+      secret: SECRET,
+      resolveProvider: makeResolve(new FakeProvider()),
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("missing_prUrl");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`result burned dispatch=${dispatchId} reason=missing_prUrl`),
+    );
+  });
+});

--- a/src/__tests__/runner-result.test.ts
+++ b/src/__tests__/runner-result.test.ts
@@ -52,6 +52,9 @@ describe("postRunnerResult", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    // vi.spyOn returns the existing spy when a method is already mocked, so an
+    // unrestored console spy carries the previous test's calls into the next one.
+    vi.restoreAllMocks();
   });
 
   // Task 4: the runner now always reports an outcome — the caller (run-autonomous.ts)
@@ -69,5 +72,45 @@ describe("postRunnerResult", () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("logs the phase and outcome when the post succeeds", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => "" });
+
+    await postRunnerResult({
+      workspaceDir: "/tmp",
+      phase: "implementation",
+      outcome: "success",
+      prUrl: "https://github.com/o/r/pull/1",
+      callbackUrl: "https://cb",
+      fetchImpl,
+    });
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("POST ok phase=implementation outcome=success"),
+    );
+  });
+
+  it("logs the status and does not claim success when the post is refused", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () => '{"error":"already_consumed"}',
+    });
+
+    await postRunnerResult({
+      workspaceDir: "/tmp",
+      phase: "implementation",
+      outcome: "success",
+      prUrl: "https://github.com/o/r/pull/1",
+      callbackUrl: "https://cb",
+      fetchImpl,
+    });
+
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("POST failed HTTP 409"));
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining("POST ok"));
   });
 });

--- a/src/__tests__/runner-tokens.test.ts
+++ b/src/__tests__/runner-tokens.test.ts
@@ -329,4 +329,22 @@ describe("verifyRunToken — claims on a refusal", () => {
       expect(badSig.claims).toBeUndefined();
     }
   });
+
+  it("carries claims when the payload verified but its row is gone", () => {
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "issue-9",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    dedup.getDb().prepare("DELETE FROM runner_tokens WHERE dispatch_id = ?").run(dispatchId);
+
+    const result = runnerTokens.verifyRunToken(token, SECRET, "result", { consume: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("malformed");
+      expect(result.claims?.dispatchId).toBe(dispatchId);
+    }
+  });
 });

--- a/src/__tests__/runner-tokens.test.ts
+++ b/src/__tests__/runner-tokens.test.ts
@@ -249,3 +249,84 @@ describe("verifyAndConsumeRunToken", () => {
     if (!result.ok) expect(result.reason).toBe("wrong_audience");
   });
 });
+
+describe("verifyRunToken — claims on a refusal", () => {
+  it("carries claims when the token is already consumed", () => {
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "issue-9",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    expect(runnerTokens.verifyAndConsumeRunToken(token, SECRET).ok).toBe(true);
+
+    const second = runnerTokens.verifyAndConsumeRunToken(token, SECRET);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.reason).toBe("already_consumed");
+      expect(second.claims?.dispatchId).toBe(dispatchId);
+      expect(second.claims?.phase).toBe("implementation");
+    }
+  });
+
+  it("carries claims when the audience does not match", () => {
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "issue-9",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      audience: "progress",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+
+    const result = runnerTokens.verifyRunToken(token, SECRET, "result", { consume: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("wrong_audience");
+      expect(result.claims?.dispatchId).toBe(dispatchId);
+    }
+  });
+
+  it("carries claims when the token has expired", () => {
+    const { token, dispatchId } = runnerTokens.mintRunToken({
+      issueId: "issue-9",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      ttlSeconds: -1,
+      secret: SECRET,
+    });
+
+    const result = runnerTokens.verifyRunToken(token, SECRET, "result", { consume: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("expired");
+      expect(result.claims?.dispatchId).toBe(dispatchId);
+    }
+  });
+
+  it("omits claims when the token is malformed or badly signed", () => {
+    const malformed = runnerTokens.verifyRunToken("not-a-token", SECRET, "result", { consume: false });
+    expect(malformed.ok).toBe(false);
+    if (!malformed.ok) {
+      expect(malformed.reason).toBe("malformed");
+      expect(malformed.claims).toBeUndefined();
+    }
+
+    const { token } = runnerTokens.mintRunToken({
+      issueId: "issue-9",
+      mappingTeamKey: "ENG",
+      phase: "implementation",
+      ttlSeconds: runnerTokens.IMPLEMENTATION_TTL_SECONDS,
+      secret: SECRET,
+    });
+    const tampered = `${token.split(".")[0]}.${"A".repeat(token.split(".")[1].length)}`;
+
+    const badSig = runnerTokens.verifyRunToken(tampered, SECRET, "result", { consume: false });
+    expect(badSig.ok).toBe(false);
+    if (!badSig.ok) {
+      expect(badSig.reason).toBe("bad_signature");
+      expect(badSig.claims).toBeUndefined();
+    }
+  });
+});

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -241,7 +241,7 @@ export async function handleRunnerResult(
   if (!verified.ok) {
     console.warn(
       `[runner-callback] result refused dispatch=${verified.claims?.dispatchId ?? "unknown"} ` +
-        `phase=${String(input.body.phase)} outcome=${String(input.body.outcome)} reason=${verified.reason}`,
+        `phase=${input.body.phase} outcome=${input.body.outcome} reason=${verified.reason}`,
     );
     return verified.reason === "already_consumed"
       ? bad(409, "already_consumed")
@@ -256,7 +256,7 @@ export async function handleRunnerResult(
   if (claims.phase !== input.body.phase) {
     console.warn(
       `[runner-callback] result burned dispatch=${claims.dispatchId} reason=phase_mismatch ` +
-        `token=${claims.phase} body=${String(input.body.phase)}`,
+        `token=${claims.phase} body=${input.body.phase}`,
     );
     return bad(400, "phase_mismatch");
   }

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -239,13 +239,27 @@ export async function handleRunnerResult(
   // if a provider outage caused dropped comments.
   const verified = verifyAndConsumeRunToken(bearerToken, input.secret);
   if (!verified.ok) {
+    console.warn(
+      `[runner-callback] result refused dispatch=${verified.claims?.dispatchId ?? "unknown"} ` +
+        `phase=${String(input.body.phase)} outcome=${String(input.body.outcome)} reason=${verified.reason}`,
+    );
     return verified.reason === "already_consumed"
       ? bad(409, "already_consumed")
       : bad(401, verified.reason);
   }
+  console.log(
+    `[runner-callback] result accepted dispatch=${verified.claims.dispatchId} ` +
+      `phase=${verified.claims.phase} outcome=${input.body.outcome} comments=${input.body.comments.length}`,
+  );
 
   const { claims, mappingTeamKey } = verified;
-  if (claims.phase !== input.body.phase) return bad(400, "phase_mismatch");
+  if (claims.phase !== input.body.phase) {
+    console.warn(
+      `[runner-callback] result burned dispatch=${claims.dispatchId} reason=phase_mismatch ` +
+        `token=${claims.phase} body=${String(input.body.phase)}`,
+    );
+    return bad(400, "phase_mismatch");
+  }
 
   // kg-refresh runs have no mapping and no tracker issue to update.
   // Route the callback directly to the refresh rail and return early.
@@ -267,6 +281,7 @@ export async function handleRunnerResult(
     !input.body.prUrl &&
     !input.body.noWork
   ) {
+    console.warn(`[runner-callback] result burned dispatch=${claims.dispatchId} reason=missing_prUrl`);
     return bad(400, "missing_prUrl");
   }
 

--- a/src/runner-result.ts
+++ b/src/runner-result.ts
@@ -77,8 +77,11 @@ export async function postRunnerResult(params: {
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${runToken}` },
       body: JSON.stringify(body),
     });
-    if (!res.ok)
+    if (!res.ok) {
       console.error(`[runner-callback] POST failed HTTP ${res.status}: ${await res.text().catch(() => "")}`);
+    } else {
+      console.log(`[runner-callback] POST ok phase=${params.phase} outcome=${params.outcome}`);
+    }
   } catch (err) {
     console.error("[runner-callback] POST failed:", err);
   }

--- a/src/runner-tokens.ts
+++ b/src/runner-tokens.ts
@@ -107,7 +107,8 @@ function verifyTokenSignatureAndLoadClaims(token: string, secret: string): Verif
   const row = db
     .prepare("SELECT consumed_at, mapping_team_key FROM runner_tokens WHERE dispatch_id = ? AND audience = ?")
     .get(claims.dispatchId, claims.audience) as { consumed_at: number | null; mapping_team_key: string } | undefined;
-  if (!row) return { ok: false, reason: "malformed" };
+  // Reason stays "malformed" though the payload verified: callers map it to a status.
+  if (!row) return { ok: false, reason: "malformed", claims };
 
   return { ok: true, claims, mappingTeamKey: row.mapping_team_key, consumedAt: row.consumed_at };
 }

--- a/src/runner-tokens.ts
+++ b/src/runner-tokens.ts
@@ -32,7 +32,8 @@ export interface MintOutput {
 
 export type VerifyResult =
   | { ok: true; claims: RunTokenClaims; mappingTeamKey: string; consumedAt: number | null }
-  | { ok: false; reason: "malformed" | "bad_signature" | "expired" | "already_consumed" | "wrong_audience" };
+  // Claims on a refusal so it can be attributed to a dispatch; absent when the payload was never trustworthy.
+  | { ok: false; reason: "malformed" | "bad_signature" | "expired" | "already_consumed" | "wrong_audience"; claims?: RunTokenClaims };
 
 export const PLANNING_TTL_SECONDS = 30 * 60;
 export const IMPLEMENTATION_TTL_SECONDS = 2 * 60 * 60;
@@ -100,7 +101,7 @@ function verifyTokenSignatureAndLoadClaims(token: string, secret: string): Verif
     return { ok: false, reason: "malformed" };
   }
   claims.audience ??= "result";
-  if (claims.exp < Date.now()) return { ok: false, reason: "expired" };
+  if (claims.exp < Date.now()) return { ok: false, reason: "expired", claims };
 
   const db = getDb();
   const row = db
@@ -120,14 +121,14 @@ export function verifyRunToken(
   const verified = verifyTokenSignatureAndLoadClaims(token, secret);
   if (!verified.ok) return verified;
   const { claims } = verified;
-  if (claims.audience !== expectedAudience) return { ok: false, reason: "wrong_audience" };
-  if (verified.consumedAt !== null) return { ok: false, reason: "already_consumed" };
+  if (claims.audience !== expectedAudience) return { ok: false, reason: "wrong_audience", claims };
+  if (verified.consumedAt !== null) return { ok: false, reason: "already_consumed", claims };
   if (!options.consume) return verified;
 
   const result = getDb()
     .prepare("UPDATE runner_tokens SET consumed_at = ? WHERE dispatch_id = ? AND audience = ? AND consumed_at IS NULL")
     .run(Date.now(), claims.dispatchId, claims.audience);
-  if (result.changes === 0) return { ok: false, reason: "already_consumed" };
+  if (result.changes === 0) return { ok: false, reason: "already_consumed", claims };
 
   return verified;
 }


### PR DESCRIPTION
A runner reports its terminal outcome by POSTing once to `/runner/result`. When that call is refused, the entire report — outcome, failure code, pull-request URL, implementation summary — is discarded, and nothing on either side records that it happened. `postRunnerResult` logs only a non-ok response, so a successful post writes nothing; the handler logs nothing at all. Four refusals across four dispatches produced exactly one line of evidence between them, and no way to tell which caller consumed the token first.

This adds that record. It does not change any behavior.

## What changed

**`runner-tokens.ts`** — `VerifyResult`'s failure variant gains an optional `claims`. The claims are already parsed and signature-checked by the time a token is rejected for `expired`, `wrong_audience` or `already_consumed`; they were simply discarded, which left a caller unable to say *which* dispatch it turned away. Optional rather than a separate variant so every existing `verified.reason === …` narrowing compiles untouched. It stays absent for `malformed` and `bad_signature`, where the payload was never trustworthy enough to attribute.

**`runner-callback.ts`** — one line per call into `handleRunnerResult`: accepted, naming dispatch, phase, outcome and comment count; or refused, naming the dispatch and the reason. The two exits below the consume — `phase_mismatch` and `missing_prUrl` — also log, because each burns a single-use token and then returns having done nothing else, which is the least visible failure in the file.

**`runner-result.ts`** — a successful post now logs its phase and outcome. This is the runner half, so it ships with the runner image rather than with the orchestrator.

**`runner-result.test.ts`** — `vi.restoreAllMocks()` added to the suite's `afterEach`. `vi.spyOn` returns the *existing* spy when a method is already mocked, so an unrestored console spy carried one test's recorded calls into the next.

## Reviewing

The change spans two deployables: the orchestrator half goes live on the next self-deploy, the runner half on the next run that pulls a rebuilt image. Both are needed before a run is attributable end to end.

Scope is deliberately observability-only. AII-567 also asks for the consume to move below the two validation checks so a malformed post stops burning the token; that is a behavior change and is not in this diff.

## Acceptance criteria

| Criterion | How it's met | Key files |
|---|---|---|
| Every `/runner/result` call writes an orchestrator line naming dispatch, phase, outcome and verification result | Accepted and refused branches both log; refusals resolve the dispatch from the retained claims | `runner-callback.ts` |
| A successful terminal post writes a runner-side line naming phase and outcome | Added to the ok branch of the response check | `runner-result.ts` |
| A refusal can be joined to its run | Failure variant retains claims wherever the payload verified | `runner-tokens.ts` |
| Existing callers unaffected | `claims` is optional; no narrowing or call site changed | `runner-tokens.ts` |

## Follow-ups

Moving the consume below `phase_mismatch` and `missing_prUrl` remains open on AII-567. AII-568 — a monitor-side label backstop for GitHub Actions runs — is the fix that makes a dropped report non-fatal regardless of cause.
