### PR TITLE
Fix Jira base selection, token expiry, and admin controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Entry points for areas that are easy to miss. Each names the module to start fro
 | KG sidecar and `/mcp` | `src/mcp.ts`, `src/mcp-oauth.ts` | [docs/kg-sidecar.md](docs/kg-sidecar.md) |
 | Deploying, clients, Bedrock | `src/deploy.ts` and its `deploy-*` siblings | [docs/deployment.md](docs/deployment.md) |
 | Ticketing provider abstraction | `src/providers/` — `linear.ts`, `jira.ts`, `registry.ts` | |
+| Jira base branch (per-issue PR target) | `src/base-branch.ts` | [docs/jira-base-branch.md](docs/jira-base-branch.md) |
 | Execution backends | `src/fly-machines.ts`, `src/local-docker.ts`, `src/github.ts` | |
 | Runner callbacks and tokens | `src/runner-callback.ts`, `src/runner-token.ts`, `src/token-vending.ts` | |
 | Merge reconciliation | `src/reconciliation.ts`, `src/reconcile-merged.ts`, `src/poll-merged-prs.ts` | |

--- a/docs/jira-base-branch.md
+++ b/docs/jira-base-branch.md
@@ -1,0 +1,88 @@
+# Jira base branch
+
+An issue can name the branch its PR targets, instead of the target repo's default
+branch. The value comes from a Jira custom field and rides to the runner in
+`run_config.baseBranch` — the same envelope field feature-branch grouping already
+uses, and the same one `push.ts` already honors when it opens the PR.
+
+Jira-only. `TicketIssue.baseBranch` is populated by the Jira provider; the Linear
+provider never sets it, exactly as with `profiles`.
+
+## Configuring it
+
+Create a **short text** custom field named exactly `AI-Implement Base Branch`, or
+pin its id with `baseBranchFieldOverride` on the mapping's `ticketingConfig`
+(Projects edit dialog, the add-project wizard's Jira step, or the mappings API).
+
+Field discovery is by name and is best-effort: a missing or ambiguous field logs a
+warning and leaves the feature inactive, rather than failing the poll. With all four
+of `statusFieldOverride`, `repoFieldOverride`, `profilesFieldOverride` and
+`baseBranchFieldOverride` set, `resolveCustomFieldIds` skips the `listFields` call
+entirely.
+
+## What happens to the value
+
+| Stage | Behavior |
+|---|---|
+| Read (`readBaseBranchValue`) | Non-string shapes return undefined — the field may be created as Paragraph (ADF object) or a number field, and an unchecked `.trim()` would take down the whole snapshot for one bad value |
+| Normalize (`normalizeBaseBranch`) | Trimmed; blank is unset; `refs/heads/` and `refs/remotes/` forms rejected; ref segments validated |
+| Invalid value | Warned and left unset **for that issue only** — never fails the snapshot |
+| Dispatch | Validated against GitHub, then carried in `run_config.baseBranch` |
+
+`normalizeBaseBranch` shares `validateRefSegments` with `normalizeBranchPrefix`, so
+the ref-safety rules (no `..`/`//`, each segment alphanumeric-initial, no trailing
+`.`/`.lock`) cannot drift between the two.
+
+## Refusals
+
+Three cases are refused **before dispatch**. Each moves the issue to
+Planning/Implementation Failed with a comment naming the reason, rather than
+dispatching a run that would fail later:
+
+1. The value is not a valid ref.
+2. The branch does not exist on GitHub.
+3. The issue is also part of a feature-branch grouping tree — the two ways of
+   choosing a base are mutually exclusive. Clear one or the other.
+
+Refusal 3 is checked **before** the grouping roll-up hold, so a misconfigured
+grouping parent surfaces the conflict instead of being held indefinitely.
+
+## Resolution order
+
+Implementation dispatch takes the validated field value when set, and otherwise
+falls through to `resolveBaseBranch` (feature-branch grouping → repo default).
+Planning does not consult `featureBranchChain` at all — that grouping applies only
+to implementation — so planning clones the field value or the repo default.
+
+## The branch comment
+
+When the field is set and differs from the repo default, the orchestrator comments
+the branch on the ticket, so a plan/implement mismatch is visible.
+
+The comment gates on the **field value**, never on the fully-resolved base. This
+matters: the resolved base also covers the feature-branch-grouping fallback, and a
+grouping run must not produce a comment claiming the user chose that branch. In
+`both` (shadow) mode the Fly dispatch passes no `branchInfo`, so the comment is
+posted exactly once.
+
+## Scope
+
+No effect on `/ai-implement` gap-fill or review-fix re-dispatches, which inherit
+their PR's established base.
+
+## Legacy-contract repos
+
+On the envelope contract the branch rides inside `run_config` and needs no workflow
+input. On the **legacy** contract it is sent as a `base_branch` `workflow_dispatch`
+input, and is only sent when it differs from the repo default so that repos on the
+common path cannot be rejected for an unexpected input.
+
+A legacy dispatch that is rejected 422 *and* whose error body mentions `base_branch`
+is attributed to a stale `claude-implement.yml` / `claude-plan.yml`, and the issue
+is failed with that explanation. The check requires the error body to name the input
+because a 422 has many possible causes and the "sent a base branch" condition is
+also true for the pre-existing grouping path.
+
+> Note: `base_branch` is not currently declared in the synced workflow templates, so
+> on a legacy-contract repo this input is rejected. That predates this feature —
+> feature-branch grouping already sends the same input — and is tracked separately.

--- a/docs/jira-base-branch.md
+++ b/docs/jira-base-branch.md
@@ -26,7 +26,7 @@ entirely.
 |---|---|
 | Read (`readBaseBranchValue`) | Non-string shapes return undefined — the field may be created as Paragraph (ADF object) or a number field, and an unchecked `.trim()` would take down the whole snapshot for one bad value |
 | Normalize (`normalizeBaseBranch`) | Trimmed; blank is unset; `refs/heads/` and `refs/remotes/` forms rejected; ref segments validated |
-| Invalid value | Warned and left unset **for that issue only** — never fails the snapshot |
+| Invalid nonblank string | Preserved in the snapshot, then refused before dispatch with a failure comment; never silently targets the default branch |
 | Dispatch | Validated against GitHub, then carried in `run_config.baseBranch` |
 
 `normalizeBaseBranch` shares `validateRefSegments` with `normalizeBranchPrefix`, so

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -1930,3 +1930,50 @@ describe("github-install-state endpoint", () => {
     expect(res.statusCode).toBe(500);
   });
 });
+
+describe("admin poll-now", () => {
+  async function pollNowRequest(
+    pollNow: (() => { started: boolean }) | undefined,
+    token?: string,
+  ): Promise<{ statusCode: number; body: string }> {
+    const req = new MockRequest("/api/poll-now", "POST", token ? { authorization: `Bearer ${token}` } : {});
+    const res = new MockResponse();
+    admin.handleAdminRequest(
+      req as never,
+      res as never,
+      { ...adminConfig("secret"), pollNow },
+      makeFakeRegistry(provider),
+    );
+    await res.done;
+    return { statusCode: res.statusCode, body: res.body };
+  }
+
+  it("triggers a poll cycle and reports it started", async () => {
+    const token = await login("secret");
+    const pollNow = vi.fn(() => ({ started: true }));
+    const res = await pollNowRequest(pollNow, token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ started: true });
+    expect(pollNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports poll_in_progress when a cycle is already running", async () => {
+    const token = await login("secret");
+    const res = await pollNowRequest(() => ({ started: false }), token);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ started: false, reason: "poll_in_progress" });
+  });
+
+  it("requires auth", async () => {
+    const pollNow = vi.fn(() => ({ started: true }));
+    const res = await pollNowRequest(pollNow);
+    expect(res.statusCode).toBe(401);
+    expect(pollNow).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when the poll trigger is not wired", async () => {
+    const token = await login("secret");
+    const res = await pollNowRequest(undefined, token);
+    expect(res.statusCode).toBe(503);
+  });
+});

--- a/src/__tests__/admin.test.ts
+++ b/src/__tests__/admin.test.ts
@@ -874,6 +874,7 @@ describe("admin mappings", () => {
       statusFieldOverride: null,
       repoFieldOverride: null,
       profilesFieldOverride: null,
+      baseBranchFieldOverride: null,
     });
   });
 

