### PR TITLE
fix: preserve external review fixes with structured verdicts

### DIFF
--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -67,6 +67,8 @@ An unsuccessful or missing terminal result, missing structured output, or invali
 
 The runner pins Claude Code in `Dockerfile.session`. Built-in model fallbacks and newly seeded workflow templates use `claude-sonnet-5`. Explicit model settings retain their existing precedence; already-seeded target-repo `WORKFLOW.md` and `PLANNING.md` files are not overwritten by template sync, so projects that pin an older model keep that model until their configuration changes. Bedrock projects still need a model ID accepted by their configured provider.
 
+Repositories that pin a runner image with `.ai-implement/image.yml` must update that image to include this executor and a Claude Code CLI supporting `--json-schema` and terminal `structured_output` (the bundled runner pins 2.1.263). Updating the orchestrator alone does not update a pinned runner image; an older CLI or executor can leave automated reviews incomplete.
+
 Claude Code documents schema-based output in [programmatic usage](https://code.claude.com/docs/en/headless#get-structured-output). Sonnet 5 migration details, including the changed tokenizer and thinking defaults, are in the [official migration guide](https://platform.claude.com/docs/en/models/sonnet-5/migration-guide).
 
 ## Hook environment and forwarded secrets

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -6,23 +6,7 @@ import { OperatorCancelledError, PrMergedError } from "../pipeline/operator-canc
 function makeCtx(execMock: any) {
   return {
     data: { issueIdentifier: "AII-200", issueTitle: "X", issueDescription: "Y", model: "claude-sonnet-4-6" },
-    llmExecutor: {
-      invoke: vi.fn(async (params: any) => {
-        const result = await execMock(params);
-        if (!params.jsonSchema || result.exitCode !== 0 || "structuredOutput" in result) return result;
-        let parsed;
-        try {
-          parsed = JSON.parse(result.stdout);
-        } catch {
-          return { ...result, structuredOutput: undefined, terminalStatus: { subtype: "success", isError: false } };
-        }
-        return {
-          ...result,
-          structuredOutput: parsed,
-          terminalStatus: { subtype: "success", isError: false },
-        };
-      }),
-    },
+    llmExecutor: { invoke: execMock },
     getOutputs: () => ({}),
     setOutputs: () => {},
     resolveInputs: (i: any) => i,
@@ -46,7 +30,7 @@ function countOccurrences(text: string, needle: string): number {
 
 describe("postPushReviewStep", () => {
   it("approves on first iteration, posts ✅ comment, returns approved=true", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -57,7 +41,7 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
     const out = await postPushReviewStep.run(
       ctx,
       { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
@@ -70,7 +54,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("submits a native COMMENT review when merge-ready", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const reviewCalls: string[][] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -80,7 +64,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     await postPushReviewStep.run(
       ctx,
@@ -96,7 +80,7 @@ describe("postPushReviewStep", () => {
 
   it("logs native review response details and PR context when submission fails", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews")) {
@@ -131,7 +115,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
     let warnings = "";
 
     try {
@@ -155,13 +139,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("submits a native COMMENT review when blockers remain", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: false,
       blocking_issues: [{ title: "Fix validation", problem: "Null owners pass.", required_fix: "Reject null owners." }],
       score: 4,
       progress_delta: 0,
       feedback: "Not ready.",
-    });
+    };
     const reviewCalls: string[][] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -171,7 +155,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     await postPushReviewStep.run(
       ctx,
@@ -184,7 +168,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("loops to cap then posts ⚠️ comment", async () => {
-    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "bug", problem: "bug", required_fix: "bug" }], feedback: "fix the bug", score: 4, progress_delta: 0 });
+    const notApproved = { approved: false, blocking_issues: [{ title: "bug", problem: "bug", required_fix: "bug" }], feedback: "fix the bug", score: 4, progress_delta: 0 };
     const ghComments: string[] = [];
     const gitPushCalls: string[][] = [];
     const pushOrder: string[] = [];
@@ -208,7 +192,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(notApproved))));
     const refreshCredentials = vi.fn(async () => {
       pushOrder.push("refresh");
     });
@@ -252,7 +236,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("defaults to two fix passes plus a final review", async () => {
-    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "bug", problem: "bug", required_fix: "bug" }], feedback: "fix the bug", score: 4, progress_delta: 0 });
+    const notApproved = { approved: false, blocking_issues: [{ title: "bug", problem: "bug", required_fix: "bug" }], feedback: "fix the bug", score: 4, progress_delta: 0 };
     const ghComments: string[] = [];
     const gitPushCalls: string[][] = [];
     const gitSpawn = vi.fn((args: string[]) => {
@@ -271,7 +255,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(notApproved))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -288,13 +272,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("runs a fix pass when reviewer approves but reports actionable issues", async () => {
-    const approvedWithIssues = JSON.stringify({
+    const approvedWithIssues = {
       approved: true,
       blocking_issues: [{ title: "Escape quoted user input", problem: "Escape quoted user input", required_fix: "Escape quoted user input" }],
       feedback: "Minor issue worth addressing.",
       score: 8,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -303,7 +287,7 @@ describe("postPushReviewStep", () => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: approvedWithIssues, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(approvedWithIssues)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -394,6 +378,25 @@ describe("postPushReviewStep", () => {
     expect(out.finalFeedback).toContain("error_during_execution");
   });
 
+  it.each([
+    ["missing terminal", { terminalStatus: undefined }, "terminal result event"],
+    ["non-success subtype", { terminalStatus: { subtype: "error_max_turns", isError: false } }, "error_max_turns"],
+    ["failed telemetry", { telemetry: { outcome: "max_turns" } }, "max_turns"],
+  ])("rejects structured approval with %s", async (_name, overrides, message) => {
+    const invoke = vi.fn(async () => ({
+      ...structuredReviewResult({ approved: true, blocking_issues: [], score: 90, progress_delta: 100, feedback: "ok" }),
+      ...overrides,
+    }));
+    const out = await postPushReviewStep.run(makeCtx(invoke), {
+      prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, reviewProviders: [],
+      ghSpawn: vi.fn(() => ({ stdout: "", exitCode: 0 })),
+      gitSpawn: vi.fn(() => ({ stdout: "", exitCode: 0 })),
+    }, { report: vi.fn(async () => undefined) });
+    expect(out.terminationReason).toBe("review_failed");
+    expect(out.finalFeedback).toContain(message);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
   it("fails closed when structured output includes legacy verdict aliases", async () => {
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -449,13 +452,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("rejects the findings alias without running a fix pass", async () => {
-    const approvedWithFindings = JSON.stringify({
+    const approvedWithFindings = {
       approved: true,
       findings: [{ title: "Missing guard", problem: "Null input reaches the write path.", required_fix: "Reject null input." }],
       feedback: "One finding remains.",
       score: 7,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -464,7 +467,7 @@ describe("postPushReviewStep", () => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: approvedWithFindings, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(approvedWithFindings)));
 
     const out = await postPushReviewStep.run(
       makeCtx(invoke),
@@ -478,13 +481,13 @@ describe("postPushReviewStep", () => {
   });
 
   it.each([true, false])("runs an external-findings fix pass with approved=%s and no internal issues", async (approved) => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved,
       blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -505,7 +508,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -525,13 +528,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("runs a fix pass when a Claude issue comment has blocking findings and internal review approves", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: true,
       blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -559,7 +562,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -585,13 +588,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not approve when the GitHub Actions Claude review reports a prose blocking finding", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: true,
       blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -626,7 +629,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -641,13 +644,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("preserves opportunistic external collection when reviewProviders is undefined", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: true,
       blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -664,7 +667,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -683,13 +686,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("skips external collection when reviewProviders is an empty array", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: true,
       blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -703,7 +706,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -722,13 +725,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("collects external findings when github-claude-code-review is configured", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: true,
       blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -745,7 +748,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -775,13 +778,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("deduplicates internal issues that repeat external review findings", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: false,
       blocking_issues: [{ title: "Missing UUID validation on path params.", problem: "Missing UUID validation on path params.", required_fix: "Missing UUID validation on path params." }],
       feedback: "External blocker is still unresolved.",
       score: 4,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -802,7 +805,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -817,14 +820,59 @@ describe("postPushReviewStep", () => {
     expect(countOccurrences(reviewComment ?? "", "Missing UUID validation on path params.")).toBe(1);
   });
 
+  it("preserves distinct internal problems when only the required fix matches external text", async () => {
+    const reviewerOutput = {
+      approved: false,
+      blocking_issues: [{ title: "Validate ownership", location: "src/owners.ts", problem: "Untrusted ownership data reaches two write paths.", required_fix: "Add a null check." }],
+      feedback: "External blocker is still unresolved.",
+      score: 4,
+      progress_delta: 0,
+    };
+    const gitSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "status") return { stdout: "", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const ghComments: string[] = [];
+    const ghSpawn = vi.fn((args: string[]) => {
+      if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
+      if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews?per_page=100")) {
+        return {
+          stdout: JSON.stringify([
+            [{ state: "CHANGES_REQUESTED", body: "Add a null check.", user: { login: "reviewer" } }],
+          ]),
+          exitCode: 0,
+        };
+      }
+      if (args[0] === "pr" && args[1] === "comment") {
+        ghComments.push(args[args.indexOf("--body") + 1]);
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
+    const ctx = makeCtx(invoke);
+
+    await postPushReviewStep.run(
+      ctx,
+      { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
+      { report: vi.fn(async () => undefined) },
+    );
+
+    const fixPrompt = invoke.mock.calls[1][0].prompt;
+    expect(fixPrompt).toContain("Untrusted ownership data reaches two write paths.");
+    expect(fixPrompt).toContain("Location: src/owners.ts");
+    expect(fixPrompt).toContain("Required external review findings");
+    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
+    expect(reviewComment).toContain("Untrusted ownership data reaches two write paths.");
+  });
+
   it("suppresses duplicate feedback that repeats external review findings", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: true,
       blocking_issues: [],
       feedback: "Missing UUID validation on path params.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -845,7 +893,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -863,13 +911,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not run a fix pass when approved feedback contains actionable language but issues is empty", async () => {
-    const approvedWithFeedback = JSON.stringify({
+    const approvedWithFeedback = {
       approved: true,
       blocking_issues: [],
       feedback: "Two minor issues worth addressing: escape quotes and use an enum.",
       score: 8,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -878,7 +926,7 @@ describe("postPushReviewStep", () => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: approvedWithFeedback, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(approvedWithFeedback)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -893,19 +941,19 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not run a fix pass for deferred future-task concerns", async () => {
-    const approvedWithDeferredConcern = JSON.stringify({
+    const approvedWithDeferredConcern = {
       approved: true,
       blocking_issues: [],
       feedback: "Clean implementation. One thing to watch in later tasks: prompt injection would need to be addressed at the API call layer, but noting it now so it doesn't get missed as the pipeline grows.",
       score: 8,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: approvedWithDeferredConcern, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(approvedWithDeferredConcern)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -920,19 +968,19 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not turn optional cosmetic review notes into blockers", async () => {
-    const approvedWithCosmeticNote = JSON.stringify({
+    const approvedWithCosmeticNote = {
       approved: true,
       blocking_issues: [],
       feedback: "Clean implementation. Minor cosmetic note for a later cleanup pass: consider hover:bg-stone-200 at some point, but that is not required by this task.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: approvedWithCosmeticNote, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(approvedWithCosmeticNote)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -947,13 +995,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("requires structured issues when reviewer marks a PR not ready", async () => {
-    const notReadyWithoutBlocker = JSON.stringify({
+    const notReadyWithoutBlocker = {
       approved: false,
       blocking_issues: [],
       feedback: "There is a bug in the timer restart flow, so this is not ready.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -963,7 +1011,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: notReadyWithoutBlocker, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(notReadyWithoutBlocker)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -980,19 +1028,19 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not treat benign should-pass approval language as actionable", async () => {
-    const approvedWithShouldPass = JSON.stringify({
+    const approvedWithShouldPass = {
       approved: true,
       blocking_issues: [],
       feedback: "The implementation is ready; tests should pass and this should be merged as-is.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: approvedWithShouldPass, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(approvedWithShouldPass)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1007,19 +1055,19 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not treat resolved prior blockers in approval feedback as actionable", async () => {
-    const approvedWithResolvedBlockers = JSON.stringify({
+    const approvedWithResolvedBlockers = {
       approved: true,
       blocking_issues: [],
       feedback: "Both Review 1 blockers are resolved. The expired-timer restart bug is fixed and the regression test covers it. Merge readiness: ready to merge.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: approvedWithResolvedBlockers, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(approvedWithResolvedBlockers)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1086,9 +1134,7 @@ describe("postPushReviewStep", () => {
     });
     const report = vi.fn(async () => undefined);
     const ctx = makeCtx(vi.fn(async () => ({
-      stdout: "this is not json",
-      exitCode: 0,
-      tokensUsed: 100,
+      ...structuredReviewResult(undefined, "this is not json"),
     })));
 
     const out = await postPushReviewStep.run(
@@ -1112,7 +1158,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not fail the job when a post-push fix-pass LLM exits non-zero", async () => {
-    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 });
+    const notApproved = { approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn();
     const ghSpawn = vi.fn((args: string[]) => {
@@ -1123,7 +1169,7 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const invoke = vi.fn()
-      .mockResolvedValueOnce({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })
+      .mockResolvedValueOnce(structuredReviewResult(notApproved))
       .mockResolvedValueOnce({
         stdout: "",
         stderr: "claude session expired",
@@ -1147,7 +1193,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("throws on git push --force-with-lease rejection", async () => {
-    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 });
+    const notApproved = { approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "M file.ts\n", exitCode: 0 };
       if (args[0] === "rev-parse" && args[1] === "--short") return { stdout: "abc1234\n", exitCode: 0 };
@@ -1157,7 +1203,7 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const ghSpawn = vi.fn(() => ({ stdout: "diff", exitCode: 0 }));
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(notApproved))));
     await expect(
       postPushReviewStep.run(
         ctx,
@@ -1168,7 +1214,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("stops without pushing when the fix pass makes no changes", async () => {
-    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 });
+    const notApproved = { approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1181,7 +1227,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(notApproved))));
     const out = await postPushReviewStep.run(
       ctx,
       { prNumber: "42", workspaceDir: "/tmp", maxIterations: 3, ghSpawn, gitSpawn },
@@ -1199,13 +1245,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("reports unresolved external findings when an externally blocked fix pass makes no changes", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: true,
       blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
-    });
+    };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1226,7 +1272,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1244,13 +1290,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not parse stdout preamble objects when structured_output is missing", async () => {
-    const reviewerJson = `pre-text {} ${JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "ok" })}`;
+    const reviewerOutput = `pre-text {} ${JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "ok" })}`;
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(undefined, reviewerOutput))));
     const out = await postPushReviewStep.run(
       ctx,
       { prNumber: "42", workspaceDir: "/tmp", maxIterations: 2, ghSpawn, gitSpawn },
@@ -1262,7 +1308,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("updates an existing marker comment instead of posting a duplicate", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "ok" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "ok" };
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args.includes("repos/:owner/:repo/issues/42/comments?per_page=100")) {
         return {
@@ -1279,7 +1325,7 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     await postPushReviewStep.run(
       ctx,
@@ -1298,13 +1344,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("passes reviewer issues through a guarded fix prompt", async () => {
-    const notApproved = JSON.stringify({
+    const notApproved = {
       approved: false,
       blocking_issues: [{ title: "Fix auth flow", problem: "Fix auth flow", required_fix: "Fix auth flow" }, { title: "Add regression test", problem: "Add regression test", required_fix: "Add regression test" }],
       feedback: "The implementation is incomplete.",
       score: 4,
       progress_delta: 0,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -1317,7 +1363,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: notApproved, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(notApproved)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -1350,20 +1396,20 @@ describe("postPushReviewStep", () => {
   });
 
   it("asks follow-up reviews to verify previous findings and continue a full review", async () => {
-    const firstReview = JSON.stringify({
+    const firstReview = {
       approved: false,
       blocking_issues: [{ title: "Fix auth flow", problem: "Fix auth flow", required_fix: "Fix auth flow" }],
       feedback: "Auth is incomplete.",
       score: 4,
       progress_delta: 0,
-    });
-    const secondReview = JSON.stringify({
+    };
+    const secondReview = {
       approved: true,
       blocking_issues: [],
       feedback: "Looks good.",
       score: 9,
       progress_delta: 1,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "M file.ts\n", exitCode: 0 };
       if (args[0] === "rev-parse" && args[1] === "--short") return { stdout: "abc1234\n", exitCode: 0 };
@@ -1377,9 +1423,9 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const invoke = vi.fn()
-      .mockResolvedValueOnce({ stdout: firstReview, exitCode: 0, tokensUsed: 100 })
+      .mockResolvedValueOnce(structuredReviewResult(firstReview))
       .mockResolvedValueOnce({ stdout: "", exitCode: 0, tokensUsed: 100 })
-      .mockResolvedValueOnce({ stdout: secondReview, exitCode: 0, tokensUsed: 100 });
+      .mockResolvedValueOnce(structuredReviewResult(secondReview));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1402,7 +1448,7 @@ describe("postPushReviewStep", () => {
 
   it("includes structured issue details in follow-up review history", async () => {
     const requiredFix = "Move the sessionStorage read into the hydrated effect and keep the dismissed flag synchronized when the first-visit panel is closed.";
-    const firstReview = JSON.stringify({
+    const firstReview = {
       approved: false,
       blocking_issues: [{
         title: "First-visit hydration state is unsafe",
@@ -1413,14 +1459,14 @@ describe("postPushReviewStep", () => {
       feedback: "The first-visit state handling still needs one fix.",
       score: 4,
       progress_delta: 0,
-    });
-    const secondReview = JSON.stringify({
+    };
+    const secondReview = {
       approved: true,
       blocking_issues: [],
       feedback: "Looks good.",
       score: 9,
       progress_delta: 1,
-    });
+    };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "M src/app/page.tsx\n", exitCode: 0 };
       if (args[0] === "rev-parse" && args[1] === "--short") return { stdout: "abc1234\n", exitCode: 0 };
@@ -1434,9 +1480,9 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const invoke = vi.fn()
-      .mockResolvedValueOnce({ stdout: firstReview, exitCode: 0, tokensUsed: 100 })
+      .mockResolvedValueOnce(structuredReviewResult(firstReview))
       .mockResolvedValueOnce({ stdout: "", exitCode: 0, tokensUsed: 100 })
-      .mockResolvedValueOnce({ stdout: secondReview, exitCode: 0, tokensUsed: 100 });
+      .mockResolvedValueOnce(structuredReviewResult(secondReview));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1456,7 +1502,7 @@ describe("postPushReviewStep", () => {
 
   it("posts full structured blocking issues in PR comments and fix prompts", async () => {
     const requiredFix = "Read sessionStorage only after the component has mounted, keep the dismissed flag in sync when the user dismisses the first-visit panel, and preserve the isHydrated guard so server-rendered markup cannot diverge from client-rendered markup.";
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: false,
       blocking_issues: [{
         title: "First-visit detection is incomplete",
@@ -1467,7 +1513,7 @@ describe("postPushReviewStep", () => {
       feedback: "The review found one blocker.",
       score: 4,
       progress_delta: 0,
-    });
+    };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1480,7 +1526,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -1503,13 +1549,13 @@ describe("postPushReviewStep", () => {
 
   it("rejects text-only blocking issue aliases without running a fix pass", async () => {
     const issueText = "The reviewer returned a legacy text-only object that should stay flat in comments and prompts.";
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: false,
       blocking_issues: [{ text: issueText }],
       feedback: issueText,
       score: 4,
       progress_delta: 0,
-    });
+    };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1522,7 +1568,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -1536,7 +1582,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("escapes markdown control characters in structured issue fields", async () => {
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: false,
       blocking_issues: [{
         title: "Fix **unsafe** label",
@@ -1547,7 +1593,7 @@ describe("postPushReviewStep", () => {
       feedback: "Structured fields contain markdown.",
       score: 4,
       progress_delta: 0,
-    });
+    };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1560,7 +1606,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -1585,7 +1631,7 @@ describe("postPushReviewStep", () => {
 
   it("includes unresolved structured issues when a fix pass makes no file changes", async () => {
     const requiredFix = "Persist the dismissed state to sessionStorage before hiding the panel and ensure the initial render waits for the hydrated guard before deciding whether to show the first-visit UI.";
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: false,
       blocking_issues: [{
         title: "Dismissed first-visit state is lost",
@@ -1596,7 +1642,7 @@ describe("postPushReviewStep", () => {
       feedback: "Not ready until the first-visit state is fixed.",
       score: 4,
       progress_delta: 0,
-    });
+    };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1609,7 +1655,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -1626,13 +1672,13 @@ describe("postPushReviewStep", () => {
 
   it("omits duplicate review summaries without truncating structured blocking issues in PR comments", async () => {
     const longIssue = "The parse API error path is missing user-visible error handling in app/page.tsx, so failed parse requests leave the user stuck on the input surface without feedback or a retry path. Add an error state, render it near OpenInput, and reset loading after failures.";
-    const notApproved = JSON.stringify({
+    const notApproved = {
       approved: false,
       blocking_issues: [{ title: "Parse failure", problem: longIssue, required_fix: "Add error handling" }],
       feedback: `Parse failure\nProblem: ${longIssue}\nRequired fix: Add error handling`,
       score: 4,
       progress_delta: 0,
-    });
+    };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1645,7 +1691,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: notApproved, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(notApproved)));
     const ctx = makeCtx(invoke);
 
     await postPushReviewStep.run(
@@ -1661,13 +1707,13 @@ describe("postPushReviewStep", () => {
   });
 
   it("posts a concrete fix summary when the fixer reports one", async () => {
-    const notApproved = JSON.stringify({
+    const notApproved = {
       approved: false,
       blocking_issues: [{ title: "Update hover affordance", problem: "Update hover affordance", required_fix: "Update hover affordance" }],
       feedback: "Hover state is invisible.",
       score: 4,
       progress_delta: 0,
-    });
+    };
     const fixStdout = JSON.stringify({
       fixed: ["Changed OpenInput mic and camera button hover states from stone-100 to stone-200 so they are visible on the landing-page surface."],
       testing: ["Not run; CSS-only class update."],
@@ -1690,10 +1736,10 @@ describe("postPushReviewStep", () => {
       return { stdout: "", exitCode: 0 };
     });
     const invoke = vi.fn()
-      .mockResolvedValueOnce({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })
+      .mockResolvedValueOnce(structuredReviewResult(notApproved))
       .mockResolvedValueOnce({ stdout: fixStdout, exitCode: 0, tokensUsed: 100 })
       .mockResolvedValueOnce({
-        stdout: JSON.stringify({ approved: true, blocking_issues: [], feedback: "Looks good.", score: 9, progress_delta: 1 }),
+        ...structuredReviewResult({ approved: true, blocking_issues: [], feedback: "Looks good.", score: 9, progress_delta: 1 }),
         exitCode: 0,
         tokensUsed: 100,
       });
@@ -1714,7 +1760,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("withholds approval and initiates a fix pass when the verdict has only minor[] entries", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "lgtm", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "lgtm", score: 9, progress_delta: 0 };
     const ghComments: string[] = [];
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -1734,7 +1780,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1756,7 +1802,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("withholds approval and initiates a fix pass when the verdict has blocking[] entries", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 };
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -1779,7 +1825,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1799,7 +1845,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not include minor external findings in the approval comment when there are none", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "lgtm", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "lgtm", score: 9, progress_delta: 0 };
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -1808,7 +1854,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -1822,7 +1868,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("waits for the external review check to complete before approving and ingests its late findings", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     let checkCompleted = false;
@@ -1857,7 +1903,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1875,7 +1921,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not auto-approve when the external review check never finishes (fail-closed)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     const ghComments: string[] = [];
     const reviewCalls: string[][] = [];
@@ -1897,7 +1943,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -1912,7 +1958,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("recognizes 'review' and 'code-review-plugin' check names as the external review gate by default", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -1936,7 +1982,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -1952,7 +1998,7 @@ describe("postPushReviewStep", () => {
 
   it("logs a warning when check runs are present but none match the external review gate", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -1972,7 +2018,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
     let warnings = "";
 
     try {
@@ -1992,7 +2038,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("fails open and approves when no external review check exists for the head SHA", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     let checkRunsQueried = false;
@@ -2007,7 +2053,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -2022,7 +2068,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when the only matching check concluded 'skipped' (fails closed immediately)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2041,7 +2087,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2056,7 +2102,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("recognizes 'claude-code-review' as the external review gate by default", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2077,7 +2123,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2093,7 +2139,7 @@ describe("postPushReviewStep", () => {
 
   it("warns with the head SHA when no check runs are present at all", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2105,7 +2151,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
     let warnings = "";
 
     try {
@@ -2123,7 +2169,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when a matching check concluded 'cancelled'", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2141,7 +2187,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2155,7 +2201,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when matching checks concluded 'timed_out' or 'action_required'", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
 
@@ -2175,7 +2221,7 @@ describe("postPushReviewStep", () => {
         }
         return { stdout: "", exitCode: 0 };
       });
-      const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+      const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
       const out = await postPushReviewStep.run(
         ctx,
@@ -2189,7 +2235,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when a matching check has an unrecognised novel conclusion", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2207,7 +2253,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2221,7 +2267,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("satisfies the gate when a matching check concluded 'failure'", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2242,7 +2288,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2257,7 +2303,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("satisfies the gate when a mixed set contains one skipped and one success check", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2281,7 +2327,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2296,7 +2342,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("uses configured reviewCheckNames for exact matching, overriding defaults", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerOutput = { approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 };
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2321,7 +2367,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2337,7 +2383,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("T-1 (AII-436): GH Actions bot clean verdict + green review check + zero findings → approved=true", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2375,7 +2421,7 @@ describe("postPushReviewStep", () => {
         exitCode: 0,
       };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2391,7 +2437,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("T-2 (KGB-9): internal approval + failing CI check → Not ready to merge, check named", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2425,7 +2471,7 @@ describe("postPushReviewStep", () => {
         exitCode: 0,
       };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2443,7 +2489,7 @@ describe("postPushReviewStep", () => {
     // AII-436: The GH Actions bot posted an approving comment with no structured finding
     // sections and no "no issues found" phrasing. Old code fabricated a finding and blocked
     // approval. New code flags findingsUnavailable and shows a note instead.
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2481,7 +2527,7 @@ describe("postPushReviewStep", () => {
         exitCode: 0,
       };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2502,7 +2548,7 @@ describe("postPushReviewStep", () => {
   it("T-4: 'Not ready to merge' comment lists concrete external findings, not just a banner", async () => {
     // Criterion 3: any Not-ready comment must enumerate the concrete blocking findings.
     // Regression: old externalBlockingCommentBlock posted a banner with no findings listed.
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2541,7 +2587,7 @@ describe("postPushReviewStep", () => {
         exitCode: 0,
       };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2557,7 +2603,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("T-5: CI gate does not block when all non-review checks pass", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       if (args[0] === "api" && args.some((a) => a === "repos/:owner/:repo/pulls/42")) {
@@ -2586,7 +2632,7 @@ describe("postPushReviewStep", () => {
         exitCode: 0,
       };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2600,13 +2646,13 @@ describe("postPushReviewStep", () => {
   it("T-6: CI gate excludes the external review check's own failure — not double-counted as a CI blocker", async () => {
     // When the external review check concludes "failure" (reviewer found issues), the CI gate
     // must not also report it as a failing CI check. The external review path handles it.
-    const reviewerJson = JSON.stringify({
+    const reviewerOutput = {
       approved: false,
       blocking_issues: [{ title: "Bug", problem: "Null ref in foo method", required_fix: "Guard against null." }],
       score: 3,
       progress_delta: 0,
       feedback: "Fix the null ref.",
-    });
+    };
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2637,7 +2683,7 @@ describe("postPushReviewStep", () => {
         exitCode: 0,
       };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
 
     const out = await postPushReviewStep.run(
       ctx,
@@ -2655,7 +2701,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("throws OperatorCancelledError when gh pr comment fails with 'issue is locked' and PR is closed-not-merged", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       if (args[0] === "pr" && args[1] === "comment") {
@@ -2666,7 +2712,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
     await expect(
       postPushReviewStep.run(
         ctx,
@@ -2761,7 +2807,7 @@ describe("postPushReviewStep", () => {
     // The most common exit is "approved", and on its last iteration it never pushes. A close
     // that lands while the reviewer LLM call is running must not become a reported success:
     // the probe after the reviewer returns (and at the top of each iteration) catches it.
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghComments: string[] = [];
     let reviewerRan = false;
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2800,7 +2846,7 @@ describe("postPushReviewStep", () => {
     const ctx = makeCtx(
       vi.fn(async () => {
         reviewerRan = true;
-        return { stdout: reviewerJson, exitCode: 0, tokensUsed: 100 };
+        return structuredReviewResult(reviewerOutput);
       }),
     );
     await expect(
@@ -2844,7 +2890,7 @@ describe("postPushReviewStep", () => {
     // A locked conversation on an OPEN, unmerged PR is not the merge race: the merged-only
     // guard must fall through to the normal review path. A locked PR that is CLOSED and
     // unmerged is an operator cancel, which assertPrWritable classifies as OPERATOR_CANCELLED.
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args[1]?.includes("/pulls/")) {
         return { stdout: '{"merged":false,"locked":true}', exitCode: 0 };
@@ -2852,7 +2898,7 @@ describe("postPushReviewStep", () => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -2867,7 +2913,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("continues normally when gh api call fails (fail-open)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args[1]?.includes("/pulls/")) {
         return { stdout: "", exitCode: 1 };
@@ -2875,7 +2921,7 @@ describe("postPushReviewStep", () => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -2890,7 +2936,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("proceeds normally when PR is open and unlocked (regression guard)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args[1]?.includes("/pulls/")) {
         return { stdout: '{"merged":false,"locked":false}', exitCode: 0 };
@@ -2898,7 +2944,7 @@ describe("postPushReviewStep", () => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
     });
-    const invoke = vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 }));
+    const invoke = vi.fn(async () => (structuredReviewResult(reviewerOutput)));
     const ctx = makeCtx(invoke);
 
     const out = await postPushReviewStep.run(
@@ -2945,13 +2991,13 @@ describe("postPushReviewStep", () => {
     // The PR is open through the first review and fix-pass LLM, then merged. The
     // assertPrWritable guard before the git push detects the merge and exits as pr_merged
     // without pushing. iteration=1 because detection fires before the second iteration starts.
-    const reviewIssues = JSON.stringify({
+    const reviewIssues = {
       approved: false,
       blocking_issues: [{ title: "Bug", problem: "Null ref", required_fix: "Guard it" }],
       feedback: "has issues",
       score: 4,
       progress_delta: 0,
-    });
+    };
     let invokeCount = 0;
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: " M src/example.ts\n", exitCode: 0 };
@@ -2975,7 +3021,7 @@ describe("postPushReviewStep", () => {
     });
     const invoke = vi.fn(async () => {
       invokeCount++;
-      if (invokeCount === 1) return { stdout: reviewIssues, exitCode: 0, tokensUsed: 100 };
+      if (invokeCount === 1) return structuredReviewResult(reviewIssues);
       // Fix-pass LLM: after this returns, invokeCount=2, so pr view returns MERGED.
       return { stdout: JSON.stringify({ fixed: ["Guarded null ref"] }), exitCode: 0, tokensUsed: 100 };
     });
@@ -3021,7 +3067,7 @@ describe("postPushReviewStep", () => {
       invokeCount++;
       if (invokeCount === 1) {
         return {
-          stdout: JSON.stringify({
+          ...structuredReviewResult({
             approved: false,
             blocking_issues: [{ title: "Bug", problem: "Missing null check", required_fix: "Add null guard" }],
             feedback: "found issues",
@@ -3036,7 +3082,7 @@ describe("postPushReviewStep", () => {
         return { stdout: JSON.stringify({ fixed: ["Added null guard"] }), exitCode: 0, tokensUsed: 100 };
       }
       // Reviewer #2: would approve, but submitPrReview's assertPrWritable detects MERGED first.
-      return { stdout: JSON.stringify({ approved: true, blocking_issues: [], score: 95, progress_delta: 100, feedback: "lgtm" }), exitCode: 0, tokensUsed: 100 };
+      return { ...structuredReviewResult({ approved: true, blocking_issues: [], score: 95, progress_delta: 100, feedback: "lgtm" }), exitCode: 0, tokensUsed: 100 };
     });
 
     const out = await postPushReviewStep.run(
@@ -3078,7 +3124,7 @@ describe("postPushReviewStep", () => {
       invokeCount++;
       if (invokeCount === 1) {
         return {
-          stdout: JSON.stringify({
+          ...structuredReviewResult({
             approved: false,
             blocking_issues: [{ title: "Bug", problem: "Missing null check", required_fix: "Add null guard" }],
             feedback: "found issues",
@@ -3111,7 +3157,7 @@ describe("postPushReviewStep", () => {
     // assertPrWritable is called in the lock handler after "issue is locked" is received.
     // When the PR is open (locked by a human, not a merge), assertPrWritable returns normally
     // and the original write error surfaces as a genuine failure.
-    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerOutput = { approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" };
     let prCommentCalls = 0;
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "view") {
@@ -3127,7 +3173,7 @@ describe("postPushReviewStep", () => {
       }
       return { stdout: "", exitCode: 0 };
     });
-    const ctx = makeCtx(vi.fn(async () => ({ stdout: reviewerJson, exitCode: 0, tokensUsed: 100 })));
+    const ctx = makeCtx(vi.fn(async () => (structuredReviewResult(reviewerOutput))));
     await expect(
       postPushReviewStep.run(
         ctx,

--- a/src/__tests__/post-push-review.test.ts
+++ b/src/__tests__/post-push-review.test.ts
@@ -18,7 +18,7 @@ function makeCtx(execMock: any) {
         }
         return {
           ...result,
-          structuredOutput: normalizeLegacyReviewFixture(parsed),
+          structuredOutput: parsed,
           terminalStatus: { subtype: "success", isError: false },
         };
       }),
@@ -27,36 +27,6 @@ function makeCtx(execMock: any) {
     setOutputs: () => {},
     resolveInputs: (i: any) => i,
   } as any;
-}
-
-function normalizeLegacyReviewFixture(parsed: any) {
-  const source = Array.isArray(parsed.blocking_issues)
-    ? parsed.blocking_issues
-    : Array.isArray(parsed.issues)
-      ? parsed.issues
-      : Array.isArray(parsed.findings)
-        ? parsed.findings
-        : [];
-  return {
-    approved: parsed.approved,
-    blocking_issues: source.map((issue: any) => {
-      if (typeof issue === "string") {
-        return { title: "Blocking issue", problem: issue, required_fix: issue };
-      }
-      if (typeof issue.text === "string") {
-        return { title: "Blocking issue", problem: issue.text, required_fix: issue.text };
-      }
-      return {
-        title: issue.title ?? "Blocking issue",
-        ...(issue.location || issue.file || issue.path ? { location: issue.location ?? issue.file ?? issue.path } : {}),
-        problem: issue.problem ?? issue.issue ?? issue.details ?? issue.description ?? issue.title ?? "Blocking issue",
-        required_fix: issue.required_fix ?? issue.requiredFix ?? issue.fix ?? issue.recommendation ?? issue.problem ?? issue.title ?? "Fix the issue",
-      };
-    }),
-    score: parsed.score,
-    progress_delta: parsed.progress_delta,
-    feedback: parsed.feedback,
-  };
 }
 
 function structuredReviewResult(structuredOutput: unknown, stdout = "ignored final text") {
@@ -76,7 +46,7 @@ function countOccurrences(text: string, needle: string): number {
 
 describe("postPushReviewStep", () => {
   it("approves on first iteration, posts ✅ comment, returns approved=true", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -100,7 +70,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("submits a native COMMENT review when merge-ready", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const reviewCalls: string[][] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -126,7 +96,7 @@ describe("postPushReviewStep", () => {
 
   it("logs native review response details and PR context when submission fails", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       if (args[0] === "api" && args.includes("repos/:owner/:repo/pulls/42/reviews")) {
@@ -214,7 +184,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("loops to cap then posts ⚠️ comment", async () => {
-    const notApproved = JSON.stringify({ approved: false, issues: ["bug"], feedback: "fix the bug", score: 4, progress_delta: 0 });
+    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "bug", problem: "bug", required_fix: "bug" }], feedback: "fix the bug", score: 4, progress_delta: 0 });
     const ghComments: string[] = [];
     const gitPushCalls: string[][] = [];
     const pushOrder: string[] = [];
@@ -267,7 +237,7 @@ describe("postPushReviewStep", () => {
     expect(ghComments.some((c) => c.includes("fix-complete") && c.includes("Fix pass 1/2"))).toBe(false);
     expect(ghComments.some((c) => c.includes("⚠️") && c.includes("cap"))).toBe(true);
     expect(ghComments.some((c) => c.includes("cap") && c.includes("Not ready to merge"))).toBe(true);
-    expect(ghComments.some((c) => c.includes("cap") && c.includes("Blocking issues:\n1. bug"))).toBe(true);
+    expect(ghComments.some((c) => c.includes("cap") && c.includes("Blocking issues:\n1. **bug**"))).toBe(true);
     expect(ctx.llmExecutor.invoke).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -282,7 +252,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("defaults to two fix passes plus a final review", async () => {
-    const notApproved = JSON.stringify({ approved: false, issues: ["bug"], feedback: "fix the bug", score: 4, progress_delta: 0 });
+    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "bug", problem: "bug", required_fix: "bug" }], feedback: "fix the bug", score: 4, progress_delta: 0 });
     const ghComments: string[] = [];
     const gitPushCalls: string[][] = [];
     const gitSpawn = vi.fn((args: string[]) => {
@@ -320,7 +290,7 @@ describe("postPushReviewStep", () => {
   it("runs a fix pass when reviewer approves but reports actionable issues", async () => {
     const approvedWithIssues = JSON.stringify({
       approved: true,
-      issues: ["Escape quoted user input"],
+      blocking_issues: [{ title: "Escape quoted user input", problem: "Escape quoted user input", required_fix: "Escape quoted user input" }],
       feedback: "Minor issue worth addressing.",
       score: 8,
       progress_delta: 0,
@@ -478,7 +448,7 @@ describe("postPushReviewStep", () => {
     expect(invoke.mock.calls[1][0].prompt).toContain("Add a regression test.");
   });
 
-  it("runs a fix pass when reviewer uses the findings alias", async () => {
+  it("rejects the findings alias without running a fix pass", async () => {
     const approvedWithFindings = JSON.stringify({
       approved: true,
       findings: [{ title: "Missing guard", problem: "Null input reaches the write path.", required_fix: "Reject null input." }],
@@ -503,15 +473,14 @@ describe("postPushReviewStep", () => {
     );
 
     expect(out.approved).toBe(false);
-    expect(invoke).toHaveBeenCalledTimes(2);
-    expect(invoke.mock.calls[1][0].prompt).toContain("Missing guard");
-    expect(invoke.mock.calls[1][0].prompt).toContain("Reject null input.");
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(out.terminationReason).toBe("invalid_review");
   });
 
-  it("runs a fix pass when an external changes-requested review blocks internal approval", async () => {
+  it.each([true, false])("runs an external-findings fix pass with approved=%s and no internal issues", async (approved) => {
     const reviewerJson = JSON.stringify({
-      approved: true,
-      issues: [],
+      approved,
+      blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
@@ -558,7 +527,7 @@ describe("postPushReviewStep", () => {
   it("runs a fix pass when a Claude issue comment has blocking findings and internal review approves", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
@@ -618,7 +587,7 @@ describe("postPushReviewStep", () => {
   it("does not approve when the GitHub Actions Claude review reports a prose blocking finding", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
@@ -674,7 +643,7 @@ describe("postPushReviewStep", () => {
   it("preserves opportunistic external collection when reviewProviders is undefined", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
@@ -716,7 +685,7 @@ describe("postPushReviewStep", () => {
   it("skips external collection when reviewProviders is an empty array", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
@@ -755,7 +724,7 @@ describe("postPushReviewStep", () => {
   it("collects external findings when github-claude-code-review is configured", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
@@ -808,7 +777,7 @@ describe("postPushReviewStep", () => {
   it("deduplicates internal issues that repeat external review findings", async () => {
     const reviewerJson = JSON.stringify({
       approved: false,
-      issues: ["Missing UUID validation on path params."],
+      blocking_issues: [{ title: "Missing UUID validation on path params.", problem: "Missing UUID validation on path params.", required_fix: "Missing UUID validation on path params." }],
       feedback: "External blocker is still unresolved.",
       score: 4,
       progress_delta: 0,
@@ -851,7 +820,7 @@ describe("postPushReviewStep", () => {
   it("suppresses duplicate feedback that repeats external review findings", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Missing UUID validation on path params.",
       score: 9,
       progress_delta: 0,
@@ -896,7 +865,7 @@ describe("postPushReviewStep", () => {
   it("does not run a fix pass when approved feedback contains actionable language but issues is empty", async () => {
     const approvedWithFeedback = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Two minor issues worth addressing: escape quotes and use an enum.",
       score: 8,
       progress_delta: 0,
@@ -926,7 +895,7 @@ describe("postPushReviewStep", () => {
   it("does not run a fix pass for deferred future-task concerns", async () => {
     const approvedWithDeferredConcern = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Clean implementation. One thing to watch in later tasks: prompt injection would need to be addressed at the API call layer, but noting it now so it doesn't get missed as the pipeline grows.",
       score: 8,
       progress_delta: 0,
@@ -953,7 +922,7 @@ describe("postPushReviewStep", () => {
   it("does not turn optional cosmetic review notes into blockers", async () => {
     const approvedWithCosmeticNote = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Clean implementation. Minor cosmetic note for a later cleanup pass: consider hover:bg-stone-200 at some point, but that is not required by this task.",
       score: 9,
       progress_delta: 0,
@@ -980,7 +949,7 @@ describe("postPushReviewStep", () => {
   it("requires structured issues when reviewer marks a PR not ready", async () => {
     const notReadyWithoutBlocker = JSON.stringify({
       approved: false,
-      issues: [],
+      blocking_issues: [],
       feedback: "There is a bug in the timer restart flow, so this is not ready.",
       score: 9,
       progress_delta: 0,
@@ -1013,7 +982,7 @@ describe("postPushReviewStep", () => {
   it("does not treat benign should-pass approval language as actionable", async () => {
     const approvedWithShouldPass = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "The implementation is ready; tests should pass and this should be merged as-is.",
       score: 9,
       progress_delta: 0,
@@ -1040,7 +1009,7 @@ describe("postPushReviewStep", () => {
   it("does not treat resolved prior blockers in approval feedback as actionable", async () => {
     const approvedWithResolvedBlockers = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Both Review 1 blockers are resolved. The expired-timer restart bug is fixed and the regression test covers it. Merge readiness: ready to merge.",
       score: 9,
       progress_delta: 0,
@@ -1143,7 +1112,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not fail the job when a post-push fix-pass LLM exits non-zero", async () => {
-    const notApproved = JSON.stringify({ approved: false, issues: ["x"], feedback: "fix", score: 4, progress_delta: 0 });
+    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 });
     const ghComments: string[] = [];
     const gitSpawn = vi.fn();
     const ghSpawn = vi.fn((args: string[]) => {
@@ -1178,7 +1147,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("throws on git push --force-with-lease rejection", async () => {
-    const notApproved = JSON.stringify({ approved: false, issues: ["x"], feedback: "fix", score: 4, progress_delta: 0 });
+    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 });
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "M file.ts\n", exitCode: 0 };
       if (args[0] === "rev-parse" && args[1] === "--short") return { stdout: "abc1234\n", exitCode: 0 };
@@ -1199,7 +1168,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("stops without pushing when the fix pass makes no changes", async () => {
-    const notApproved = JSON.stringify({ approved: false, issues: ["x"], feedback: "fix", score: 4, progress_delta: 0 });
+    const notApproved = JSON.stringify({ approved: false, blocking_issues: [{ title: "x", problem: "x", required_fix: "x" }], feedback: "fix", score: 4, progress_delta: 0 });
     const ghComments: string[] = [];
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
@@ -1232,7 +1201,7 @@ describe("postPushReviewStep", () => {
   it("reports unresolved external findings when an externally blocked fix pass makes no changes", async () => {
     const reviewerJson = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Internal reviewer approves.",
       score: 9,
       progress_delta: 0,
@@ -1275,7 +1244,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not parse stdout preamble objects when structured_output is missing", async () => {
-    const reviewerJson = `pre-text {} ${JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "ok" })}`;
+    const reviewerJson = `pre-text {} ${JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "ok" })}`;
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -1293,7 +1262,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("updates an existing marker comment instead of posting a duplicate", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "ok" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "ok" });
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args.includes("repos/:owner/:repo/issues/42/comments?per_page=100")) {
         return {
@@ -1331,7 +1300,7 @@ describe("postPushReviewStep", () => {
   it("passes reviewer issues through a guarded fix prompt", async () => {
     const notApproved = JSON.stringify({
       approved: false,
-      issues: ["Fix auth flow", "Add regression test"],
+      blocking_issues: [{ title: "Fix auth flow", problem: "Fix auth flow", required_fix: "Fix auth flow" }, { title: "Add regression test", problem: "Add regression test", required_fix: "Add regression test" }],
       feedback: "The implementation is incomplete.",
       score: 4,
       progress_delta: 0,
@@ -1374,7 +1343,8 @@ describe("postPushReviewStep", () => {
     expect(fixPrompt).toContain("Summary:\nThe implementation is incomplete.");
     const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
     expect(reviewComment).toContain("fix pass 1/2");
-    expect(reviewComment).toContain("Blocking issues:\n1. Fix auth flow\n2. Add regression test");
+    expect(reviewComment).toContain("Blocking issues:\n1. **Fix auth flow**");
+    expect(reviewComment).toContain("2. **Add regression test**");
     expect(reviewComment).toContain("Reviewer summary:\nThe implementation is incomplete.");
     expect(reviewComment).not.toContain("Feedback:\n");
   });
@@ -1382,14 +1352,14 @@ describe("postPushReviewStep", () => {
   it("asks follow-up reviews to verify previous findings and continue a full review", async () => {
     const firstReview = JSON.stringify({
       approved: false,
-      issues: ["Fix auth flow"],
+      blocking_issues: [{ title: "Fix auth flow", problem: "Fix auth flow", required_fix: "Fix auth flow" }],
       feedback: "Auth is incomplete.",
       score: 4,
       progress_delta: 0,
     });
     const secondReview = JSON.stringify({
       approved: true,
-      issues: [],
+      blocking_issues: [],
       feedback: "Looks good.",
       score: 9,
       progress_delta: 1,
@@ -1531,7 +1501,7 @@ describe("postPushReviewStep", () => {
     expect(fixPrompt).not.toContain(`${requiredFix.slice(0, 80)}...`);
   });
 
-  it("renders text-only blocking issue objects like legacy string issues", async () => {
+  it("rejects text-only blocking issue aliases without running a fix pass", async () => {
     const issueText = "The reviewer returned a legacy text-only object that should stay flat in comments and prompts.";
     const reviewerJson = JSON.stringify({
       approved: false,
@@ -1561,13 +1531,8 @@ describe("postPushReviewStep", () => {
       { report: vi.fn(async () => undefined) },
     );
 
-    const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
-    expect(reviewComment).toContain(`Blocking issues:\n1. ${issueText}`);
-    expect(reviewComment).not.toContain("**Blocking issue**");
-
-    const fixPrompt = invoke.mock.calls[1][0].prompt;
-    expect(fixPrompt).toContain(`Issues:\n1. ${issueText}`);
-    expect(fixPrompt).not.toContain("**Blocking issue**");
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(ghComments.some((comment) => comment.includes("unexpected field blocking_issues[0].text"))).toBe(true);
   });
 
   it("escapes markdown control characters in structured issue fields", async () => {
@@ -1659,12 +1624,12 @@ describe("postPushReviewStep", () => {
     expect(noChangesComment).toContain(requiredFix);
   });
 
-  it("omits duplicate review summaries without truncating legacy blocking issues in PR comments", async () => {
+  it("omits duplicate review summaries without truncating structured blocking issues in PR comments", async () => {
     const longIssue = "The parse API error path is missing user-visible error handling in app/page.tsx, so failed parse requests leave the user stuck on the input surface without feedback or a retry path. Add an error state, render it near OpenInput, and reset loading after failures.";
     const notApproved = JSON.stringify({
       approved: false,
-      issues: [longIssue],
-      feedback: longIssue,
+      blocking_issues: [{ title: "Parse failure", problem: longIssue, required_fix: "Add error handling" }],
+      feedback: `Parse failure\nProblem: ${longIssue}\nRequired fix: Add error handling`,
       score: 4,
       progress_delta: 0,
     });
@@ -1690,14 +1655,15 @@ describe("postPushReviewStep", () => {
     );
 
     const reviewComment = ghComments.find((comment) => comment.includes("Reviewer found issues"));
-    expect(reviewComment).toContain(`Blocking issues:\n1. ${longIssue}`);
+    expect(reviewComment).toContain("Blocking issues:\n1. **Parse failure**");
+    expect(reviewComment).toContain(`Problem: ${longIssue}`);
     expect(reviewComment).not.toContain("Reviewer summary:");
   });
 
   it("posts a concrete fix summary when the fixer reports one", async () => {
     const notApproved = JSON.stringify({
       approved: false,
-      issues: ["Update hover affordance"],
+      blocking_issues: [{ title: "Update hover affordance", problem: "Update hover affordance", required_fix: "Update hover affordance" }],
       feedback: "Hover state is invisible.",
       score: 4,
       progress_delta: 0,
@@ -1727,7 +1693,7 @@ describe("postPushReviewStep", () => {
       .mockResolvedValueOnce({ stdout: notApproved, exitCode: 0, tokensUsed: 100 })
       .mockResolvedValueOnce({ stdout: fixStdout, exitCode: 0, tokensUsed: 100 })
       .mockResolvedValueOnce({
-        stdout: JSON.stringify({ approved: true, issues: [], feedback: "Looks good.", score: 9, progress_delta: 1 }),
+        stdout: JSON.stringify({ approved: true, blocking_issues: [], feedback: "Looks good.", score: 9, progress_delta: 1 }),
         exitCode: 0,
         tokensUsed: 100,
       });
@@ -1748,7 +1714,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("withholds approval and initiates a fix pass when the verdict has only minor[] entries", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "lgtm", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "lgtm", score: 9, progress_delta: 0 });
     const ghComments: string[] = [];
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -1790,7 +1756,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("withholds approval and initiates a fix pass when the verdict has blocking[] entries", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
     const gitSpawn = vi.fn((args: string[]) => {
       if (args[0] === "status") return { stdout: "", exitCode: 0 };
       return { stdout: "", exitCode: 0 };
@@ -1833,7 +1799,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not include minor external findings in the approval comment when there are none", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "lgtm", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "lgtm", score: 9, progress_delta: 0 });
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -1856,7 +1822,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("waits for the external review check to complete before approving and ingests its late findings", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     let checkCompleted = false;
@@ -1909,7 +1875,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not auto-approve when the external review check never finishes (fail-closed)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     const ghComments: string[] = [];
     const reviewCalls: string[][] = [];
@@ -1946,7 +1912,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("recognizes 'review' and 'code-review-plugin' check names as the external review gate by default", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -1986,7 +1952,7 @@ describe("postPushReviewStep", () => {
 
   it("logs a warning when check runs are present but none match the external review gate", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2026,7 +1992,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("fails open and approves when no external review check exists for the head SHA", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "Internal reviewer approves.", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     let checkRunsQueried = false;
@@ -2056,7 +2022,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when the only matching check concluded 'skipped' (fails closed immediately)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2090,7 +2056,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("recognizes 'claude-code-review' as the external review gate by default", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2127,7 +2093,7 @@ describe("postPushReviewStep", () => {
 
   it("warns with the head SHA when no check runs are present at all", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2157,7 +2123,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when a matching check concluded 'cancelled'", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2189,7 +2155,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when matching checks concluded 'timed_out' or 'action_required'", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
 
@@ -2223,7 +2189,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("does not satisfy the gate when a matching check has an unrecognised novel conclusion", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2255,7 +2221,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("satisfies the gate when a matching check concluded 'failure'", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2291,7 +2257,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("satisfies the gate when a mixed set contains one skipped and one success check", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2330,7 +2296,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("uses configured reviewCheckNames for exact matching, overriding defaults", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], feedback: "ok", score: 9, progress_delta: 0 });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], feedback: "ok", score: 9, progress_delta: 0 });
     const sleep = vi.fn(async () => undefined);
     let checkProbes = 0;
     const gitSpawn = vi.fn(() => ({ stdout: "", exitCode: 0 }));
@@ -2371,7 +2337,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("T-1 (AII-436): GH Actions bot clean verdict + green review check + zero findings → approved=true", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2425,7 +2391,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("T-2 (KGB-9): internal approval + failing CI check → Not ready to merge, check named", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2477,7 +2443,7 @@ describe("postPushReviewStep", () => {
     // AII-436: The GH Actions bot posted an approving comment with no structured finding
     // sections and no "no issues found" phrasing. Old code fabricated a finding and blocked
     // approval. New code flags findingsUnavailable and shows a note instead.
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2536,7 +2502,7 @@ describe("postPushReviewStep", () => {
   it("T-4: 'Not ready to merge' comment lists concrete external findings, not just a banner", async () => {
     // Criterion 3: any Not-ready comment must enumerate the concrete blocking findings.
     // Regression: old externalBlockingCommentBlock posted a banner with no findings listed.
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghComments: string[] = [];
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
@@ -2591,7 +2557,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("T-5: CI gate does not block when all non-review checks pass", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       if (args[0] === "api" && args.some((a) => a === "repos/:owner/:repo/pulls/42")) {
@@ -2689,7 +2655,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("throws OperatorCancelledError when gh pr comment fails with 'issue is locked' and PR is closed-not-merged", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "pr" && args[1] === "diff") return { stdout: "diff", exitCode: 0 };
       if (args[0] === "pr" && args[1] === "comment") {
@@ -2795,7 +2761,7 @@ describe("postPushReviewStep", () => {
     // The most common exit is "approved", and on its last iteration it never pushes. A close
     // that lands while the reviewer LLM call is running must not become a reported success:
     // the probe after the reviewer returns (and at the top of each iteration) catches it.
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghComments: string[] = [];
     let reviewerRan = false;
     const ghSpawn = vi.fn((args: string[]) => {
@@ -2878,7 +2844,7 @@ describe("postPushReviewStep", () => {
     // A locked conversation on an OPEN, unmerged PR is not the merge race: the merged-only
     // guard must fall through to the normal review path. A locked PR that is CLOSED and
     // unmerged is an operator cancel, which assertPrWritable classifies as OPERATOR_CANCELLED.
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args[1]?.includes("/pulls/")) {
         return { stdout: '{"merged":false,"locked":true}', exitCode: 0 };
@@ -2901,7 +2867,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("continues normally when gh api call fails (fail-open)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args[1]?.includes("/pulls/")) {
         return { stdout: "", exitCode: 1 };
@@ -2924,7 +2890,7 @@ describe("postPushReviewStep", () => {
   });
 
   it("proceeds normally when PR is open and unlocked (regression guard)", async () => {
-    const reviewerJson = JSON.stringify({ approved: true, issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
+    const reviewerJson = JSON.stringify({ approved: true, blocking_issues: [], score: 9, progress_delta: 0, feedback: "lgtm" });
     const ghSpawn = vi.fn((args: string[]) => {
       if (args[0] === "api" && args[1]?.includes("/pulls/")) {
         return { stdout: '{"merged":false,"locked":false}', exitCode: 0 };

--- a/src/__tests__/review-verdict.test.ts
+++ b/src/__tests__/review-verdict.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseReviewVerdict } from "../pipeline/review-verdict.js";
+import { parseReviewVerdict, REVIEW_VERDICT_JSON_SCHEMA } from "../pipeline/review-verdict.js";
 
 const validApproved = {
   approved: true,
@@ -10,6 +10,30 @@ const validApproved = {
 };
 
 describe("parseReviewVerdict", () => {
+  it("uses only supported structural constraints in the wire schema", () => {
+    const schema = JSON.stringify(REVIEW_VERDICT_JSON_SCHEMA);
+    for (const keyword of ["minLength", "maxLength", "minimum", "maximum", "multipleOf", "pattern"]) {
+      expect(schema).not.toContain(`"${keyword}":`);
+    }
+  });
+
+  it.each(["score", "progress_delta"])("validates %s bounds locally", (field) => {
+    for (const value of [-1, 101, 1.5, "50", undefined]) {
+      expect(() => parseReviewVerdict({ ...validApproved, [field]: value })).toThrow(`expected ${field}`);
+    }
+    for (const value of [0, 100]) {
+      expect(() => parseReviewVerdict({ ...validApproved, [field]: value })).not.toThrow();
+    }
+  });
+
+  it.each(["title", "problem", "required_fix"])("rejects empty %s locally", (field) => {
+    for (const value of ["", "   "]) {
+      expect(() => parseReviewVerdict({ ...validApproved, approved: false,
+        blocking_issues: [{ title: "Bug", problem: "Fails", required_fix: "Fix it", [field]: value }],
+      })).toThrow(`blocking_issues[0].${field}`);
+    }
+  });
+
   it("accepts a valid approving verdict", () => {
     expect(parseReviewVerdict(validApproved)).toEqual({
       approved: true,

--- a/src/__tests__/review-verdict.test.ts
+++ b/src/__tests__/review-verdict.test.ts
@@ -48,9 +48,9 @@ describe("parseReviewVerdict", () => {
     expect(verdict.blockingIssues).toHaveLength(1);
   });
 
-  it("rejects a negative verdict with no blocking issues", () => {
-    expect(() => parseReviewVerdict({ ...validApproved, approved: false }))
-      .toThrow("approved=false requires at least one blocking_issues entry");
+  it("preserves a negative verdict with no internal issues for caller policy", () => {
+    expect(parseReviewVerdict({ ...validApproved, approved: false }))
+      .toMatchObject({ approved: false, blockingIssues: [] });
   });
 
   it("rejects wrong typed fields", () => {

--- a/src/__tests__/review.test.ts
+++ b/src/__tests__/review.test.ts
@@ -19,7 +19,6 @@ const reviewResult = (structuredOutput: unknown = REVIEW_VERDICT) => ({
   exitCode: 0,
   tokensUsed: 100,
   structuredOutput,
-  hasTerminalResult: true,
   terminalStatus: { subtype: "success", isError: false },
   telemetry: {
     outcome: "success" as const,
@@ -141,7 +140,6 @@ describe("reviewStep", () => {
       stdout: fenced,
       exitCode: 0,
       tokensUsed: 100,
-      hasTerminalResult: true,
       terminalStatus: { subtype: "success", isError: false },
       telemetry: { outcome: "success", numTurns: 1, durationMs: 1, costUsd: null, tokensIn: 1, tokensOut: 1 },
     })));

--- a/src/__tests__/steps-review.test.ts
+++ b/src/__tests__/steps-review.test.ts
@@ -49,6 +49,30 @@ describe("reviewStep", () => {
     vi.clearAllMocks();
   });
 
+  it("rejects a negative verdict without actionable implementation issues", async () => {
+    const executor = makeExecutor({ ...APPROVED_VERDICT, approved: false });
+    await expect(reviewStep.run(makeContext(executor), {}, new NoopStepReporter()))
+      .rejects.toThrow("approved=false requires at least one blocking_issues entry");
+  });
+
+  it.each([
+    ["missing terminal event", { terminalStatus: undefined }, "did not return a terminal result event"],
+    ["error terminal event", { terminalStatus: { subtype: "success", isError: true } }, "error terminal result"],
+    ["unsuccessful subtype", { terminalStatus: { subtype: "error_max_turns", isError: false } }, "without a successful terminal result"],
+    ["unsuccessful telemetry", { telemetry: { outcome: "max_turns" } }, "without a successful terminal result"],
+  ])("rejects approval with %s", async (_name, overrides, message) => {
+    const executor: LLMExecutor = {
+      invoke: vi.fn().mockResolvedValue({
+        stdout: "Review complete", exitCode: 0, tokensUsed: 0,
+        structuredOutput: APPROVED_VERDICT,
+        terminalStatus: { subtype: "success", isError: false },
+        ...overrides,
+      }),
+    };
+    await expect(reviewStep.run(makeContext(executor), {}, new NoopStepReporter()))
+      .rejects.toThrow(message);
+  });
+
   it("parses approved=true from structured JSON response", async () => {
     const executor = makeExecutor(APPROVED_VERDICT);
     const outputs = await reviewStep.run(makeContext(executor), {}, new NoopStepReporter());

--- a/src/__tests__/structured-executor.test.ts
+++ b/src/__tests__/structured-executor.test.ts
@@ -69,7 +69,6 @@ describe("structured Claude CLI results", () => {
     const result = await executor.invoke({ prompt: "review", model: "m", jsonSchema: schema });
     expect(result.structuredOutput).toBeUndefined();
     expect(result.terminalStatus).toBeUndefined();
-    expect(result.hasTerminalResult).toBe(false);
   });
 
   it("keeps the final failure status even when an earlier result approved", async () => {

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -54,7 +54,7 @@ function mapOutcome(subtype: unknown): RunTelemetry["outcome"] {
   return "unknown";
 }
 
-export function terminalStatus(events: StreamEvent[]): LLMTerminalStatus | undefined {
+export function extractTerminalStatus(events: StreamEvent[]): LLMTerminalStatus | undefined {
   const result = lastResult(events);
   if (!result) return undefined;
   return {

--- a/src/pipeline/claude-stream.ts
+++ b/src/pipeline/claude-stream.ts
@@ -43,10 +43,6 @@ export function finalStructuredOutput(events: StreamEvent[]): unknown {
   return lastResult(events)?.structured_output;
 }
 
-export function hasTerminalResult(events: StreamEvent[]): boolean {
-  return lastResult(events) !== undefined;
-}
-
 function num(v: unknown): number | null {
   return typeof v === "number" ? v : null;
 }

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -6,7 +6,6 @@ import {
   formatEvent,
   finalText,
   finalStructuredOutput,
-  hasTerminalResult,
   terminalStatus,
   extractTelemetry,
   summaryLine,
@@ -196,7 +195,6 @@ export class ClaudeCliExecutor implements LLMExecutor {
           tokensUsed: (telemetry.tokensIn ?? 0) + (telemetry.tokensOut ?? 0),
           telemetry,
           structuredOutput: finalStructuredOutput(events),
-          hasTerminalResult: hasTerminalResult(events),
           terminalStatus: terminalStatus(events),
         });
       });

--- a/src/pipeline/executor.ts
+++ b/src/pipeline/executor.ts
@@ -6,7 +6,7 @@ import {
   formatEvent,
   finalText,
   finalStructuredOutput,
-  terminalStatus,
+  extractTerminalStatus,
   extractTelemetry,
   summaryLine,
   type StreamEvent,
@@ -195,7 +195,7 @@ export class ClaudeCliExecutor implements LLMExecutor {
           tokensUsed: (telemetry.tokensIn ?? 0) + (telemetry.tokensOut ?? 0),
           telemetry,
           structuredOutput: finalStructuredOutput(events),
-          terminalStatus: terminalStatus(events),
+          terminalStatus: extractTerminalStatus(events),
         });
       });
 

--- a/src/pipeline/review-verdict.ts
+++ b/src/pipeline/review-verdict.ts
@@ -106,9 +106,6 @@ export function parseReviewVerdict(value: unknown): ReviewVerdict {
   if (typeof raw.feedback !== "string") throw new Error("expected feedback to be a string");
 
   const blockingIssues = raw.blocking_issues.map(parseIssue);
-  if (!raw.approved && blockingIssues.length === 0) {
-    throw new Error("approved=false requires at least one blocking_issues entry");
-  }
 
   return {
     approved: raw.approved && blockingIssues.length === 0,

--- a/src/pipeline/review-verdict.ts
+++ b/src/pipeline/review-verdict.ts
@@ -13,6 +13,8 @@ export interface ReviewVerdict {
   feedback: string;
 }
 
+// Keep wire constraints within the provider-supported subset; parseReviewVerdict
+// enforces non-empty strings and numeric bounds locally.
 export const REVIEW_VERDICT_JSON_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
@@ -26,15 +28,15 @@ export const REVIEW_VERDICT_JSON_SCHEMA: Record<string, unknown> = {
         additionalProperties: false,
         required: ["title", "problem", "required_fix"],
         properties: {
-          title: { type: "string", minLength: 1 },
+          title: { type: "string", description: "Must contain non-whitespace text." },
           location: { type: "string" },
-          problem: { type: "string", minLength: 1 },
-          required_fix: { type: "string", minLength: 1 },
+          problem: { type: "string", description: "Must contain non-whitespace text." },
+          required_fix: { type: "string", description: "Must contain non-whitespace text." },
         },
       },
     },
-    score: { type: "integer", minimum: 0, maximum: 100 },
-    progress_delta: { type: "integer", minimum: 0, maximum: 100 },
+    score: { type: "integer", description: "Integer from 0 to 100 inclusive." },
+    progress_delta: { type: "integer", description: "Integer from 0 to 100 inclusive." },
     feedback: { type: "string" },
   },
 };

--- a/src/pipeline/step-utils.ts
+++ b/src/pipeline/step-utils.ts
@@ -1,3 +1,5 @@
+import type { LLMResult } from "./types.js";
+
 export function formatLlmResultDetail(result: { stdout?: string; stderr?: string }): string {
   const detail = (result.stderr || result.stdout || "").trim();
   return detail ? `: ${detail}` : "";
@@ -12,4 +14,20 @@ export function formatGitNameStatusSummary(stdout: string): string {
     const label = status === "A" ? "Added" : status === "M" ? "Modified" : status === "D" ? "Deleted" : "Changed";
     return `- ${label}: \`${file ?? line}\``;
   }).join("\n");
+}
+
+/** Both review stages require a successful terminal event before using a verdict. */
+export function terminalResultFailureMessage(
+  result: Pick<LLMResult, "terminalStatus" | "telemetry" | "stdout" | "stderr">,
+  label: string,
+): string | null {
+  const detail = formatLlmResultDetail(result);
+  if (!result.terminalStatus) return `${label} did not return a terminal result event${detail}`;
+  const { subtype, isError } = result.terminalStatus;
+  if (isError === true) return `${label} returned an error terminal result (subtype=${subtype ?? "unknown"})${detail}`;
+  if (subtype !== "success") return `${label} finished without a successful terminal result (subtype=${subtype ?? "unknown"})${detail}`;
+  if (result.telemetry?.outcome && result.telemetry.outcome !== "success") {
+    return `${label} finished without a successful terminal result (${result.telemetry.outcome})${detail}`;
+  }
+  return null;
 }

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -710,9 +710,6 @@ function failedReviewOutputs(feedback: string) {
 }
 
 function issueFromVerdictIssue(issue: VerdictReviewIssue): ReviewIssue {
-  if (issue.title === "Blocking issue" && issue.problem === issue.requiredFix) {
-    return issueFromString(issue.problem);
-  }
   return {
     title: issue.title,
     ...(issue.location ? { location: issue.location } : {}),

--- a/src/pipeline/steps/post-push-review.ts
+++ b/src/pipeline/steps/post-push-review.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { OperatorCancelledError, PrMergedError } from "../operator-cancelled.js";
-import type { PipelineContext, StepModule, StepReporter } from "../types.js";
-import { formatGitNameStatusSummary, formatLlmResultDetail } from "../step-utils.js";
+import type { LLMResult, PipelineContext, StepModule, StepReporter } from "../types.js";
+import { formatGitNameStatusSummary, terminalResultFailureMessage } from "../step-utils.js";
 import { extractFirstJsonObject } from "../json-extract.js";
 import { REVIEW_VERDICT_JSON_SCHEMA, parseReviewVerdict, type ReviewIssue as VerdictReviewIssue } from "../review-verdict.js";
 import { refreshRunnerGithubCredentials } from "../../runner-token.js";
@@ -197,7 +197,7 @@ function issueFromString(text: string): ReviewIssue {
   };
 }
 
-function plainIssueText(issue: ReviewIssue): string {
+function postPushIssueText(issue: ReviewIssue): string {
   if (issue.rawText) return issue.rawText;
   return [
     issue.title,
@@ -257,7 +257,7 @@ function reviewerSummaryBlock(feedback: string, issues: ReviewIssue[]): string {
   const summary = feedback.trim();
   if (!summary) return "";
   const normalizedSummary = normalizeForComparison(summary);
-  const issueTexts = issues.map(plainIssueText);
+  const issueTexts = issues.map(postPushIssueText);
   const repeatsIssue = issueTexts.some((issue) => normalizeForComparison(issue) === normalizedSummary);
   const repeatsAllIssues = normalizeForComparison(issueTexts.join("\n")) === normalizedSummary;
   if (repeatsIssue || repeatsAllIssues) return "";
@@ -327,11 +327,10 @@ function dedupeIssuesAgainstExternalFindings(
   const externalBodies = new Set(externalFindings.map((finding) => normalizeForComparison(finding.body)));
   const seen = new Set<string>();
   return issues.filter((issue) => {
-    const normalized = normalizeForComparison(plainIssueText(issue));
+    const normalized = normalizeForComparison(postPushIssueText(issue));
     const issueParts = [
       normalized,
       normalizeForComparison(issue.problem),
-      normalizeForComparison(issue.requiredFix),
       normalizeForComparison(issue.rawText ?? ""),
     ].filter(Boolean);
     if (!normalized || issueParts.some((part) => externalBodies.has(part)) || seen.has(normalized)) return false;
@@ -704,7 +703,7 @@ function failedReviewOutputs(feedback: string) {
   return {
     approved: false,
     feedback,
-    issues: [plainIssueText(issue)],
+    issues: [postPushIssueText(issue)],
     blockingIssues: [issue],
   };
 }
@@ -718,21 +717,9 @@ function issueFromVerdictIssue(issue: VerdictReviewIssue): ReviewIssue {
   };
 }
 
-function reviewFailureMessage(result: { exitCode: number; terminalStatus?: { subtype: string | null; isError: boolean | null }; telemetry?: { outcome: string }; stdout?: string; stderr?: string }): string | null {
+function reviewFailureMessage(result: LLMResult): string | null {
   if (result.exitCode !== 0) return `Reviewer LLM failed (${llmResultMessage(result)})`;
-  if (!result.terminalStatus) {
-    return `Reviewer LLM did not return a terminal result event${formatLlmResultDetail(result)}`;
-  }
-  if (result.terminalStatus.isError === true) {
-    return `Reviewer LLM returned an error terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`;
-  }
-  if (result.terminalStatus.subtype !== "success") {
-    return `Reviewer LLM finished without a successful terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`;
-  }
-  if (result.telemetry?.outcome && result.telemetry.outcome !== "success") {
-    return `Reviewer LLM finished without a successful terminal result (${result.telemetry.outcome})${formatLlmResultDetail(result)}`;
-  }
-  return null;
+  return terminalResultFailureMessage(result, "Reviewer LLM");
 }
 
 async function reportInvalidStructuredReview(
@@ -998,7 +985,7 @@ Output ONLY valid JSON: {"approved": bool, "blocking_issues": [{"title": "string
         ended_at: new Date().toISOString(),
         parent_step_id: "post-push-review",
         inputs: { iteration, prNumber },
-        outputs: { approved, feedback, issues: issues.map(plainIssueText), blockingIssues: issues },
+        outputs: { approved, feedback, issues: issues.map(postPushIssueText), blockingIssues: issues },
         logs_url: null,
       });
 

--- a/src/pipeline/steps/review.ts
+++ b/src/pipeline/steps/review.ts
@@ -1,5 +1,5 @@
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
-import { formatLlmResultDetail } from "../step-utils.js";
+import { formatLlmResultDetail, terminalResultFailureMessage } from "../step-utils.js";
 import { REVIEW_VERDICT_JSON_SCHEMA, parseReviewVerdict, plainIssueText } from "../review-verdict.js";
 import { wrapWithPlanningGuard } from "../../planning-context-assembly.js";
 import { READ_ONLY_ALLOWED_TOOLS } from "./read-only-tools.js";
@@ -101,18 +101,8 @@ export const reviewStep: StepModule<ReviewInputs, ReviewOutputs> = {
     if (result.exitCode !== 0) {
       throw new Error(`Review LLM invocation failed with exit code ${result.exitCode}${formatLlmResultDetail(result)}`);
     }
-    if (!result.terminalStatus) {
-      throw new Error(`Review LLM invocation did not return a terminal result event${formatLlmResultDetail(result)}`);
-    }
-    if (result.terminalStatus.isError === true) {
-      throw new Error(`Review LLM invocation returned an error terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`);
-    }
-    if (result.terminalStatus.subtype !== "success") {
-      throw new Error(`Review LLM invocation finished without a successful terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`);
-    }
-    if (result.telemetry?.outcome && result.telemetry.outcome !== "success") {
-      throw new Error(`Review LLM invocation finished without a successful terminal result (${result.telemetry.outcome})${formatLlmResultDetail(result)}`);
-    }
+    const terminalFailure = terminalResultFailureMessage(result, "Review LLM invocation");
+    if (terminalFailure) throw new Error(terminalFailure);
     if (result.structuredOutput === undefined) {
       throw new Error(`Review LLM invocation did not return structured_output${formatLlmResultDetail(result)}`);
     }

--- a/src/pipeline/steps/review.ts
+++ b/src/pipeline/steps/review.ts
@@ -104,7 +104,7 @@ export const reviewStep: StepModule<ReviewInputs, ReviewOutputs> = {
     if (!result.terminalStatus) {
       throw new Error(`Review LLM invocation did not return a terminal result event${formatLlmResultDetail(result)}`);
     }
-    if (result.terminalStatus?.isError === true) {
+    if (result.terminalStatus.isError === true) {
       throw new Error(`Review LLM invocation returned an error terminal result (subtype=${result.terminalStatus.subtype ?? "unknown"})${formatLlmResultDetail(result)}`);
     }
     if (result.terminalStatus.subtype !== "success") {
@@ -118,6 +118,9 @@ export const reviewStep: StepModule<ReviewInputs, ReviewOutputs> = {
     }
 
     const verdict = parseReviewVerdict(result.structuredOutput);
+    if (!verdict.approved && verdict.blockingIssues.length === 0) {
+      throw new Error("approved=false requires at least one blocking_issues entry");
+    }
 
     return {
       approved: verdict.approved,

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -139,7 +139,6 @@ export interface LLMResult {
   tokensUsed: number;
   telemetry?: RunTelemetry;
   structuredOutput?: unknown;
-  hasTerminalResult?: boolean;
   terminalStatus?: LLMTerminalStatus;
 }
 


### PR DESCRIPTION
A structured verdict with `approved=false` and no internal blockers must still allow a post-push fix pass when external reviewers reported actionable findings. The parser introduced in #475 rejected it too early. This follow-up leaves that contextual decision to the review steps: implementation review rejects an unexplained negative verdict, while post-push review can act on external findings.

Also addresses the related CloudShare review findings:
- Replace legacy fixture normalization with canonical fixtures and explicit alias-rejection tests; remove the matching production formatting heuristic.
- Remove the redundant terminal-result flag and cover missing, error, unsuccessful-subtype, and unsuccessful-telemetry results.
- Document the runner-image pin requirement. Keep score and progress fields required by the shared schema.

These corrections are also in https://github.com/cloudshare/ai-implement/pull/117. This PR contains only the review corrections against upstream `testing`; #475 already merged.

Validation on current upstream `testing`:
- 4,602 tests passed across 196 files (`npm test -- --maxWorkers=4`, isolated temporary directory).
- TypeScript build and `git diff --check` passed.
- CloudShare port: 3,526 tests and TypeScript build passed.

Updated review findings:
- The wire schema now uses descriptions instead of unsupported `minLength`, `minimum`, and `maximum` constraints. Local validation still rejects blank issue fields and non-integer/out-of-range score and progress values, with regression coverage. See [Anthropic schema transformation guidance](https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works).
- Dedupe no longer discards an internal issue solely because its required fix matches an external finding. A regression test preserves the internal problem and location.
- Both review stages share terminal-result validation. Post-push tests now supply structured results directly, with explicit missing-terminal, subtype, and telemetry failure cases.
- Renamed the post-push text formatter and terminal-status extractor to distinguish their roles. Score and progress remain required for the single shared verdict contract.
