### PR TITLE
AII-178: Share the reference-token response contract between its two sides

### DIFF
--- a/src/pipeline/steps/reference-repos.ts
+++ b/src/pipeline/steps/reference-repos.ts
@@ -3,6 +3,7 @@ import type { SpawnSyncOptions, SpawnSyncReturns } from "node:child_process";
 import path from "node:path";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { normalizeReferenceRepos, type ReferenceRepo, type ReferenceRepoResult, type ReferenceRepoResultCause } from "../../reference-repos.js";
+import type { ReferenceTokenOwnerEntry } from "../../reference-token-vending.js";
 import { appendExcludePaths } from "../scratch-exclude.js";
 
 export type SpawnSyncFn = (
@@ -24,13 +25,6 @@ interface ReferenceReposInputs extends Record<string, unknown> {
 
 interface ReferenceReposOutputs extends Record<string, unknown> {
   results: ReferenceRepoResult[];
-}
-
-interface ReferenceTokenOwnerEntry {
-  owner: string;
-  token: string | null;
-  expiresAt: string | null;
-  authMode: "installation" | "public" | "error";
 }
 
 async function fetchReferenceTokens(params: {


### PR DESCRIPTION
## Summary

A cohesiveness pass over the code the reference-repositories block landed, checking that everything it introduced is used and that it left no structural debt behind. One finding, fixed here.

`ReferenceTokenOwnerEntry` — the response shape of `POST /api/runner/reference-token` — was declared twice: exported from `src/reference-token-vending.ts`, which produces it, and re-declared privately in `src/pipeline/steps/reference-repos.ts`, which parses it. Field-for-field identical, `authMode` union included, with nothing linking them. Adding a field on the orchestrator side and forgetting the runner copy compiles cleanly and silently drops it.

The step now imports the type from the module that owns it. `import type` is erased, so nothing orchestrator-side reaches the runner bundle and no runtime edge is created — verified against the module graph.

No test accompanies this: the compiler is the guarantee, which is the point of the change.

## What the pass checked and found clean

- Every export the block added has a consumer, and `SpawnSyncFn` is exercised by its test suite.
- All 85 element ids across the edit dialog and the stepper are addressed by a script, and no script looks up an id that no markup declares.
- The reference-repository results reach both consumers — the agent prompt through the feedback loop, and the operator comment through the terminal callback — with no dead end on either path.
- No import cycle is introduced. Every new `pipeline/ → top-level` edge is type-only except `steps/implement.ts` and `steps/reference-repos.ts`, both matching the existing pattern in `steps/clone.ts` and `steps/push.ts`.
