### PR TITLE
Use structured review verdicts and upgrade Claude runner

### DIFF
--- a/Dockerfile.session
+++ b/Dockerfile.session
@@ -25,7 +25,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Pinned versions for reproducibility.
 ARG YQ_VERSION=v4.53.2
 ARG AST_GREP_VERSION=0.42.1
-ARG CLAUDE_CODE_VERSION=2.1.114
+ARG CLAUDE_CODE_VERSION=2.1.263
 
 # System dependencies — base tools + power tools for the agent.
 # dbus + libsecret-1-0 are required so Claude Code's startup keychain read

--- a/PLANNING.md
+++ b/PLANNING.md
@@ -2,14 +2,14 @@
 # Claude model used for planning. Passed through verbatim to
 # `claude-code --model`, so any ID your configured provider accepts is fine.
 # Examples:
-#   Anthropic API / OAuth: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5-20251001
+#   Anthropic API / OAuth: claude-sonnet-5, claude-opus-4-7, claude-haiku-4-5-20251001
 #   AWS Bedrock:           anthropic.claude-sonnet-4-6-20250805-v1:0
 #                          or an inference-profile ARN (arn:aws:bedrock:...)
 # The default below works for the Anthropic provider. If this repo's mapping
 # is switched to provider=bedrock in the orchestrator admin UI, replace this
 # with a Bedrock model ID — the workflow will hard-fail otherwise, since
 # Bedrock IDs are account- and region-specific and have no safe default.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 <!--

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -2,7 +2,7 @@
 # Model for implementation and review passes. Passed to `claude --model`
 # verbatim, so any ID this repo's provider accepts works. This repo's mapping
 # runs on the Anthropic provider; replace with a Bedrock model ID if that changes.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 <!--

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -59,6 +59,16 @@ Two consequences worth internalising:
 
 **The pipeline owns all repository writes.** `push` runs for both initial and gap-fill runs: an initial run creates the implementation branch and opens a PR, while a gap-fill run commits any remaining uncommitted changes and force-pushes to the existing PR branch. `WORKFLOW.md` must instruct the agent to leave changes uncommitted in both modes — the pipeline always handles the commit and push.
 
