### PR TITLE
AII-567: stop runner test suites consuming the run's callback token

### DIFF
--- a/docs/workflow-envelope.md
+++ b/docs/workflow-envelope.md
@@ -29,6 +29,8 @@ The envelope consolidates all YAML-safe data into a single base64-encoded JSON b
 
 The three runner tokens stay outside the envelope specifically so the workflow can `::add-mask::` them before the runner container starts — secret values inside base64 blobs cannot be masked by GHA. The publication token is exposed only to the pipeline process, never to model child processes or persisted step inputs.
 
+**These are live credentials in the runner's environment, and a test suite running inside that container inherits them.** `run_token` is single-use: the first `POST /runner/result` consumes it, and every later post is refused `409 already_consumed`. So a suite that reaches a runner callback with the ambient values still set burns the token long before the run reports its own outcome — the real report is discarded, the tracker never advances, and on GitHub Actions the issue holds a dispatch slot until someone repairs it by hand. Any suite exercising a callback path must clear `RUN_TOKEN` and `RUNNER_CALLBACK_URL` in a hook rather than per call site, and a test that deliberately re-arms them must point the callback at an unroutable host.
+
 ---
 
 ## `RunConfigV1` Schema

--- a/src/__tests__/kg-refresh-run.test.ts
+++ b/src/__tests__/kg-refresh-run.test.ts
@@ -54,6 +54,26 @@ const baseIssue = {
   description: "Refresh the knowledge-graph snapshot",
 };
 
+// A dispatched runner sets both of these, and `npm test` inside that container inherits
+// them. postRunnerResult skips the callback when either is absent, so clearing them here
+// is what stops a suite reaching the live orchestrator and consuming the run's single-use
+// result token. File-level so a new describe cannot miss it; the describes that exercise a
+// callback re-arm the pair themselves, pointing it at an unroutable host.
+beforeEach(() => {
+  vi.stubEnv("RUN_TOKEN", "");
+  vi.stubEnv("RUNNER_CALLBACK_URL", "");
+});
+
+describe("runner callback credentials", () => {
+  // Asserting the cleared values rather than an absent fetch: outside a dispatched runner
+  // these variables are unset anyway, so nothing posts with or without the hook and a
+  // network assertion would pass in CI while the hook was missing. This fails anywhere.
+  it("are cleared for every test in this file", () => {
+    expect(process.env.RUN_TOKEN).toBe("");
+    expect(process.env.RUNNER_CALLBACK_URL).toBe("");
+  });
+});
+
 // ── RunConfigV1 envelope roundtrip ────────────────────────────────────────────
 
 describe("RunConfigV1 kg-refresh fields", () => {


### PR DESCRIPTION
A dispatched runner sets `RUN_TOKEN` and `RUNNER_CALLBACK_URL` in its container, and the agent's own `npm test` inherits them. `postRunnerResult` reads both straight off the environment and falls back to the global `fetch` when a caller passes no `fetchImpl`. `kg-refresh-run.test.ts` calls `runKgRefresh` at ten sites and eight pass none — so every implementation dispatch posted eight times to the live orchestrator mid-run, and the first of those consumed the run's single-use result token.

The run's own terminal report then arrived minutes later and was refused `409 already_consumed`, taking the outcome, the pull-request URL and the implementation summary with it. On GitHub Actions the tracker never advanced, because that monitor has no label backstop, so the issue held a dispatch slot until someone repaired it by hand. Every implementation dispatch since 2026-09-04 has been affected.

## What changed

`kg-refresh-run.test.ts` gains a file-level `beforeEach` clearing both credentials. That is the mechanism `run-autonomous.test.ts` has used since before kg-refresh existed — it makes fifty-six `runAutonomous` calls with no risk because its hook clears the same pair. `kg-refresh-run.test.ts` instead *restored* them from the ambient environment in its `afterEach`, so every test in that file ran armed.

File-level rather than per-describe so a new describe cannot miss it. Outer hooks run first, so the two describes that deliberately exercise a callback keep working — they re-arm the pair themselves against an unroutable host.

`docs/workflow-envelope.md` gains a paragraph beside the eight-input contract, where `run_token` is already documented as *"empty skips callback"*. What was missing is that a test process inheriting a non-empty one posts for real, and the one rule no enforcement can check: a test that re-arms must point somewhere unroutable.

## No production change

`postRunnerResult` already skips the callback when either credential is absent. The precondition was correct; nothing was supplying it. A guard making it fail closed on a detected test process was considered and rejected — it puts a test-only branch in production code, and the throwing variant is unsafe: each terminal exit awaits it inside a `try`, so a throw lands in that function's `catch`, which posts again.

## Verification

Ran the suite against a local HTTP listener with the ambient credentials set, simulating a dispatched runner:

| | `POST /runner/result` | Suite |
|---|---|---|
| With the hook | **0** | 147 passed |
| Without it | **8** | 147 passed |

Eight matches the eight unstubbed call sites. The suite is green either way — which is why this went undetected for four days, and why the listener rather than the test result is the evidence.

Full suite 190 files / 4419 tests, typecheck clean.

## Follow-ups

A `vitest` `setupFiles` clearing runner credentials for every suite would close the class rather than this instance. Deferred: the repo has no setup file today and introducing that mechanism belongs with the stability pass.

The consume-before-validation item on AII-567 is unaffected and still open. AII-568 stands on its own — a monitor-side backstop makes any dropped report a delayed transition rather than a consumed dispatch slot, whatever the cause.
