### PR TITLE
docs: run lifecycle, run-kind contract, ADRs 015-017 (proposed, ahead of implementation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Entry points for areas that are easy to miss. Each names the module to start fro
 | Pipeline, steps, custom overrides | `src/pipeline/` | [docs/pipeline-architecture.md](docs/pipeline-architecture.md) |
 | Review findings → fix dispatches | `src/review-fix-queue.ts` | [docs/review-fix-rail.md](docs/review-fix-rail.md) |
 | Parent/child grouping and roll-up | `src/feature-branch.ts`, `src/merge-up.ts` | [docs/feature-branch-grouping.md](docs/feature-branch-grouping.md) |
+| Run lifecycle and run kinds (the glue around the pipeline) | the `dispatch*` functions in `src/index.ts`, `src/runner-callback.ts` | [docs/run-lifecycle.md](docs/run-lifecycle.md), [docs/run-kind-contract.md](docs/run-kind-contract.md) (proposed) |
 | Issueless run kinds (kg-refresh lifecycle and pattern) | `src/kg-refresh.ts`, `src/index.ts` | [docs/issueless-runs.md](docs/issueless-runs.md) |
 | Dispatch envelope (`RunConfigV1`) | `src/run-config.ts` | [docs/workflow-envelope.md](docs/workflow-envelope.md) |
 | Runner context settings (skills repo, dependency token scope) | `src/pipeline/steps/install-skills.ts`, `src/pipeline/steps/dependency-auth.ts` | [docs/runner-context.md](docs/runner-context.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Two tiers, distinguished by what a file *is* rather than what it covers.
 | [issueless-runs.md](issueless-runs.md) | The pattern for run kinds dispatched without a tracker issue: envelope shape, jobs-store tracking row, credential flow, state machine lifecycle, reaper reconciliation, operator cancel, observability, and a checklist for adding a new issueless run kind |
 | [runner-context.md](runner-context.md) | Per-project settings that provision something into a run: the shared mapping-to-effect shape, which run phases apply each one, and what enabling each costs |
 | [runner-callbacks.md](runner-callbacks.md) | The run tokens and callback endpoints: who mints, carries, reads, verifies, and consumes each credential; the process boundary inside the runner; the blast radius of one stray use |
+| [run-lifecycle.md](run-lifecycle.md) | The five lifecycle steps around the pipeline, the module that implements each today, the six loops that read one run, and the seams a new run kind touches |
+| [run-kind-contract.md](run-kind-contract.md) | Proposed: one registration per run kind (pipeline, dispatch inputs, report, tracker effect), today's kinds expressed in it, and what it deletes |
 
 Two references live outside this directory because they are consumed directly rather than read: `.env.example` is the canonical list of orchestrator environment variables, and `CLAUDE.md` is the index that points at everything here.
 

--- a/docs/adr/015-the-terminal-report-is-an-idempotent-signed-fact.md
+++ b/docs/adr/015-the-terminal-report-is-an-idempotent-signed-fact.md
@@ -1,0 +1,41 @@
+# 015. The terminal report is an idempotent signed fact keyed by dispatch id
+
+**Status:** Proposed
+**Date:** 2026-09-08
+**References:** AII-567 (incident), PR #467, AII-572, ADR 014, `docs/runner-callbacks.md`, `docs/solutions/workflow-patterns/runner-test-suite-burned-the-run-token.md`
+
+## Context
+
+A dispatched run reports its terminal result once, to `POST /runner/result`, with a single-use token. `verifyRunToken(…, "result", { consume: true })` in `src/runner-tokens.ts` marks the token consumed on first use, and the handler in `src/runner-callback.ts` refuses a second post with `409 already_consumed`. The design treats the report as an event that must arrive exactly once, and enforces that by destroying the credential.
+
+From 2026-09-04 to 2026-09-07 a test suite running inside dispatched runners posted to the live orchestrator before the run finished. The first post consumed the token. Every run's real report was then refused, and with it the outcome, the PR URL, the summary, the approval mark (ADR 014), and on GitHub Actions the tracker transition. Nothing crashed. The failure surfaced in other subsystems as held PRs, a full dispatch cap, and a fix that had nothing to stamp. Cost: about three days.
+
+The credential fix (a disarmed test suite, AII-588, and the process boundary in ADR 016) makes the stray call unlikely. It does not make it harmless. Any future stray call, from any process that holds the token, still destroys the run's ability to report.
+
+## Decision
+
+The terminal report becomes a fact keyed by the run's identity, not an event guarded by a consumable credential.
+
+- **Key.** The dispatch id. One report row per dispatch id in `dispatch_log` or a sibling table, written by one code path.
+- **Signature.** The runner signs the report body with a per-run key: an HMAC (hash-based message authentication code) over the dispatch id, the outcome, and the PR URL. The orchestrator verifies the signature. It does not consume anything. The run token's `result` audience becomes verify-only.
+- **Identical resubmission.** A report whose body matches the recorded report answers `200` with `already_recorded`. It is a no-op.
+- **Conflicting resubmission.** A report whose outcome or PR URL differs from the recorded one answers `409 conflicting_report` and names both outcomes in the body. The first report stands. The conflict is logged and surfaced on the run.
+- **Empty or partial resubmission.** A post with no outcome answers `400`. It records nothing and consumes nothing.
+- **The monitors write "runner ended" only.** The GHA and Fly monitors keep writing the execution-layer conclusion. The approval mark and the runner's conclusion come only from the accepted report. The `CASE` guard in `updateJobStatus` stays.
+
+Modules that change: `src/runner-callback.ts` (accept-by-key, conflict answer), `src/log.ts` (the report row and one writer per transition), `src/runner-tokens.ts` (verify without consume for `result`), and the runner's `postRunnerResult` in `src/runner-result.ts` (sign, and resend safely on a network error).
+
+## Alternatives considered
+
+- **Keep consume-on-first-use and rely on disarmed tests.** Rejected. The disarm protects one repository's suite (AII-588). Any other process that reaches the token, in any target repository, can still burn a run.
+- **Idempotency keys at the HTTP layer only** (an `Idempotency-Key` header with a short cache). Rejected. It dedupes retries of one request; it does not define what a conflicting second report means, and it expires.
+- **Keep the report an event and add a "re-open the report" admin action.** Rejected. It keeps the failure class and adds an operator step to every occurrence.
+- **A new column for the runner's outcome.** Unnecessary. The conclusion column and the `CASE` guard already carry it (ADR 014).
+
+## Consequences
+
+Easier: a stray or duplicate post cannot destroy a run's report. The runner can retry a failed post safely. The failure class of AII-567 becomes a logged no-op.
+
+Harder: the result token is no longer single-use, so its exposure window matters more. ADR 016 narrows that window. A captured report replayed identically is a no-op; a forged conflicting report needs the per-run key, which never leaves the pipeline process. The report row is a new write path in `src/log.ts` and must have exactly one writer.
+
+Follow-on: the tests that prove the incident harmless (eight stray posts, then the real one) ship with the change, and fail on the current code.

--- a/docs/adr/016-run-credentials-stop-at-the-process-boundary.md
+++ b/docs/adr/016-run-credentials-stop-at-the-process-boundary.md
@@ -1,0 +1,38 @@
+# 016. Run credentials stop at the process boundary
+
+**Status:** Proposed
+**Date:** 2026-09-08
+**References:** AII-567, AII-588, AII-396 (`src/pipeline/process-env.ts`), AII-458 and AII-462 (forwarded secrets), ADR 009, ADR 015, `docs/runner-callbacks.md`
+
+## Context
+
+The runner container receives `RUN_TOKEN`, `RUN_PROGRESS_TOKEN`, `RUN_PUBLICATION_TOKEN`, and the callback URL in its environment. `src/pipeline/process-env.ts` builds two child environments. `modelProcessEnv()` strips the run tokens, so the model process and everything it spawns cannot reach them (AII-396, 2026-09-02). `repoProcessEnv()` strips only the model credentials, so every repository-owned process keeps the run tokens: `install`, the `setup`, `verify`, and `teardown` hooks, and `preflight`, which runs the repository's `typecheck`, `lint`, and `test` scripts.
+
+The AII-567 test suite ran under `preflight`. It held the run's result token because the process that ran it was allowed to. The forwarded-secrets work (AII-458, AII-462) already established the pattern: a value that only the pipeline needs is removed from every child environment, and the pipeline reads it from its own `process.env`.
+
+One repository-side process does read a run credential today. The dependency credential helper (`session/git-credential-helper.sh`, installed by `src/pipeline/steps/dependency-auth.ts`) reads its GitHub token from a mode-0600 cache file the pipeline writes, and reads `RUN_PROGRESS_TOKEN` from the environment only to re-mint that token when it has under ten minutes left.
+
+## Decision
+
+The pipeline reads the run credentials once, at start, into memory. No repository-owned process receives them.
+
+- `repoProcessEnv()` strips `RUNNER_CREDENTIAL_KEYS` (`RUN_TOKEN`, `RUN_PROGRESS_TOKEN`, `RUN_PUBLICATION_TOKEN`), exactly as `modelProcessEnv()` does today.
+- Pipeline steps that need a credential keep reading it from `process.env` in the pipeline process, the pattern `dependency-auth` already documents in `docs/pipeline-architecture.md`.
+- The dependency credential helper keeps reading the GitHub token from the cache file. Its re-mint path moves into the pipeline: the pipeline refreshes the cache file on a timer for the life of the run, and the helper never sees `RUN_PROGRESS_TOKEN`.
+- The kg-push helper (`session/git-credential-helper-kg-push.sh`) is unaffected: it runs inside the kg-refresh pipeline's own git commands, and AII-583 deletes it.
+- The test-suite disarm (AII-588) stays. It protects a run against a repository that is not this one and has not adopted this boundary yet.
+
+## Alternatives considered
+
+- **Disarm tests only.** Necessary, not sufficient. It protects one suite in one repository. Any hook, script, or tool a target repository runs under `preflight` still holds the run's authority.
+- **A runner-side "am I in a test" guard.** Rejected in PR #467: a test-only branch in production code, and the throwing variant lands in the same `catch` that posts again.
+- **Keep `RUN_PROGRESS_TOKEN` in repository processes for the credential helper.** Rejected. It keeps a live bearer credential in every hook and test process to serve one re-mint path that the pipeline can serve itself.
+- **A separate, narrowly scoped token for repository processes.** Not needed today: no hook or test has a legitimate reason to call the orchestrator. Revisit if one appears.
+
+## Consequences
+
+Easier: a repository process cannot report, cannot mint tokens, and cannot burn anything, whatever code it runs. With ADR 015 the stray call is harmless; with this ADR it is impossible from repository code.
+
+Harder: a hook that wanted to call the orchestrator has no credential. None does today. The dependency helper's re-mint moves into the pipeline, which is a small change in `dependency-auth` and the helper script. A target repository that depends on the old behavior would fail its private dependency install after ten minutes; the cache-file refresh is what prevents that, and it ships in the same change.
+
+Follow-on: the test for this boundary is a listener counting `POST /runner/result` during a full `preflight` run of a suite that tries to post. Expected count: zero.

--- a/docs/adr/017-move-the-run-lifecycle-onto-a-durable-execution-engine.md
+++ b/docs/adr/017-move-the-run-lifecycle-onto-a-durable-execution-engine.md
@@ -1,0 +1,51 @@
+# 017. Move the run lifecycle onto a durable-execution engine, Restate first
+
+**Status:** Proposed
+**Date:** 2026-09-08
+**References:** AII-567 incident report (sections 5 and 6), the plan documents "Plan, Part 1" and "Plan, Part 2" of 2026-09-08, AII-441 and children AII-472 to AII-477, AII-521 and AII-555 (the cost of adding a run kind), ADR 012, ADR 013, ADR 014, ADR 015, ADR 016, `docs/run-lifecycle.md`, `docs/run-kind-contract.md`
+
+## Context
+
+One run's state lives in six loops that each infer it from a different signal (`docs/run-lifecycle.md`). Adding the kg-refresh run kind touched about seven lifecycle modules (AII-555 retrospective). Two incidents in one week, the child-PR merge race (AII-560) and the run-token burn (AII-567), were failures of that glue, not of the pipeline. The lifecycle can only be tested by a live run of about thirty minutes.
+
+A durable-execution engine models exactly this lifecycle: a workflow keyed by identity for dedup, journaled steps with retries and deadlines for dispatch and gates, a durable promise for the report, timers for loss detection, child workflows for the cascade, and a journal as history. The candidates sized for one Node process with SQLite on one Fly machine are Temporal Cloud (managed, per-action billing, deterministic workflow code), Temporal self-hosted (a cluster with its own database, larger than the orchestrator), DBOS (a library, needs Postgres), Restate (one binary with an embedded store, TypeScript SDK, Business Source License 1.1 with a grant that covers our use), and the same shape hand-built inside the orchestrator.
+
+No decision on this question existed in the knowledge graph before this record.
+
+## Decision
+
+We move the run lifecycle onto Restate, in this order, and we decide each step against written criteria.
+
+1. **First, the engine-independent changes**: ADR 015 (idempotent signed report) and ADR 016 (credentials stop at the process boundary). They fix the incident's causes and are what any engine will call.
+2. **First Restate implementation: the integration-testing lifecycle (AII-441).** AII-474 as a Workflow keyed by the deployed commit; AII-476 as a Virtual Object keyed by the PR number; AII-477 as a Workflow keyed by PR and head SHA. This lifecycle is green field, isolated behind its own flags, and has the same shape as the run lifecycle. Its tests run in seconds against a Restate container with fake Fly, GitHub, and tracker.
+3. **Then the run kinds, by the contract in `docs/run-kind-contract.md`**: kg-refresh first, then the implementation run kind, the cascade last.
+4. **Restate runs as one more process in the Fly app**, with its embedded store on a volume. SQLite stays for everything that is not the run lifecycle. Postgres is not required by this decision.
+
+The migration of the run kinds proceeds only when the AII-441 spike passes all of these:
+
+| Criterion | Pass condition |
+|---|---|
+| Tests | The lifecycle scenarios pass in CI in under 60 seconds per file with Docker on the runner |
+| Live run | One merge to `testing` produces exactly one integration-test run whose report resolves the promise |
+| Restart | A deploy during a live run produces no second dispatch, and the run completes after the restart |
+| Footprint | The Restate machine runs one week within its memory allocation |
+| Code removed | AII-474 and AII-476 ship with no new sweep, no new settings state machine, and no new code in `src/reaper.ts` |
+| Operations | Upgrades and restarts documented in `docs/deployment.md`; one week unattended |
+
+If any criterion fails, this ADR moves to Rejected with the reason, AII-474 and AII-476 ship as their pre-Restate bodies say, and steps 1 and 3 still stand on their own.
+
+## Alternatives considered
+
+- **Temporal Cloud.** The most complete model and the most mature. Rejected for now: a vendor and a per-action bill, a determinism discipline across about twelve modules, and a footprint larger than a one-operator system needs. Revisit if a second tenant or cross-service durability appears.
+- **Temporal self-hosted.** Rejected: a server cluster with Postgres or Cassandra, larger than the orchestrator.
+- **DBOS.** Rejected: needs Postgres, which we do not run, for a benefit Restate gives without it.
+- **The same shape inside the orchestrator only** (a ledger with explicit transitions, timers instead of sweeps). Partly adopted: ADR 015 and ADR 016 are that shape. Rejected as the end state, because we would keep maintaining loss detection, retries, and history ourselves, with no test environment.
+- **Do nothing.** Rejected. The seams in `docs/run-lifecycle.md` grow a sibling per run kind, the pattern ADR 013 exists to stop.
+
+## Consequences
+
+Easier: one predicate per lifecycle question; exactly-once per key without a dedup table; a report that cannot be burned; lifecycle tests in seconds; a journal instead of six inferring loops.
+
+Harder: one more process to run, upgrade, and back up, with its own volume; a determinism rule for lifecycle code; the Restate server calls the SDK endpoint, so the orchestrator opens an internal listener that must never be public; a restore must restore SQLite and the Restate store to the same point.
+
+Not verified at the time of writing, to be settled in the spike: the SDK endpoint registration and port, the durable timer API, Restate's memory footprint on Fly, and the `fly.toml` process-group shape.

--- a/docs/run-kind-contract.md
+++ b/docs/run-kind-contract.md
@@ -1,0 +1,63 @@
+# Run-kind contract
+
+Status: **proposed**, 2026-09-08. This page defines one registration per run kind so that adding a kind is one file, not seven seams. It maps the two kinds that exist today onto the contract and lists what the contract deletes. It informs the planning parent that files the change; it does not describe landed code. The current seams are in [run-lifecycle.md](run-lifecycle.md).
+
+## The four parts of a registration
+
+| Part | Question it answers | Today's location |
+|---|---|---|
+| Pipeline | Which steps run inside the runner | `pipelines/autonomous.yml`, `pipelines/kg-refresh.yml`; wiring in `src/pipeline/pipeline-loader.ts` |
+| Dispatch inputs | Which envelope fields the kind needs and which backend runs it | `RunConfigV1.runnerPhase` plus kind-specific fields in `src/run-config.ts`; the dispatch functions in `src/index.ts` |
+| Report | What the terminal report carries and what "reported" means | The phase branches of `handleRunnerResult` in `src/runner-callback.ts` |
+| Tracker effect | What each terminal outcome does to the issue or to settings | `markPlanComplete`, `markPrReady`, `markImplementationFailed` through `src/providers/`; the kg-refresh branch writes no tracker state |
+
+A registration is one object per kind, in one module, read by the dispatch, callback, reaper, and admin paths. The lifecycle code never branches on the kind's name. It calls the registration.
+
+```typescript
+// Shape, not code. The names are illustrative.
+interface RunKind {
+  name: "implementation" | "planning" | "gap-analysis" | "kg-refresh";
+  pipeline: string;                       // pipelines/<file>.yml
+  envelope: (input) => RunConfigV1;       // kind-specific fields
+  backends: ReadonlyArray<"github-actions" | "fly-machines" | "local-docker">;
+  reported: (body) => Terminal;           // outcome, pr, summary, approved
+  onTerminal: (terminal, job) => Promise<void>;   // tracker effect
+  lossRule?: ReaperRule;                  // only when the default does not apply
+}
+```
+
+## Today's kinds, expressed in the contract
+
+| Part | implementation (with planning and gap-fill phases) | kg-refresh |
+|---|---|---|
+| Pipeline | `pipelines/autonomous.yml` | `pipelines/kg-refresh.yml` |
+| Dispatch inputs | `issue`, `baseBranch`, `prNumber` for gap-fill, `maxTurns`, `maxIterations`, `sensitiveFiles`, `profiles`, `planningContext`, `groupingParent`, `dependencyTokenScope`, `referenceRepos` | `kgSourceRepo`, a synthetic `issue.id = "kg-refresh"`, `runnerPhase = "kg-refresh"` |
+| Backends | all three; Bedrock mappings are GHA-only | default GHA; Fly and local by runner mode; `shadow` collapses to GHA |
+| Reported | outcome, `prUrl`, summary, `failureCode`; success with a PR writes `runner_approved` (ADR 014) | outcome and the snapshot commit; the KG refresh rail stages it |
+| Tracker effect | planning: `markPlanComplete`; success: `markPrReady`; coded failure: `markImplementationFailed` and bounded cleanup; Done on merge by reconciliation | none; settings stamp and the served snapshot |
+| Loss rule | default: monitor conclusion, stuck watchdog, reaper | `kg-refresh-gha-dispatch-lost` in `src/reaper.ts` (AII-545); the deploy hold interlock (AII-518) |
+
+## What the contract deletes
+
+Once kg-refresh is a registration, these leave the lifecycle code:
+
+- The `phase === "kg-refresh"` branch in `src/runner-callback.ts` and the phase switch around it.
+- The kg-push token vending (`src/kg-push-token-vending.ts`, `session/git-credential-helper-kg-push.sh`), the one authentication path that differs from a standard run. Staged as AII-583 under AII-555.
+- The GHA-specific kg-refresh rule in `src/reaper.ts`, replaced by the kind's `lossRule`, or by the default when the deadline model in ADR 017 lands.
+- The `dispatchKgRefreshRun` special cases that exist because the kind has no issue: the synthetic row values in [issueless-runs.md](issueless-runs.md) become the kind's `envelope`.
+
+## Appending an AI task, both ways
+
+Example: a "security review" pass after the implement loop.
+
+| | Today | Under the contract |
+|---|---|---|
+| Runner side | A step module under `src/pipeline/steps/`, a YAML entry, and an `applyWiring` case in `src/pipeline/pipeline-loader.ts` | The same three; the runner side does not change |
+| Lifecycle side | Any seam that learns a new step output: the callback branch if the report shape changes, the admin page if the step is shown | Nothing. The lifecycle reads the registration, and the registration's `reported` already defines the report shape |
+| Tests | Step tests plus a live run to see the report flow | Step tests plus the registration's own report test |
+
+The contract does not make the step cheaper. It makes the step's existence invisible to the lifecycle, which is the cost ADR 013 exists to stop growing.
+
+## Relation to ADR 017
+
+A registration is what a workflow engine calls a workflow definition. Writing the registrations first, in our own words, is the prerequisite for moving the lifecycle onto an engine, because the workflow functions then already exist. See [adr/017-move-the-run-lifecycle-onto-a-durable-execution-engine.md](adr/017-move-the-run-lifecycle-onto-a-durable-execution-engine.md).

--- a/docs/run-lifecycle.md
+++ b/docs/run-lifecycle.md
@@ -1,0 +1,61 @@
+# Run lifecycle
+
+What happens to one AI-Implement run from trigger to terminal state, which module implements each step today, and which seams a new run kind must touch. This is the reference for the lifecycle glue around the pipeline: the poll loop, the dispatch functions, the callback handler, the monitors, the reaper, the stuck watchdog, and the deploy hold. The pipeline inside the runner is documented in [pipeline-architecture.md](pipeline-architecture.md). The credentials that cross the boundary are documented in [runner-callbacks.md](runner-callbacks.md).
+
+Status: this page describes the code on `testing` as of 2026-09-08. The run-kind contract that would replace the per-kind seams is proposed in [run-kind-contract.md](run-kind-contract.md).
+
+## The five steps
+
+```mermaid
+flowchart LR
+    T[1. Trigger and identity] --> D[2. Dispatch and wait]
+    D --> R[3. Report]
+    R --> G[4. Gates and tracker]
+    D -. loss .-> L[5. Loss and recovery]
+    L --> G
+```
+
+| Step | What it means | Modules today |
+|---|---|---|
+| 1. Trigger and identity | A label, a status field, a comment, or a rail call names an issue and a kind. The identity is issue plus kind plus attempt. Duplicates are refused. | Poll loop in `src/index.ts` (60 s); per-team capacity in `src/poll-selection.ts`; dedup table in `src/dedup.ts` (no TTL); comment trigger in `src/webhook.ts` and `src/comment-gapfill-drain.ts`; kg-refresh trigger in `src/kg-refresh.ts` |
+| 2. Dispatch and wait | One backend starts a runner with the envelope. The orchestrator then waits for the report, with a heartbeat and a deadline. | `dispatchGitHubActions`, `dispatchPlanning`, `dispatchSession`, `dispatchFlyMachine`, `dispatchLocalDocker`, `dispatchKgRefreshRun` in `src/index.ts`; envelope `RunConfigV1` in `src/run-config.ts`; jobs row in `src/log.ts`; run tokens in `src/runner-tokens.ts`; GHA and Fly monitors in `src/index.ts` |
+| 3. Report | The runner posts its terminal result once: outcome, PR URL, summary, and the approval mark. Progress posts stream step state during the run. | `postRunnerResult` in `src/runner-result.ts`; `/runner/result` and `/runner/progress` in `src/runner-callback.ts`, with one branch per phase: `planning`, `implementation`, `gap-analysis`, `kg-refresh`; `step_log` in `src/step-log.ts` |
+| 4. Gates and tracker | Review verdict, approval mark, merge, cascade to a parent, tracker transition. | `markPlanComplete`, `markPrReady`, `markImplementationFailed` through `src/providers/`; the approval mark in `src/log.ts` (`runner_approved`, ADR 014); `src/auto-merge.ts`; `src/feature-branch.ts` and `src/merge-up.ts`; `src/reconciliation.ts` and `src/poll-merged-prs.ts`; `src/review-fix-queue.ts` |
+| 5. Loss and recovery | No heartbeat, runner gone, or a restart under the run: recover, retry, or give up with a reason, and tell the tracker. | `src/reaper.ts` (machine and GHA reconciliation, including the kg-refresh rule); `src/stuck-watchdog.ts`; `src/deploy-hold.ts`; `src/completion-classification.ts` and `src/run-autopsy.ts` |
+
+## Six loops read the same run
+
+The run's state is not in one place. Each loop below infers it from a different signal, and each writes a different column.
+
+| Loop | Reads | Writes |
+|---|---|---|
+| Poll loop | Tracker labels or status field, dedup table, in-flight rows | `dispatched`, `dispatch_log` |
+| GHA monitor | Workflow run status | `status`, `conclusion` from the workflow result |
+| Fly monitor | Machine state | `status`, `conclusion` from the machine result |
+| Callback handler | The runner's report | `pr_url`, `conclusion = runner_approved`, tracker transitions |
+| Reaper | Machine registry, workflow run, row age | Closes rows, fails chains |
+| Stuck watchdog and deploy hold | Row age, in-flight set | Requeue, give up, pause dispatch |
+
+The monitors write the execution-layer conclusion. The callback writes the runner's conclusion. The `CASE` guard in `updateJobStatus` (`src/log.ts`) keeps `operator_cancelled` and `runner_approved` from being overwritten by a later monitor write. When the report does not arrive, every other loop still sees a healthy run. That is the shape of the AII-567 incident.
+
+## What a new run kind touches today
+
+Adding `kg-refresh` (AII-521, AII-555) touched these seams. A new kind touches the same list until the run-kind contract exists.
+
+- A dispatch function in `src/index.ts`, or a branch in an existing one.
+- A `runnerPhase` value in `src/run-config.ts` and a phase branch in `src/runner-callback.ts`.
+- A pipeline YAML under `pipelines/` and its `applyWiring` cases in `src/pipeline/pipeline-loader.ts`.
+- A monitor path, or a reason the existing one applies.
+- A reaper rule in `src/reaper.ts` when the kind can lose its runner in a new way.
+- The deploy hold in `src/deploy-hold.ts`, so a deploy does not restart the machine under the run.
+- Admin visibility: the pipelines page and the MCP tools read `dispatch_log` by phase.
+- A credential path in `src/runner-tokens.ts` and a vending endpoint when the kind needs a new scope.
+
+## Checklist: before you add a run kind
+
+1. Read [run-kind-contract.md](run-kind-contract.md). If the contract has landed, register the kind there and stop.
+2. Otherwise list every seam above with the file and line you will change. A seam you cannot name is a seam you will miss.
+3. Write the tracker effect of each terminal outcome before writing the callback branch.
+4. Add the reaper rule and the deploy-hold case in the same change as the dispatch function.
+5. Add a test that starts the kind, reports, and reaches the terminal state without a live backend.
+6. Update this page and `docs/issueless-runs.md` or `docs/feature-branch-grouping.md`, whichever the kind belongs to, in the same PR.


### PR DESCRIPTION
Docs only, **draft for review, not to be merged by the session**. Tier A of the 2026-09-08 plan ("Plan, Part 1", section 3.1), written ahead of implementation so the planning parent that files the work starts from a written design.

| Document | Status | What it holds |
|---|---|---|
| `docs/run-lifecycle.md` | describes `testing` today | The five lifecycle steps, the module for each, the six loops that read one run, the seams a new run kind touches, a checklist |
| `docs/run-kind-contract.md` | proposed | One registration per run kind; today's two kinds mapped onto it; the deletion list (phase branches, kg-push vending, the GHA kg-refresh reaper rule); "append an AI task" both ways |
| `docs/adr/015-…` | Proposed | The terminal report as an idempotent signed fact keyed by dispatch id: HMAC per run, verify-not-consume, identical resubmission 200 no-op, conflict 409 naming both outcomes, monitors write "runner ended" only |
| `docs/adr/016-…` | Proposed | Run credentials stripped from every repository-owned process; the dependency credential helper's re-mint moves into the pipeline (the one trade-off found in the census) |
| `docs/adr/017-…` | Proposed | Durable execution on Restate: AII-441 first, then the run kinds by the contract; the pass/fail criteria; alternatives |

Index rows added to `docs/README.md` and one row to the CLAUDE.md subsystem index. Diagrams validated with mermaid-cli.

Open question for the reviewer: whether these documents merge before the implementing issues are filed, or ride with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)