### PR TITLE
AII-511: Add the reference-repositories editor to the admin interface

### DIFF
--- a/src/__tests__/projects-page.test.ts
+++ b/src/__tests__/projects-page.test.ts
@@ -295,6 +295,8 @@ describe("reference repositories — staging and rendering", () => {
     expect(html).not.toContain(">https://github.com/BuildDownAI/docs<");
     expect(html).toContain('title="https://github.com/BuildDownAI/docs"');
     expect(html).toContain("&mdash;");
+    // Every cell ellipsis-truncates, so each value that can be long needs hover recovery.
+    expect(html).toContain('title="refs/docs"');
     expect(html).toContain('onclick="npRemoveRefRepo(0)"');
   });
 
@@ -305,6 +307,7 @@ describe("reference repositories — staging and rendering", () => {
     );
     expect(html).toContain('onclick="removeRefRepo(1)"');
     expect(html).toContain(">main<");
+    expect(html).toContain('title="main"');
   });
 
   it("renders nothing at all for an empty draft", () => {
@@ -345,6 +348,19 @@ describe("reference repositories — both surfaces", () => {
     expect(toClear).not.toBe("");
     for (const id of ["np-refrepo-repo", "np-refrepo-path", "np-refrepo-ref"]) {
       expect(toClear).toContain(id);
+    }
+  });
+
+  // The scripts reach every input by id, and a rename on one side is silent — the lookup
+  // just returns null and the field stops working.
+  it.each([
+    ["dialog", projectsHtml, projectsScript, "md-refrepo"],
+    ["stepper", stepperHtml, stepperScript, "np-refrepo"],
+  ])("declares every %s element its script looks up", (_name, html, script, prefix) => {
+    const referenced = [...script.matchAll(new RegExp(`'(${prefix}-[a-z-]+)'`, "g"))].map((m) => m[1]);
+    expect(referenced.length).toBeGreaterThan(0);
+    for (const id of new Set(referenced)) {
+      expect(html, `${id} is looked up but never declared`).toContain(`id="${id}"`);
     }
   });
 

--- a/src/__tests__/projects-page.test.ts
+++ b/src/__tests__/projects-page.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { projectsHtml, projectsScript } from "../admin-ui/pages/projects.js";
-import { stepperHtml } from "../admin-ui/stepper.js";
+import { stepperHtml, stepperScript } from "../admin-ui/stepper.js";
 
 /** Tab keys in the order the strip presents them. */
 const TABS = ["ticketing", "source", "context", "execution", "capacity", "guardrails", "provider"];
@@ -94,6 +94,9 @@ describe("mapping dialog — field placement", () => {
     ["md-branch", "source"],
     ["md-branch-prefix", "source"],
     ["md-skills-repo", "context"],
+    ["md-refrepo-repo", "context"],
+    ["md-refrepo-path", "context"],
+    ["md-refrepo-ref", "context"],
     ["md-dep-token-scope", "context"],
     ["md-exec-mode", "execution"],
     ["md-env", "execution"],
@@ -175,6 +178,170 @@ describe("projects page — owns the surfaces only it opens", () => {
       projectsHtml.indexOf('id="np-stepper-wrap"'),
     );
     expect(projectsHtml.indexOf('id="np-stepper-wrap"')).toBeLessThan(projectsHtml.lastIndexOf("</section>"));
+  });
+});
+
+/**
+ * The page script ships as a string, so its logic cannot be imported. Evaluating it against
+ * stub globals reaches the functions it publishes on `window`, which is the only way to test
+ * the reference-repository rules as behavior instead of as source text. The escaping helpers
+ * are stubbed rather than real — `esc` round-trips through the DOM, and correctness of the
+ * helpers themselves belongs to the escaping ADR's own tests, not here.
+ */
+function loadProjectsGlobals(): Record<string, any> {
+  const win: Record<string, any> = {
+    registerPage: () => {},
+    esc: (s: unknown) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"),
+    escAttr: (s: unknown) => String(s).replace(/&/g, "&amp;").replace(/"/g, "&quot;"),
+  };
+  const doc = { getElementById: () => null, querySelectorAll: () => [] };
+  new Function("window", "document", projectsScript)(win, doc);
+  return win;
+}
+
+describe("reference repositories — the rules, exercised", () => {
+  const win = loadProjectsGlobals();
+  const problem = (repo: string, path: string, draft: any[] = [], self = -1) =>
+    win.refRepoProblem(repo, path, draft, self);
+
+  it.each([
+    ["", "refs/docs", "needs both"],
+    ["owner/repo", "", "needs both"],
+    ["owner/repo", "/abs/path", "not absolute"],
+    ["owner/repo", "C:/win", "not absolute"],
+    ["owner/repo", "../escapes", "stay inside"],
+    ["owner/repo", "refs/../../out", "stay inside"],
+    ["owner/repo", ".git/hooks", ".git"],
+    ["owner/repo", "refs\\docs", "forward slashes"],
+    ["https://gitlab.com/a/b", "refs/x", "owner/repo or an https://github.com"],
+    ["https://user:token@github.com/a/b", "refs/x", "owner/repo or an https://github.com"],
+    ["git@github.com:a/b.git", "refs/x", "owner/repo or an https://github.com"],
+  ])("rejects %s → %s", (repo, path, fragment) => {
+    expect(problem(repo, path)).toContain(fragment);
+  });
+
+  it.each([
+    ["owner/repo", "refs/docs"],
+    ["https://github.com/owner/repo", "vendor/upstream/api"],
+    ["owner.name/repo-name", "a/b/c/d"],
+  ])("accepts %s → %s", (repo, path) => {
+    expect(problem(repo, path)).toBeNull();
+  });
+
+  it("rejects a path another entry already holds", () => {
+    const draft = [{ repo: "https://github.com/a/b", path: "refs/docs" }];
+    expect(problem("owner/repo", "refs/docs", draft)).toContain("already uses the path");
+  });
+
+  // Re-checking a stored entry passes its own index; without that it collides with itself
+  // and every entry reads as a duplicate.
+  it("does not measure an existing entry against itself", () => {
+    const draft = [{ repo: "https://github.com/a/b", path: "refs/docs" }];
+    expect(problem("a/b", "refs/docs", draft, 0)).toBeNull();
+  });
+
+  it("caps new entries at ten, and still validates an existing one at the cap", () => {
+    const draft = Array.from({ length: 10 }, (_, i) => ({ repo: "a/b", path: "p" + i }));
+    expect(problem("owner/repo", "refs/new", draft)).toContain("Up to ten");
+    expect(problem("a/b", "p0", draft, 0)).toBeNull();
+  });
+});
+
+describe("reference repositories — staging and rendering", () => {
+  const win = loadProjectsGlobals();
+
+  it("strips a trailing slash, so a duplicate path cannot slip past the check", () => {
+    const draft: any[] = [];
+    expect(win.refRepoStage({ repo: "owner/repo", path: "refs/docs/" }, draft)).toBeNull();
+    expect(draft[0].path).toBe("refs/docs");
+    expect(win.refRepoStage({ repo: "owner/other", path: "refs/docs" }, draft)).toContain("already uses");
+  });
+
+  // An absent ref must be omitted rather than stored empty: the server rejects a present-
+  // but-empty ref, and the runner reads absence as "the default branch".
+  it("omits ref when blank and keeps it when given", () => {
+    const draft: any[] = [];
+    win.refRepoStage({ repo: "owner/repo", path: "a", ref: "   " }, draft);
+    win.refRepoStage({ repo: "owner/repo", path: "b", ref: "testing" }, draft);
+    expect(draft[0]).not.toHaveProperty("ref");
+    expect(draft[1].ref).toBe("testing");
+  });
+
+  it("leaves the draft untouched when the entry is refused", () => {
+    const draft: any[] = [];
+    expect(win.refRepoStage({ repo: "owner/repo", path: "../out" }, draft)).toBeTruthy();
+    expect(draft).toHaveLength(0);
+  });
+
+  it("renders owner/repo, an em dash for no ref, and the caller's remove handler", () => {
+    const html = win.refRepoRowsHtml(
+      [{ repo: "https://github.com/BuildDownAI/docs", path: "refs/docs" }],
+      "npRemoveRefRepo",
+    );
+    expect(html).toContain(">BuildDownAI/docs<");
+    expect(html).not.toContain(">https://github.com/BuildDownAI/docs<");
+    expect(html).toContain('title="https://github.com/BuildDownAI/docs"');
+    expect(html).toContain("&mdash;");
+    expect(html).toContain('onclick="npRemoveRefRepo(0)"');
+  });
+
+  it("indexes remove by position, so the second row removes the second entry", () => {
+    const html = win.refRepoRowsHtml(
+      [{ repo: "a/b", path: "p0" }, { repo: "c/d", path: "p1", ref: "main" }],
+      "removeRefRepo",
+    );
+    expect(html).toContain('onclick="removeRefRepo(1)"');
+    expect(html).toContain(">main<");
+  });
+
+  it("renders nothing at all for an empty draft", () => {
+    expect(win.refRepoRowsHtml([], "removeRefRepo")).toBe("");
+  });
+});
+
+describe("reference repositories — both surfaces", () => {
+  // The stepper reaches the rules through these; a missing publish is a TypeError on click
+  // that no other gate sees, since one module is a string and the other never imports it.
+  it.each([["refRepoRowsHtml"], ["refRepoStage"]])("projects publishes window.%s for the stepper", (fn) => {
+    expect(projectsScript).toContain(`window.${fn} = ${fn}`);
+    expect(stepperScript).toContain(`window.${fn}(`);
+  });
+
+  it("sends the field from the dialog and the stepper alike", () => {
+    expect(projectsScript).toContain("referenceRepos: refRepoValue()");
+    expect(stepperScript).toContain("referenceRepos: data.referenceRepos.length ? data.referenceRepos : null");
+  });
+
+  it("places the field between its two Context neighbours on both surfaces", () => {
+    for (const html of [projectsHtml, stepperHtml]) {
+      const skills = html.indexOf("skills-repo");
+      const refRepo = html.indexOf("refrepo-repo");
+      const depScope = html.indexOf("dep-token-scope");
+      expect(skills).toBeLessThan(refRepo);
+      expect(refRepo).toBeLessThan(depScope);
+    }
+  });
+
+  // The stepper resets data and inputs from two separate lists, so a field added to one and
+  // not the other leaks a previous attempt's text into the next project.
+  it("resets the stepper's draft and its add row together", () => {
+    expect(stepperScript).toContain("data.referenceRepos = []");
+    // Against the reset list itself: these ids appear elsewhere in the script, so asserting
+    // on the whole string would pass with the field missing from the reset.
+    const toClear = stepperScript.match(/const toClear = \[([^\]]*)\]/)?.[1] ?? "";
+    expect(toClear).not.toBe("");
+    for (const id of ["np-refrepo-repo", "np-refrepo-path", "np-refrepo-ref"]) {
+      expect(toClear).toContain(id);
+    }
+  });
+
+  it("reviews the count beside the other Context settings", () => {
+    expect(stepperHtml).toContain('data-review="referenceRepos"');
+    expect(stepperHtml.indexOf('data-review="referenceRepos"')).toBeLessThan(
+      stepperHtml.indexOf('data-review="dependencyTokenScope"'),
+    );
+    expect(stepperScript).toContain("' repository'");
+    expect(stepperScript).toContain("' repositories'");
   });
 });
 

--- a/src/__tests__/projects-page.test.ts
+++ b/src/__tests__/projects-page.test.ts
@@ -228,6 +228,19 @@ describe("reference repositories — the rules, exercised", () => {
     expect(problem(repo, path)).toBeNull();
   });
 
+  // These checks only hold their contract while they stay looser than the server's. Each of
+  // the two below is a value normalizeReferenceRepos accepts, so rejecting it here would
+  // block a save the server would have allowed.
+  it("matches the server's case-insensitive host rather than the literal prefix", () => {
+    expect(problem("https://GitHub.com/owner/repo", "refs/docs")).toBeNull();
+  });
+
+  it("treats only a drive letter as absolute, not any second-character colon", () => {
+    expect(problem("owner/repo", "1:30/notes")).toBeNull();
+    expect(problem("owner/repo", "C:/win")).toContain("not absolute");
+    expect(problem("owner/repo", "c:/win")).toContain("not absolute");
+  });
+
   it("rejects a path another entry already holds", () => {
     const draft = [{ repo: "https://github.com/a/b", path: "refs/docs" }];
     expect(problem("owner/repo", "refs/docs", draft)).toContain("already uses the path");

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -184,6 +184,23 @@ export const projectsHtml = `
             <div class="field-hint">Cloned at dispatch and installed into the runner's ~/.claude/skills. Blank = none. Requires the target repo to re-sync claude-implement.yml.</div>
           </div>
           <div class="field">
+            <label class="field-label">Reference Repositories</label>
+            <div style="display:flex;gap:8px;align-items:flex-end">
+              <input class="input mono" id="md-refrepo-repo" style="flex:2;min-width:0" placeholder="repository">
+              <input class="input mono" id="md-refrepo-path" style="flex:2;min-width:0" placeholder="workspace path">
+              <input class="input mono" id="md-refrepo-ref" style="flex:1;min-width:0" placeholder="ref (optional)">
+              <button class="btn btn-icon" style="flex:none;color:var(--accent)" onclick="addRefRepo()" title="Add">+</button>
+            </div>
+            <div id="md-refrepo-list"></div>
+            <div class="field-hint">Cloned read-only into the run's workspace so the agent can check a claim against real source instead of trusting the issue. Blank = none. Up to ten entries.</div>
+            <details class="explain">
+              <summary>What each field accepts</summary>
+              <div class="explain-body">The path is where the clone lands in the runner's workspace, alongside the checked-out target repository, and it is also the address the agent is given &mdash; so it should match whatever the target repo's own instructions call that source. If they say to check claims against <span class="mono">ai-implement-source</span>, that is the path to enter here. Any depth works, and each entry needs its own directory.</div>
+              <div class="explain-body">The repository is either <span class="mono">owner/repo</span> shorthand or a full <span class="mono">https://github.com/owner/repo</span> URL. Private repositories work as long as the App is installed on that owner.</div>
+              <div class="explain-body">The ref pins a branch, a tag, or a full commit hash. Blank clones the default branch.</div>
+            </details>
+          </div>
+          <div class="field">
             <label class="field-label">Dependency Token Scope</label>
             <select class="select" id="md-dep-token-scope">
               <option value="">Off (default)</option>
@@ -422,6 +439,128 @@ export const projectsScript = `
     }
   }
 
+  // Staged like the Access page's allowlist: nothing is written until Save.
+  var refRepoDraft = [];
+
+  // Shown as owner/repo, matching the projects table; the stored URL rides the title.
+  function refRepoLabel(repo) {
+    var host = 'https://github.com/';
+    return repo.indexOf(host) === 0 ? repo.slice(host.length) : repo;
+  }
+
+  // Rows mirror the add row's flex proportions, which is what makes column headers
+  // unnecessary. Shared with the stepper, which passes its own draft and remove handler.
+  function refRepoRowsHtml(draft, removeFn) {
+    var cell = 'min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+    return draft.map(function (e, i) {
+      return '<div style="display:flex;gap:8px;align-items:center;padding:7px 0;font-size:12.5px;border-top:1px solid var(--border-subtle)">'
+        + '<span class="mono" style="flex:2;' + cell + '" title="' + window.escAttr(e.repo) + '">' + window.esc(refRepoLabel(e.repo)) + '</span>'
+        + '<span class="mono" style="flex:2;' + cell + '">' + window.esc(e.path) + '</span>'
+        + '<span class="mono" style="flex:1;color:var(--fg-tertiary);' + cell + '">'
+        + (e.ref ? window.esc(e.ref) : '&mdash;') + '</span>'
+        + '<button class="btn btn-icon btn-danger" style="flex:none" onclick="'
+        + window.escAttr(removeFn) + '(' + i + ')" title="Remove">&times;</button>'
+        + '</div>';
+    }).join('');
+  }
+  window.refRepoRowsHtml = refRepoRowsHtml;
+
+  function renderRefRepos() {
+    document.getElementById('md-refrepo-list').innerHTML = refRepoRowsHtml(refRepoDraft, 'removeRefRepo');
+  }
+
+  // A looser echo of the server's rules, so a mistyped entry fails at the row rather than
+  // at Save. selfIndex is the draft position being re-checked, or -1 for a new entry.
+  function refRepoProblem(repo, path, draft, selfIndex) {
+    if (selfIndex < 0 && draft.length >= 10) return 'Up to ten reference repositories per project.';
+    if (!repo || !path) return 'A reference repository needs both a repository and a workspace path.';
+    var isUrl = repo.indexOf('https://github.com/') === 0;
+    var isShorthand = repo.split('/').length === 2 && repo.indexOf(':') === -1
+      && repo.indexOf('@') === -1 && repo.charAt(0) !== '/' && repo.charAt(repo.length - 1) !== '/';
+    if (!isUrl && !isShorthand) {
+      return 'Repository must be owner/repo or an https://github.com/owner/repo URL, with no credentials in it.';
+    }
+    if (path.charAt(0) === '/' || path.charAt(1) === ':') return 'Path must be relative to the workspace, not absolute.';
+    // Four backslashes here yield one in the emitted script: this module is a template literal.
+    if (path.indexOf('\\\\') !== -1) return 'Path must use forward slashes.';
+    if (path === '..' || path.indexOf('../') === 0 || path.indexOf('/../') !== -1) {
+      return 'Path must stay inside the workspace.';
+    }
+    if (path === '.git' || path.indexOf('.git/') === 0) return 'Path must not write into the repository .git directory.';
+    for (var j = 0; j < draft.length; j++) {
+      if (j !== selfIndex && draft[j].path === path) return 'Another entry already uses the path ' + path + '.';
+    }
+    return null;
+  }
+  window.refRepoProblem = refRepoProblem;
+
+  // Stored entries never pass through the add row, so a value saved before a rule tightened
+  // is only caught here.
+  function refRepoDraftProblem() {
+    for (var i = 0; i < refRepoDraft.length; i++) {
+      var problem = refRepoProblem(refRepoDraft[i].repo, refRepoDraft[i].path, refRepoDraft, i);
+      if (problem) return refRepoLabel(refRepoDraft[i].repo) + ' → ' + refRepoDraft[i].path + ': ' + problem;
+    }
+    return null;
+  }
+
+  // Shared with the stepper, which reads its own inputs and passes raw values so the
+  // trailing-slash rule stays in one place. Returns a problem message, or null on success.
+  function refRepoStage(values, draft) {
+    var repo = (values.repo || '').trim();
+    var path = (values.path || '').trim();
+    while (path.length > 1 && path.charAt(path.length - 1) === '/') path = path.slice(0, -1);
+    var ref = (values.ref || '').trim();
+    var problem = refRepoProblem(repo, path, draft, -1);
+    if (problem) return problem;
+    draft.push(ref ? { repo: repo, path: path, ref: ref } : { repo: repo, path: path });
+    return null;
+  }
+  window.refRepoStage = refRepoStage;
+
+  function stageRefRepo() {
+    var problem = refRepoStage({
+      repo: document.getElementById('md-refrepo-repo').value,
+      path: document.getElementById('md-refrepo-path').value,
+      ref: document.getElementById('md-refrepo-ref').value,
+    }, refRepoDraft);
+    if (problem) return problem;
+    clearRefRepoInputs();
+    renderRefRepos();
+    return null;
+  }
+
+  function addRefRepo() {
+    var problem = stageRefRepo();
+    // No tab argument: switching scrolls the body to the top, moving the row out of view.
+    if (problem) showMappingError(problem);
+    else document.getElementById('md-error').classList.add('hidden');
+  }
+  window.addRefRepo = addRefRepo;
+
+  var REFREPO_INPUTS = ['md-refrepo-repo', 'md-refrepo-path', 'md-refrepo-ref'];
+
+  function clearRefRepoInputs() {
+    for (var k = 0; k < REFREPO_INPUTS.length; k++) document.getElementById(REFREPO_INPUTS[k]).value = '';
+  }
+
+  function pendingRefRepo() {
+    for (var k = 0; k < REFREPO_INPUTS.length; k++) {
+      if (document.getElementById(REFREPO_INPUTS[k]).value.trim()) return true;
+    }
+    return false;
+  }
+
+  function removeRefRepo(i) {
+    refRepoDraft.splice(i, 1);
+    renderRefRepos();
+  }
+  window.removeRefRepo = removeRefRepo;
+
+  function refRepoValue() {
+    return refRepoDraft.length ? refRepoDraft : null;
+  }
+
   function openMappingDialog(key) {
     const isNew = !key;
     document.getElementById('md-title').textContent = isNew ? 'Add Mapping' : 'Edit Mapping: ' + key;
@@ -455,6 +594,11 @@ export const projectsScript = `
     document.getElementById('md-sensitive-add').value = (m.sensitiveAddPatterns || []).join('\\n');
     document.getElementById('md-sensitive-allow').value = (m.sensitiveAllowPatterns || []).join('\\n');
     document.getElementById('md-dep-token-scope').value = m.dependencyTokenScope || '';
+    // slice() so editing the draft never mutates the cached mapping behind it.
+    refRepoDraft = (m.referenceRepos || []).slice();
+    // The add row survives a Cancel, so an abandoned attempt would reappear on the next open.
+    clearRefRepoInputs();
+    renderRefRepos();
 
     // Ticketing provider + Jira config
     const tp = m.ticketingProvider || 'linear';
@@ -789,6 +933,18 @@ export const projectsScript = `
       return;
     }
 