--- a/src/__tests__/base-branch.test.ts
+++ b/src/__tests__/base-branch.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  normalizeBaseBranch,
+  resolveIssueBaseBranch,
+  validateIssueBaseBranch,
+  dispatchBranchComment,
+  sanitizeBranchForDisplay,
+  postBranchComment,
+} from "../base-branch.js";
+import { GitHubApiError } from "../github-errors.js";
+
+describe("normalizeBaseBranch", () => {
+  it("returns null for null input", () => {
+    expect(normalizeBaseBranch(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(normalizeBaseBranch(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(normalizeBaseBranch("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(normalizeBaseBranch("   ")).toBeNull();
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(normalizeBaseBranch("  my-feature  ")).toBe("my-feature");
+  });
+
+  it("accepts a simple branch name", () => {
+    expect(normalizeBaseBranch("my-feature")).toBe("my-feature");
+  });
+
+  it("accepts a multi-segment branch name", () => {
+    expect(normalizeBaseBranch("feat/x-1")).toBe("feat/x-1");
+  });
+
+  it("accepts an origin/-prefixed branch name", () => {
+    expect(normalizeBaseBranch("origin/my-feature")).toBe("origin/my-feature");
+  });
+
+  it("accepts a branch with digits, dots, underscores, and hyphens", () => {
+    expect(normalizeBaseBranch("release/1.2_patch-3")).toBe("release/1.2_patch-3");
+  });
+
+  it("rejects refs/heads/... form", () => {
+    expect(() => normalizeBaseBranch("refs/heads/main")).toThrow(/refs\/heads\//);
+  });
+
+  it("rejects refs/remotes/... form", () => {
+    expect(() => normalizeBaseBranch("refs/remotes/origin/main")).toThrow(/refs\/remotes\//);
+  });
+
+  it("rejects a branch name longer than 255 characters", () => {
+    const long = "a".repeat(256);
+    expect(() => normalizeBaseBranch(long)).toThrow(/255 characters/);
+  });
+
+  it("accepts exactly 255 characters", () => {
+    const exactly255 = "a".repeat(255);
+    expect(normalizeBaseBranch(exactly255)).toBe(exactly255);
+  });
+
+  it("accepts a real 71-character stacked-slice branch name (this PR's own branch)", () => {
+    const real = "ai-implement/bac-26006-1-5-base-branch-jira-field-discovery-ticketissue";
+    expect(real.length).toBe(71);
+    expect(normalizeBaseBranch(real)).toBe(real);
+  });
+
+  it("rejects '..' in the branch name", () => {
+    expect(() => normalizeBaseBranch("feat..broken")).toThrow(/\.\./);
+  });
+
+  it("rejects '//' in the branch name", () => {
+    expect(() => normalizeBaseBranch("feat//broken")).toThrow(/\/\//);
+  });
+
+  it("rejects a segment ending with '.'", () => {
+    expect(() => normalizeBaseBranch("feat/broken.")).toThrow(/'\.' or '\.lock'/);
+  });
+
+  it("rejects a segment ending with '.lock'", () => {
+    expect(() => normalizeBaseBranch("feat/broken.lock")).toThrow(/'\.' or '\.lock'/);
+  });
+
+  it("rejects a leading hyphen (--upload-pack=x)", () => {
+    expect(() => normalizeBaseBranch("--upload-pack=x")).toThrow(/must each start with a letter or digit/);
+  });
+
+  it("rejects a segment starting with '-'", () => {
+    expect(() => normalizeBaseBranch("feat/-bad")).toThrow(/must each start with a letter or digit/);
+  });
+
+  it("rejects a segment with a special character like '='", () => {
+    expect(() => normalizeBaseBranch("feat/bad=name")).toThrow(/must each start with a letter or digit/);
+  });
+});
+
+describe("resolveIssueBaseBranch", () => {
+  const baseOpts = { ghToken: "tok", owner: "acme", repo: "proj" };
+
+  it("returns found with one lookup when the branch exists literally", async () => {
+    const getBranchShaImpl = vi.fn().mockResolvedValue("sha1");
+    const result = await resolveIssueBaseBranch({ ...baseOpts, value: "my-feature", getBranchShaImpl });
+    expect(result).toEqual({ found: true, branch: "my-feature", lookupCount: 1 });
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(1);
+    expect(getBranchShaImpl).toHaveBeenCalledWith("tok", "acme", "proj", "my-feature");
+  });
+
+  it("returns not-found with one lookup when the branch does not exist and has no origin/ prefix", async () => {
+    const getBranchShaImpl = vi.fn().mockResolvedValue(null);
+    const result = await resolveIssueBaseBranch({ ...baseOpts, value: "nonexistent", getBranchShaImpl });
+    expect(result).toEqual({ found: false, tried: ["nonexistent"], lookupCount: 1 });
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("origin/-prefixed: strips prefix and returns the stripped branch on second lookup", async () => {
+    const getBranchShaImpl = vi.fn()
+      .mockResolvedValueOnce(null)      // origin/my-feature doesn't exist
+      .mockResolvedValueOnce("sha1");   // my-feature exists
+    const result = await resolveIssueBaseBranch({ ...baseOpts, value: "origin/my-feature", getBranchShaImpl });
+    expect(result).toEqual({ found: true, branch: "my-feature", lookupCount: 2 });
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(2);
+    expect(getBranchShaImpl).toHaveBeenNthCalledWith(1, "tok", "acme", "proj", "origin/my-feature");
+    expect(getBranchShaImpl).toHaveBeenNthCalledWith(2, "tok", "acme", "proj", "my-feature");
+  });
+
+  it("a branch literally named origin/foo resolves with one lookup when it exists", async () => {
+    const getBranchShaImpl = vi.fn().mockResolvedValue("sha1");
+    const result = await resolveIssueBaseBranch({ ...baseOpts, value: "origin/foo", getBranchShaImpl });
+    expect(result).toEqual({ found: true, branch: "origin/foo", lookupCount: 1 });
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("origin/-prefixed: returns not-found when neither form exists", async () => {
+    const getBranchShaImpl = vi.fn().mockResolvedValue(null);
+    const result = await resolveIssueBaseBranch({ ...baseOpts, value: "origin/gone", getBranchShaImpl });
+    expect(result).toEqual({ found: false, tried: ["origin/gone", "gone"], lookupCount: 2 });
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves a multi-segment branch name with a single lookup, passed through unmangled", async () => {
+    // The bug this guards against: a prior implementation encoded the whole branch
+    // string with encodeURIComponent before hitting /branches/<name>, turning "/"
+    // into "%2F" and 404ing on exactly the branch shapes this feature targets
+    // (ai-implement/feature/…, feat/…, another ai-implement/<key>-… branch).
+    const getBranchShaImpl = vi.fn().mockResolvedValue("sha1");
+    const result = await resolveIssueBaseBranch({
+      ...baseOpts,
+      value: "ai-implement/feature/ool-78",
+      getBranchShaImpl,
+    });
+    expect(result).toEqual({ found: true, branch: "ai-implement/feature/ool-78", lookupCount: 1 });
+    expect(getBranchShaImpl).toHaveBeenCalledWith("tok", "acme", "proj", "ai-implement/feature/ool-78");
+  });
+
+  it("propagates (does not swallow) a non-404 error from getBranchSha", async () => {
+    const apiError = new GitHubApiError({ status: 403, path: "/repos/acme/proj/git/ref/heads/main", bodyText: "rate limited" });
+    const getBranchShaImpl = vi.fn().mockRejectedValue(apiError);
+    await expect(resolveIssueBaseBranch({ ...baseOpts, value: "main", getBranchShaImpl })).rejects.toBe(apiError);
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a non-404 error on the origin/-prefixed literal lookup without falling through to the stripped form", async () => {
+    // A transient failure on the literal "origin/foo" lookup must not silently
+    // retarget to "foo" — that's the exact ambiguity this two-form resolution
+    // exists to avoid.
+    const apiError = new GitHubApiError({ status: 500, path: "/repos/acme/proj/git/ref/heads/origin/foo", bodyText: "boom" });
+    const getBranchShaImpl = vi.fn().mockRejectedValue(apiError);
+    await expect(resolveIssueBaseBranch({ ...baseOpts, value: "origin/foo", getBranchShaImpl })).rejects.toBe(apiError);
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults to the real getBranchSha and preserves slash separators over the wire", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ object: { sha: "sha1" } }),
+    }));
+    try {
+      const result = await resolveIssueBaseBranch({ ...baseOpts, value: "ai-implement/feature/ool-78" });
+      expect(result).toEqual({ found: true, branch: "ai-implement/feature/ool-78", lookupCount: 1 });
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).toBe("https://api.github.com/repos/acme/proj/git/ref/heads/ai-implement/feature/ool-78");
+      expect(url).not.toContain("%2F");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("defaults to the real getBranchSha, which throws on a non-404 status", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 403, text: async () => "forbidden" }));
+    try {
+      await expect(resolveIssueBaseBranch({ ...baseOpts, value: "main" })).rejects.toThrow(GitHubApiError);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+describe("validateIssueBaseBranch", () => {
+  const baseIssue = { id: "issue-1", scopeKey: "BAC", baseBranch: "my-feature" };
+  const baseOpts = { ghToken: "tok", owner: "acme", repo: "proj" };
+
+  it("returns refused=false branch=null when baseBranch is not set (planning verb)", async () => {
+    const markFailed = vi.fn();
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { id: "i1", scopeKey: "S", baseBranch: undefined },
+      markFailed,
+    });
+    expect(result).toEqual({ refused: false, branch: null });
+    expect(markFailed).not.toHaveBeenCalled();
+  });
+
+  it("returns refused=false branch=null when baseBranch is empty string", async () => {
+    const markFailed = vi.fn();
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { id: "i1", scopeKey: "S", baseBranch: "" },
+      markFailed,
+    });
+    expect(result).toEqual({ refused: false, branch: null });
+    expect(markFailed).not.toHaveBeenCalled();
+  });
+
+  it("returns refused=false branch=null when baseBranch is whitespace-only (truthy string, normalizes to null)", async () => {
+    // Distinct from the empty-string case above: "   " is truthy, so the
+    // `!issue.baseBranch` early-return guard is skipped and normalizeBaseBranch's
+    // truthy-but-null return path is what has to handle it instead.
+    const markFailed = vi.fn();
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { id: "i1", scopeKey: "S", baseBranch: "   " },
+      markFailed,
+    });
+    expect(result).toEqual({ refused: false, branch: null });
+    expect(markFailed).not.toHaveBeenCalled();
+  });
+
+  it("refusal #1: invalid value — calls markFailed with the specific rule and returns refused (planning verb)", async () => {
+    const markFailed = vi.fn().mockResolvedValue(undefined);
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, baseBranch: "--upload-pack=x" },
+      markFailed,
+    });
+    expect(result).toEqual({ refused: true });
+    expect(markFailed).toHaveBeenCalledOnce();
+    const [id, scopeKey, reason] = markFailed.mock.calls[0];
+    expect(id).toBe("issue-1");
+    expect(scopeKey).toBe("BAC");
+    expect(reason).toMatch(/must each start with a letter or digit/);
+  });
+
+  it("refusal #1: invalid value — calls markFailed with implementation verb when markFailed is markImplementationFailed", async () => {
+    const markImplementationFailed = vi.fn().mockResolvedValue(undefined);
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, baseBranch: "refs/heads/main" },
+      markFailed: markImplementationFailed,
+    });
+    expect(result).toEqual({ refused: true });
+    expect(markImplementationFailed).toHaveBeenCalledOnce();
+    expect(markImplementationFailed.mock.calls[0][2]).toMatch(/refs\/heads\//);
+  });
+
+  it("refusal #2: featureBranchChain non-empty — calls markFailed with combination message (planning verb)", async () => {
+    const markFailed = vi.fn().mockResolvedValue(undefined);
+    const getBranchShaImpl = vi.fn();
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, featureBranchChain: [{ identifier: "OOL-78", mode: "feature" }] },
+      markFailed,
+      getBranchShaImpl,
+    });
+    expect(result).toEqual({ refused: true });
+    expect(markFailed).toHaveBeenCalledOnce();
+    expect(markFailed.mock.calls[0][2]).toMatch(/unsupported combination/);
+    expect(getBranchShaImpl).not.toHaveBeenCalled();
+  });
+
+  it("refusal #2: featureBranchChain non-empty — calls markFailed with implementation verb", async () => {
+    const markImplementationFailed = vi.fn().mockResolvedValue(undefined);
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, featureBranchChain: [{ identifier: "OOL-78", mode: "feature" }, { identifier: "OOL-96", mode: "feature" }] },
+      markFailed: markImplementationFailed,
+      getBranchShaImpl: vi.fn(),
+    });
+    expect(result).toEqual({ refused: true });
+    expect(markImplementationFailed).toHaveBeenCalledOnce();
+    expect(markImplementationFailed.mock.calls[0][2]).toMatch(/feature-branch/);
+  });
+
+  it("refusal #3: branch not found — reports both forms tried (planning verb)", async () => {
+    const markFailed = vi.fn().mockResolvedValue(undefined);
+    const getBranchShaImpl = vi.fn().mockResolvedValue(null);
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, baseBranch: "origin/gone" },
+      markFailed,
+      getBranchShaImpl,
+    });
+    expect(result).toEqual({ refused: true });
+    expect(markFailed).toHaveBeenCalledOnce();
+    const reason = markFailed.mock.calls[0][2] as string;
+    expect(reason).toMatch(/"origin\/gone"/);
+    expect(reason).toMatch(/"gone"/);
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("refusal #3: branch not found (single form) — reports only that form (implementation verb)", async () => {
+    const markImplementationFailed = vi.fn().mockResolvedValue(undefined);
+    const getBranchShaImpl = vi.fn().mockResolvedValue(null);
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, baseBranch: "nonexistent" },
+      markFailed: markImplementationFailed,
+      getBranchShaImpl,
+    });
+    expect(result).toEqual({ refused: true });
+    expect(markImplementationFailed).toHaveBeenCalledOnce();
+    expect(markImplementationFailed.mock.calls[0][2]).toMatch(/"nonexistent"/);
+    expect(getBranchShaImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("happy path: valid branch exists — returns refused=false with resolved branch", async () => {
+    const markFailed = vi.fn();
+    const getBranchShaImpl = vi.fn().mockResolvedValue("sha1");
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, baseBranch: "my-feature" },
+      markFailed,
+      getBranchShaImpl,
+    });
+    expect(result).toEqual({ refused: false, branch: "my-feature" });
+    expect(markFailed).not.toHaveBeenCalled();
+  });
+
+  it("happy path: origin/-prefixed branch resolves to stripped form", async () => {
+    const markFailed = vi.fn();
+    const getBranchShaImpl = vi.fn()
+      .mockResolvedValueOnce(null)    // origin/my-feature not found
+      .mockResolvedValueOnce("sha1"); // my-feature found
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { ...baseIssue, baseBranch: "origin/my-feature" },
+      markFailed,
+      getBranchShaImpl,
+    });
+    expect(result).toEqual({ refused: false, branch: "my-feature" });
+    expect(markFailed).not.toHaveBeenCalled();
+  });
+
+  it("regression: blank baseBranch → no base_branch in dispatch payload (refused=false, branch=null)", async () => {
+    const markFailed = vi.fn();
+    const result = await validateIssueBaseBranch({
+      ...baseOpts,
+      issue: { id: "i", scopeKey: "S" },
+      markFailed,
+    });
+    expect(result).toEqual({ refused: false, branch: null });
+    expect(markFailed).not.toHaveBeenCalled();
+  });
+});
+
+describe("dispatchBranchComment", () => {
+  it("returns null when resolved branch equals default branch", () => {
+    expect(dispatchBranchComment("main", "main", "planning")).toBeNull();
+    expect(dispatchBranchComment("main", "main", "implementation")).toBeNull();
+  });
+
+  it("returns null for develop === develop", () => {
+    expect(dispatchBranchComment("develop", "develop", "planning")).toBeNull();
+  });
+
+  it("returns planning comment when branch differs from default", () => {
+    const comment = dispatchBranchComment("my-feature", "main", "planning");
+    expect(comment).toBe("Planning against branch: `my-feature`");
+  });
+
+  it("returns implementation comment when branch differs from default", () => {
+    const comment = dispatchBranchComment("my-feature", "main", "implementation");
+    expect(comment).toBe("Implementing against branch: `my-feature`");
+  });
+
+  it("includes multi-segment branch names verbatim", () => {
+    const comment = dispatchBranchComment("ai-implement/feature/PROJ-1", "main", "planning");
+    expect(comment).toBe("Planning against branch: `ai-implement/feature/PROJ-1`");
+  });
+});
+
+describe("sanitizeBranchForDisplay", () => {
+  it("leaves an ordinary branch name unchanged", () => {
+    expect(sanitizeBranchForDisplay("ai-implement/feature/PROJ-1")).toBe("ai-implement/feature/PROJ-1");
+  });
+
+  it("neutralizes backticks so they cannot close the surrounding code span", () => {
+    expect(sanitizeBranchForDisplay("weird`branch")).toBe("weird'branch");
+  });
+
+  it("collapses embedded newlines to a single space", () => {
+    expect(sanitizeBranchForDisplay("weird\nbranch\r\nname")).toBe("weird branch name");
+  });
+});
+
+describe("postBranchComment", () => {
+  const issue = { id: "issue-1", identifier: "PROJ-1" };
+
+  it("does not post when fieldValue is null — the feature-branch-grouping-only case", () => {
+    // This is the exact shape of the bug fixed in this PR: an issue with no
+    // "AI-Implement Base Branch" field set (fieldValue null) whose *resolved*
+    // base branch nonetheless differs from the repo default because it fell
+    // through to the unrelated feature-branch-grouping resolution
+    // (resolveBaseBranch → "ai-implement/feature/<key>"). The old call sites
+    // passed that resolved branch straight into dispatchBranchComment, which
+    // only compares against defaultBranch and so fired a spurious
+    // "Implementing against branch" comment for every feature-tree child.
+    // postBranchComment must gate on fieldValue (null here) and post nothing,
+    // regardless of what the resolved/default branches are.
+    const postComment = vi.fn().mockResolvedValue(undefined);
+    postBranchComment(
+      { postComment },
+      issue,
+      /* fieldValue */ null,
+      /* defaultBranch */ "main",
+      "implementation",
+    );
+    expect(postComment).not.toHaveBeenCalled();
+  });
+
+  it("posts when fieldValue is set and differs from the default branch", async () => {
+    const postComment = vi.fn().mockResolvedValue(undefined);
+    postBranchComment({ postComment }, issue, "my-feature", "main", "implementation");
+    await Promise.resolve(); // let the fire-and-forget promise settle
+    expect(postComment).toHaveBeenCalledWith("issue-1", "Implementing against branch: `my-feature`");
+  });
+
+  it("uses the phase argument for the comment verb, not a hardcoded phase", async () => {
+    const postComment = vi.fn().mockResolvedValue(undefined);
+    postBranchComment({ postComment }, issue, "my-feature", "main", "planning");
+    await Promise.resolve();
+    expect(postComment).toHaveBeenCalledWith("issue-1", "Planning against branch: `my-feature`");
+  });
+
+  it("does not post when fieldValue equals the default branch", () => {
+    const postComment = vi.fn().mockResolvedValue(undefined);
+    postBranchComment({ postComment }, issue, "main", "main", "implementation");
+    expect(postComment).not.toHaveBeenCalled();
+  });
+
+  it("swallows a postComment rejection rather than throwing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const postComment = vi.fn().mockRejectedValue(new Error("network blip"));
+    expect(() =>
+      postBranchComment({ postComment }, issue, "my-feature", "main", "implementation"),
+    ).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to post implementation branch comment for PROJ-1:"),
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -390,6 +390,7 @@ describe("config", () => {
         statusFieldOverride: "customfield_10001",
         repoFieldOverride: "customfield_10002",
         profilesFieldOverride: null,
+        baseBranchFieldOverride: null,
       });
     });
 

--- a/src/__tests__/github-app-auth.test.ts
+++ b/src/__tests__/github-app-auth.test.ts
@@ -177,6 +177,54 @@ describe("getInstallationToken", () => {
     const token = await getInstallationToken(APP_ID, escapedKey, "my-org");
     expect(token).toBe("ghs_pkcs1_esc");
   });
+
+  it("derives cache TTL from expires_at minus a 5-minute safety margin", async () => {
+    const T0 = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(T0);
+
+    const expiresAt = new Date(T0 + 30 * 60 * 1000).toISOString(); // 30 min from T0
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 1 } },
+      { ok: true, json: { token: "tok1", expires_at: expiresAt } },
+    ]));
+
+    await getInstallationToken(APP_ID, privateKey, "org");
+    expect(fetch).toHaveBeenCalledTimes(2);
+
+    // At T0 + 24min: cache expires at T0 + 25min (30 - 5 margin) → still valid
+    vi.spyOn(Date, "now").mockReturnValue(T0 + 24 * 60 * 1000);
+    const t2 = await getInstallationToken(APP_ID, privateKey, "org");
+    expect(t2).toBe("tok1");
+    expect(fetch).toHaveBeenCalledTimes(2); // cache hit
+
+    // At T0 + 26min: past the 25-min cache window → re-fetch
+    vi.spyOn(Date, "now").mockReturnValue(T0 + 26 * 60 * 1000);
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 1 } },
+      { ok: true, json: { token: "tok2", expires_at: expiresAt } },
+    ]));
+    const t3 = await getInstallationToken(APP_ID, privateKey, "org");
+    expect(t3).toBe("tok2");
+    expect(fetch).toHaveBeenCalledTimes(4); // re-fetched after derived expiry
+  });
+
+  it("falls back to 50-minute TTL when expires_at is absent or invalid", async () => {
+    const T0 = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(T0);
+
+    vi.mocked(fetch).mockImplementation(mockFetch([
+      { ok: true, json: { id: 1 } },
+      { ok: true, json: { token: "tok", expires_at: "" } }, // empty → fallback to 50 min
+    ]));
+
+    await getInstallationToken(APP_ID, privateKey, "org");
+
+    // At T0 + 49min: within the 50-min fallback window → cache still valid
+    vi.spyOn(Date, "now").mockReturnValue(T0 + 49 * 60 * 1000);
+    const t2 = await getInstallationToken(APP_ID, privateKey, "org");
+    expect(t2).toBe("tok");
+    expect(fetch).toHaveBeenCalledTimes(2); // still cached
+  });
 });
 
 describe("getInstallation", () => {
@@ -190,6 +238,7 @@ describe("getInstallation", () => {
 
     expect(result).toEqual({
       token: "ghs_inst",
+      expiresAt: 0, // expires_at was "" in the mock → fallback to 0
       installationId: 55,
       repositorySelection: "selected",
     });

--- a/src/__tests__/github-install-state.test.ts
+++ b/src/__tests__/github-install-state.test.ts
@@ -43,6 +43,7 @@ describe("probeInstallState", () => {
   it("ready: an 'all' install short-circuits without listing repos", async () => {
     vi.mocked(getInstallation).mockResolvedValueOnce({
       token: "ghs_x",
+      expiresAt: 0,
       installationId: 7,
       repositorySelection: "all",
     });
@@ -56,6 +57,7 @@ describe("probeInstallState", () => {
   it("ready: a 'selected' install that includes the repo", async () => {
     vi.mocked(getInstallation).mockResolvedValueOnce({
       token: "ghs_x",
+      expiresAt: 0,
       installationId: 8,
       repositorySelection: "selected",
     });
@@ -70,6 +72,7 @@ describe("probeInstallState", () => {
   it("repo-not-selected: a selected install missing the repo -> the same install-flow URL", async () => {
     vi.mocked(getInstallation).mockResolvedValueOnce({
       token: "ghs_x",
+      expiresAt: 0,
       installationId: 9,
       repositorySelection: "selected",
     });

--- a/src/__tests__/providers/jira-fields.test.ts
+++ b/src/__tests__/providers/jira-fields.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { resolveCustomFieldIds, getCachedFieldIds, clearFieldCache, adfParagraph, adfWithLink, STATUS_VALUES } from "../../providers/jira-fields.js";
 
-const baseOverrides = { statusOverride: null, repoOverride: null, profilesOverride: null };
+const baseOverrides = { statusOverride: null, repoOverride: null, profilesOverride: null, baseBranchOverride: null };
 const baseFields = [
   { id: "customfield_10042", name: "AI-Implement Status", custom: true },
   { id: "customfield_10043", name: "AI-Implement Repo", custom: true },
@@ -21,12 +21,13 @@ describe("resolveCustomFieldIds", () => {
     expect(ids.repoFieldId).toBe("customfield_10043");
   });
 
-  it("respects explicit overrides without calling listFields when all three are set", async () => {
+  it("respects explicit overrides without calling listFields when all four are set", async () => {
     const client = { listFields: vi.fn() };
     const ids = await resolveCustomFieldIds(client as any, {
       statusOverride: "customfield_99",
       repoOverride: "customfield_98",
       profilesOverride: "customfield_97",
+      baseBranchOverride: "customfield_96",
     });
     expect(ids.statusFieldId).toBe("customfield_99");
     expect(ids.repoFieldId).toBe("customfield_98");
@@ -131,18 +132,21 @@ describe("resolveCustomFieldIds — profilesFieldId (lenient resolution)", () =>
       statusOverride: null,
       repoOverride: null,
       profilesOverride: "customfield_explicit_profiles",
+      baseBranchOverride: null,
     });
     expect(ids.profilesFieldId).toBe("customfield_explicit_profiles");
   });
 
-  it("does not call listFields when all three overrides are set (profiles included)", async () => {
+  it("does not call listFields when all four overrides are set (profiles and base branch included)", async () => {
     const client = { listFields: vi.fn() };
     const ids = await resolveCustomFieldIds(client as any, {
       statusOverride: "customfield_s",
       repoOverride: "customfield_r",
       profilesOverride: "customfield_p",
+      baseBranchOverride: "customfield_b",
     });
     expect(ids.profilesFieldId).toBe("customfield_p");
+    expect(ids.baseBranchFieldId).toBe("customfield_b");
     expect(client.listFields).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/providers/jira.test.ts
+++ b/src/__tests__/providers/jira.test.ts
@@ -4,6 +4,7 @@ import { JiraClient } from "../../providers/jira-client.js";
 import { MissingProviderConfigError, type TicketingProvider } from "../../providers/types.js";
 import { clearFieldCache } from "../../providers/jira-fields.js";
 import { validateTicketingConfig } from "../../providers/ticketing-config.js";
+import { validateIssueBaseBranch } from "../../base-branch.js";
 import type { RepoMapping } from "../../config.js";
 
 const stubClient = () => new JiraClient({ token: "t", cloudId: "c" });
@@ -349,6 +350,29 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
 
   const searchOk = (issues: unknown[]): Response =>
     ({ ok: true, json: async () => ({ issues }) }) as Response;
+
+  it("refuses an invalid branch from the Jira snapshot instead of falling back to the default", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const raw = issue("10001", "P-1", "Ready", "acme/x");
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(searchOk([{ ...raw, fields: { ...raw.fields, customfield_10300: "release..bad" } }]))
+      .mockResolvedValueOnce(searchOk([]))
+      .mockResolvedValueOnce(searchOk([]));
+    const p = makeProvider({ cacheScope: "invalid-base", mappings: { "acme/x": jiraMapping({
+      statusFieldOverride: "customfield_10100", repoFieldOverride: "customfield_10101",
+      profilesFieldOverride: "customfield_10200", baseBranchFieldOverride: "customfield_10300",
+    }) } });
+    const snap = await p.fetchAIImplementSnapshot();
+    const markFailed = vi.fn(async () => {});
+    const lookup = vi.fn(async () => null);
+    const result = await validateIssueBaseBranch({
+      ghToken: "test", owner: "acme", repo: "x", issue: snap.needsPlanning[0],
+      markFailed, getBranchShaImpl: lookup,
+    });
+    expect(result).toEqual({ refused: true });
+    expect(markFailed).toHaveBeenCalledWith("10001", "acme/x", expect.stringContaining("invalid"));
+    expect(lookup).not.toHaveBeenCalled();
+  });
 
   it("buckets issues by status field value", async () => {
     vi.mocked(fetch)

--- a/src/__tests__/providers/jira.test.ts
+++ b/src/__tests__/providers/jira.test.ts
@@ -141,6 +141,7 @@ const jiraMapping = (
     statusFieldOverride: string | null;
     repoFieldOverride: string | null;
     profilesFieldOverride: string | null;
+    baseBranchFieldOverride: string | null;
   }> = {},
 ): RepoMapping => ({
   ...baseMapping,
@@ -152,6 +153,7 @@ const jiraMapping = (
     statusFieldOverride: overrides.statusFieldOverride,
     repoFieldOverride: overrides.repoFieldOverride,
     profilesFieldOverride: overrides.profilesFieldOverride,
+    baseBranchFieldOverride: overrides.baseBranchFieldOverride,
   },
 });
 
@@ -410,6 +412,7 @@ describe("JiraProvider.fetchAIImplementSnapshot", () => {
           statusFieldOverride: "status",
           repoFieldOverride: "customfield_10101",
           profilesFieldOverride: "customfield_10200",
+          baseBranchFieldOverride: "customfield_10300",
         }),
       }),
     });
@@ -743,6 +746,7 @@ describe("JiraProvider.fetchAIImplementSnapshot — feature branches", () => {
           statusFieldOverride: "customfield_10100",
           repoFieldOverride: "customfield_10101",
           profilesFieldOverride: "customfield_10200",
+          baseBranchFieldOverride: "customfield_10300",
         }),
       }),
     });
@@ -1037,7 +1041,7 @@ describe("JiraProvider.fetchFeatureNodeRollUps", () => {
     new JiraProvider({
       client, cacheScope: "c", siteUrl: "https://x",
       getMappings: () => ({
-        m1: jiraMapping({ repoFieldValue: "acme/x", statusFieldOverride: "customfield_10100", repoFieldOverride: "customfield_10101", profilesFieldOverride: "customfield_10200" }),
+        m1: jiraMapping({ repoFieldValue: "acme/x", statusFieldOverride: "customfield_10100", repoFieldOverride: "customfield_10101", profilesFieldOverride: "customfield_10200", baseBranchFieldOverride: "customfield_10300" }),
       }),
     });
 
@@ -1155,6 +1159,7 @@ describe("JiraProvider — grouping mode from ai-implement.yml", () => {
           statusFieldOverride: "customfield_10100",
           repoFieldOverride: "customfield_10101",
           profilesFieldOverride: "customfield_10200",
+          baseBranchFieldOverride: "customfield_10300",
         }),
       }),
     });
@@ -1432,7 +1437,7 @@ describe("JiraProvider.fetchAIImplementSnapshot — profiles field", () => {
     warnSpy.mockRestore();
   });
 
-  it("uses profilesFieldOverride to resolve profiles without calling listFields for all three overrides", async () => {
+  it("uses profilesFieldOverride to resolve profiles without calling listFields when all four overrides are set", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(searchOk([{
         id: "10001", key: "P-1",
@@ -1459,6 +1464,7 @@ describe("JiraProvider.fetchAIImplementSnapshot — profiles field", () => {
         statusFieldOverride: "customfield_10100",
         repoFieldOverride: "customfield_10101",
         profilesFieldOverride: "customfield_10200",
+        baseBranchFieldOverride: "customfield_10300",
       },
     };
 

--- a/src/__tests__/providers/ticketing-config.test.ts
+++ b/src/__tests__/providers/ticketing-config.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { validateTicketingConfig, DEFAULT_TICKETING_CONFIG } from "../../providers/ticketing-config.js";
+import { resolveCustomFieldIds } from "../../providers/jira-fields.js";
+import type { JiraMappingConfig } from "../../providers/ticketing-config.js";
+
+const jiraBase = { kind: "jira", jql: "project = ENG", repoFieldValue: "owner/repo" };
+
+describe("validateTicketingConfig", () => {
+  it("returns the linear default for a null config on the linear provider", () => {
+    expect(validateTicketingConfig("linear", null)).toEqual(DEFAULT_TICKETING_CONFIG);
+  });
+
+  it("throws when kind does not match the provider", () => {
+    expect(() => validateTicketingConfig("jira", { kind: "linear" })).toThrow(/must match ticketingProvider/);
+  });
+
+  it("requires a non-empty jql and repoFieldValue for jira", () => {
+    expect(() => validateTicketingConfig("jira", { kind: "jira", repoFieldValue: "owner/repo" })).toThrow(/jql/);
+    expect(() => validateTicketingConfig("jira", { kind: "jira", jql: "project = ENG" })).toThrow(/repoFieldValue/);
+  });
+
+  it("keeps a valid field override, trimmed", () => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: "  customfield_10042  ",
+    }) as JiraMappingConfig;
+    expect(cfg.statusFieldOverride).toBe("customfield_10042");
+  });
+
+  // The bug this file exists for: a blank-but-present override used to survive
+  // validation and reach jira-fields.ts as a literal field id.
+  it.each([
+    ["empty string", ""],
+    ["whitespace only", "   "],
+    ["a non-string", 42],
+    ["null", null],
+    ["undefined", undefined],
+  ])("normalizes a %s field override to null", (_label, value) => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: value,
+      repoFieldOverride: value,
+      profilesFieldOverride: value,
+    }) as JiraMappingConfig;
+    expect(cfg.statusFieldOverride).toBeNull();
+    expect(cfg.repoFieldOverride).toBeNull();
+    expect(cfg.profilesFieldOverride).toBeNull();
+  });
+});
+
+describe("blank overrides no longer reach jira-fields as field ids", () => {
+  const fields = [
+    { id: "customfield_10042", name: "AI-Implement Status", custom: true },
+    { id: "customfield_10043", name: "AI-Implement Repo", custom: true },
+  ];
+
+  const overridesFrom = (cfg: JiraMappingConfig) => ({
+    statusOverride: cfg.statusFieldOverride ?? null,
+    repoOverride: cfg.repoFieldOverride ?? null,
+    profilesOverride: cfg.profilesFieldOverride ?? null,
+  });
+
+  it('falls back to discovery by name for an "" override rather than using it as an id', async () => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: "",
+      repoFieldOverride: "",
+    }) as JiraMappingConfig;
+    const client = { listFields: vi.fn().mockResolvedValue(fields) };
+
+    const ids = await resolveCustomFieldIds(client as any, overridesFrom(cfg));
+
+    expect(ids.statusFieldId).toBe("customfield_10042");
+    expect(ids.repoFieldId).toBe("customfield_10043");
+  });
+
+  it("still calls listFields when every override is whitespace-only", async () => {
+    const cfg = validateTicketingConfig("jira", {
+      ...jiraBase,
+      statusFieldOverride: "   ",
+      repoFieldOverride: "   ",
+      profilesFieldOverride: "   ",
+    }) as JiraMappingConfig;
+    const client = { listFields: vi.fn().mockResolvedValue(fields) };
+
+    const ids = await resolveCustomFieldIds(client as any, overridesFrom(cfg));
+
+    // Before the fix these were truthy, so the all-overrides-set short-circuit
+    // returned "   " for all three and listFields was never called.
+    expect(client.listFields).toHaveBeenCalled();
+    expect(ids.statusFieldId).toBe("customfield_10042");
+    expect(ids.repoFieldId).toBe("customfield_10043");
+  });
+});

--- a/src/__tests__/ref-segment-validation.test.ts
+++ b/src/__tests__/ref-segment-validation.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { validateRefSegments } from "../ref-segment-validation.js";
+
+describe("validateRefSegments", () => {
+  it.each([
+    ["a single segment", "feature"],
+    ["multiple segments", "team/feature/sub"],
+    ["dots, dashes and underscores inside a segment", "v1.2_x-y"],
+    ["a segment starting with a digit", "2026-cleanup"],
+  ])("accepts %s", (_label, value) => {
+    expect(() => validateRefSegments(value, "field")).not.toThrow();
+  });
+
+  it.each([
+    ["a parent-directory traversal", "a/../b"],
+    ["an empty segment via '//'", "a//b"],
+  ])("rejects %s", (_label, value) => {
+    expect(() => validateRefSegments(value, "field")).toThrow(/must not contain/);
+  });
+
+  // The rule that matters most: a leading '-' would otherwise be read as an
+  // option by the git plumbing that consumes the ref.
+  it.each([
+    ["a leading dash", "--upload-pack=touch /tmp/pwn"],
+    ["a leading dot", ".hidden"],
+    ["a space", "has space"],
+    ["a shell metacharacter", "a;b"],
+    ["an empty string", ""],
+  ])("rejects %s", (_label, value) => {
+    expect(() => validateRefSegments(value, "field")).toThrow(/may contain only letters/);
+  });
+
+  it.each([
+    ["a segment ending in '.'", "trailing."],
+    ["a segment ending in '.lock'", "branch.lock"],
+    ["a non-final segment ending in '.lock'", "branch.lock/tail"],
+  ])("rejects %s", (_label, value) => {
+    expect(() => validateRefSegments(value, "field")).toThrow(/must not end with/);
+  });
+
+  it("names the caller's field in every message", () => {
+    expect(() => validateRefSegments("a//b", "baseBranch")).toThrow(/^baseBranch /);
+    expect(() => validateRefSegments("-x", "baseBranch")).toThrow(/^baseBranch /);
+    expect(() => validateRefSegments("x.lock", "baseBranch")).toThrow(/^baseBranch /);
+  });
+
+  it("checks '..' before segment shape, so traversal reports as traversal", () => {
+    // "..": also fails REF_SEGMENT_PATTERN, but the traversal message is the
+    // useful one and must win.
+    expect(() => validateRefSegments("..", "field")).toThrow(/must not contain/);
+  });
+
+  it("leaves length and refs/ prefixes to the caller", () => {
+    expect(() => validateRefSegments("refs/heads/main", "field")).not.toThrow();
+    expect(() => validateRefSegments("a".repeat(500), "field")).not.toThrow();
+  });
+});

--- a/src/admin-ui/__tests__/overview.test.ts
+++ b/src/admin-ui/__tests__/overview.test.ts
@@ -49,4 +49,19 @@ describe("overview page", () => {
     expect(overviewScript).toContain("status === 'review_failed'");
     expect(overviewScript).toContain("review failed");
   });
+
+  it("includes stuck_giveup in the attention KPI filter", () => {
+    expect(overviewScript).toContain("stuck_giveup");
+    expect(overviewScript).toContain("e.conclusion === 'stuck_giveup'");
+  });
+
+  it("includes timed_out in statusBadge map for display consistency", () => {
+    expect(overviewScript).toContain("timed_out: 'warn'");
+  });
+
+  it("includes stuck_giveup in renderRecentFailures filter", () => {
+    const failuresIdx = overviewScript.indexOf("renderRecentFailures");
+    const afterFn = overviewScript.slice(failuresIdx);
+    expect(afterFn).toContain("stuck_giveup");
+  });
 });

--- a/src/admin-ui/__tests__/pipelines.test.ts
+++ b/src/admin-ui/__tests__/pipelines.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { pipelinesHtml, pipelinesScript } from "../pages/pipelines.js";
+
+describe("pipelines page", () => {
+  it("registers the 'jobs' route and exposes loadLog on window", () => {
+    expect(pipelinesScript).toContain("window.registerPage('jobs'");
+    expect(pipelinesScript).toContain("window.loadLog = loadLog");
+  });
+
+  it("renders 'Needs human' badge for stuck_giveup conclusion", () => {
+    expect(pipelinesScript).toContain("stuck_giveup");
+    expect(pipelinesScript).toContain("Needs human");
+  });
+
+  it("associates stuck_giveup with the fail badge class", () => {
+    expect(pipelinesScript).toMatch(/stuck_giveup[\s\S]{0,60}fail/);
+  });
+
+  it("ordinary timed_out still maps to warn class", () => {
+    expect(pipelinesScript).toContain("timed_out: 'warn'");
+  });
+
+  it("jobBadge takes status and conclusion parameters", () => {
+    expect(pipelinesScript).toContain("function jobBadge(status, conclusion)");
+  });
+
+  it("has no bare api(/esc( calls (must use window.api/window.esc)", () => {
+    const stripped = pipelinesScript.replace(/window\.api\(/g, "").replace(/window\.esc\(/g, "");
+    expect(stripped).not.toMatch(/\bapi\(/);
+    expect(stripped).not.toMatch(/\besc\(/);
+  });
+
+  it("uses const/let, not var", () => {
+    expect(pipelinesScript).not.toMatch(/\bvar\s+\w/);
+  });
+
+  it("declares the log table elements the script targets", () => {
+    expect(pipelinesHtml).toContain('id="log-body"');
+    expect(pipelinesHtml).toContain('id="log-empty"');
+    expect(pipelinesHtml).toContain('id="log-count"');
+  });
+});

--- a/src/admin-ui/pages/overview.ts
+++ b/src/admin-ui/pages/overview.ts
@@ -6,6 +6,7 @@ export const overviewHtml = `
       <div class="page-subtitle" id="overview-subtitle">&mdash;</div>
     </div>
     <div class="page-header-actions">
+      <button class="btn btn-sm" id="overview-poll-now" onclick="pollNowClick()">&#9889; Poll now</button>
       <button class="btn btn-sm" onclick="loadOverview()">&#8635; Refresh</button>
     </div>
   </header>
@@ -476,6 +477,27 @@ export const overviewScript = `
   }
 
   window.loadOverview = loadOverview;
+
+  async function pollNowClick() {
+    const btn = document.getElementById('overview-poll-now');
+    const original = btn.innerHTML;
+    btn.disabled = true;
+    try {
+      const res = await window.api('/api/poll-now', { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok) btn.textContent = (data && data.error) || 'Unavailable';
+      else btn.textContent = data.started ? 'Poll started' : 'Poll already running';
+    } catch (err) {
+      btn.textContent = 'Failed';
+      console.error('pollNow failed:', err);
+    }
+    setTimeout(function () {
+      btn.innerHTML = original;
+      btn.disabled = false;
+      loadOverview();
+    }, 2500);
+  }
+  window.pollNowClick = pollNowClick;
 
   window.registerPage('overview', function () {
     loadOverview();

--- a/src/admin-ui/pages/overview.ts
+++ b/src/admin-ui/pages/overview.ts
@@ -182,7 +182,7 @@ export const overviewScript = `
   }
 
   function statusBadge(status) {
-    const map = { running: 'running', review_failed: 'warn', failed: 'fail', completed: 'success' };
+    const map = { running: 'running', review_failed: 'warn', timed_out: 'warn', failed: 'fail', completed: 'success' };
     const kind = map[status] || 'neutral';
     const label = status === 'review_failed' ? 'review failed' : status;
     return '<span class="badge ' + kind + '">' + window.esc(label) + '</span>';
@@ -211,7 +211,7 @@ export const overviewScript = `
   function renderKpis(log, mappings, running) {
     const now = Date.now();
     const failed24h = log.filter(function (e) {
-      return (e.status === 'failed' || e.status === 'review_failed') && (now - new Date(e.dispatchedAt).getTime()) < 86400000;
+      return (e.status === 'failed' || e.status === 'review_failed' || (e.status === 'timed_out' && e.conclusion === 'stuck_giveup')) && (now - new Date(e.dispatchedAt).getTime()) < 86400000;
     });
 
     const mappingEntries = Object.entries(mappings);
@@ -321,7 +321,7 @@ export const overviewScript = `
     if (!tbody || !empty) return;
     const now = Date.now();
     const failures = log.filter(function (e) {
-      return (e.status === 'failed' || e.status === 'review_failed') && (now - new Date(e.dispatchedAt).getTime()) < 86400000;
+      return (e.status === 'failed' || e.status === 'review_failed' || (e.status === 'timed_out' && e.conclusion === 'stuck_giveup')) && (now - new Date(e.dispatchedAt).getTime()) < 86400000;
     }).sort(function (a, b) {
       return new Date(b.dispatchedAt).getTime() - new Date(a.dispatchedAt).getTime();
     }).slice(0, 8);

--- a/src/admin-ui/pages/pipelines.ts
+++ b/src/admin-ui/pages/pipelines.ts
@@ -63,7 +63,10 @@ export const pipelinesScript = `
       function makeBadge(cls, text) {
         return '<span class="badge tight ' + cls + '">' + window.esc(text) + '</span>';
       }
-      function statusBadge(status) {
+      function jobBadge(status, conclusion) {
+        if (status === 'timed_out' && conclusion === 'stuck_giveup') {
+          return makeBadge('fail', 'Needs human');
+        }
         const label = status === 'review_failed' ? 'review failed' : (status || 'dispatched');
         return makeBadge(statusClass[status] || 'neutral', label);
       }
@@ -124,7 +127,7 @@ export const pipelinesScript = `
           const imageCell = impl.sessionImage
             ? '<td class="mono" title="' + window.esc(impl.sessionImage) + '">' + window.esc(impl.sessionImage.split('/').pop()) + '</td>'
             : '<td style="color:#aaa">—</td>';
-          const combinedStatus = statusBadge(plan.status) + ' <span style="color:#aaa;font-size:0.8em">→</span> ' + statusBadge(impl.status);
+          const combinedStatus = jobBadge(plan.status, plan.conclusion) + ' <span style="color:#aaa;font-size:0.8em">→</span> ' + jobBadge(impl.status, impl.conclusion);
           const prLink = impl.prUrl ? '<a href="' + window.esc(impl.prUrl) + '" target="_blank">View</a>' : '—';
           tr.innerHTML = '<td style="white-space:nowrap">' + dt + '</td>'
             + '<td style="text-align:center">' + dnBadge + '</td>'
@@ -158,7 +161,7 @@ export const pipelinesScript = `
             + '<td class="mono">' + window.esc(entry.repo || '—') + '</td>'
             + '<td>' + runnerCell + '</td>'
             + imageCell
-            + '<td>' + statusBadge(entry.status) + '</td>'
+            + '<td>' + jobBadge(entry.status, entry.conclusion) + '</td>'
             + '<td>' + (entry.prUrl ? '<a href="' + window.esc(entry.prUrl) + '" target="_blank">View</a>' : '—') + '</td>';
         }
         tbody.appendChild(tr);

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -129,6 +129,13 @@ export const projectsHtml = `
               <div class="field-hint">Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Profiles&rdquo;. Otherwise pick the multi-select field that holds the implementation profiles for an issue.</div>
             </div>
             <div class="field">
+              <label class="field-label">Base Branch Field</label>
+              <select class="select" id="md-jira-base-branch-field">
+                <option value="">(auto-discover by name "AI-Implement Base Branch")</option>
+              </select>
+              <div class="field-hint">Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Base Branch&rdquo;. Otherwise pick the text field that holds the branch an issue&#x27;s PR should target instead of the repo&#x27;s default branch.</div>
+            </div>
+            <div class="field">
               <label class="field-label">Repo Field Value</label>
               <select class="select" id="md-jira-repo-value">
                 <option value="">Select a Repo Field first</option>
@@ -465,15 +472,19 @@ export const projectsScript = `
     const pendingStatus = (tp === 'jira' && tc.statusFieldOverride) ? tc.statusFieldOverride : '';
     const pendingRepoFld = (tp === 'jira' && tc.repoFieldOverride) ? tc.repoFieldOverride : '';
     const pendingProfilesFld = (tp === 'jira' && tc.profilesFieldOverride) ? tc.profilesFieldOverride : '';
+    const pendingBaseBranchFld = (tp === 'jira' && tc.baseBranchFieldOverride) ? tc.baseBranchFieldOverride : '';
     const statusFldEl = document.getElementById('md-jira-status-field');
     const repoFldEl = document.getElementById('md-jira-repo-field');
     const profilesFldEl = document.getElementById('md-jira-profiles-field');
+    const baseBranchFldEl = document.getElementById('md-jira-base-branch-field');
     statusFldEl.dataset.pendingValue = pendingStatus;
     repoFldEl.dataset.pendingValue = pendingRepoFld;
     profilesFldEl.dataset.pendingValue = pendingProfilesFld;
+    baseBranchFldEl.dataset.pendingValue = pendingBaseBranchFld;
     statusFldEl.value = pendingStatus;
     repoFldEl.value = pendingRepoFld;
     profilesFldEl.value = pendingProfilesFld;
+    baseBranchFldEl.value = pendingBaseBranchFld;
     // Repo field value: stash for after the dropdown loads
     const pendingRepoVal = (tp === 'jira' && tc.kind === 'jira' && tc.repoFieldValue) ? tc.repoFieldValue : '';
     const sel = document.getElementById('md-jira-repo-value');
@@ -574,6 +585,7 @@ export const projectsScript = `
     const statusSel = document.getElementById('md-jira-status-field');
     const repoSel = document.getElementById('md-jira-repo-field');
     const profilesSel = document.getElementById('md-jira-profiles-field');
+    const baseBranchSel = document.getElementById('md-jira-base-branch-field');
     if (jiraFieldsLoaded) return;
     try {
       const res = await window.api('/api/jira/fields');
@@ -585,15 +597,19 @@ export const projectsScript = `
       const prevStatus = statusSel ? (statusSel.value || statusSel.dataset.pendingValue || '') : '';
       const prevRepo = repoSel ? (repoSel.value || repoSel.dataset.pendingValue || '') : '';
       const prevProfiles = profilesSel ? (profilesSel.value || profilesSel.dataset.pendingValue || '') : '';
+      const prevBaseBranch = baseBranchSel ? (baseBranchSel.value || baseBranchSel.dataset.pendingValue || '') : '';
       const statusPlaceholder = statusSel && statusSel.options[0] ? statusSel.options[0] : null;
       const repoPlaceholder = repoSel && repoSel.options[0] ? repoSel.options[0] : null;
       const profilesPlaceholder = profilesSel && profilesSel.options[0] ? profilesSel.options[0] : null;
+      const baseBranchPlaceholder = baseBranchSel && baseBranchSel.options[0] ? baseBranchSel.options[0] : null;
       if (statusSel) statusSel.innerHTML = '';
       if (repoSel) repoSel.innerHTML = '';
       if (profilesSel) profilesSel.innerHTML = '';
+      if (baseBranchSel) baseBranchSel.innerHTML = '';
       if (statusSel && statusPlaceholder) statusSel.appendChild(statusPlaceholder);
       if (repoSel && repoPlaceholder) repoSel.appendChild(repoPlaceholder);
       if (profilesSel && profilesPlaceholder) profilesSel.appendChild(profilesPlaceholder);
+      if (baseBranchSel && baseBranchPlaceholder) baseBranchSel.appendChild(baseBranchPlaceholder);
       for (const f of fields) {
         const labelText = f.name + ' (' + f.id + ')';
         if (statusSel) {
@@ -614,11 +630,18 @@ export const projectsScript = `
           o3.textContent = labelText;
           profilesSel.appendChild(o3);
         }
+        if (baseBranchSel) {
+          const o4 = document.createElement('option');
+          o4.value = f.id;
+          o4.textContent = labelText;
+          baseBranchSel.appendChild(o4);
+        }
       }
       // Restore previously set values (e.g. from openMappingDialog before fields loaded)
       if (statusSel && prevStatus) statusSel.value = prevStatus;
       if (repoSel && prevRepo) repoSel.value = prevRepo;
       if (profilesSel && prevProfiles) profilesSel.value = prevProfiles;
+      if (baseBranchSel && prevBaseBranch) baseBranchSel.value = prevBaseBranch;
       jiraFieldsLoaded = true;
     } catch (err) {
       console.error('loadJiraFields failed:', err);
@@ -829,6 +852,7 @@ export const projectsScript = `
       const statusFieldOverride = document.getElementById('md-jira-status-field').value.trim() || null;
       const repoFieldOverride = document.getElementById('md-jira-repo-field').value.trim() || null;
       const profilesFieldOverride = document.getElementById('md-jira-profiles-field').value.trim() || null;
+      const baseBranchFieldOverride = document.getElementById('md-jira-base-branch-field').value.trim() || null;
       body.ticketingConfig = {
         kind: 'jira',
         jql: jql,
@@ -836,6 +860,7 @@ export const projectsScript = `
         statusFieldOverride: statusFieldOverride,
         repoFieldOverride: repoFieldOverride,
         profilesFieldOverride: profilesFieldOverride,
+        baseBranchFieldOverride: baseBranchFieldOverride,
       };
     }
 

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -71,6 +71,13 @@ export const stepperHtml = `
             <div class="field-hint">Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Profiles&rdquo;. Otherwise pick the multi-select field that holds the implementation profiles for an issue.</div>
           </div>
           <div class="field">
+            <label class="field-label">Base Branch Field</label>
+            <select class="input" id="np-jira-base-branch-field">
+              <option value="">(auto-discover by name "AI-Implement Base Branch")</option>
+            </select>
+            <div class="field-hint">Leave at auto-discover if your Jira instance has a custom field named exactly &ldquo;AI-Implement Base Branch&rdquo;. Otherwise pick the text field that holds the branch an issue's PR should target instead of the repo's default branch.</div>
+          </div>
+          <div class="field">
             <label class="field-label">Repo Field Value</label>
             <select class="input" id="np-jira-repo-value" onchange="updateStepperNextButton()">
               <option value="">Select a Repo Field first</option>
@@ -427,6 +434,7 @@ export const stepperScript = `
     jiraStatusFieldOverride: '',
     jiraRepoFieldOverride: '',
     jiraProfilesFieldOverride: '',
+    jiraBaseBranchFieldOverride: '',
     teamKey: '', owner: '', repo: '', defaultBranch: '', branchPrefix: '', sensitiveAddPatterns: '', sensitiveAllowPatterns: '',
     skillsRepo: '', dependencyTokenScope: null,
     executionMode: 'github-actions', machineCpus: 2, machineMemoryMb: 4096, sessionMode: 'autonomous',
@@ -446,6 +454,7 @@ export const stepperScript = `
     data.jiraStatusFieldOverride = '';
     data.jiraRepoFieldOverride = '';
     data.jiraProfilesFieldOverride = '';
+    data.jiraBaseBranchFieldOverride = '';
     data.teamKey = '';
     data.owner = '';
     data.repo = '';
@@ -531,6 +540,8 @@ export const stepperScript = `
     if (repoFldEl) repoFldEl.value = '';
     const profilesFldEl = document.getElementById('np-jira-profiles-field');
     if (profilesFldEl) profilesFldEl.value = '';
+    const baseBranchFldEl = document.getElementById('np-jira-base-branch-field');
+    if (baseBranchFldEl) baseBranchFldEl.value = '';
     const jqlStatus = document.getElementById('np-jira-jql-status');
     if (jqlStatus) { jqlStatus.textContent = ''; jqlStatus.style.color = ''; }
     const linearCfg = document.getElementById('np-linear-config');
@@ -745,9 +756,11 @@ export const stepperScript = `
         const sf = document.getElementById('np-jira-status-field');
         const rf = document.getElementById('np-jira-repo-field');
         const pf = document.getElementById('np-jira-profiles-field');
+        const bbf = document.getElementById('np-jira-base-branch-field');
         if (sf) data.jiraStatusFieldOverride = sf.value.trim();
         if (rf) data.jiraRepoFieldOverride = rf.value.trim();
         if (pf) data.jiraProfilesFieldOverride = pf.value.trim();
+        if (bbf) data.jiraBaseBranchFieldOverride = bbf.value.trim();
       } else {
         const tkEl = document.getElementById('np-teamKey');
         if (tkEl) data.teamKey = tkEl.value.trim();
@@ -890,6 +903,7 @@ export const stepperScript = `
       if (data.jiraStatusFieldOverride) cfgText += ' &middot; statusField=' + window.esc(data.jiraStatusFieldOverride);
       if (data.jiraRepoFieldOverride) cfgText += ' &middot; repoField=' + window.esc(data.jiraRepoFieldOverride);
       if (data.jiraProfilesFieldOverride) cfgText += ' &middot; profilesField=' + window.esc(data.jiraProfilesFieldOverride);
+      if (data.jiraBaseBranchFieldOverride) cfgText += ' &middot; baseBranchField=' + window.esc(data.jiraBaseBranchFieldOverride);
     } else {
       cfgText = 'team=' + (window.esc(data.teamKey) || '&mdash;');
     }
@@ -1006,8 +1020,9 @@ export const stepperScript = `
     const statusSel = document.getElementById('np-jira-status-field');
     const repoSel = document.getElementById('np-jira-repo-field');
     const profilesSel = document.getElementById('np-jira-profiles-field');
+    const baseBranchSel = document.getElementById('np-jira-base-branch-field');
     if (jiraFieldsLoaded) return;
-    if (!statusSel && !repoSel && !profilesSel) return;
+    if (!statusSel && !repoSel && !profilesSel && !baseBranchSel) return;
     try {
       const res = await window.api('/api/jira/fields');
       if (!res.ok) return;
@@ -1018,15 +1033,19 @@ export const stepperScript = `
       const prevStatus = statusSel ? (statusSel.value || statusSel.dataset.pendingValue || '') : '';
       const prevRepo = repoSel ? (repoSel.value || repoSel.dataset.pendingValue || '') : '';
       const prevProfiles = profilesSel ? (profilesSel.value || profilesSel.dataset.pendingValue || '') : '';
+      const prevBaseBranch = baseBranchSel ? (baseBranchSel.value || baseBranchSel.dataset.pendingValue || '') : '';
       const statusPlaceholder = statusSel && statusSel.options[0] ? statusSel.options[0] : null;
       const repoPlaceholder = repoSel && repoSel.options[0] ? repoSel.options[0] : null;
       const profilesPlaceholder = profilesSel && profilesSel.options[0] ? profilesSel.options[0] : null;
+      const baseBranchPlaceholder = baseBranchSel && baseBranchSel.options[0] ? baseBranchSel.options[0] : null;
       if (statusSel) statusSel.innerHTML = '';
       if (repoSel) repoSel.innerHTML = '';
       if (profilesSel) profilesSel.innerHTML = '';
+      if (baseBranchSel) baseBranchSel.innerHTML = '';
       if (statusSel && statusPlaceholder) statusSel.appendChild(statusPlaceholder);
       if (repoSel && repoPlaceholder) repoSel.appendChild(repoPlaceholder);
       if (profilesSel && profilesPlaceholder) profilesSel.appendChild(profilesPlaceholder);
+      if (baseBranchSel && baseBranchPlaceholder) baseBranchSel.appendChild(baseBranchPlaceholder);
       for (const f of fields) {
         const labelText = f.name + ' (' + f.id + ')';
         if (statusSel) {
@@ -1047,10 +1066,17 @@ export const stepperScript = `
           o3.textContent = labelText;
           profilesSel.appendChild(o3);
         }
+        if (baseBranchSel) {
+          const o4 = document.createElement('option');
+          o4.value = f.id;
+          o4.textContent = labelText;
+          baseBranchSel.appendChild(o4);
+        }
       }
       if (statusSel && prevStatus) statusSel.value = prevStatus;
       if (repoSel && prevRepo) repoSel.value = prevRepo;
       if (profilesSel && prevProfiles) profilesSel.value = prevProfiles;
+      if (baseBranchSel && prevBaseBranch) baseBranchSel.value = prevBaseBranch;
       jiraFieldsLoaded = true;
     } catch (err) {
       console.error('stepperLoadJiraFields failed:', err);
@@ -1253,6 +1279,7 @@ export const stepperScript = `
             statusFieldOverride: data.jiraStatusFieldOverride || null,
             repoFieldOverride: data.jiraRepoFieldOverride || null,
             profilesFieldOverride: data.jiraProfilesFieldOverride || null,
+            baseBranchFieldOverride: data.jiraBaseBranchFieldOverride || null,
           }
         : { kind: 'linear' },
     };

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -172,6 +172,8 @@ export interface AdminConfig {
   flySessionsRegion: string | null;
   githubAppId: string;
   githubAppPrivateKey: string;
+  /** Triggers an immediate poll cycle; reports false if one is already running. Unset in tests that don't exercise it. */
+  pollNow?: () => { started: boolean };
 }
 
 export function handleAdminRequest(
@@ -315,6 +317,16 @@ export function handleAdminRequest(
       const n = parseInt(limitParam ?? "20", 10);
       const limit = Math.min(100, Number.isFinite(n) && n > 0 ? n : 20);
       json(res, 200, listReaperActions(limit));
+      return true;
+    }
+
+    if (url === "/api/poll-now" && method === "POST") {
+      if (!config.pollNow) {
+        json(res, 503, { error: "Poll trigger not available" });
+        return true;
+      }
+      const result = config.pollNow();
+      json(res, 200, result.started ? { started: true } : { started: false, reason: "poll_in_progress" });
       return true;
     }
 

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -159,6 +159,24 @@ function validateTicketingMapping(body: { ticketingProvider?: unknown; ticketing
     throw new Error(`Invalid ticketingProvider: expected "linear" or "jira", got ${JSON.stringify(provider)}`);
   }
   const config = validateTicketingConfig(provider, body.ticketingConfig ?? null);
+  if (config.kind === "jira") {
+    // A field-id override is interpolated into JQL and into the fields list of a REST
+    // query, so reject anything that is not a bare identifier here rather than letting
+    // it reach Jira as a malformed query. Blank values are already normalized to null
+    // by validateTicketingConfig, so only genuinely malformed ids reach this check.
+    const overrideKeys = [
+      "statusFieldOverride",
+      "repoFieldOverride",
+      "profilesFieldOverride",
+      "baseBranchFieldOverride",
+    ] as const;
+    for (const key of overrideKeys) {
+      const value = config[key];
+      if (value != null && !/^[A-Za-z0-9_]+$/.test(value)) {
+        throw new Error(`Invalid ${key} "${value}" — Jira field ids may only contain letters, digits, and underscores`);
+      }
+    }
+  }
   return { ticketingProvider: provider, ticketingConfig: config };
 }
 

--- a/src/base-branch.ts
+++ b/src/base-branch.ts
@@ -1,0 +1,271 @@
+import { getBranchSha } from "./github.js";
+import { validateRefSegments } from "./ref-segment-validation.js";
+import type { FeatureBranchChainEntry } from "./providers/types.js";
+
+// A prefix (like branchPrefix) and a full base-branch name have very different
+// length distributions: branches this repo generates via buildIssueBranchName are
+// `ai-implement/<key>-<summary-up-to-48-chars>`, comfortably into the 70s (e.g. this
+// PR's own branch is 71 chars). 255 is ref-realistic while keeping the character/segment
+// rules as the actual security control.
+const MAX_BASE_BRANCH_LENGTH = 255;
+
+/**
+ * Validates and normalizes a base branch value read from the Jira
+ * "AI-Implement Base Branch" field.
+ *
+ * - Blank/whitespace → null (feature inactive, not an error).
+ * - refs/heads/... and refs/remotes/... are explicitly rejected — only plain or
+ *   origin/-prefixed branch names are supported.
+ * - Per-segment rules are shared with normalizeBranchPrefix (src/pipeline/branch-name.ts)
+ *   via validateRefSegments: first character alphanumeric, no '..', no '//', no segment
+ *   ending '.' or '.lock', ≤ 255 chars total.
+ *
+ * Requiring the first character to be alphanumeric is the primary security control:
+ * it kills --upload-pack= argument injection outright when the value reaches a git
+ * fetch positional refspec slot (see clone.ts incremental path).
+ *
+ * Throws on an invalid non-blank value so callers can surface the specific rule broken.
+ */
+export function normalizeBaseBranch(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const value = raw.trim();
+  if (value === "") return null;
+
+  if (value.startsWith("refs/heads/") || value.startsWith("refs/remotes/")) {
+    throw new Error("baseBranch must not use refs/heads/ or refs/remotes/ form — use the plain branch name");
+  }
+  if (value.length > MAX_BASE_BRANCH_LENGTH) {
+    throw new Error(`baseBranch must be ${MAX_BASE_BRANCH_LENGTH} characters or fewer`);
+  }
+  validateRefSegments(value, "baseBranch");
+  return value;
+}
+
+export interface ResolveIssueBaseBranchOptions {
+  ghToken: string;
+  owner: string;
+  repo: string;
+  /** Already-normalized (non-null) branch value from normalizeBaseBranch(). */
+  value: string;
+  /** Injectable for tests, the same way other callers inject collaborators. Defaults to the
+   *  real getBranchSha (src/github.ts), which already handles multi-segment ref encoding
+   *  correctly and distinguishes 404 (branch absent) from other error statuses. */
+  getBranchShaImpl?: typeof getBranchSha;
+}
+
+export type ResolveIssueBaseBranchResult =
+  | { found: true; branch: string; lookupCount: number }
+  | { found: false; tried: string[]; lookupCount: number };
+
+/**
+ * D6 resolution: resolve the base branch by looking it up on GitHub, do not guess.
+ *
+ * 1. Check the value literally as a branch name (one API call).
+ * 2. If absent and the value starts with "origin/", retry with that prefix stripped
+ *    (one additional API call).
+ *    Rationale: "origin/my-feature" is a legal git branch name; blind stripping would
+ *    silently retarget to "my-feature" even when both coexist. Plain "my-feature" costs
+ *    exactly one lookup.
+ * 3. If neither form exists, return not-found carrying both forms tried.
+ *
+ * Delegates existence checks to getBranchSha (src/github.ts) rather than rolling its own
+ * fetch: getBranchSha already encodes multi-segment refs correctly (encoding the whole
+ * branch string, as this function used to, turns "/" into "%2F" and 404s on realistic
+ * values like "ai-implement/feature/…") and already throws a GitHubApiError on any
+ * non-200/non-404 response instead of treating it as "branch absent" — auth/permission
+ * failures, rate limiting, and 5xx propagate to the caller instead of being silently
+ * misread as not-found.
+ */
+export async function resolveIssueBaseBranch(
+  opts: ResolveIssueBaseBranchOptions,
+): Promise<ResolveIssueBaseBranchResult> {
+  const { ghToken, owner, repo, value, getBranchShaImpl = getBranchSha } = opts;
+
+  const exists = async (branch: string): Promise<boolean> =>
+    (await getBranchShaImpl(ghToken, owner, repo, branch)) !== null;
+
+  if (await exists(value)) {
+    return { found: true, branch: value, lookupCount: 1 };
+  }
+
+  if (value.startsWith("origin/")) {
+    const stripped = value.slice("origin/".length);
+    if (await exists(stripped)) {
+      return { found: true, branch: stripped, lookupCount: 2 };
+    }
+    return { found: false, tried: [value, stripped], lookupCount: 2 };
+  }
+
+  return { found: false, tried: [value], lookupCount: 1 };
+}
+
+export type ValidateIssueBaseBranchResult =
+  | { refused: true }
+  | { refused: false; branch: string | null };
+
+/**
+ * Orchestrator-side validator for the Jira "AI-Implement Base Branch" field (D5).
+ * Called at the top of both dispatchPlanning and the implementation dispatch path,
+ * before any dispatch that depends on the resolved branch.
+ *
+ * Handles three pre-dispatch refusal conditions, calling markFailed for each:
+ *   1. issue.baseBranch fails normalizeBaseBranch — the specific rule is reported.
+ *   2. issue.baseBranch set AND featureBranchChain non-empty — unsupported
+ *      combination; clear one.
+ *   3. The branch doesn't exist on GitHub — both forms tried are reported.
+ *
+ * The fourth refusal (dispatch returns 422 while base_branch was sent → target repo
+ * must re-sync) is handled at the dispatch call site, not here.
+ *
+ * Returns { refused: false, branch: null } when issue.baseBranch is not set —
+ * the caller falls through to its own default branch resolution.
+ * Returns { refused: false, branch: string } when the value is valid and found.
+ * Returns { refused: true } (after calling markFailed) on any refusal — the issue
+ * must NOT be dispatched.
+ */
+export async function validateIssueBaseBranch(opts: {
+  ghToken: string;
+  owner: string;
+  repo: string;
+  issue: { id: string; scopeKey: string; baseBranch?: string; featureBranchChain?: FeatureBranchChainEntry[] };
+  markFailed: (issueId: string, scopeKey: string, reason: string) => Promise<void>;
+  getBranchShaImpl?: typeof getBranchSha;
+}): Promise<ValidateIssueBaseBranchResult> {
+  const { ghToken, owner, repo, issue, markFailed, getBranchShaImpl } = opts;
+
+  if (!issue.baseBranch) {
+    return { refused: false, branch: null };
+  }
+
+  // Refusal #1: field value fails normalizeBaseBranch — report the specific rule.
+  let normalized: string | null;
+  try {
+    normalized = normalizeBaseBranch(issue.baseBranch);
+  } catch (err) {
+    const rule = err instanceof Error ? err.message : String(err);
+    await markFailed(
+      issue.id,
+      issue.scopeKey,
+      `AI-Implement Base Branch value "${issue.baseBranch}" is invalid: ${rule}`,
+    );
+    return { refused: true };
+  }
+
+  // issue.baseBranch was truthy (we returned above otherwise) but can still be a
+  // whitespace-only string, which normalizeBaseBranch trims down to "" and returns
+  // null for — without throwing. Treat that as unset, not a refusal: falling through
+  // with normalized still typed `string` (via the old `!` assertion) let a real `null`
+  // reach resolveIssueBaseBranch → getBranchSha at runtime and throw there instead,
+  // which escaped to the per-issue try/catch in poll() and silently skipped the issue
+  // every tick with no ticket feedback.
+  if (!normalized) {
+    return { refused: false, branch: null };
+  }
+
+  // Refusal #2: field set AND featureBranchChain non-empty — checked before the
+  // GitHub lookup to avoid an unnecessary API call on a clearly invalid state.
+  if (issue.featureBranchChain && issue.featureBranchChain.length > 0) {
+    await markFailed(
+      issue.id,
+      issue.scopeKey,
+      `AI-Implement Base Branch and feature-branch grouping are an unsupported combination — ` +
+        `clear one: either remove the Base Branch field value or remove the issue from the feature-branch tree`,
+    );
+    return { refused: true };
+  }
+
+  // Refusal #3: branch not found on GitHub — report both forms tried.
+  const resolved = await resolveIssueBaseBranch({ ghToken, owner, repo, value: normalized, getBranchShaImpl });
+  if (!resolved.found) {
+    const tried = resolved.tried.map((t) => `"${t}"`).join(" and ");
+    await markFailed(
+      issue.id,
+      issue.scopeKey,
+      `AI-Implement Base Branch "${normalized}" not found on ${owner}/${repo} — tried ${tried}`,
+    );
+    return { refused: true };
+  }
+
+  return { refused: false, branch: resolved.branch };
+}
+
+/**
+ * Escapes characters that would break out of a markdown inline code span (or
+ * fracture a single-line comment/PR-body line into multiple paragraphs) when
+ * a base branch name is interpolated into user-facing text.
+ *
+ * Backticks would prematurely close the surrounding code span, and markdown
+ * does not honor backslash-escapes inside a code span — so a backslash-escape
+ * would render literally rather than being treated as an escape. Newlines
+ * would split what's meant to be a single line into multiple paragraphs.
+ * Both are neutralized outright rather than escaped for that reason.
+ *
+ * Applied at the display boundary only — callers still use the raw,
+ * git-valid branch string for git operations and the GitHub API `base`
+ * field; this is purely for text wrapped in backticks.
+ */
+export function sanitizeBranchForDisplay(value: string): string {
+  return value.replace(/`/g, "'").replace(/\r?\n/g, " ");
+}
+
+/**
+ * Returns the Jira comment text to post at dispatch time when a planning or
+ * implementation run targets a non-default base branch, so the ticket visibly
+ * records which branch each phase used.
+ *
+ * Returns null when resolvedBranch equals defaultBranch — the common path
+ * should produce no extra noise.
+ */
+export function dispatchBranchComment(
+  resolvedBranch: string,
+  defaultBranch: string,
+  phase: "planning" | "implementation",
+): string | null {
+  if (resolvedBranch === defaultBranch) return null;
+  const verb = phase === "planning" ? "Planning" : "Implementing";
+  return `${verb} against branch: \`${sanitizeBranchForDisplay(resolvedBranch)}\``;
+}
+
+/**
+ * Posts the "Planning/Implementing against branch: `x`" ticket comment,
+ * fire-and-forget (errors are logged, never thrown/awaited by the caller).
+ * Extracted here (rather than left duplicated inline at every dispatch call
+ * site — GHA implementation, Fly implementation, local-docker implementation,
+ * GHA planning, session planning) so the "build comment, post it, catch and
+ * log failures" pattern has exactly one implementation.
+ *
+ * `fieldValue` must be the *validated* "AI-Implement Base Branch" field value
+ * (`implValidated.branch` / `planningValidated.branch` from
+ * validateIssueBaseBranch), not the fully-resolved base branch used for the
+ * actual clone/dispatch. For implementation dispatch those differ: the
+ * resolved base branch also falls back to the feature-branch-grouping branch
+ * (src/feature-branch.ts `resolveBaseBranch`) when the field is unset, which
+ * is unrelated to this field and must never trigger this comment. Passing the
+ * resolved branch here was the original bug — every feature-tree child
+ * dispatch posted a spurious "Implementing against branch" comment because
+ * its resolved base (the feature branch) always differs from the repo
+ * default, even though the Jira field was never set. Planning never applies
+ * feature-branch grouping, so its "resolved" and "field" values already
+ * coincided — which is exactly why only the implementation path showed the
+ * bug.
+ *
+ * Takes a minimal duck-typed provider/issue shape (rather than importing
+ * TicketingProvider/TicketIssue from providers/types.ts) so this module
+ * stays free of that dependency and — more importantly — so it can be
+ * unit-tested without importing src/index.ts, which runs the orchestrator's
+ * main() at module load with no test guard.
+ */
+export function postBranchComment(
+  provider: { postComment(issueId: string, body: string): Promise<void> },
+  issue: { id: string; identifier: string },
+  fieldValue: string | null,
+  defaultBranch: string,
+  phase: "planning" | "implementation",
+): void {
+  if (!fieldValue) return;
+  const comment = dispatchBranchComment(fieldValue, defaultBranch, phase);
+  if (!comment) return;
+  provider.postComment(issue.id, comment).catch(
+    (err) => console.error(`[poll] Failed to post ${phase} branch comment for ${issue.identifier}:`, err),
+  );
+}

--- a/src/github-app-auth.ts
+++ b/src/github-app-auth.ts
@@ -3,6 +3,7 @@ import { GitHubApiError } from "./github-errors.js";
 
 export interface InstallationDetails {
   token: string;
+  expiresAt: number; // ms since epoch; parsed from the token response's expires_at field (0 if absent/invalid)
   installationId: number; // Currently inert — no caller reads this yet. Reserved for an OAuth follow-up (if approved), which will add a repo to a "selected repositories" install via the API and needs the installation id to target it
   repositorySelection: "all" | "selected";
 }
@@ -145,10 +146,14 @@ export async function getInstallation(
       message: `Failed to get installation token for owner "${owner}" (${tokenRes.status}): ${body}`,
     });
   }
-  const tokenData = (await tokenRes.json()) as { token: string };
+  const tokenData = (await tokenRes.json()) as { token: string; expires_at?: string };
+
+  const parsedMs = tokenData.expires_at ? new Date(tokenData.expires_at).getTime() : NaN;
+  const expiresAt = Number.isFinite(parsedMs) ? parsedMs : 0;
 
   return {
     token: tokenData.token,
+    expiresAt,
     installationId: install.id,
     repositorySelection: install.repository_selection === "all" ? "all" : "selected",
   };
@@ -214,10 +219,16 @@ export async function getAppSlug(appId: string, privateKey: string): Promise<str
   return cachedAppSlug;
 }
 
+// Applied to the token's actual expires_at before caching so we never hand out a token that's about
+// to expire. Falls back to a 50-minute default when the response omits expires_at.
+const SAFETY_MARGIN_MS = 5 * 60 * 1000;
+const FALLBACK_TTL_MS = 50 * 60 * 1000;
+
 /**
  * Returns a cached installation access token for the given owner.
- * Tokens are valid for 1 hour; we cache for 50 minutes.
- * 
+ * Cache TTL is derived from the token response's expires_at minus a 5-minute safety margin.
+ * Falls back to a 50-minute TTL if expires_at is absent or unparseable.
+ *
  * Thin caching layer over getInstallation — the hot dispatch path only needs the token.
  */
 export async function getInstallationToken(
@@ -229,8 +240,9 @@ export async function getInstallationToken(
   if (cached && Date.now() < cached.expiresAt) {
     return cached.token;
   }
-  const { token } = await getInstallation(appId, privateKey, owner);
-  tokenCache.set(owner, { token, expiresAt: Date.now() + 50 * 60 * 1000 });
+  const { token, expiresAt } = await getInstallation(appId, privateKey, owner);
+  const cacheExpiresAt = expiresAt > 0 ? expiresAt - SAFETY_MARGIN_MS : Date.now() + FALLBACK_TTL_MS;
+  tokenCache.set(owner, { token, expiresAt: cacheExpiresAt });
   return token;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2633,6 +2633,12 @@ function startServer(config: AppConfig, registry: ProviderRegistry): http.Server
         flySessionsRegion: config.flySessionsRegion,
         githubAppId: config.githubAppId,
         githubAppPrivateKey: config.githubAppPrivateKey,
+        pollNow: () => {
+          if (pollInProgress) return { started: false };
+          console.log("[poll] Immediate poll requested via admin UI");
+          void poll(config, registry);
+          return { started: true };
+        },
       }, registry)) return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3661,13 +3661,7 @@ function startServer(config: AppConfig, registry: ProviderRegistry, sidecar: KgS
             githubAppId: config.githubAppId,
             githubAppPrivateKey: config.githubAppPrivateKey,
             notifyType: config.notifyType,
-            pollNow: () => {
-          if (pollInProgress) return { started: false };
-          console.log("[poll] Immediate poll requested via admin UI");
-          void poll(config, registry);
-          return { started: true };
-        },
-        notifyWebhookUrl: config.notifyWebhookUrl,
+            notifyWebhookUrl: config.notifyWebhookUrl,
           },
           onKgRefreshRunnerComplete: kgRefresh.onRunnerComplete.bind(kgRefresh),
         });
@@ -3936,6 +3930,12 @@ function startServer(config: AppConfig, registry: ProviderRegistry, sidecar: KgS
         flySessionsRegion: config.flySessionsRegion,
         githubAppId: config.githubAppId,
         githubAppPrivateKey: config.githubAppPrivateKey,
+        pollNow: () => {
+          // poll() claims beginCycle synchronously before its first await.
+          const before = getPollStats().pollCount;
+          void poll(config, registry).catch((err) => console.error("[poll] Immediate poll failed:", err));
+          return { started: getPollStats().pollCount > before };
+        },
         notifyWebhookUrl: config.notifyWebhookUrl,
       }, registry, { startDeploy, selfDeployTarget: config.selfDeployTarget, kgRefresh })) return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ import type { RunPrCandidate, RunPrMatch } from "./monitor-status.js";
 import { pickPrForRun } from "./monitor-status.js";
 import { type RunConfigV1, encodeRunConfig } from "./run-config.js";
 import { resolveBaseBranch, findOpenRollUpPr } from "./feature-branch.js";
+import { validateIssueBaseBranch, postBranchComment } from "./base-branch.js";
 import { runMergeUps, clearRollUpHandledMarkersByIdentifier } from "./merge-up.js";
 import { runGroupingBranchAutoMerge } from "./auto-merge.js";
 import { getPendingReviewFixes, recordReviewFixDispatch, updateReviewFixStatus } from "./review-fix-queue.js";
@@ -606,6 +607,21 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
           // is per-owner cached, so the in-dispatch-fn fetches below are cache hits.
           const baseGhToken = await getInstallationToken(config.githubAppId, config.githubAppPrivateKey, mapping.owner);
 
+          // Validate the "AI-Implement Base Branch" field before dispatch. On refusal
+          // markImplementationFailed has already been called — skip this issue.
+          // Deliberately runs BEFORE the grouping roll-up hold below: the
+          // field-plus-grouping conflict is exactly one of the refusals, so a
+          // misconfigured grouping parent must surface that error rather than being
+          // silently held forever.
+          const implValidated = await validateIssueBaseBranch({
+            ghToken: baseGhToken,
+            owner: mapping.owner,
+            repo: mapping.repo,
+            issue,
+            markFailed: (id, sk, reason) => issueProvider.markImplementationFailed(id, sk, reason),
+          });
+          if (implValidated.refused) continue;
+
           // AII-264 r3: a grouping parent with an OPEN top-of-tree roll-up PR has no
           // dispatchable work — hold it (dedup untouched) until the PR merges or closes.
           // Checked BEFORE resolveBaseBranch so the hold never (re)creates branches.
@@ -617,18 +633,26 @@ async function poll(config: AppConfig, registry: ProviderRegistry): Promise<void
             }
           }
 
-          const baseBranch = await resolveBaseBranch({ ghToken: baseGhToken, issue, mapping });
+          // When the field was set and validated, it wins; otherwise fall through to
+          // feature-branch grouping resolution (featureBranchChain → feature branch).
+          const baseBranch = implValidated.branch ?? await resolveBaseBranch({ ghToken: baseGhToken, issue, mapping });
+
+          // The validated field value (null when unset) — threaded separately from
+          // baseBranch so each dispatch path can gate its branch comment on the FIELD,
+          // not on the fully-resolved base (which also covers the unrelated
+          // feature-branch-grouping fallback and must not trigger a comment).
+          const implFieldValue = implValidated.branch;
 
           if (execPath === "both") {
             // Shadow: GHA is primary (controls ticket state and dedup); Fly is secondary
-            await dispatchGitHubActions(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch);
-            await dispatchFlyMachine(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch, true);
+            await dispatchGitHubActions(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch, implFieldValue);
+            await dispatchFlyMachine(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch, implFieldValue, true);
           } else if (execPath === "local-docker") {
-            await dispatchLocalDocker(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch);
+            await dispatchLocalDocker(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch, implFieldValue);
           } else if (execPath === "fly-machines") {
-            await dispatchFlyMachine(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch);
+            await dispatchFlyMachine(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch, implFieldValue);
           } else {
-            await dispatchGitHubActions(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch);
+            await dispatchGitHubActions(config, issueProvider, issue, mapping, prior, runnerMode, baseBranch, implFieldValue);
           }
         }
       } catch (err) {
@@ -825,6 +849,9 @@ async function dispatchGitHubActions(
   prior: { count: number; lastDispatchedAt: number | null },
   runnerMode: string,
   baseBranch: string,
+  /** The validated "AI-Implement Base Branch" field value, or null when unset. Distinct
+   *  from baseBranch, which also covers the feature-branch-grouping fallback. */
+  baseBranchFieldValue: string | null,
 ): Promise<void> {
   const ghToken = await getInstallationToken(config.githubAppId, config.githubAppPrivateKey, mapping.owner);
 
@@ -857,6 +884,10 @@ async function dispatchGitHubActions(
   }
 
   const runnerImage = await resolveDispatchRunnerImage(config, mapping, ghToken);
+
+  // True whenever base_branch is forwarded as a legacy workflow input — set by the
+  // field OR by feature-branch grouping. Used only to attribute a 422 below.
+  const implSentBaseBranch = baseBranch !== mapping.defaultBranch;
 
   const workflowCapabilities = await resolveWorkflowCapabilities({
     owner: mapping.owner,
@@ -936,6 +967,20 @@ async function dispatchGitHubActions(
         phase: "implementation",
       },
     );
+    // Only reachable on the legacy contract — under the envelope base_branch is not a
+    // workflow input at all (it rides inside run_config), so a 422 can never be about
+    // it. implSentBaseBranch is also true for the pre-existing feature-branch grouping
+    // path, and a 422 has many possible causes, so also require the error body itself
+    // to mention base_branch before attributing it to a stale claude-implement.yml.
+    if (contract === "legacy" && result.status === 422 && implSentBaseBranch && /base_branch/.test(result.error ?? "")) {
+      await provider.markImplementationFailed(
+        issue.id,
+        issue.scopeKey,
+        "dispatch rejected (422): base_branch was not accepted. Either the target repo has not "
+          + "re-synced claude-implement.yml, or the workflow-contract probe cached \"legacy\" for a repo "
+          + "that has since re-synced to the envelope contract (that cache is short-lived — retry first).",
+      );
+    }
     // No dedup row was written at this point (markDispatched is called only on success below).
     const _brImpl = recordDispatchFailure(issue.id, "implementation", "workflow_dispatch_failed");
     if (_brImpl.tripped) {
@@ -968,6 +1013,8 @@ async function dispatchGitHubActions(
   }
 
   await postDispatch(config, provider, issue, mapping, ghToken, jobId, "github-actions");
+
+  postBranchComment(provider, issue, baseBranchFieldValue, mapping.defaultBranch, "implementation");
 
   console.log(`[poll] Dispatched ${issue.identifier} -> ${mapping.owner}/${mapping.repo} (github-actions, image: ${runnerImage ?? "workflow-default"})`);
 }
@@ -1019,6 +1066,29 @@ async function dispatchPlanning(
     );
     return;
   }
+
+  // Validate the "AI-Implement Base Branch" field before planning dispatch: planning
+  // clones this branch, so the check must run before any dispatch work. Placed after
+  // the early returns above so an unrelated skip (bedrock, missing credential, missing
+  // Fly config) still reports its own reason rather than an installation error.
+  // The token is only fetched when there is a value to validate — validateIssueBaseBranch
+  // short-circuits without touching ghToken when issue.baseBranch is unset, which is
+  // always the case for Linear (the field is Jira-only). getInstallationToken is
+  // per-owner cached, so the later unconditional fetches are cache hits.
+  const planningValidated = await validateIssueBaseBranch({
+    ghToken: issue.baseBranch
+      ? await getInstallationToken(config.githubAppId, config.githubAppPrivateKey, mapping.owner)
+      : "",
+    owner: mapping.owner,
+    repo: mapping.repo,
+    issue,
+    markFailed: (id, sk, reason) => provider.markPlanningFailed(id, sk, reason),
+  });
+  if (planningValidated.refused) return;
+
+  // featureBranchChain is NOT consulted for planning — that grouping applies only to
+  // implementation dispatches. Planning clones the validated field value or the default.
+  const resolvedPlanningBranch = planningValidated.branch ?? mapping.defaultBranch;
 
   // Build planning context (PARENT/SIBLINGS/DEPENDENCIES) for all execution paths.
   const planningContextInputs = await buildPlanningContextInputs({
@@ -1109,7 +1179,7 @@ async function dispatchPlanning(
             issueDescription: issue.description || issue.title,
             owner: mapping.owner,
             repo: mapping.repo,
-            defaultBranch: mapping.defaultBranch,
+            defaultBranch: resolvedPlanningBranch,
             anthropicApiKey: config.anthropicApiKey ?? undefined,
             claudeOAuthToken: config.claudeOAuthToken ?? undefined,
             githubToken: ghToken,
@@ -1166,7 +1236,7 @@ async function dispatchPlanning(
             issueDescription: issue.description || issue.title,
             owner: mapping.owner,
             repo: mapping.repo,
-            defaultBranch: mapping.defaultBranch,
+            defaultBranch: resolvedPlanningBranch,
             anthropicApiKey: config.anthropicApiKey ?? undefined,
             claudeOAuthToken: config.claudeOAuthToken ?? undefined,
             githubToken: ghToken,
@@ -1215,6 +1285,7 @@ async function dispatchPlanning(
             err,
           );
         }
+        postBranchComment(provider, issue, planningValidated.branch, mapping.defaultBranch, "planning");
       },
     });
     return;
@@ -1250,6 +1321,12 @@ async function dispatchPlanning(
   // claude-plan.yml are not rejected with a 422 "unexpected inputs".
   const runnerImage = await resolveDispatchRunnerImage(config, mapping, ghToken);
 
+  // Only forward base_branch when it differs from the repo default — same guard as the
+  // implementation dispatch: GitHub rejects unknown workflow_dispatch inputs with 422,
+  // so repos that have not re-synced claude-plan.yml keep working on the common path.
+  // Legacy contract only; under the envelope the branch rides inside run_config.
+  const planningSentBaseBranch = resolvedPlanningBranch !== mapping.defaultBranch;
+
   const planningContract = await resolveWorkflowContract({
     owner: mapping.owner,
     repo: mapping.repo,
@@ -1261,6 +1338,8 @@ async function dispatchPlanning(
   const planningDispatchInputs = planningContract === "envelope"
     ? buildEnvelopeDispatchInputs(planningMapping, issue, {
         runnerPhase: "planning",
+        // Base branch for the planning clone. Rides inside run_config on the envelope.
+        baseBranch: planningSentBaseBranch ? resolvedPlanningBranch : undefined,
         runnerCallbackUrl: runnerCallbackUrl || undefined,
         runToken,
         // No runProgressToken: planning dispatches don't mint progress tokens.
@@ -1274,6 +1353,9 @@ async function dispatchPlanning(
         issue_description: issue.description || issue.title,
         ...planningContextInputs,
         ...providerDispatchFields(planningMapping),
+        // Gated: an empty spread when unset, so legacy repos on the common path still
+        // send no unexpected inputs and cannot 422.
+        ...(planningSentBaseBranch ? { base_branch: resolvedPlanningBranch } : {}),
         runner_callback_url: runnerCallbackUrl,
         run_token: runToken,
         ...(runnerImage ? { runner_image: runnerImage } : {}),
@@ -1300,6 +1382,17 @@ async function dispatchPlanning(
         phase: "planning",
       },
     );
+    // Same legacy-only, content-gated attribution as the implementation path: under the
+    // envelope base_branch is not an input at all, and planningSentBaseBranch alone is
+    // not a reliable signal, so require the error body to mention base_branch before
+    // blaming a stale claude-plan.yml.
+    if (planningContract === "legacy" && result.status === 422 && planningSentBaseBranch && /base_branch/.test(result.error ?? "")) {
+      await provider.markPlanningFailed(
+        issue.id,
+        issue.scopeKey,
+        "dispatch rejected (422): target repo must re-sync claude-plan.yml to accept the base_branch input",
+      );
+    }
     // Planning never writes a dedup row (intentional), but we still count the failure.
     const _brPlan = recordDispatchFailure(issue.id, "planning", "workflow_dispatch_failed");
     if (_brPlan.tripped) {
@@ -1343,6 +1436,8 @@ async function dispatchPlanning(
     );
   }
 
+  postBranchComment(provider, issue, planningValidated.branch, mapping.defaultBranch, "planning");
+
   console.log(`[poll] Dispatched planning for ${issue.identifier} -> ${mapping.owner}/${mapping.repo} (${mapping.planningWorkflowFile}, image: ${runnerImage ?? "workflow-default"})`);
 }
 
@@ -1384,6 +1479,11 @@ async function dispatchSession(
       jobId: number,
       executionMode: "github-actions" | "fly-machines" | "local-docker",
     ) => Promise<void>;
+    /** When set, post a ticket comment naming the base branch, gated on the validated
+     *  "AI-Implement Base Branch" field value (fieldValue), NOT on the fully-resolved
+     *  base — see postBranchComment for why that distinction matters. Uses opts.phase
+     *  for the comment text. */
+    branchInfo?: { fieldValue: string | null; defaultBranch: string };
   },
 ): Promise<void> {
   const sessionToken = generateSessionToken();
@@ -1442,6 +1542,12 @@ async function dispatchSession(
       const doPostDispatch = opts.onPostDispatch ?? postDispatch;
       await doPostDispatch(config, provider, issue, mapping, result.ghToken, jobId, result.executionMode);
 
+      // No-op unless the caller passed branchInfo — the shadow Fly dispatch
+      // deliberately passes none, so "both" mode posts exactly once.
+      if (opts.branchInfo) {
+        postBranchComment(provider, issue, opts.branchInfo.fieldValue, opts.branchInfo.defaultBranch, opts.phase);
+      }
+
       if (result.statusComment) {
         postStatusComment(provider, issue.id, {
           type: "machine_created",
@@ -1477,6 +1583,8 @@ async function dispatchFlyMachine(
   prior: { count: number; lastDispatchedAt: number | null },
   runnerMode: string,
   baseBranch: string,
+  /** The validated "AI-Implement Base Branch" field value, or null when unset. */
+  baseBranchFieldValue: string | null,
   shadow = false,
 ): Promise<void> {
   if (mapping.provider === "bedrock") {
@@ -1509,6 +1617,7 @@ async function dispatchFlyMachine(
     tokenTtlSeconds: IMPLEMENTATION_TTL_SECONDS,
     doMarkDispatched: !shadow,
     shadow,
+    branchInfo: shadow ? undefined : { fieldValue: baseBranchFieldValue, defaultBranch: mapping.defaultBranch },
     backend: async ({ sessionToken, machineNonce, runnerCallbackUrl, runToken }) => {
       const minSecretsVersion = getFlySecretsMinVersion();
 
@@ -1614,6 +1723,9 @@ async function dispatchLocalDocker(
   prior: { count: number; lastDispatchedAt: number | null },
   runnerMode: string,
   baseBranch: string,
+  /** The validated "AI-Implement Base Branch" field value, or null when unset. Distinct
+   *  from baseBranch, which also covers the feature-branch-grouping fallback. */
+  baseBranchFieldValue: string | null,
 ): Promise<void> {
   if (mapping.provider === "bedrock") {
     console.error(`[poll] Cannot dispatch ${issue.identifier} via local Docker: provider=bedrock is not supported on container runners`);
@@ -1630,6 +1742,7 @@ async function dispatchLocalDocker(
     tokenTtlSeconds: IMPLEMENTATION_TTL_SECONDS,
     doMarkDispatched: true,
     shadow: false,
+    branchInfo: { fieldValue: baseBranchFieldValue, defaultBranch: mapping.defaultBranch },
     backend: async ({ sessionToken, machineNonce, runnerCallbackUrl, runToken }) => {
       const localOrchestratorUrl =
         config.localRunnerOrchestratorUrl ??

--- a/src/pipeline/branch-name.ts
+++ b/src/pipeline/branch-name.ts
@@ -1,6 +1,7 @@
+import { validateRefSegments } from "../ref-segment-validation.js";
+
 const MAX_BRANCH_SUMMARY_LENGTH = 48;
 const MAX_BRANCH_PREFIX_LENGTH = 64;
-const BRANCH_PREFIX_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 
 function slugify(value: string | undefined, fallback: string): string {
   const slug = (value ?? "")
@@ -27,19 +28,7 @@ export function normalizeBranchPrefix(raw: string | null | undefined): string | 
   if (value.length > MAX_BRANCH_PREFIX_LENGTH) {
     throw new Error(`branchPrefix must be ${MAX_BRANCH_PREFIX_LENGTH} characters or fewer`);
   }
-  if (value.includes("..") || value.includes("//")) {
-    throw new Error("branchPrefix must not contain '..' or '//'");
-  }
-  for (const segment of value.split("/")) {
-    if (!BRANCH_PREFIX_SEGMENT_PATTERN.test(segment)) {
-      throw new Error(
-        "branchPrefix segments may contain only letters, digits, '.', '_', '-' and must each start with a letter or digit",
-      );
-    }
-    if (segment.endsWith(".") || segment.endsWith(".lock")) {
-      throw new Error("branchPrefix segments must not end with '.' or '.lock'");
-    }
-  }
+  validateRefSegments(value, "branchPrefix");
   return value;
 }
 

--- a/src/providers/jira-fields.ts
+++ b/src/providers/jira-fields.ts
@@ -3,21 +3,26 @@ import type { JiraClient } from "./jira-client.js";
 export const STATUS_FIELD_NAME = "AI-Implement Status";
 export const REPO_FIELD_NAME = "AI-Implement Repo";
 export const PROFILES_FIELD_NAME = "AI-Implement Profiles";
+export const BASE_BRANCH_FIELD_NAME = "AI-Implement Base Branch";
 
 export interface ResolvedFieldIds {
   statusFieldId: string;
   repoFieldId: string;
   /** Classic-project "Epic Link" custom field, when the instance has one. Best-effort:
    *  absent on next-gen/team-managed projects (which use the native parent field) and
-   *  when all three overrides short-circuit the listFields call. */
+   *  when all four overrides short-circuit the listFields call. */
   epicLinkFieldId?: string;
   profilesFieldId: string | null;
+  /** "AI-Implement Base Branch" text field id. null when the field is absent or ambiguous
+   *  (feature inactive, not an error). */
+  baseBranchFieldId: string | null;
 }
 
 interface OverrideOptions {
   statusOverride: string | null;
   repoOverride: string | null;
   profilesOverride: string | null;
+  baseBranchOverride: string | null;
 }
 
 interface ListFieldsClient {
@@ -28,11 +33,12 @@ export async function resolveCustomFieldIds(
   client: ListFieldsClient,
   overrides: OverrideOptions,
 ): Promise<ResolvedFieldIds> {
-  if (overrides.statusOverride && overrides.repoOverride && overrides.profilesOverride) {
+  if (overrides.statusOverride && overrides.repoOverride && overrides.profilesOverride && overrides.baseBranchOverride) {
     return {
       statusFieldId: overrides.statusOverride,
       repoFieldId: overrides.repoOverride,
       profilesFieldId: overrides.profilesOverride,
+      baseBranchFieldId: overrides.baseBranchOverride,
     };
   }
 
@@ -66,11 +72,26 @@ export async function resolveCustomFieldIds(
     }
   }
 
+  let baseBranchFieldId: string | null = overrides.baseBranchOverride;
+  if (baseBranchFieldId === null) {
+    const baseBranchMatches = fields.filter((f) => f.name === BASE_BRANCH_FIELD_NAME);
+    if (baseBranchMatches.length === 0) {
+      console.warn(`[jira] Custom field "${BASE_BRANCH_FIELD_NAME}" not found — base branch will not be populated`);
+    } else if (baseBranchMatches.length > 1) {
+      console.warn(
+        `[jira] Multiple custom fields named "${BASE_BRANCH_FIELD_NAME}" — set an explicit baseBranchFieldOverride to disambiguate`,
+      );
+    } else {
+      baseBranchFieldId = baseBranchMatches[0].id;
+    }
+  }
+
   return {
     statusFieldId: overrides.statusOverride ?? lookup(STATUS_FIELD_NAME),
     repoFieldId: overrides.repoOverride ?? lookup(REPO_FIELD_NAME),
     ...(epicLink ? { epicLinkFieldId: epicLink.id } : {}),
     profilesFieldId,
+    baseBranchFieldId,
   };
 }
 
@@ -82,7 +103,7 @@ export async function getCachedFieldIds(
   overrides: OverrideOptions,
 ): Promise<ResolvedFieldIds> {
   // Override values must participate in the key — changing them on a live mapping otherwise serves stale IDs.
-  const fullKey = `${cacheKey}::${overrides.statusOverride ?? ""}::${overrides.repoOverride ?? ""}::${overrides.profilesOverride ?? ""}`;
+  const fullKey = `${cacheKey}::${overrides.statusOverride ?? ""}::${overrides.repoOverride ?? ""}::${overrides.profilesOverride ?? ""}::${overrides.baseBranchOverride ?? ""}`;
   const existing = cache.get(fullKey);
   if (existing) return existing;
   const ids = await resolveCustomFieldIds(client, overrides);

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -8,6 +8,7 @@ import type {
   TicketingProvider,
 } from "./types.js";
 import { MissingProviderConfigError } from "./types.js";
+import { normalizeBaseBranch } from "../base-branch.js";
 import { JiraApiError, JiraClient } from "./jira-client.js";
 import {
   adfParagraph,
@@ -111,6 +112,32 @@ function isTerminalStatus(fields: Record<string, unknown>): boolean {
   return ((fields.status as { statusCategory?: { key?: string } } | null)?.statusCategory?.key) === "done";
 }
 
+/**
+ * Reads and validates the "AI-Implement Base Branch" field value. Defensive about
+ * shape the same way parseMultiSelectValues is below: the field may be created as
+ * Paragraph (rich text, serializes as an ADF object) or a number/array field rather
+ * than the expected short-text field, so a bare `.trim()` on an unchecked cast can
+ * throw and take down mapIssue (and the whole snapshot) for one bad field.
+ *
+ * Also runs the value through normalizeBaseBranch so a human-typed value that would
+ * be unsafe as a git refspec segment is caught here — with a warning and the field
+ * left unset for this issue — rather than reaching a dispatch/git-fetch path
+ * unchecked. One bad value disables the feature for its own issue only.
+ */
+function readBaseBranchValue(raw: unknown, issueKey: string): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  try {
+    return normalizeBaseBranch(trimmed) ?? undefined;
+  } catch (err) {
+    console.warn(
+      `[jira] Ignoring invalid AI-Implement Base Branch value on ${issueKey}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return undefined;
+  }
+}
+
 function parseMultiSelectValues(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
   return (raw as Array<unknown>)
@@ -201,6 +228,7 @@ export class JiraProvider implements TicketingProvider {
       statusOverride: m.ticketingConfig.statusFieldOverride ?? null,
       repoOverride: m.ticketingConfig.repoFieldOverride ?? null,
       profilesOverride: m.ticketingConfig.profilesFieldOverride ?? null,
+      baseBranchOverride: m.ticketingConfig.baseBranchFieldOverride ?? null,
     });
   }
 
@@ -233,6 +261,7 @@ export class JiraProvider implements TicketingProvider {
         fieldIds.repoFieldId,
         ...(fieldIds.epicLinkFieldId ? [fieldIds.epicLinkFieldId] : []),
         ...(fieldIds.profilesFieldId ? [fieldIds.profilesFieldId] : []),
+        ...(fieldIds.baseBranchFieldId ? [fieldIds.baseBranchFieldId] : []),
       ];
 
       // Reference the status field by its resolved customfield id, not a hardcoded
@@ -302,6 +331,9 @@ export class JiraProvider implements TicketingProvider {
     const profiles = fieldIds.profilesFieldId
       ? parseMultiSelectValues(raw.fields[fieldIds.profilesFieldId])
       : [];
+    const baseBranch = fieldIds.baseBranchFieldId
+      ? readBaseBranchValue(raw.fields[fieldIds.baseBranchFieldId], raw.key)
+      : undefined;
     return {
       id: raw.id,
       identifier: raw.key,
@@ -310,6 +342,7 @@ export class JiraProvider implements TicketingProvider {
       scopeKey,
       nativeStatus: statusOption?.value ?? "",
       ...(profiles.length > 0 ? { profiles } : {}),
+      ...(baseBranch ? { baseBranch } : {}),
     };
   }
   /**

--- a/src/providers/jira.ts
+++ b/src/providers/jira.ts
@@ -8,7 +8,6 @@ import type {
   TicketingProvider,
 } from "./types.js";
 import { MissingProviderConfigError } from "./types.js";
-import { normalizeBaseBranch } from "../base-branch.js";
 import { JiraApiError, JiraClient } from "./jira-client.js";
 import {
   getCachedFieldIds,
@@ -127,30 +126,12 @@ function isTerminalStatus(fields: Record<string, unknown>): boolean {
   return ((fields.status as { statusCategory?: { key?: string } } | null)?.statusCategory?.key) === "done";
 }
 
-/**
- * Reads and validates the "AI-Implement Base Branch" field value. Defensive about
- * shape the same way parseMultiSelectValues is below: the field may be created as
- * Paragraph (rich text, serializes as an ADF object) or a number/array field rather
- * than the expected short-text field, so a bare `.trim()` on an unchecked cast can
- * throw and take down mapIssue (and the whole snapshot) for one bad field.
- *
- * Also runs the value through normalizeBaseBranch so a human-typed value that would
- * be unsafe as a git refspec segment is caught here — with a warning and the field
- * left unset for this issue — rather than reaching a dispatch/git-fetch path
- * unchecked. One bad value disables the feature for its own issue only.
+/** Preserve a nonblank branch choice so dispatch validation can refuse invalid refs.
+ * Dropping an invalid choice here would silently dispatch against the default branch.
+ * Unexpected Jira field shapes remain absent, matching other optional field readers.
  */
-function readBaseBranchValue(raw: unknown, issueKey: string): string | undefined {
-  if (typeof raw !== "string") return undefined;
-  const trimmed = raw.trim();
-  if (trimmed === "") return undefined;
-  try {
-    return normalizeBaseBranch(trimmed) ?? undefined;
-  } catch (err) {
-    console.warn(
-      `[jira] Ignoring invalid AI-Implement Base Branch value on ${issueKey}: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return undefined;
-  }
+function readBaseBranchValue(raw: unknown): string | undefined {
+  return typeof raw === "string" ? raw.trim() || undefined : undefined;
 }
 
 function parseMultiSelectValues(raw: unknown): string[] {
@@ -347,7 +328,7 @@ export class JiraProvider implements TicketingProvider {
       ? parseMultiSelectValues(raw.fields[fieldIds.profilesFieldId])
       : [];
     const baseBranch = fieldIds.baseBranchFieldId
-      ? readBaseBranchValue(raw.fields[fieldIds.baseBranchFieldId], raw.key)
+      ? readBaseBranchValue(raw.fields[fieldIds.baseBranchFieldId])
       : undefined;
     return {
       id: raw.id,

--- a/src/providers/ticketing-config.ts
+++ b/src/providers/ticketing-config.ts
@@ -23,6 +23,29 @@ export type TicketingMappingConfig = LinearMappingConfig | JiraMappingConfig;
 export const DEFAULT_TICKETING_CONFIG: LinearMappingConfig = { kind: "linear" };
 
 /**
+ * Normalizes a `*FieldOverride` value from untrusted JSON: anything that is not a
+ * non-blank string becomes null, and a non-blank string is trimmed.
+ *
+ * Without this, a blank-but-present override survives validation and is then read
+ * as a literal Jira field id by resolveCustomFieldIds (src/providers/jira-fields.ts):
+ * - `""` is not nullish, so `overrides.statusOverride ?? lookup(STATUS_FIELD_NAME)`
+ *   yields `""` instead of falling back to discovery by name; profilesFieldId's
+ *   `=== null` guard is likewise skipped.
+ * - `"   "` is truthy, so the all-overrides-set short-circuit returns early and
+ *   listFields() is never called at all.
+ * Both leave the provider querying an empty or whitespace field id.
+ *
+ * The admin UI already normalizes with `|| null` at both call sites, so this closes
+ * the API path and puts the rule at the validation boundary rather than in two
+ * callers that have to remember it.
+ */
+function normalizeFieldOverride(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
  * Validates that the parsed JSON is a valid TicketingMappingConfig matching
  * the expected provider. Throws on mismatch.
  */
@@ -50,9 +73,9 @@ export function validateTicketingConfig(provider: ProviderId, value: unknown): T
       kind: "jira",
       jql: obj.jql,
       repoFieldValue: obj.repoFieldValue,
-      statusFieldOverride: typeof obj.statusFieldOverride === "string" ? obj.statusFieldOverride : null,
-      repoFieldOverride: typeof obj.repoFieldOverride === "string" ? obj.repoFieldOverride : null,
-      profilesFieldOverride: typeof obj.profilesFieldOverride === "string" ? obj.profilesFieldOverride : null,
+      statusFieldOverride: normalizeFieldOverride(obj.statusFieldOverride),
+      repoFieldOverride: normalizeFieldOverride(obj.repoFieldOverride),
+      profilesFieldOverride: normalizeFieldOverride(obj.profilesFieldOverride),
     };
   }
   throw new Error(`Unknown provider for ticketingConfig: ${provider}`);

--- a/src/providers/ticketing-config.ts
+++ b/src/providers/ticketing-config.ts
@@ -16,6 +16,8 @@ export interface JiraMappingConfig {
   repoFieldOverride?: string | null;
   /** Optional explicit customfield_NNNNN override for the profiles field. */
   profilesFieldOverride?: string | null;
+  /** Optional explicit customfield_NNNNN override for the base branch field. */
+  baseBranchFieldOverride?: string | null;
 }
 
 export type TicketingMappingConfig = LinearMappingConfig | JiraMappingConfig;
@@ -76,6 +78,7 @@ export function validateTicketingConfig(provider: ProviderId, value: unknown): T
       statusFieldOverride: normalizeFieldOverride(obj.statusFieldOverride),
       repoFieldOverride: normalizeFieldOverride(obj.repoFieldOverride),
       profilesFieldOverride: normalizeFieldOverride(obj.profilesFieldOverride),
+      baseBranchFieldOverride: normalizeFieldOverride(obj.baseBranchFieldOverride),
     };
   }
   throw new Error(`Unknown provider for ticketingConfig: ${provider}`);

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -46,6 +46,10 @@ export interface TicketIssue {
   /** AI-Implement Profiles selections from the Jira multi-select field. Jira-only; absent for
    *  Linear issues and for Jira issues without the field or with an empty selection. */
   profiles?: string[];
+  /** Target base branch for this issue's PR, from a provider-specific field (Jira:
+   *  the "AI-Implement Base Branch" text field). Absent when the provider has no such
+   *  field, the field is unset, or the value failed validation. */
+  baseBranch?: string;
 }
 
 export interface AIImplementSnapshot {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -48,7 +48,8 @@ export interface TicketIssue {
   profiles?: string[];
   /** Target base branch for this issue's PR, from a provider-specific field (Jira:
    *  the "AI-Implement Base Branch" text field). Absent when the provider has no such
-   *  field, the field is unset, or the value failed validation. */
+   *  field, the field is unset, or the field has an unexpected shape. Nonblank strings
+   *  remain present until dispatch validation can refuse invalid refs. */
   baseBranch?: string;
 }
 

--- a/src/ref-segment-validation.ts
+++ b/src/ref-segment-validation.ts
@@ -1,0 +1,37 @@
+export const REF_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * Validates that a slash-separated value is safe to use as git ref path segments.
+ *
+ * The rules, in the order they are checked:
+ * - the whole value must not contain '..' or '//'
+ * - each '/'-separated segment must start with a letter or digit and otherwise
+ *   contain only letters, digits, '.', '_', '-'
+ * - no segment may end with '.' or '.lock'
+ *
+ * The leading-alphanumeric rule is the security-relevant one: it is what stops a
+ * value beginning with '-' from being read as an option by the git plumbing that
+ * later consumes it (`--upload-pack=`-style argument injection).
+ *
+ * Deliberately does NOT check overall length, nor reject `refs/heads/` /
+ * `refs/remotes/` forms — callers differ on both, so those stay caller-side.
+ *
+ * `label` names the caller's field (e.g. "branchPrefix") so the thrown message is
+ * contextual; keeping the rules in one place is what stops them drifting between
+ * call sites as more of them appear.
+ */
+export function validateRefSegments(value: string, label: string): void {
+  if (value.includes("..") || value.includes("//")) {
+    throw new Error(`${label} must not contain '..' or '//'`);
+  }
+  for (const segment of value.split("/")) {
+    if (!REF_SEGMENT_PATTERN.test(segment)) {
+      throw new Error(
+        `${label} segments may contain only letters, digits, '.', '_', '-' and must each start with a letter or digit`,
+      );
+    }
+    if (segment.endsWith(".") || segment.endsWith(".lock")) {
+      throw new Error(`${label} segments must not end with '.' or '.lock'`);
+    }
+  }
+}


### PR DESCRIPTION
Restores four useful pending changes on current `testing`: Jira per-issue base selection, needs-human job visibility, owner-token expiry, and the admin Poll now action. Supersedes #433, #122, #224, and #205; their source branches are preserved.

The old implementations conflict with today's code. This integration retains current admin authorization, safe HTML/URL escaping, grouped-plan completion inference, runner forced-token refresh, and all existing KG behavior. It also fixes two problems found during build-down:

- An invalid Jira branch was discarded in the provider and could silently dispatch against the default. The branch choice now reaches dispatch validation and is refused. A provider-to-dispatch regression test failed before the fix and passes after it.
- Poll now referenced the removed pollInProgress variable. It now uses the existing poll cycle's synchronous beginCycle guard, reporting whether a new cycle actually started.

Token expiry is applied in refreshInstallationToken, preserving both ordinary cache hits and forced refresh. Needs-human rendering remains limited to timed_out + stuck_giveup.

Validation: TypeScript typecheck passed; all 4,671 tests passed across 198 files; diff whitespace check passed. The first sandboxed full run passed 4,669 tests but could not bind localhost for two shell tests; the unrestricted rerun passed all tests. No authenticated provider calls, deployment, or database migration was performed.

The coding pipeline reported that it no longer has records for #122 and #224, so this replacement carries their changes without modifying their agent branches. Linear's connected app is in another workspace; tracker reconciliation remains outstanding.