+## Review result contract
+
+The built-in implementation review and post-push review request a JSON Schema through the executor. Claude Code still emits `stream-json` events for progress and telemetry; the verdict comes from the terminal result's `structured_output` field, not JSON extracted from assistant prose. Review consumers validate the required fields and their types before applying the verdict. Outstanding issues prevent approval even if the reviewer sets `approved` to true.
+
+An unsuccessful or missing terminal result, missing structured output, or invalid review payload is an incomplete review, not actionable implementation feedback. The feedback loop stops rather than running another implementation pass on a formatting error. Post-push review preserves the PR and reports that automated review did not complete. Custom executors used with these built-in review steps must implement the structured-result contract in `src/pipeline/types.ts`.
+
+The runner pins Claude Code in `Dockerfile.session`. Built-in model fallbacks and newly seeded workflow templates use `claude-sonnet-5`. Explicit model settings retain their existing precedence; already-seeded target-repo `WORKFLOW.md` and `PLANNING.md` files are not overwritten by template sync, so projects that pin an older model keep that model until their configuration changes. Bedrock projects still need a model ID accepted by their configured provider.
+
+Claude Code documents schema-based output in [programmatic usage](https://code.claude.com/docs/en/headless#get-structured-output). Sonnet 5 migration details, including the changed tokenizer and thinking defaults, are in the [official migration guide](https://platform.claude.com/docs/en/models/sonnet-5/migration-guide).
+
 ## Hook environment and forwarded secrets
 
 The dispatch side declares which secrets are present by naming them in `AI_IMPLEMENT_FORWARDED_SECRETS` (a comma-separated list of environment variable names). `setup`, `verify`, `teardown`, and `dependency-auth` all run as repo-owned processes that inherit the full runner env and therefore see those values. `modelProcessEnv()` in `src/pipeline/process-env.ts` strips each named key — and the `AI_IMPLEMENT_FORWARDED_SECRETS` list variable itself — before starting Claude Code, so the model and any processes it spawns never see them.

--- a/src/__tests__/claude-stream.test.ts
+++ b/src/__tests__/claude-stream.test.ts
@@ -79,7 +79,7 @@ describe("extractTelemetry", () => {
     });
   });
   it("maps error_max_turns to outcome=max_turns", () => {
-    const t = extractTelemetry([{ type: "result", subtype: "error_max_turns", num_turns: 50 }]);
+    const t = extractTelemetry([{ type: "result", subtype: "error_max_turns", is_error: true, num_turns: 50 }]);
     expect(t.outcome).toBe("max_turns");
     expect(t.numTurns).toBe(50);
   });

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -6,11 +6,68 @@ import { OperatorCancelledError, PrMergedError } from "../pipeline/operator-canc
 function makeCtx(execMock: any) {
   return {
     data: { issueIdentifier: "AII-200", issueTitle: "X", issueDescription: "Y", model: "claude-sonnet-4-6" },
-    llmExecutor: { invoke: execMock },
+    llmExecutor: {
+      invoke: vi.fn(async (params: any) => {
+        const result = await execMock(params);
+        if (!params.jsonSchema || result.exitCode !== 0 || "structuredOutput" in result) return result;
+        let parsed;
+        try {
+          parsed = JSON.parse(result.stdout);
+        } catch {
+          return { ...result, structuredOutput: undefined, terminalStatus: { subtype: "success", isError: false } };
+        }
+        return {
+          ...result,
+          structuredOutput: normalizeLegacyReviewFixture(parsed),
+          terminalStatus: { subtype: "success", isError: false },
+        };
+      }),
+    },
     getOutputs: () => ({}),
     setOutputs: () => {},
     resolveInputs: (i: any) => i,
   } as any;
+}
+
+function normalizeLegacyReviewFixture(parsed: any) {
+  const source = Array.isArray(parsed.blocking_issues)
+    ? parsed.blocking_issues
+    : Array.isArray(parsed.issues)
+      ? parsed.issues
+      : Array.isArray(parsed.findings)
+        ? parsed.findings
+        : [];
+  return {
+    approved: parsed.approved,
+    blocking_issues: source.map((issue: any) => {
+      if (typeof issue === "string") {
+        return { title: "Blocking issue", problem: issue, required_fix: issue };
+      }
+      if (typeof issue.text === "string") {
+        return { title: "Blocking issue", problem: issue.text, required_fix: issue.text };
+      }
+      return {
+        title: issue.title ?? "Blocking issue",
+        ...(issue.location || issue.file || issue.path ? { location: issue.location ?? issue.file ?? issue.path } : {}),
+        problem: issue.problem ?? issue.issue ?? issue.details ?? issue.description ?? issue.title ?? "Blocking issue",
+        required_fix: issue.required_fix ?? issue.requiredFix ?? issue.fix ?? issue.recommendation ?? issue.problem ?? issue.title ?? "Fix the issue",
+      };
+    }),
+    score: parsed.score,
+    progress_delta: parsed.progress_delta,
+    feedback: parsed.feedback,
+  };
+}
+
+function structuredReviewResult(structuredOutput: unknown, stdout = "ignored final text") {
+  return {
+    stdout,
+    exitCode: 0,
+    tokensUsed: 100,
+    structuredOutput,
+    terminalStatus: { subtype: "success", isError: false },
+    telemetry: { outcome: "success" as const, numTurns: 1, durationMs: 1, costUsd: null, tokensIn: 1, tokensOut: 1 },
+  };
 }
 
 function countOccurrences(text: string, needle: string): number {
@@ -288,6 +345,137 @@ describe("postPushReviewStep", () => {
     expect(out.approved).toBe(false);
     expect(invoke).toHaveBeenCalledTimes(2);
     expect(invoke.mock.calls[1][0].prompt).toContain("1. Escape quoted user input");
+  });
+
+  it("passes the review schema to internal post-push review calls", async () => {
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
+    const invoke = vi.fn(async () => structuredReviewResult({
+      approved: true,
+      blocking_issues: [],
+      score: 95,
+      progress_delta: 100,
+      feedback: "Ready.",
+    }));
+
+    await postPushReviewStep.run(
+      makeCtx(invoke),
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 1, ghSpawn, gitSpawn, reviewProviders: [] },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({
+      jsonSchema: expect.objectContaining({ required: ["approved", "blocking_issues", "score", "progress_delta", "feedback"] }),
+      model: "claude-sonnet-4-6",
+    }));
+  });
+
+  it("fails closed when the reviewer returns text but no structured_output", async () => {
+    const comments: string[] = [];
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "pr" && args[1] === "comment") comments.push(args[args.indexOf("--body") + 1]);
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({
+      stdout: "```json\n{\"approved\":true,\"blocking_issues\":[],\"score\":95,\"progress_delta\":100,\"feedback\":\"ok\"}\n```",
+      exitCode: 0,
+      tokensUsed: 100,
+      structuredOutput: undefined,
+      terminalStatus: { subtype: "success", isError: false },
+    }));
+
+    const out = await postPushReviewStep.run(
+      makeCtx(invoke),
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn: vi.fn(() => ({ stdout: "", exitCode: 0 })), reviewProviders: [] },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(out.terminationReason).toBe("invalid_review");
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(comments.some((comment) => comment.includes("returned no structured_output"))).toBe(true);
+  });
+
+  it("fails closed when the terminal result is an error even with exit 0", async () => {
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => ({
+      stdout: "structured output unavailable",
+      exitCode: 0,
+      tokensUsed: 100,
+      structuredOutput: { approved: true, blocking_issues: [], score: 95, progress_delta: 100, feedback: "ok" },
+      terminalStatus: { subtype: "error_during_execution", isError: true },
+    }));
+
+    const out = await postPushReviewStep.run(
+      makeCtx(invoke),
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn: vi.fn(() => ({ stdout: "", exitCode: 0 })), reviewProviders: [] },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(out.terminationReason).toBe("review_failed");
+    expect(out.finalFeedback).toContain("error_during_execution");
+  });
+
+  it("fails closed when structured output includes legacy verdict aliases", async () => {
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => structuredReviewResult({
+      approved: true,
+      blocking_issues: [],
+      issues: ["Hidden blocker"],
+      score: 95,
+      progress_delta: 100,
+      feedback: "Ready.",
+    }));
+
+    const out = await postPushReviewStep.run(
+      makeCtx(invoke),
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn: vi.fn(() => ({ stdout: "", exitCode: 0 })), reviewProviders: [] },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(out.terminationReason).toBe("invalid_review");
+    expect(out.finalFeedback).toContain("unexpected field review.issues");
+  });
+
+  it("runs a fix pass for a valid negative structured review", async () => {
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => structuredReviewResult({
+      approved: false,
+      blocking_issues: [{ title: "Missing test", location: "src/app.ts", problem: "No regression coverage.", required_fix: "Add a regression test." }],
+      score: 65,
+      progress_delta: 70,
+      feedback: "One blocker remains.",
+    }));
+
+    const out = await postPushReviewStep.run(
+      makeCtx(invoke),
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn, reviewProviders: [] },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    expect(out.approved).toBe(false);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[1][0].prompt).toContain("Missing test");
+    expect(invoke.mock.calls[1][0].prompt).toContain("Add a regression test.");
   });
 
   it("runs a fix pass when reviewer uses the findings alias", async () => {
@@ -918,7 +1106,7 @@ describe("postPushReviewStep", () => {
     expect(ghComments.some((comment) => comment.includes("Not ready to merge until manually reviewed"))).toBe(false);
   });
 
-  it("reports invalid non-JSON reviewer output with structured blocking issue outputs", async () => {
+  it("reports missing structured reviewer output with structured blocking issue outputs", async () => {
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -945,9 +1133,9 @@ describe("postPushReviewStep", () => {
       id: "post-push-review.1",
       status: "failed",
       outputs: expect.objectContaining({
-        issues: [expect.stringContaining("Reviewer returned non-JSON output")],
+        issues: [expect.stringContaining("Reviewer returned no structured_output")],
         blockingIssues: [expect.objectContaining({
-          rawText: expect.stringContaining("Reviewer returned non-JSON output"),
+          rawText: expect.stringContaining("Reviewer returned no structured_output"),
         })],
       }),
     }));
@@ -1086,7 +1274,7 @@ describe("postPushReviewStep", () => {
     expect(noChangesComment).toContain("Not ready to merge");
   });
 
-  it("skips empty JSON preamble objects when parsing reviewer output", async () => {
+  it("does not parse stdout preamble objects when structured_output is missing", async () => {
     const reviewerJson = `pre-text {} ${JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "ok" })}`;
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -1100,7 +1288,8 @@ describe("postPushReviewStep", () => {
       { report: vi.fn(async () => undefined) },
     );
 
-    expect(out.approved).toBe(true);
+    expect(out.approved).toBe(false);
+    expect(out.terminationReason).toBe("invalid_review");
   });
 
   it("updates an existing marker comment instead of posting a duplicate", async () => {
@@ -2784,7 +2973,7 @@ describe("postPushReviewStep", () => {
     expect(out.terminationReason).toBe("pr_merged");
     expect(out.iterations).toBe(0);
     expect(invoke).not.toHaveBeenCalled();
-    expect(ghSpawn.mock.calls.some((c) => c[0] === "pr" && c[1] === "comment")).toBe(false);
+    expect(ghSpawn.mock.calls.some(([args]) => args[0] === "pr" && args[1] === "comment")).toBe(false);
   });
   it("exits with pr_merged during a fix pass when assertPrWritable detects the merge before the push", async () => {
     // The PR is open through the first review and fix-pass LLM, then merged. The
@@ -2870,6 +3059,8 @@ describe("postPushReviewStep", () => {
             approved: false,
             blocking_issues: [{ title: "Bug", problem: "Missing null check", required_fix: "Add null guard" }],
             feedback: "found issues",
+            score: 70,
+            progress_delta: 50,
           }),
           exitCode: 0,
           tokensUsed: 100,
@@ -2879,7 +3070,7 @@ describe("postPushReviewStep", () => {
         return { stdout: JSON.stringify({ fixed: ["Added null guard"] }), exitCode: 0, tokensUsed: 100 };
       }
       // Reviewer #2: would approve, but submitPrReview's assertPrWritable detects MERGED first.
-      return { stdout: JSON.stringify({ approved: true, blocking_issues: [], feedback: "lgtm" }), exitCode: 0, tokensUsed: 100 };
+      return { stdout: JSON.stringify({ approved: true, blocking_issues: [], score: 95, progress_delta: 100, feedback: "lgtm" }), exitCode: 0, tokensUsed: 100 };
     });
 
     const out = await postPushReviewStep.run(
@@ -2925,6 +3116,8 @@ describe("postPushReviewStep", () => {
             approved: false,
             blocking_issues: [{ title: "Bug", problem: "Missing null check", required_fix: "Add null guard" }],
             feedback: "found issues",
+            score: 70,
+            progress_delta: 50,
           }),
           exitCode: 0,
           tokensUsed: 100,

--- a/src/__tests__/review-verdict.test.ts
+++ b/src/__tests__/review-verdict.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { parseReviewVerdict } from "../pipeline/review-verdict.js";
+
+const validApproved = {
+  approved: true,
+  blocking_issues: [],
+  score: 92,
+  progress_delta: 15,
+  feedback: "Clean implementation.",
+};
+
+describe("parseReviewVerdict", () => {
+  it("accepts a valid approving verdict", () => {
+    expect(parseReviewVerdict(validApproved)).toEqual({
+      approved: true,
+      blockingIssues: [],
+      score: 92,
+      progressDelta: 15,
+      feedback: "Clean implementation.",
+    });
+  });
+
+  it("accepts a valid negative verdict", () => {
+    expect(parseReviewVerdict({
+      approved: false,
+      blocking_issues: [{ title: "Missing test", problem: "No regression coverage.", required_fix: "Add the regression test." }],
+      score: 60,
+      progress_delta: 40,
+      feedback: "One blocker remains.",
+    })).toMatchObject({
+      approved: false,
+      score: 60,
+      progressDelta: 40,
+      blockingIssues: [{ title: "Missing test", problem: "No regression coverage.", requiredFix: "Add the regression test." }],
+    });
+  });
+
+  it("forces approved=false when approved=true includes canonical blockers", () => {
+    const verdict = parseReviewVerdict({
+      approved: true,
+      blocking_issues: [{ title: "Bug", problem: "It fails.", required_fix: "Fix it." }],
+      score: 70,
+      progress_delta: 40,
+      feedback: "Contradictory verdict.",
+    });
+
+    expect(verdict.approved).toBe(false);
+    expect(verdict.blockingIssues).toHaveLength(1);
+  });
+
+  it("rejects a negative verdict with no blocking issues", () => {
+    expect(() => parseReviewVerdict({ ...validApproved, approved: false }))
+      .toThrow("approved=false requires at least one blocking_issues entry");
+  });
+
+  it("rejects wrong typed fields", () => {
+    expect(() => parseReviewVerdict({ ...validApproved, feedback: 12 }))
+      .toThrow("expected feedback to be a string");
+  });
+
+  it("rejects wrong typed optional location when present", () => {
+    expect(() => parseReviewVerdict({
+      ...validApproved,
+      approved: false,
+      blocking_issues: [{ title: "Bug", location: 42, problem: "It fails.", required_fix: "Fix it." }],
+    })).toThrow("expected blocking_issues[0].location to be a string when present");
+  });
+
+  it("rejects legacy alias fields instead of ignoring them", () => {
+    expect(() => parseReviewVerdict({
+      ...validApproved,
+      issues: ["Hidden blocker"],
+    })).toThrow("unexpected field review.issues");
+  });
+});

--- a/src/__tests__/review.test.ts
+++ b/src/__tests__/review.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { reviewStep } from "../pipeline/steps/review.js";
+import { REVIEW_VERDICT_JSON_SCHEMA } from "../pipeline/review-verdict.js";
 
 function makeCtx(execMock: ReturnType<typeof vi.fn>) {
   return {
@@ -11,14 +12,31 @@ function makeCtx(execMock: ReturnType<typeof vi.fn>) {
   } as never;
 }
 
-const REVIEW_JSON = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "ok" });
+const REVIEW_VERDICT = { approved: true, blocking_issues: [], score: 90, progress_delta: 0, feedback: "ok" };
+
+const reviewResult = (structuredOutput: unknown = REVIEW_VERDICT) => ({
+  stdout: "ignored final text",
+  exitCode: 0,
+  tokensUsed: 100,
+  structuredOutput,
+  hasTerminalResult: true,
+  terminalStatus: { subtype: "success", isError: false },
+  telemetry: {
+    outcome: "success" as const,
+    numTurns: 1,
+    durationMs: 1,
+    costUsd: null,
+    tokensIn: 1,
+    tokensOut: 1,
+  },
+});
 
 describe("reviewStep", () => {
   it("omits acceptance bar framing when acceptanceBar is absent", async () => {
     let capturedPrompt = "";
     const ctx = makeCtx(vi.fn(async ({ prompt }: { prompt: string }) => {
       capturedPrompt = prompt;
-      return { stdout: REVIEW_JSON, exitCode: 0, tokensUsed: 100 };
+      return reviewResult();
     }));
     await reviewStep.run(ctx, { diff: "diff", issueTitle: "T", issueDescription: "D", iteration: 1 }, { report: vi.fn() });
     expect(capturedPrompt).not.toContain("Planning defined this acceptance bar");
@@ -30,7 +48,7 @@ describe("reviewStep", () => {
     let capturedPrompt = "";
     const ctx = makeCtx(vi.fn(async ({ prompt }: { prompt: string }) => {
       capturedPrompt = prompt;
-      return { stdout: REVIEW_JSON, exitCode: 0, tokensUsed: 100 };
+      return reviewResult();
     }));
     await reviewStep.run(
       ctx,
@@ -52,11 +70,11 @@ describe("reviewStep", () => {
     let promptB = "";
     const ctxA = makeCtx(vi.fn(async ({ prompt }: { prompt: string }) => {
       promptA = prompt;
-      return { stdout: REVIEW_JSON, exitCode: 0, tokensUsed: 100 };
+      return reviewResult();
     }));
     const ctxB = makeCtx(vi.fn(async ({ prompt }: { prompt: string }) => {
       promptB = prompt;
-      return { stdout: REVIEW_JSON, exitCode: 0, tokensUsed: 100 };
+      return reviewResult();
     }));
     const baseInputs = { diff: "diff", issueTitle: "T", issueDescription: "D", iteration: 1 };
     await reviewStep.run(ctxA, baseInputs, { report: vi.fn() });
@@ -69,7 +87,7 @@ describe("reviewStep", () => {
     let capturedPrompt = "";
     const ctx = makeCtx(vi.fn(async ({ prompt }: { prompt: string }) => {
       capturedPrompt = prompt;
-      return { stdout: REVIEW_JSON, exitCode: 0, tokensUsed: 100 };
+      return reviewResult();
     }));
     await reviewStep.run(
       ctx,
@@ -88,7 +106,7 @@ describe("reviewStep", () => {
     let capturedPrompt = "";
     const ctx = makeCtx(vi.fn(async ({ prompt }: { prompt: string }) => {
       capturedPrompt = prompt;
-      return { stdout: REVIEW_JSON, exitCode: 0, tokensUsed: 100 };
+      return reviewResult();
     }));
     await reviewStep.run(
       ctx,
@@ -105,5 +123,59 @@ describe("reviewStep", () => {
     // The closing tag must precede the diff so the bar cannot bleed into prompt structure
     const diffIdx = capturedPrompt.indexOf("## Implementation Diff");
     expect(closeIdx).toBeLessThan(diffIdx);
+  });
+
+  it("passes the canonical review verdict schema to the LLM executor", async () => {
+    const invoke = vi.fn(async () => reviewResult());
+    await reviewStep.run(makeCtx(invoke), { diff: "diff" }, { report: vi.fn() });
+
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({
+      model: "claude-sonnet-5",
+      jsonSchema: REVIEW_VERDICT_JSON_SCHEMA,
+    }));
+  });
+
+  it("does not repair or parse stdout when structured_output is absent", async () => {
+    const fenced = "```json\n{\"approved\":true,\"blocking_issues\":[],\"score\":90,\"progress_delta\":0,\"feedback\":\"ok\"}\n```";
+    const ctx = makeCtx(vi.fn(async () => ({
+      stdout: fenced,
+      exitCode: 0,
+      tokensUsed: 100,
+      hasTerminalResult: true,
+      terminalStatus: { subtype: "success", isError: false },
+      telemetry: { outcome: "success", numTurns: 1, durationMs: 1, costUsd: null, tokensIn: 1, tokensOut: 1 },
+    })));
+
+    await expect(reviewStep.run(ctx, { diff: "diff" }, { report: vi.fn() }))
+      .rejects.toThrow("did not return structured_output");
+  });
+
+  it("forces approved=false when structured blockers are present", async () => {
+    const ctx = makeCtx(vi.fn(async () => reviewResult({
+      approved: true,
+      blocking_issues: [{ title: "Bug", problem: "It fails.", required_fix: "Fix it." }],
+      score: 50,
+      progress_delta: 20,
+      feedback: "Needs work.",
+    })));
+
+    const out = await reviewStep.run(ctx, { diff: "diff" }, { report: vi.fn() });
+
+    expect(out.approved).toBe(false);
+    expect(out.issues[0]).toContain("Bug");
+    expect(out.feedback).toBe("Needs work.");
+  });
+
+  it("rejects wrong typed structured review fields", async () => {
+    const ctx = makeCtx(vi.fn(async () => reviewResult({
+      approved: true,
+      blocking_issues: [],
+      score: 90,
+      progress_delta: 0,
+      feedback: 12,
+    })));
+
+    await expect(reviewStep.run(ctx, { diff: "diff" }, { report: vi.fn() }))
+      .rejects.toThrow("expected feedback to be a string");
   });
 });

--- a/src/__tests__/run-autonomous.test.ts
+++ b/src/__tests__/run-autonomous.test.ts
@@ -530,7 +530,7 @@ describe("runAutonomous", () => {
     expect(capturedModel).toBe("claude-haiku-4-5");
   });
 
-  it("falls back to claude-sonnet-4-6 when no model configured", async () => {
+  it("falls back to claude-sonnet-5 when no model configured", async () => {
     let capturedModel: string | undefined;
     const mod: StepModule = {
       run: vi.fn(async (ctx) => {
@@ -548,7 +548,7 @@ describe("runAutonomous", () => {
       llmExecutor: makeMockExecutor(0),
     });
 
-    expect(capturedModel).toBe("claude-sonnet-4-6");
+    expect(capturedModel).toBe("claude-sonnet-5");
   });
 
   it("invokes the provided llmExecutor when step calls it", async () => {
@@ -570,7 +570,7 @@ describe("runAutonomous", () => {
     });
 
     expect(executor.invoke).toHaveBeenCalledOnce();
-    expect((executor.invoke as ReturnType<typeof vi.fn>).mock.calls[0][0].model).toBe("claude-sonnet-4-6");
+    expect((executor.invoke as ReturnType<typeof vi.fn>).mock.calls[0][0].model).toBe("claude-sonnet-5");
   });
 
   it("fetches planning context from the orchestrator using the progress token", async () => {

--- a/src/__tests__/steps-implement.test.ts
+++ b/src/__tests__/steps-implement.test.ts
@@ -51,7 +51,7 @@ describe("implementStep", () => {
     );
   });
 
-  it("defaults model to claude-sonnet-4-6 when not specified", async () => {
+  it("defaults model to claude-sonnet-5 when not specified", async () => {
     const executor = makeExecutor();
     const ctx = makeContext(executor);
 
@@ -62,7 +62,7 @@ describe("implementStep", () => {
     );
 
     expect(executor.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "claude-sonnet-4-6" }),
+      expect.objectContaining({ model: "claude-sonnet-5" }),
     );
   });
 

--- a/src/__tests__/steps-review.test.ts
+++ b/src/__tests__/steps-review.test.ts
@@ -4,9 +4,9 @@ import { DefaultPipelineContext } from "../pipeline/context.js";
 import { NoopStepReporter } from "../pipeline/reporter.js";
 import type { LLMExecutor, LLMResult } from "../pipeline/types.js";
 
-function makeExecutor(stdout = "", exitCode = 0, tokensUsed = 0): LLMExecutor {
+function makeExecutor(structuredOutput: unknown = undefined, exitCode = 0, tokensUsed = 0, stdout = "Review complete"): LLMExecutor {
   return {
-    invoke: vi.fn().mockResolvedValue({ stdout, exitCode, tokensUsed } satisfies LLMResult),
+    invoke: vi.fn().mockResolvedValue({ stdout, exitCode, tokensUsed, structuredOutput, terminalStatus: { subtype: "success", isError: false } } satisfies LLMResult),
   };
 }
 
@@ -25,21 +25,24 @@ function makeContext(executor?: LLMExecutor): DefaultPipelineContext {
   );
 }
 
-const APPROVED_JSON = JSON.stringify({
+const APPROVED_VERDICT = {
   approved: true,
-  issues: [],
+  blocking_issues: [],
   score: 95,
   progress_delta: 100,
   feedback: "Looks good",
-});
+};
 
-const REJECTED_JSON = JSON.stringify({
+const REJECTED_VERDICT = {
   approved: false,
-  issues: ["Missing tests", "No error handling"],
+  blocking_issues: [
+    { title: "Missing tests", problem: "Error paths lack coverage", required_fix: "Add regression tests" },
+    { title: "No error handling", problem: "Failures escape uncaught", required_fix: "Handle request errors" },
+  ],
   score: 40,
   progress_delta: 50,
   feedback: "Needs improvement",
-});
+};
 
 describe("reviewStep", () => {
   beforeEach(() => {
@@ -47,7 +50,7 @@ describe("reviewStep", () => {
   });
 
   it("parses approved=true from structured JSON response", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
     expect(outputs.approved).toBe(true);
@@ -58,49 +61,50 @@ describe("reviewStep", () => {
   });
 
   it("parses approved=false with issues from JSON response", async () => {
-    const executor = makeExecutor(REJECTED_JSON);
+    const executor = makeExecutor(REJECTED_VERDICT);
     const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
     expect(outputs.approved).toBe(false);
-    expect(outputs.issues).toEqual(["Missing tests", "No error handling"]);
+    expect(outputs.issues).toEqual([
+      "Missing tests\nProblem: Error paths lack coverage\nRequired fix: Add regression tests",
+      "No error handling\nProblem: Failures escape uncaught\nRequired fix: Handle request errors",
+    ]);
     expect(outputs.score).toBe(40);
     expect(outputs.progressDelta).toBe(50);
   });
 
   it("fails closed when reviewer returns approved=true with non-empty issues", async () => {
-    const executor = makeExecutor(JSON.stringify({
+    const executor = makeExecutor({
       approved: true,
-      issues: ["Still missing a regression test"],
+      blocking_issues: [{ title: "Still missing a regression test", problem: "No error-path coverage", required_fix: "Add a regression test" }],
       score: 79,
       progress_delta: 85,
       feedback: "Nearly ready, but one blocker remains.",
-    }));
+    });
 
     const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
     expect(outputs.approved).toBe(false);
-    expect(outputs.issues).toEqual(["Still missing a regression test"]);
+    expect(outputs.issues).toHaveLength(1);
+    expect(outputs.issues[0]).toContain("Still missing a regression test");
     expect(outputs.feedback).toContain("Nearly ready");
   });
 
-  it("extracts JSON embedded in surrounding text", async () => {
-    const stdout = `Here is my review:\n${APPROVED_JSON}\nEnd of review.`;
-    const executor = makeExecutor(stdout);
-    const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
-
-    expect(outputs.approved).toBe(true);
+  it("does not recover an approval from prose when structured output is absent", async () => {
+    const stdout = `Here is my review:\n${JSON.stringify(APPROVED_VERDICT)}\nEnd of review.`;
+    const executor = makeExecutor(undefined, 0, 0, stdout);
+    await expect(reviewStep.run(makeContext(executor), {}, new NoopStepReporter()))
+      .rejects.toThrow("structured_output");
   });
 
-  it("defaults to approved=false when JSON cannot be parsed", async () => {
+  it("throws on malformed output instead of returning actionable review feedback", async () => {
     const executor = makeExecutor("not valid json at all");
-    const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
-
-    expect(outputs.approved).toBe(false);
-    expect(outputs.feedback).toBe("not valid json at all");
+    await expect(reviewStep.run(makeContext(executor), {}, new NoopStepReporter()))
+      .rejects.toThrow("structured review output");
   });
 
   it("includes diff in prompt when provided", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     const ctx = makeContext(executor);
 
     await reviewStep.run(
@@ -115,17 +119,17 @@ describe("reviewStep", () => {
   });
 
   it("tells reviewers that any listed issue blocks approval", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
 
     await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
     const call = vi.mocked(executor.invoke).mock.calls[0][0];
-    expect(call.prompt).toContain("If issues[] is non-empty, approved must be false");
+    expect(call.prompt).toContain("If blocking_issues[] is non-empty, approved must be false");
     expect(call.prompt).toContain("Do not set approved=true while listing unresolved issues");
   });
 
   it("includes iteration number in prompt", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     await reviewStep.run(
       makeContext(executor),
       { iteration: 3 },
@@ -137,7 +141,7 @@ describe("reviewStep", () => {
   });
 
   it("uses provided model", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     await reviewStep.run(
       makeContext(executor),
       { model: "claude-opus-4-7" },
@@ -150,7 +154,7 @@ describe("reviewStep", () => {
   });
 
   it("constrains review sessions to read-only tools", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
 
     await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
@@ -167,14 +171,14 @@ describe("reviewStep", () => {
   });
 
   it("returns tokensUsed from executor", async () => {
-    const executor = makeExecutor(APPROVED_JSON, 0, 200);
+    const executor = makeExecutor(APPROVED_VERDICT, 0, 200);
     const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
     expect(outputs.tokensUsed).toBe(200);
   });
 
   it("truncates an oversized diff so the prompt stays within the model context window", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     // A regenerated-codegen diff can be hundreds of KB — far past the model's
     // input limit. The review prompt must cap it rather than embed it verbatim.
     const hugeDiff = "+".repeat(500_000);
@@ -187,7 +191,7 @@ describe("reviewStep", () => {
   });
 
   it("truncates an oversized diff at a clean line boundary when one precedes the cap", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     // Oversized diff whose only newline sits before the 200k char cap, so the
     // cut should land on that newline (the `cut > 0` branch) rather than the
     // hard cap. Lengths chosen so the boundary is unambiguous: 150_000.
@@ -207,7 +211,7 @@ describe("reviewStep", () => {
   });
 
   it("does not truncate a normal-sized diff", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     const smallDiff = "diff --git a/foo.ts\n+added line";
 
     await reviewStep.run(makeContext(executor), { diff: smallDiff }, new NoopStepReporter());
@@ -217,11 +221,9 @@ describe("reviewStep", () => {
     expect(call.prompt).not.toContain("diff truncated");
   });
 
-  it("correctly extracts JSON when preamble contains stray braces", async () => {
-    // Greedy regex would match from first '{' in preamble to last '}' → invalid JSON.
-    // Balanced-brace scanner skips the empty preamble '{}' and finds the real object.
-    const stdout = `Result: {} — here is the JSON: ${APPROVED_JSON}`;
-    const executor = makeExecutor(stdout);
+  it("uses structured output independently of stray braces in prose", async () => {
+    const stdout = "Result: {broken prose";
+    const executor = makeExecutor(APPROVED_VERDICT, 0, 0, stdout);
     const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
     expect(outputs.approved).toBe(true);
@@ -229,7 +231,7 @@ describe("reviewStep", () => {
   });
 
   it("appends reviewRubric to prompt when supplied", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     await reviewStep.run(
       makeContext(executor),
       { reviewRubric: "CUSTOM RUBRIC TEXT FOR THIS RUN TYPE" },
@@ -242,7 +244,7 @@ describe("reviewStep", () => {
   });
 
   it("does not include rubric section when reviewRubric is undefined", async () => {
-    const executor = makeExecutor(APPROVED_JSON);
+    const executor = makeExecutor(APPROVED_VERDICT);
     await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());
 
     const call = vi.mocked(executor.invoke).mock.calls[0][0];

--- a/src/__tests__/structured-executor.test.ts
+++ b/src/__tests__/structured-executor.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { ClaudeCliExecutor } from "../pipeline/executor.js";
+import type { StreamEvent } from "../pipeline/claude-stream.js";
+
+const schema = {
+  type: "object",
+  properties: { approved: { type: "boolean" } },
+  required: ["approved"],
+  additionalProperties: false,
+};
+
+function executorWithEvents(events: StreamEvent[]) {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  const proc = Object.assign(new EventEmitter(), { stdout, stderr, stdin });
+  const spawnMock = vi.fn(() => {
+    setImmediate(() => {
+      // Split a JSON event across chunks and omit the trailing newline, as a
+      // real process can do independently of message boundaries.
+      const data = events.map(event => JSON.stringify(event)).join("\n");
+      const midpoint = Math.floor(data.length / 2);
+      stdout.write(data.slice(0, midpoint));
+      stdout.end(data.slice(midpoint));
+      stderr.end();
+      setImmediate(() => proc.emit("close", 0));
+    });
+    return proc as unknown as ChildProcessWithoutNullStreams;
+  });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  return {
+    executor: new ClaudeCliExecutor("/tmp", "summary", true, spawnMock as unknown as typeof spawn),
+    spawnMock,
+    stdin,
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("structured Claude CLI results", () => {
+  it("passes the schema as one argument and preserves structured data independently of prose", async () => {
+    const verdict = { approved: false };
+    const { executor, spawnMock, stdin } = executorWithEvents([
+      { type: "assistant", message: { content: [{ type: "text", text: "I approve this." }] } },
+      { type: "result", subtype: "success", is_error: false, result: "```json\nnot valid JSON\n```", structured_output: verdict,
+        usage: { input_tokens: 20, output_tokens: 5 } },
+    ]);
+    const result = await executor.invoke({ prompt: "Review this", model: "claude-sonnet-5", jsonSchema: schema });
+    const call: unknown[] = spawnMock.mock.calls[0];
+    const args = call[1] as string[];
+    expect(args[args.indexOf("--output-format") + 1]).toBe("stream-json");
+    expect(args).toContain("--verbose");
+    expect(JSON.parse(args[args.indexOf("--json-schema") + 1])).toEqual(schema);
+    expect(args).not.toContain("Review this");
+    expect(stdin.read()?.toString()).toBe("Review this");
+    expect(result.structuredOutput).toEqual(verdict);
+    expect(result.stdout).toContain("not valid JSON");
+    expect(result.terminalStatus).toEqual({ subtype: "success", isError: false });
+    expect(result.tokensUsed).toBe(25);
+  });
+
+  it("does not promote assistant structured_output into a terminal verdict", async () => {
+    const { executor } = executorWithEvents([
+      { type: "assistant", structured_output: { approved: true } },
+    ]);
+    const result = await executor.invoke({ prompt: "review", model: "m", jsonSchema: schema });
+    expect(result.structuredOutput).toBeUndefined();
+    expect(result.terminalStatus).toBeUndefined();
+    expect(result.hasTerminalResult).toBe(false);
+  });
+
+  it("keeps the final failure status even when an earlier result approved", async () => {
+    const { executor } = executorWithEvents([
+      { type: "result", subtype: "success", is_error: false, structured_output: { approved: true } },
+      { type: "result", subtype: "error_max_structured_output_retries", is_error: true },
+    ]);
+    const result = await executor.invoke({ prompt: "review", model: "m", jsonSchema: schema });
+    expect(result.exitCode).toBe(0);
+    expect(result.structuredOutput).toBeUndefined();
+    expect(result.terminalStatus).toEqual({ subtype: "error_max_structured_output_retries", isError: true });
+    expect(result.telemetry?.outcome).toBe("error");
+  });
+
+  it("preserves is_error even when subtype incorrectly says success", async () => {
+    const { executor } = executorWithEvents([
+      { type: "result", subtype: "success", is_error: true, structured_output: { approved: true } },
+    ]);
+    const result = await executor.invoke({ prompt: "review", model: "m", jsonSchema: schema });
+    expect(result.terminalStatus?.isError).toBe(true);
+  });
+
+  it("leaves ordinary text invocations without a schema flag", async () => {
+    const { executor, spawnMock } = executorWithEvents([
+      { type: "result", subtype: "success", result: "Done" },
+    ]);
+    const result = await executor.invoke({ prompt: "implement", model: "m" });
+    const call: unknown[] = spawnMock.mock.calls[0];
+    expect(call[1]).not.toContain("--json-schema");
+    expect(result.stdout).toBe("Done");
+  });
+});

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -1,4 +1,4 @@
-import type { RunTelemetry } from "./types.js";
+import type { LLMTerminalStatus, RunTelemetry } from "./types.js";
 
 export interface StreamEvent {
   type?: string;
@@ -39,6 +39,14 @@ export function finalText(events: StreamEvent[]): string {
   return texts.join("\n");
 }
 
+export function finalStructuredOutput(events: StreamEvent[]): unknown {
+  return lastResult(events)?.structured_output;
+}
+
+export function hasTerminalResult(events: StreamEvent[]): boolean {
+  return lastResult(events) !== undefined;
+}
+
 function num(v: unknown): number | null {
   return typeof v === "number" ? v : null;
 }
@@ -48,6 +56,15 @@ function mapOutcome(subtype: unknown): RunTelemetry["outcome"] {
   if (subtype === "error_max_turns") return "max_turns";
   if (typeof subtype === "string" && subtype.startsWith("error")) return "error";
   return "unknown";
+}
+
+export function terminalStatus(events: StreamEvent[]): LLMTerminalStatus | undefined {
+  const result = lastResult(events);
+  if (!result) return undefined;
+  return {
+    subtype: typeof result.subtype === "string" ? result.subtype : null,
+    isError: typeof result.is_error === "boolean" ? result.is_error : null,
+  };
 }
 
 export function extractTelemetry(events: StreamEvent[]): RunTelemetry {
@@ -78,7 +95,7 @@ export function extractTelemetry(events: StreamEvent[]): RunTelemetry {
   const cacheRead = num(usage.cache_read_input_tokens);
   const inParts = [uncachedIn, cacheCreation, cacheRead].filter((v): v is number => v != null);
   return {
-    outcome: mapOutcome(result.subtype),
+    outcome: result.subtype === "error_max_turns" ? "max_turns" : result.is_error === true ? "error" : mapOutcome(result.subtype),
     numTurns: num(result.num_turns),
     durationMs: num(result.duration_ms),
     costUsd: num(result.total_cost_usd),

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -5,6 +5,9 @@ import {
   parseLine,
   formatEvent,
   finalText,
+  finalStructuredOutput,
+  hasTerminalResult,
+  terminalStatus,
   extractTelemetry,
   summaryLine,
   type StreamEvent,
@@ -71,6 +74,7 @@ export class ClaudeCliExecutor implements LLMExecutor {
     model: string;
     maxTurns?: number;
     tools?: string[];
+    jsonSchema?: Record<string, unknown>;
   }): Promise<LLMResult> {
     let restoreOrigin: (() => void) | null = null;
     if (!this.allowRepositoryWrites) {
@@ -98,6 +102,9 @@ export class ClaudeCliExecutor implements LLMExecutor {
       if (params.maxTurns != null) args.push("--max-turns", String(params.maxTurns));
       if (params.tools && params.tools.length > 0) {
         args.push("--allowed-tools", params.tools.join(","));
+      }
+      if (params.jsonSchema) {
+        args.push("--json-schema", JSON.stringify(params.jsonSchema));
       }
       // Pass the prompt on stdin rather than as an argv element. A large prompt
       // (e.g. one carrying full planning context) can exceed the OS single-argument
@@ -188,6 +195,9 @@ export class ClaudeCliExecutor implements LLMExecutor {
           exitCode: code ?? 1,
           tokensUsed: (telemetry.tokensIn ?? 0) + (telemetry.tokensOut ?? 0),
           telemetry,
+          structuredOutput: finalStructuredOutput(events),
+          hasTerminalResult: hasTerminalResult(events),
+          terminalStatus: terminalStatus(events),
         });
       });
 

--- a/src/pipeline/review-verdict.ts
+++ b/src/pipeline/review-verdict.ts
@@ -1,0 +1,129 @@
+export interface ReviewIssue {
+  title: string;
+  location?: string;
+  problem: string;
+  requiredFix: string;
+}
+
+export interface ReviewVerdict {
+  approved: boolean;
+  blockingIssues: ReviewIssue[];
+  score: number;
+  progressDelta: number;
+  feedback: string;
+}
+
+export const REVIEW_VERDICT_JSON_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  required: ["approved", "blocking_issues", "score", "progress_delta", "feedback"],
+  properties: {
+    approved: { type: "boolean" },
+    blocking_issues: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["title", "problem", "required_fix"],
+        properties: {
+          title: { type: "string", minLength: 1 },
+          location: { type: "string" },
+          problem: { type: "string", minLength: 1 },
+          required_fix: { type: "string", minLength: 1 },
+        },
+      },
+    },
+    score: { type: "integer", minimum: 0, maximum: 100 },
+    progress_delta: { type: "integer", minimum: 0, maximum: 100 },
+    feedback: { type: "string" },
+  },
+};
+
+interface RawReviewIssue {
+  title?: unknown;
+  location?: unknown;
+  problem?: unknown;
+  required_fix?: unknown;
+}
+
+interface RawReviewVerdict {
+  approved?: unknown;
+  blocking_issues?: unknown;
+  score?: unknown;
+  progress_delta?: unknown;
+  feedback?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function boundedInteger(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 100) {
+    throw new Error(`expected ${field} to be an integer from 0 to 100`);
+  }
+  return value;
+}
+
+function rejectUnexpectedKeys(record: Record<string, unknown>, allowed: Set<string>, context: string): void {
+  for (const key of Object.keys(record)) {
+    if (!allowed.has(key)) throw new Error(`unexpected field ${context}.${key}`);
+  }
+}
+
+const REVIEW_VERDICT_KEYS = new Set(["approved", "blocking_issues", "score", "progress_delta", "feedback"]);
+const REVIEW_ISSUE_KEYS = new Set(["title", "location", "problem", "required_fix"]);
+
+function parseIssue(value: unknown, index: number): ReviewIssue {
+  if (!isRecord(value)) throw new Error(`expected blocking_issues[${index}] to be an object`);
+  rejectUnexpectedKeys(value, REVIEW_ISSUE_KEYS, `blocking_issues[${index}]`);
+  const issue = value as RawReviewIssue;
+  const title = nonEmptyString(issue.title);
+  if (!title) throw new Error(`expected blocking_issues[${index}].title to be a non-empty string`);
+  const problem = nonEmptyString(issue.problem);
+  if (!problem) throw new Error(`expected blocking_issues[${index}].problem to be a non-empty string`);
+  const requiredFix = nonEmptyString(issue.required_fix);
+  if (!requiredFix) throw new Error(`expected blocking_issues[${index}].required_fix to be a non-empty string`);
+  if (issue.location !== undefined && typeof issue.location !== "string") {
+    throw new Error(`expected blocking_issues[${index}].location to be a string when present`);
+  }
+  const location = nonEmptyString(issue.location) ?? undefined;
+  return { title, ...(location ? { location } : {}), problem, requiredFix };
+}
+
+export function parseReviewVerdict(value: unknown): ReviewVerdict {
+  if (!isRecord(value)) throw new Error("expected structured review output to be an object");
+  rejectUnexpectedKeys(value, REVIEW_VERDICT_KEYS, "review");
+  const raw = value as RawReviewVerdict;
+  if (typeof raw.approved !== "boolean") throw new Error("expected approved to be a boolean");
+  if (!Array.isArray(raw.blocking_issues)) throw new Error("expected blocking_issues to be an array");
+  if (typeof raw.feedback !== "string") throw new Error("expected feedback to be a string");
+
+  const blockingIssues = raw.blocking_issues.map(parseIssue);
+  if (!raw.approved && blockingIssues.length === 0) {
+    throw new Error("approved=false requires at least one blocking_issues entry");
+  }
+
+  return {
+    approved: raw.approved && blockingIssues.length === 0,
+    blockingIssues,
+    score: boundedInteger(raw.score, "score"),
+    progressDelta: boundedInteger(raw.progress_delta, "progress_delta"),
+    feedback: raw.feedback.trim(),
+  };
+}
+
+export function plainIssueText(issue: ReviewIssue): string {
+  return [
+    issue.title,
+    issue.location ? `Location: ${issue.location}` : "",
+    issue.problem ? `Problem: ${issue.problem}` : "",
+    issue.requiredFix ? `Required fix: ${issue.requiredFix}` : "",
+  ].filter(Boolean).join("\n");
+}

--- a/src/pipeline/steps/feedback-loop.ts
+++ b/src/pipeline/steps/feedback-loop.ts
@@ -11,7 +11,7 @@ import { capDiff } from "./review.js";
 import { wrapWithPlanningGuard } from "../../planning-context-assembly.js";
 
 const DEFAULT_MAX_ITERATIONS = 3;
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MODEL = "claude-sonnet-5";
 
 const ACCEPTANCE_BAR_HEADER = "## ✅ AI Planning: Acceptance Bar";
 const MAP_HEADER = "## 🗺 AI Planning: Implementation Map";

--- a/src/pipeline/steps/implement.ts
+++ b/src/pipeline/steps/implement.ts
@@ -70,7 +70,7 @@ export const implementStep: StepModule<ImplementInputs, ImplementOutputs> = {
 
     const result = await context.llmExecutor.invoke({
       prompt: fullPrompt,
-      model: model ?? "claude-sonnet-4-6",
+      model: model ?? "claude-sonnet-5",
       maxTurns,
     });
 

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from "node:child_process";
 import { OperatorCancelledError, PrMergedError } from "../operator-cancelled.js";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
-import { formatGitNameStatusSummary } from "../step-utils.js";
+import { formatGitNameStatusSummary, formatLlmResultDetail } from "../step-utils.js";
 import { extractFirstJsonObject } from "../json-extract.js";
+import { REVIEW_VERDICT_JSON_SCHEMA, parseReviewVerdict, type ReviewIssue as VerdictReviewIssue } from "../review-verdict.js";
 import { refreshRunnerGithubCredentials } from "../../runner-token.js";
 import { getPublicationCredential } from "../../publication-credential.js";
 import {
@@ -196,50 +197,6 @@ function issueFromString(text: string): ReviewIssue {
   };
 }
 
-function stringValue(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function parseReviewIssue(value: unknown): ReviewIssue | null {
-  if (typeof value === "string") {
-    const text = value.trim();
-    return text ? issueFromString(text) : null;
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-
-  const issue = value as Record<string, unknown>;
-  const title = stringValue(issue.title) || stringValue(issue.summary) || "Blocking issue";
-  const location = stringValue(issue.location) || stringValue(issue.file) || stringValue(issue.path) || undefined;
-  const problem = stringValue(issue.problem) || stringValue(issue.issue) || stringValue(issue.details) || stringValue(issue.description);
-  const requiredFix = stringValue(issue.required_fix) || stringValue(issue.requiredFix) || stringValue(issue.fix) || stringValue(issue.recommendation);
-  const rawText = stringValue(issue.text);
-  if (!problem && !requiredFix && !rawText) return null;
-  if (rawText && !problem && !requiredFix) return issueFromString(rawText);
-
-  return {
-    title,
-    location,
-    problem: problem || rawText || title,
-    requiredFix,
-  };
-}
-
-function parseReviewIssues(parsed: Record<string, unknown>): ReviewIssue[] {
-  const source = Array.isArray(parsed.blocking_issues)
-    ? parsed.blocking_issues
-    : Array.isArray(parsed.blockingIssues)
-      ? parsed.blockingIssues
-      : Array.isArray(parsed.issues)
-        ? parsed.issues
-        : Array.isArray(parsed.findings)
-          ? parsed.findings
-          : [];
-
-  return source
-    .map(parseReviewIssue)
-    .filter((issue): issue is ReviewIssue => issue !== null);
-}
-
 function plainIssueText(issue: ReviewIssue): string {
   if (issue.rawText) return issue.rawText;
   return [
@@ -371,7 +328,13 @@ function dedupeIssuesAgainstExternalFindings(
   const seen = new Set<string>();
   return issues.filter((issue) => {
     const normalized = normalizeForComparison(plainIssueText(issue));
-    if (!normalized || externalBodies.has(normalized) || seen.has(normalized)) return false;
+    const issueParts = [
+      normalized,
+      normalizeForComparison(issue.problem),
+      normalizeForComparison(issue.requiredFix),
+      normalizeForComparison(issue.rawText ?? ""),
+    ].filter(Boolean);
+    if (!normalized || issueParts.some((part) => externalBodies.has(part)) || seen.has(normalized)) return false;
     seen.add(normalized);
     return true;
   });
@@ -746,6 +709,35 @@ function failedReviewOutputs(feedback: string) {
   };
 }
 
+function issueFromVerdictIssue(issue: VerdictReviewIssue): ReviewIssue {
+  if (issue.title === "Blocking issue" && issue.problem === issue.requiredFix) {
+    return issueFromString(issue.problem);
+  }
+  return {
+    title: issue.title,
+    ...(issue.location ? { location: issue.location } : {}),
+    problem: issue.problem,
+    requiredFix: issue.requiredFix,
+  };
+}
+
+function reviewFailureMessage(result: { exitCode: number; terminalStatus?: { subtype: string | null; isError: boolean | null }; telemetry?: { outcome: string }; stdout?: string; stderr?: string }): string | null {
+  if (result.exitCode !== 0) return `Reviewer LLM failed (${llmResultMessage(result)})`;
+  if (!result.terminalStatus) {
+    return `Reviewer LLM did not return a terminal result event${formatLlmResultDetail(result)}`;
+  }
+  if (result.terminalStatus.isError === true) {
+    return `Reviewer LLM returned an error terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`;
+  }
+  if (result.terminalStatus.subtype !== "success") {
+    return `Reviewer LLM finished without a successful terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`;
+  }
+  if (result.telemetry?.outcome && result.telemetry.outcome !== "success") {
+    return `Reviewer LLM finished without a successful terminal result (${result.telemetry.outcome})${formatLlmResultDetail(result)}`;
+  }
+  return null;
+}
+
 async function reportInvalidStructuredReview(
   reporter: StepReporter,
   ghSpawn: (args: string[]) => SpawnResult,
@@ -778,7 +770,7 @@ export const postPushReviewStep: StepModule<PostPushReviewInputs, PostPushReview
     const ghSpawn = inputs.ghSpawn ?? makeDefaultGhSpawn(inputs.workspaceDir);
     const gitSpawn = inputs.gitSpawn ?? makeDefaultGitSpawn(inputs.workspaceDir);
     const maxIterations = inputs.maxIterations ?? DEFAULT_MAX_ITERATIONS;
-    const model = inputs.model ?? context.data.model ?? "claude-sonnet-4-6";
+    const model = inputs.model ?? context.data.model ?? "claude-sonnet-5";
     const prNumber = String(inputs.prNumber ?? "");
     if (!prNumber) throw new Error("post-push-review requires a PR number");
 
@@ -871,12 +863,13 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         model,
         maxTurns: REVIEW_MAX_TURNS,
         tools: READ_ONLY_ALLOWED_TOOLS,
+        jsonSchema: REVIEW_VERDICT_JSON_SCHEMA,
       });
-      if (reviewResult.exitCode !== 0) {
+      const reviewFailure = reviewFailureMessage(reviewResult);
+      if (reviewFailure) {
         priorLlmFailure = true;
         terminationReason = "review_failed";
-        const failure = `Reviewer LLM failed (${llmResultMessage(reviewResult)})`;
-        feedback = compactErrorMessage(failure);
+        feedback = compactErrorMessage(reviewFailure);
         await reporter.report({
           id: `post-push-review.${iteration}`,
           type: "custom",
@@ -898,36 +891,20 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         break;
       }
 
-      const parsed = extractFirstJsonObject(reviewResult.stdout) as
-        | { approved?: boolean; feedback?: string; issues?: unknown[]; findings?: unknown[]; blocking_issues?: unknown[]; blockingIssues?: unknown[] }
-        | null;
-      if (!parsed) {
+      if (reviewResult.structuredOutput === undefined) {
         terminationReason = "invalid_review";
-        feedback = compactErrorMessage(`Reviewer returned non-JSON output: ${reviewResult.stdout || "(empty stdout)"}`);
-        await reporter.report({
-          id: `post-push-review.${iteration}`,
-          type: "custom",
-          status: "failed",
-          started_at: new Date().toISOString(),
-          ended_at: new Date().toISOString(),
-          parent_step_id: "post-push-review",
-          inputs: { iteration, prNumber },
-          outputs: failedReviewOutputs(feedback),
-          logs_url: null,
-        });
-        const marker = `<!-- ai-implement post-push iter=${iteration} review-invalid -->`;
-        postPrComment(
-          ghSpawn,
-          prNumber,
-          `${marker}\n⚠️ Post-push review returned invalid output.\n\n${feedback}\n\nThe implementation PR is still available, but this automated review pass did not finish. No actionable code feedback was produced by this review attempt.\n\n**Merge readiness:** Manual review required; automated review did not complete.`,
-          marker,
-        );
+        feedback = compactErrorMessage(`Reviewer returned no structured_output: ${reviewResult.stdout || "(empty stdout)"}`);
+        await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
         break;
       }
 
-      if (typeof parsed.approved !== "boolean") {
+      let verdict;
+      try {
+        verdict = parseReviewVerdict(reviewResult.structuredOutput);
+      } catch (err) {
         terminationReason = "invalid_review";
-        feedback = "Reviewer returned invalid structured review output: expected approved:boolean.";
+        const reason = err instanceof Error ? err.message : String(err);
+        feedback = compactErrorMessage(`Reviewer returned invalid structured review output: ${reason}.`);
         await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
         break;
       }
@@ -962,10 +939,10 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         ? findFailingCiChecks(ghSpawn, externalReviewResult.headSha, inputs.reviewCheckNames)
         : [];
 
-      feedback = suppressDuplicateExternalFeedback(String(parsed.feedback ?? ""), externalFindings);
-      let issues = parseReviewIssues(parsed);
+      feedback = suppressDuplicateExternalFeedback(verdict.feedback, externalFindings);
+      let issues = verdict.blockingIssues.map(issueFromVerdictIssue);
       issues = dedupeIssuesAgainstExternalFindings(issues, externalFindings);
-      if (issues.length === 0 && parsed.approved === false && !hasExternalFindings) {
+      if (issues.length === 0 && verdict.approved === false && !hasExternalFindings) {
         terminationReason = "invalid_review";
         feedback = "Reviewer returned invalid structured review output: approved=false requires at least one blocking_issues[] entry.";
         await reportInvalidStructuredReview(reporter, ghSpawn, prNumber, iteration, feedback);
@@ -988,7 +965,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
       // Fail closed: the internal verdict is clean and no blockers are visible, but the
       // external review check did not finish within the wait budget. Do not auto-approve
       // against a reviewer that is still in flight — defer to a human.
-      const internalApprovable = parsed.approved === true && issues.length === 0 && !hasExternalFindings;
+      const internalApprovable = verdict.approved === true && issues.length === 0 && !hasExternalFindings;
       if (internalApprovable && externalReviewPending) {
         terminationReason = "external_review_pending";
         feedback = "External review did not complete within the wait budget; not auto-approving.";

--- a/src/pipeline/steps/review.ts
+++ b/src/pipeline/steps/review.ts
@@ -1,6 +1,6 @@
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { formatLlmResultDetail } from "../step-utils.js";
-import { extractFirstJsonObject } from "../json-extract.js";
+import { REVIEW_VERDICT_JSON_SCHEMA, parseReviewVerdict, plainIssueText } from "../review-verdict.js";
 import { wrapWithPlanningGuard } from "../../planning-context-assembly.js";
 import { READ_ONLY_ALLOWED_TOOLS } from "./read-only-tools.js";
 
@@ -21,14 +21,6 @@ interface ReviewOutputs extends Record<string, unknown> {
   progressDelta: number;
   feedback: string;
   tokensUsed: number;
-}
-
-interface ReviewJson {
-  approved?: boolean;
-  issues?: string[];
-  score?: number;
-  progress_delta?: number;
-  feedback?: string;
 }
 
 /**
@@ -69,16 +61,16 @@ const REVIEW_PROMPT = (
   prompt += `\n\nRespond with a JSON object only:
 {
   "approved": true | false,
-  "issues": ["<issue 1>", "<issue 2>"],
+  "blocking_issues": [{"title": "<issue title>", "location": "<file/function; omit when unknown>", "problem": "<full failing behavior>", "required_fix": "<full required fix>"}],
   "score": <0-100 quality score>,
   "progress_delta": <0-100 percentage of issue addressed>,
   "feedback": "<concise reviewer notes>"
 }
 
 Approval contract:
-- If issues[] is non-empty, approved must be false.
+- If blocking_issues[] is non-empty, approved must be false.
 - Do not set approved=true while listing unresolved issues.
-- Put every required fix in issues[]; feedback is only summary context.`;
+- Put every required fix in blocking_issues[]; feedback is only summary context.`;
 
   if (reviewRubric) {
     prompt += `\n\n## Run-specific review rubric\n${reviewRubric}`;
@@ -101,38 +93,39 @@ export const reviewStep: StepModule<ReviewInputs, ReviewOutputs> = {
 
     const result = await context.llmExecutor.invoke({
       prompt,
-      model: model ?? "claude-sonnet-4-6",
+      model: model ?? "claude-sonnet-5",
       tools: READ_ONLY_ALLOWED_TOOLS,
+      jsonSchema: REVIEW_VERDICT_JSON_SCHEMA,
     });
 
     if (result.exitCode !== 0) {
       throw new Error(`Review LLM invocation failed with exit code ${result.exitCode}${formatLlmResultDetail(result)}`);
     }
-
-    let approved = false;
-    let issues: string[] = [];
-    let score = 0;
-    let progressDelta = 0;
-    let feedback = "";
-
-    try {
-      const parsed = extractFirstJsonObject(result.stdout);
-      if (parsed) {
-        const json = parsed as ReviewJson;
-        issues = Array.isArray(json.issues)
-          ? json.issues.filter((issue): issue is string => typeof issue === "string" && issue.trim().length > 0)
-          : [];
-        approved = (json.approved ?? false) && issues.length === 0;
-        score = typeof json.score === "number" ? json.score : 0;
-        progressDelta = typeof json.progress_delta === "number" ? json.progress_delta : 0;
-        feedback = json.feedback ?? "";
-      } else {
-        feedback = result.stdout.trim();
-      }
-    } catch {
-      feedback = result.stdout.trim();
+    if (!result.terminalStatus) {
+      throw new Error(`Review LLM invocation did not return a terminal result event${formatLlmResultDetail(result)}`);
+    }
+    if (result.terminalStatus?.isError === true) {
+      throw new Error(`Review LLM invocation returned an error terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`);
+    }
+    if (result.terminalStatus.subtype !== "success") {
+      throw new Error(`Review LLM invocation finished without a successful terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`);
+    }
+    if (result.telemetry?.outcome && result.telemetry.outcome !== "success") {
+      throw new Error(`Review LLM invocation finished without a successful terminal result (${result.telemetry.outcome})${formatLlmResultDetail(result)}`);
+    }
+    if (result.structuredOutput === undefined) {
+      throw new Error(`Review LLM invocation did not return structured_output${formatLlmResultDetail(result)}`);
     }
 
-    return { approved, issues, score, progressDelta, feedback, tokensUsed: result.tokensUsed };
+    const verdict = parseReviewVerdict(result.structuredOutput);
+
+    return {
+      approved: verdict.approved,
+      issues: verdict.blockingIssues.map(plainIssueText),
+      score: verdict.score,
+      progressDelta: verdict.progressDelta,
+      feedback: verdict.feedback,
+      tokensUsed: result.tokensUsed,
+    };
   },
 };

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -127,12 +127,20 @@ export interface RunTelemetry {
   toolTrace?: string[];
 }
 
+export interface LLMTerminalStatus {
+  subtype: string | null;
+  isError: boolean | null;
+}
+
 export interface LLMResult {
   stdout: string;
   stderr?: string;
   exitCode: number;
   tokensUsed: number;
   telemetry?: RunTelemetry;
+  structuredOutput?: unknown;
+  hasTerminalResult?: boolean;
+  terminalStatus?: LLMTerminalStatus;
 }
 
 export interface LLMExecutor {
@@ -141,6 +149,7 @@ export interface LLMExecutor {
     model: string;
     maxTurns?: number;
     tools?: string[];
+    jsonSchema?: Record<string, unknown>;
   }): Promise<LLMResult>;
 }
 

--- a/src/run-autonomous.ts
+++ b/src/run-autonomous.ts
@@ -455,7 +455,7 @@ export async function runAutonomous(opts: RunAutonomousOptions = {}): Promise<Ru
     appendPipelineOwnedGitInstructions(implementationPrompt, prNumber),
   );
   implementationPrompt = appendOperatorInstruction(implementationPrompt, commentInstruction);
-  const model = claudeModel || workflowModel || "claude-sonnet-4-6";
+  const model = claudeModel || workflowModel || "claude-sonnet-5";
   const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir, logLevel);
   const orchestratorUrl = process.env.ORCHESTRATOR_URL;
   const nonce = process.env.MACHINE_NONCE ?? "";
@@ -832,7 +832,7 @@ export async function runAutonomousLocally(
   implementationPrompt = appendValidationCommandDiscipline(
     appendPipelineOwnedGitInstructions(implementationPrompt, ""),
   );
-  const model = opts.model ?? workflowModel ?? "claude-sonnet-4-6";
+  const model = opts.model ?? workflowModel ?? "claude-sonnet-5";
   const llmExecutor = opts.llmExecutor ?? new ClaudeCliExecutor(workspaceDir, "summary");
   const reporter = opts.reporter ?? new NoopStepReporter();
 

--- a/src/run-planning.ts
+++ b/src/run-planning.ts
@@ -113,7 +113,7 @@ export async function runPlanningLocally(
     SIBLINGS: opts.siblings ?? "None",
     DEPENDENCIES: opts.dependencies ?? "None",
   };
-  let model = opts.model ?? "claude-sonnet-4-6";
+  let model = opts.model ?? "claude-sonnet-5";
   let prompt = buildDefaultPlanningPrompt(subs);
   const planningMdPath = join(opts.workspaceDir, "PLANNING.md");
   if (existsSync(planningMdPath)) {
@@ -188,7 +188,7 @@ export async function runPlanning(opts: RunPlanningOptions = {}): Promise<{ exit
     SIBLINGS: envelopePlanningContext?.siblings ?? process.env.SIBLINGS?.trim() ?? "None",
     DEPENDENCIES: envelopePlanningContext?.dependencies ?? process.env.DEPENDENCIES?.trim() ?? "None",
   };
-  let model = process.env.CLAUDE_MODEL || "claude-sonnet-4-6";
+  let model = process.env.CLAUDE_MODEL || "claude-sonnet-5";
   let prompt = buildDefaultPlanningPrompt(subs);
   const planningMdPath = join(workspaceDir, "PLANNING.md");
   if (existsSync(planningMdPath)) {

--- a/workflows/PLANNING.md
+++ b/workflows/PLANNING.md
@@ -2,14 +2,14 @@
 # Claude model used for planning. Passed through verbatim to
 # `claude-code --model`, so any ID your configured provider accepts is fine.
 # Examples:
-#   Anthropic API / OAuth: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5-20251001
+#   Anthropic API / OAuth: claude-sonnet-5, claude-opus-4-7, claude-haiku-4-5-20251001
 #   AWS Bedrock:           anthropic.claude-sonnet-4-6-20250805-v1:0
 #                          or an inference-profile ARN (arn:aws:bedrock:...)
 # The default below works for the Anthropic provider. If this repo's mapping
 # is switched to provider=bedrock in the orchestrator admin UI, replace this
 # with a Bedrock model ID: nothing validates the pairing, so an Anthropic-style
 # ID reaches Bedrock verbatim and fails at invocation time rather than early.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 <!--

--- a/workflows/WORKFLOW.md
+++ b/workflows/WORKFLOW.md
@@ -2,14 +2,14 @@
 # Claude model used for implementation. Passed through verbatim to
 # `claude-code --model`, so any ID your configured provider accepts is fine.
 # Examples:
-#   Anthropic API / OAuth: claude-sonnet-4-6, claude-opus-4-7, claude-haiku-4-5-20251001
+#   Anthropic API / OAuth: claude-sonnet-5, claude-opus-4-7, claude-haiku-4-5-20251001
 #   AWS Bedrock:           anthropic.claude-sonnet-4-6-20250805-v1:0
 #                          or an inference-profile ARN (arn:aws:bedrock:...)
 # The default below works for the Anthropic provider. If this repo's mapping
 # is switched to provider=bedrock in the orchestrator admin UI, replace this
 # with a Bedrock model ID: nothing validates the pairing, so an Anthropic-style
 # ID reaches Bedrock verbatim and fails at invocation time rather than early.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 
 # To run a cheaper model for the automated review pass than for implementation,
 # set models.implement / models.review in .ai-implement/config.yml. Those take


### PR DESCRIPTION
Automated reviews can fail after returning an otherwise useful verdict because the pipeline extracts JSON from free-form assistant text. Both review stages now request a JSON Schema through Claude Code and read `structured_output` from a successful terminal result. The validator rejects missing or malformed verdicts and keeps unresolved blockers from approving a PR.

The runner pins Claude Code 2.1.263 and uses `claude-sonnet-5` for built-in defaults and seeded templates. Explicit project overrides retain precedence. Existing max-turn termination behavior is preserved.

This is a focused change against upstream `testing`. The separate CloudShare port is https://github.com/cloudshare/ai-implement/pull/117. It carries the same behavior onto CloudShare's own base without merging unrelated upstream history; the PRs can land independently.

Validation:
- Full suite: 4,460 tests passed across 192 files.
- TypeScript build passed.
- Runner Docker image built from this branch.
- Non-root, network-disabled container smoke check passed: CLI version, compiled runner/executor imports, verdict validation, and invalid-schema rejection in stream-json mode.

No authenticated provider review or deployment was performed.
