### PR TITLE
AII-178: Surface reference repositories to operators and to the subsystem index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Entry points for areas that are easy to miss. Each names the module to start fro
 | Parent/child grouping and roll-up | `src/feature-branch.ts`, `src/merge-up.ts` | [docs/feature-branch-grouping.md](docs/feature-branch-grouping.md) |
 | Issueless run kinds (kg-refresh lifecycle and pattern) | `src/kg-refresh.ts`, `src/index.ts` | [docs/issueless-runs.md](docs/issueless-runs.md) |
 | Dispatch envelope (`RunConfigV1`) | `src/run-config.ts` | [docs/workflow-envelope.md](docs/workflow-envelope.md) |
-| Runner context settings (skills repo, dependency token scope) | `src/pipeline/steps/install-skills.ts`, `src/pipeline/steps/dependency-auth.ts` | [docs/runner-context.md](docs/runner-context.md) |
+| Runner context settings (skills repo, reference repositories, dependency token scope) | `src/pipeline/steps/install-skills.ts`, `src/pipeline/steps/reference-repos.ts`, `src/pipeline/steps/dependency-auth.ts` | [docs/runner-context.md](docs/runner-context.md) |
 | Runner image selection | `src/repo-image.ts` | [docs/runner-images.md](docs/runner-images.md) |
 | Knowledge graph end-to-end (ingest → snapshot → image → serve) | `Dockerfile` KG stages, `docker-entrypoint.sh` | [docs/kg-architecture.md](docs/kg-architecture.md) |
 | KG sidecar and `/mcp` | `src/mcp.ts`, `src/mcp-oauth.ts` | [docs/kg-sidecar.md](docs/kg-sidecar.md) |

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -636,6 +636,7 @@ describe("handleMcpRequest", () => {
           maxJobMinutes: 60,
           branchPrefix: "feat",
           skillsRepo: "org/skills",
+          referenceRepos: [{ repo: "https://github.com/org/source", path: "refs/source", ref: "v1.1.0" }],
           dependencyTokenScope: "installation",
           sensitiveAddPatterns: ["*.pem", "secrets/**"],
           sensitiveAllowPatterns: ["public/**"],
@@ -670,6 +671,10 @@ describe("handleMcpRequest", () => {
       expect(p.maxJobMinutes).toBe(60);
       expect(p.branchPrefix).toBe("feat");
       expect(p.skillsRepo).toBe("org/skills");
+      // Entries round-trip whole: the tool projects named fields, so a dropped one is silent.
+      expect(p.referenceRepos).toEqual([
+        { repo: "https://github.com/org/source", path: "refs/source", ref: "v1.1.0" },
+      ]);
       expect(p.dependencyTokenScope).toBe("installation");
       expect(p.sensitiveAddPatterns).toEqual(["*.pem", "secrets/**"]);
       expect(p.sensitiveAllowPatterns).toEqual(["public/**"]);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -144,6 +144,7 @@ async function callDiagnosticTool(
         maxJobMinutes: m.maxJobMinutes,
         branchPrefix: m.branchPrefix,
         skillsRepo: m.skillsRepo,
+        referenceRepos: m.referenceRepos,
         dependencyTokenScope: m.dependencyTokenScope,
         sensitiveAddPatterns: m.sensitiveAddPatterns,
         sensitiveAllowPatterns: m.sensitiveAllowPatterns,


### PR DESCRIPTION
## Summary

Two omissions found by sweeping the reference-repositories work for surfaces it should have reached and didn't. Neither was caught during the feature's own issues, because no issue touched either file.

**`list_projects` omitted `referenceRepos`.** The tool projects mapping fields explicitly rather than returning the record wholesale — deliberately, so `/mcp` can stay role-blind without exposing `extraEnv` — which means a new mapping field is invisible to the entire MCP surface until it is named there. Every other runner-context setting was already listed: the skills repository, the dependency token scope, and both sensitive-glob lists. This adds the missing one, so "does this project declare reference repositories?" is answerable without opening the admin UI.

**The subsystem index named two of the three runner-context settings.** `docs/runner-context.md` documents skills repository, reference repositories, and dependency token scope; the `CLAUDE.md` row naming that reference listed only the first and third, and its entry points omitted `src/pipeline/steps/reference-repos.ts`. The row now matches the page it points at.

## Why they were missed

Both files sit outside the feature's implementation path, so nothing in the work prompted a visit. The MCP projection is the more interesting of the two: an explicit allowlist is the right design for a role-blind endpoint, and its cost is that additions are silent — the field simply isn't there, with no type error and no failing test. Worth knowing for the next mapping field.