+    // A filled-in add row is staged rather than discarded. Ahead of the payload so
+    // refRepoValue() below picks it up.
+    if (pendingRefRepo()) {
+      const pending = stageRefRepo();
+      if (pending) { showMappingError(pending, 'context'); return; }
+    }
+    const staleRefRepo = refRepoDraftProblem();
+    if (staleRefRepo) {
+      showMappingError(staleRefRepo + ' Remove the entry and add it again.', 'context');
+      return;
+    }
+
     const body = {
       teamKey,
       owner: document.getElementById('md-owner').value.trim(),
@@ -815,6 +971,7 @@ export const projectsScript = `
       sensitiveAddPatterns: (function(){ var v = document.getElementById('md-sensitive-add').value.trim(); return v === '' ? null : v; })(),
       sensitiveAllowPatterns: (function(){ var v = document.getElementById('md-sensitive-allow').value.trim(); return v === '' ? null : v; })(),
       dependencyTokenScope: (function(){ var v = document.getElementById('md-dep-token-scope').value; return v === '' ? null : v; })(),
+      referenceRepos: refRepoValue(),
     };
 
     const ticketingProvider = document.getElementById('md-ticketing-provider').value;

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -455,8 +455,10 @@ export const projectsScript = `
     return draft.map(function (e, i) {
       return '<div style="display:flex;gap:8px;align-items:center;padding:7px 0;font-size:12.5px;border-top:1px solid var(--border-subtle)">'
         + '<span class="mono" style="flex:2;' + cell + '" title="' + window.escAttr(e.repo) + '">' + window.esc(refRepoLabel(e.repo)) + '</span>'
-        + '<span class="mono" style="flex:2;' + cell + '">' + window.esc(e.path) + '</span>'
-        + '<span class="mono" style="flex:1;color:var(--fg-tertiary);' + cell + '">'
+        + '<span class="mono" style="flex:2;' + cell + '" title="' + window.escAttr(e.path) + '">'
+        + window.esc(e.path) + '</span>'
+        + '<span class="mono" style="flex:1;color:var(--fg-tertiary);' + cell + '"'
+        + (e.ref ? ' title="' + window.escAttr(e.ref) + '"' : '') + '>'
         + (e.ref ? window.esc(e.ref) : '&mdash;') + '</span>'
         + '<button class="btn btn-icon btn-danger" style="flex:none" onclick="'
         + window.escAttr(removeFn) + '(' + i + ')" title="Remove">&times;</button>'

--- a/src/admin-ui/pages/projects.ts
+++ b/src/admin-ui/pages/projects.ts
@@ -474,13 +474,17 @@ export const projectsScript = `
   function refRepoProblem(repo, path, draft, selfIndex) {
     if (selfIndex < 0 && draft.length >= 10) return 'Up to ten reference repositories per project.';
     if (!repo || !path) return 'A reference repository needs both a repository and a workspace path.';
-    var isUrl = repo.indexOf('https://github.com/') === 0;
+    // Lowercased for the test only: the server compares a parsed, lowercased hostname.
+    var isUrl = repo.toLowerCase().indexOf('https://github.com/') === 0;
     var isShorthand = repo.split('/').length === 2 && repo.indexOf(':') === -1
       && repo.indexOf('@') === -1 && repo.charAt(0) !== '/' && repo.charAt(repo.length - 1) !== '/';
     if (!isUrl && !isShorthand) {
       return 'Repository must be owner/repo or an https://github.com/owner/repo URL, with no credentials in it.';
     }
-    if (path.charAt(0) === '/' || path.charAt(1) === ':') return 'Path must be relative to the workspace, not absolute.';
+    // A drive letter, matching the server's [A-Za-z]: rather than any second-character colon.
+    var head = path.charAt(0);
+    var isDrive = path.charAt(1) === ':' && ((head >= 'a' && head <= 'z') || (head >= 'A' && head <= 'Z'));
+    if (head === '/' || isDrive) return 'Path must be relative to the workspace, not absolute.';
     // Four backslashes here yield one in the emitted script: this module is a template literal.
     if (path.indexOf('\\\\') !== -1) return 'Path must use forward slashes.';
     if (path === '..' || path.indexOf('../') === 0 || path.indexOf('/../') !== -1) {

--- a/src/admin-ui/stepper.ts
+++ b/src/admin-ui/stepper.ts
@@ -154,6 +154,23 @@ export const stepperHtml = `
             <div class="field-hint">Cloned at dispatch and installed into the runner's ~/.claude/skills. Blank = none. Requires the target repo to re-sync claude-implement.yml.</div>
           </div>
           <div class="field">
+            <label class="field-label">Reference Repositories <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
+            <div style="display:flex;gap:8px;align-items:flex-end">
+              <input class="input mono" id="np-refrepo-repo" style="flex:2;min-width:0" placeholder="repository" autocomplete="off">
+              <input class="input mono" id="np-refrepo-path" style="flex:2;min-width:0" placeholder="workspace path" autocomplete="off">
+              <input class="input mono" id="np-refrepo-ref" style="flex:1;min-width:0" placeholder="ref (optional)" autocomplete="off">
+              <button class="btn btn-icon" style="flex:none;color:var(--accent)" onclick="npAddRefRepo()" title="Add">+</button>
+            </div>
+            <div id="np-refrepo-list"></div>
+            <div class="field-hint">Cloned read-only into the run's workspace so the agent can check a claim against real source instead of trusting the issue. Blank = none. Up to ten entries.</div>
+            <details class="explain">
+              <summary>What each field accepts</summary>
+              <div class="explain-body">The path is where the clone lands in the runner's workspace, alongside the checked-out target repository, and it is also the address the agent is given &mdash; so it should match whatever the target repo's own instructions call that source. If they say to check claims against <span class="mono">ai-implement-source</span>, that is the path to enter here. Any depth works, and each entry needs its own directory.</div>
+              <div class="explain-body">The repository is either <span class="mono">owner/repo</span> shorthand or a full <span class="mono">https://github.com/owner/repo</span> URL. Private repositories work as long as the App is installed on that owner.</div>
+              <div class="explain-body">The ref pins a branch, a tag, or a full commit hash. Blank clones the default branch.</div>
+            </details>
+          </div>
+          <div class="field">
             <label class="field-label">Dependency Token Scope <span style="font-weight:400;color:var(--fg-tertiary)">(optional)</span></label>
             <select class="input" id="np-dep-token-scope">
               <option value="">Off (default)</option>
@@ -342,6 +359,10 @@ export const stepperHtml = `
             <div data-review="skillsRepo"></div>
           </div>
           <div class="np-review-row">
+            <div class="np-review-label">Reference repositories</div>
+            <div data-review="referenceRepos"></div>
+          </div>
+          <div class="np-review-row">
             <div class="np-review-label">Dependency token scope</div>
             <div data-review="dependencyTokenScope"></div>
           </div>
@@ -428,7 +449,7 @@ export const stepperScript = `
     jiraRepoFieldOverride: '',
     jiraProfilesFieldOverride: '',
     teamKey: '', owner: '', repo: '', defaultBranch: '', branchPrefix: '', sensitiveAddPatterns: '', sensitiveAllowPatterns: '',
-    skillsRepo: '', dependencyTokenScope: null,
+    skillsRepo: '', referenceRepos: [], dependencyTokenScope: null,
     executionMode: 'github-actions', machineCpus: 2, machineMemoryMb: 4096, sessionMode: 'autonomous',
     provider: 'anthropic', awsRegion: '',
     planningEnabled: true, autoApprovePlans: true, autoMerge: false,
@@ -452,6 +473,7 @@ export const stepperScript = `
     data.defaultBranch = '';
     data.branchPrefix = '';
     data.skillsRepo = '';
+    data.referenceRepos = [];
     data.sensitiveAddPatterns = '';
     data.sensitiveAllowPatterns = '';
     data.dependencyTokenScope = null;
@@ -471,13 +493,15 @@ export const stepperScript = `
     data.secrets = [];
 
     // Clear inputs. Not derived from the initializer above — a new field needs both.
-    const toClear = ['np-teamKey', 'np-owner', 'np-repo', 'np-defaultBranch', 'np-branch-prefix', 'np-skills-repo', 'np-sensitive-add', 'np-sensitive-allow', 'np-awsRegion', 'np-maxTurns', 'np-maxIterations', 'np-maxJobMinutes'];
+    const toClear = ['np-teamKey', 'np-owner', 'np-repo', 'np-defaultBranch', 'np-branch-prefix', 'np-skills-repo', 'np-refrepo-repo', 'np-refrepo-path', 'np-refrepo-ref', 'np-sensitive-add', 'np-sensitive-allow', 'np-awsRegion', 'np-maxTurns', 'np-maxIterations', 'np-maxJobMinutes'];
     const depScopeEl = document.getElementById('np-dep-token-scope');
     if (depScopeEl) depScopeEl.value = '';
     for (const id of toClear) {
       const el = document.getElementById(id);
       if (el) el.value = '';
     }
+    refRepoPending = null;
+    npRenderRefRepos();
     const cpusEl = document.getElementById('np-cpus');
     if (cpusEl) cpusEl.value = '2';
     const memEl = document.getElementById('np-mem');
@@ -698,6 +722,52 @@ export const stepperScript = `
     if (btn) btn.textContent = 'Check installation';
   }
 
+  // Row markup and rules come from the Projects page; this side owns its inputs and draft.
+  // refRepoPending carries the last staging attempt's message for validateStep.
+  let refRepoPending = null;
+  const NP_REFREPO_INPUTS = ['np-refrepo-repo', 'np-refrepo-path', 'np-refrepo-ref'];
+
+  function npRenderRefRepos() {
+    const el = document.getElementById('np-refrepo-list');
+    if (el) el.innerHTML = window.refRepoRowsHtml(data.referenceRepos, 'npRemoveRefRepo');
+  }
+
+  function npStageRefRepo() {
+    const value = function (id) {
+      const el = document.getElementById(id);
+      return el ? el.value : '';
+    };
+    const problem = window.refRepoStage(
+      { repo: value(NP_REFREPO_INPUTS[0]), path: value(NP_REFREPO_INPUTS[1]), ref: value(NP_REFREPO_INPUTS[2]) },
+      data.referenceRepos,
+    );
+    if (problem) return problem;
+    for (const id of NP_REFREPO_INPUTS) {
+      const el = document.getElementById(id);
+      if (el) el.value = '';
+    }
+    npRenderRefRepos();
+    return null;
+  }
+
+  function npPendingRefRepo() {
+    return NP_REFREPO_INPUTS.some(function (id) {
+      const el = document.getElementById(id);
+      return !!(el && el.value.trim());
+    });
+  }
+
+  function npAddRefRepo() {
+    const problem = npStageRefRepo();
+    if (problem) showError(problem);
+    else hideError();
+  }
+
+  function npRemoveRefRepo(i) {
+    data.referenceRepos.splice(i, 1);
+    npRenderRefRepos();
+  }
+
   function stepperBack() {
     collectStep(step);
     step--;
@@ -770,6 +840,8 @@ export const stepperScript = `
       const dtsEl = document.getElementById('np-dep-token-scope');
       if (srEl) data.skillsRepo = srEl.value.trim();
       if (dtsEl) data.dependencyTokenScope = dtsEl.value || null;
+      // A filled add row is staged rather than discarded, as on the edit dialog.
+      refRepoPending = npPendingRefRepo() ? npStageRefRepo() : null;
     } else if (n === 4) {
       const smEl = document.getElementById('np-sessionMode');
       const cpEl = document.getElementById('np-cpus');
@@ -836,7 +908,8 @@ export const stepperScript = `
       if (!data.repo) { showError('Repository Name is required.'); return false; }
       if (!data.defaultBranch) { showError('Default Branch is required.'); return false; }
     } else if (n === 3) {
-      // Both Context fields are optional — always valid
+      // Every Context setting is optional; only an add row that cannot be staged blocks.
+      if (refRepoPending) { showError(refRepoPending); return false; }
     } else if (n === 4) {
       // executionMode is set via card selection — always valid
     } else if (n === 5) {
@@ -902,6 +975,11 @@ export const stepperScript = `
     set('skillsRepo', monoOr(data.skillsRepo));
     set('sensitiveAddPatterns', data.sensitiveAddPatterns ? (data.sensitiveAddPatterns.split('\\n').filter(function(l){return l.trim();}).length + ' pattern(s)') : '&mdash;');
     set('sensitiveAllowPatterns', data.sensitiveAllowPatterns ? (data.sensitiveAllowPatterns.split('\\n').filter(function(l){return l.trim();}).length + ' exception(s)') : '&mdash;');
+    // Counted rather than listed, like the glob rows above.
+    const refRepoCount = data.referenceRepos.length;
+    set('referenceRepos', refRepoCount
+      ? (refRepoCount + (refRepoCount === 1 ? ' repository' : ' repositories'))
+      : '&mdash;');
     set('dependencyTokenScope', data.dependencyTokenScope ? window.esc(data.dependencyTokenScope) : '&mdash;');
 
     let runnerText = window.esc(data.executionMode);
@@ -1241,6 +1319,7 @@ export const stepperScript = `
       maxIterations: data.maxIterations,
       maxJobMinutes: data.maxJobMinutes,
       skillsRepo: data.skillsRepo || null,
+      referenceRepos: data.referenceRepos.length ? data.referenceRepos : null,
       sensitiveAddPatterns: data.sensitiveAddPatterns || null,
       sensitiveAllowPatterns: data.sensitiveAllowPatterns || null,
       dependencyTokenScope: data.dependencyTokenScope || null,
@@ -1309,6 +1388,8 @@ export const stepperScript = `
   window.selectProvider = selectProvider;
   window.addSecretRow = addSecretRow;
   window.removeSecretRow = removeSecretRow;
+  window.npAddRefRepo = npAddRefRepo;
+  window.npRemoveRefRepo = npRemoveRefRepo;
   window.onStepperTicketingProviderChange = onStepperTicketingProviderChange;
   window.onStepperRepoFieldChange = onStepperRepoFieldChange;
   window.stepperValidateJql = stepperValidateJql;


### PR DESCRIPTION
## Summary

Adds the reference-repositories editor to the two surfaces that configure a project mapping: the Context tab of the edit dialog, and the Context step of the New project stepper. On both it sits between Skills Repo and Dependency Token Scope, the other two settings that provision something into a run.

An entry is a repository, a workspace path, and an optional ref. The add row is three inputs and a `+`; staged entries render beneath it as plain rows mirroring the add row's proportions, so each value sits under the input that produced it. Rows are not editable — remove and re-add.

## The path is the address the agent is given

This is the one field an operator can get valid-but-wrong. The clone step joins the declared path onto the runner's workspace, and the implement step tells the agent the repository is "available at `<path>`". So the path needs to match whatever the target repo's own instructions call that source; anything else leaves those instructions pointing at nothing. The field's explainer leads with it for that reason.

## What is shared between the two surfaces

`projects.ts` publishes three functions on `window`; `stepper.ts` consumes two of them.

| Function | Role |
|---|---|
| `refRepoRowsHtml(draft, removeFn)` | Row markup |
| `refRepoStage(values, draft)` | Normalize, validate, push into the caller's draft |
| `refRepoProblem(repo, path, draft, selfIndex)` | The rules. The stepper reaches these through `refRepoStage`; only the dialog's stored-entry re-check calls it directly |

Each caller passes raw values and owns its own element ids, draft array and handlers, so the DOM stays page-local while the rules and the markup have a single home. `refRepoProblem` is published rather than closed over so the tests can exercise it directly.

This uses a channel the two modules already share: `stepper.ts` calls `window.loadMappings` and `window.pollSyncStatus` from `projects.ts` today.

## Validation

The client-side checks are a deliberately **looser** echo of `normalizeReferenceRepos` — missing fields, a repository that is neither `owner/repo` nor an `https://github.com` URL, an absolute or Windows path, a `..` escape, `.git`, a duplicate path, and the ten-entry cap. Because they are looser, anything they reject the server would reject too, so they can never block a save the server would have accepted.

Three behaviors worth review:

- **A filled add row is staged, not discarded.** Save on the dialog and Next on the stepper both stage through the same `refRepoStage` the `+` button uses; only a value `+` would have refused stops the action.
- **Entries already in the draft are re-checked before save.** Nothing validates on read, so a value stored before a rule tightened loads in verbatim and would otherwise surface as an opaque 400 naming a field the operator never touched. `refRepoProblem` takes a `selfIndex` so an existing entry is not measured against itself by the duplicate and cap rules.
- **The `+` button's error goes to the pinned banner with no tab argument**, because `switchMappingTab` resets the body scroll and would push the row being edited out of view. The save-time checks do pass `'context'`, since the operator can be on any tab by then.

## Tests

Placement and wiring follow this file's existing substring style. The rules are exercised as behavior instead: the page script's top level only declares functions before calling `registerPage`, so `new Function("window", "document", projectsScript)` against stub globals reaches the published functions and runs the real logic. That approach is new for the admin-UI suites here and is the part most worth a look. The escaping helpers are stubbed deliberately — `esc` round-trips through the DOM, and their own correctness belongs to ADR 002's tests.
