### PR TITLE
AII-593: kg-refresh rail: push the snapshot on a branch, open a refresh PR with the report, merge it on a clean guard

### DIFF
--- a/docs/issueless-runs.md
+++ b/docs/issueless-runs.md
@@ -33,7 +33,7 @@ flowchart TD
     D --> E["Fly Machine or\nlocal Docker\nrunConfig + runToken"]
     E --> F["runner pipeline\nclone → dependency-auth → clone-code-repo → clone-secondary-repos\n→ kg-tracker-data → kg-ingest\n→ kg-snapshot-push"]
     F --> G["POST /api/runner/result\nphase=kg-refresh"]
-    G --> I["onRunnerComplete()\nverify snapshot commit"]
+    G --> I["onRunnerComplete()\nmerge refresh PR (merge commit)\ndelete the kg-refresh branch\nverify snapshot commit"]
     I --> H
     H -->|"success"| J["stage=serving\nonOutcome('success')\ncloseJobLog(completed)"]
     H -->|"failure / revert"| K["stage=failed or reverted\nonOutcome('failure')\ncloseJobLog(failed)"]
@@ -291,7 +291,7 @@ The endpoint validates that `teamKey` is present in the orchestrator's configure
 
 ### Callback
 
-The runner reports completion to `POST /api/runner/result` with `{ phase: "kg-refresh", outcome: "success"|"failure", snapshotCommit?, failureCode?, failureReason? }`. The routing carve-out in `src/runner-callback.ts` (~line 252):
+The runner reports completion to `POST /api/runner/result` with `{ phase: "kg-refresh", outcome: "success"|"failure", snapshotCommit?, snapshotPr?, snapshotBranch?, failureCode?, failureReason? }`. `snapshotPr` and `snapshotBranch` are set when `kg-snapshot-push` pushed the snapshot and opened the refresh PR (AII-593, below). The routing carve-out in `src/runner-callback.ts` (~line 252):
 
 ```typescript
 if (input.body.phase === "kg-refresh") {
@@ -468,7 +468,11 @@ The comment includes the failure code and dispatch ID for correlation.
 
 ## 9. KG-visible surfaces
 
-The runner produces a new snapshot commit in the KG source repository (`KG_SOURCE_REPO`). That commit is the sole persistent record of what ran. Commit messages should encode enough context for a future reader to identify when and why a given snapshot was produced.
+The runner pushes the new snapshot to a per-refresh branch `kg-refresh/<stamp>` in the KG source repository (`KG_SOURCE_REPO`) and opens a **refresh PR** against the default branch (title `kg-refresh: snapshot @ <stamp> (<N> quads)`). The PR body is the refresh report: the per-part line-count table (prev, new, delta), quads serialized, issue counts by team, each secondary repo with its branch and commit, ingest warnings (`WARN`/`ERROR` lines from `ai-output/kg-ingest.log`), and the guard verdict. The step reuses the implement pipeline's PR helper (`openOrFindPullRequest` in `src/pipeline/step-utils.ts`); no second PR helper exists (ADR 013).
+
+On a successful callback the orchestrator (`onRunnerComplete` in `src/kg-refresh.ts`) merges that PR with the **merge** method — never squash or rebase, because it then verifies `snapshotCommit` is reachable on the default branch — deletes the `kg-refresh/<stamp>` branch, and continues with the local rail (fetch, stage, swap, verify). A merge that returns `blocked` or `conflict`, or a callback that carries `snapshotPr` without `snapshotCommit`, ends the refresh as `failed` with the PR named in `lastRefresh.detail`; the default branch is untouched. On a failed callback that carries `snapshotPr`, the orchestrator posts a comment naming the gate, closes the PR unmerged, and deletes the branch.
+
+The refresh PR is the persistent record of what ran, and the KG ingests PRs, so every refresh becomes searchable. The refresh PR is never picked up by the grouping auto-merge (`src/auto-merge.ts` only considers `ai-implement/feature/*` and `ai-implement/multi-issue/*` bases). The laptop never pushes `snapshot/`: `bd-kg-refresh` triggers the rail, and `bd-mega-kg-refresh` iterates on the ingest locally and PRs manifest changes only.
 
 The designated tracker issue (if configured) receives failure comments; there is no "success" comment posted to it. Success is observable through the KG stamp served by `GET /api/kg/status`.
 
@@ -491,7 +495,7 @@ npm run dev:run -- \
 - The KG source checkout is bind-mounted read-only at `/kg-source`. The `clone` step is replaced with `devHarnessKgCloneStep`, which clones from `file:///kg-source` into the container's scratch workspace. Uncommitted edits to `sources.yml` therefore take effect immediately.
 - `--tracker-data <file>` is required. The file is the pre-fetched body of `POST /api/runner/kg-tracker-data` (one team's worth). It is bind-mounted at `/dev-tracker-data.json`; the `kg-tracker-data` step detects `KG_TRACKER_DATA_FILE` and uses it rather than calling the orchestrator.
 - The operator's `GH_TOKEN` is injected as `AI_IMPLEMENT_DEP_TOKEN_OVERRIDE`. This swaps in a stub `dependency-auth` step that marks `acquired=true`, satisfying `clone-secondary-repos` without an orchestrator token vend. If the token lacks `contents: read` on a secondary repo, the clone fails with a 404/403 — exactly the parity check the harness is designed to surface.
-- `kg-snapshot-push` runs in dry-run mode (`AI_IMPLEMENT_KG_DRY_RUN=true`). Guards and validation run in full; the per-part line-count table is printed; no commit or push happens.
+- `kg-snapshot-push` runs in dry-run mode (`AI_IMPLEMENT_KG_DRY_RUN=true`). Guards and validation run in full; the refresh report (the same markdown that becomes the refresh PR body on a real run) is printed to the log; no commit, push, branch or PR happens.
 
 **`--until` and `--shell`** both work for this phase. The shell opens in `/workspace` (the scratch clone); `git remote -v` shows `file:///kg-source`.
 

--- a/docs/kg-architecture.md
+++ b/docs/kg-architecture.md
@@ -41,8 +41,8 @@ the newest committed snapshot. **The graph's age stamp can change without anyone
 An operator who deploys a code fix and then finds the graph newer than they left it is seeing this,
 not a bug.
 
-The reverse also holds, and it is the sequencing rule in `bd-kg-refresh`: confirm the snapshot push
-has landed *before* triggering the deploy. The deploy is the only thing that picks it up.
+The reverse also holds: a deploy picks up whatever snapshot is on the default branch when it builds.
+The rail (`POST /api/kg/refresh`) is the only path that writes `snapshot/`; the laptop never pushes it.
 
 ### A broken snapshot blocks unrelated code deploys
 
@@ -198,7 +198,7 @@ builder's git cache served a stale `--depth 1` clone. Both are benign. Wait, red
 With the refresh rail (AII-426), publishing data no longer rides a release. Run `bd-kg-refresh`,
 or these steps by hand.
 
-1. Reconcile scope, ingest, and commit + push the snapshot — steps 1–5 below, unchanged.
+1. Reconcile scope in `sources.yml` (through a PR on the KG repo when it changes) — the rail runs the ingest and pushes the snapshot itself; no laptop ingest, no laptop push.
 2. **Trigger the refresh**: `POST /api/kg/refresh` with an admin session token (or the
    Deployments page's "Refresh graph now"). `202` = accepted; `409` = a refresh or a deploy is
    already in progress; `422` = callback not configured or credential preflight failed (see below). The orchestrator
@@ -237,22 +237,20 @@ blocking all future refreshes for the remainder of the 4-hour ingest TTL. A live
 dispatched a runner and received no callback within the TTL self-heals at the next `POST
 /api/kg/refresh` call.
 
-**Redeploy remains the fallback** — an orchestrator predating the rail (the route answers 404),
-or a change that touches the sidecar's code rather than its data, still refreshes by deploy:
+**Redeploy remains the path for code, not data** — a change that touches the sidecar's code rather
+than its data ships by deploy, and the image build reads whatever snapshot is on the KG repo's default
+branch at that moment (the rail keeps it current):
 
-1. **Reconcile scope.** Call `list_projects` on the orchestrator MCP, diff against `sources.yml`, and
-   commit the manifest before ingesting.
-2. **Ingest** in the KG checkout:
-   `./.venv/bin/python -m kg_ingest.cli --repo ../AI-Implement --tracker --secondary`
-3. **Read the report.** Quads, cards, `SHACL conforms`, the age stamp, and the docs-crawl line. Treat
-   `embeddings SKIPPED` as a warning, not an aside.
-4. **Commit and push** `snapshot/` to `main`. Generated data goes straight to the default branch.
-5. **Confirm the push landed** with `git log origin/main`. This is the monolith's sequencing rule:
-   the deploy is what reads the snapshot, so a deploy that races the push builds the old graph.
-6. **Self-deploy** — `POST /api/deploy` with an admin session token. Expect `202`, or `409` if one is
+1. **Refresh the data first if it must be current** — `POST /api/kg/refresh`, wait for `serving`.
+2. **Self-deploy** — `POST /api/deploy` with an admin session token. Expect `202`, or `409` if one is
    already running. Never a plain `fly deploy`; see [deployment.md](deployment.md#deploy-paths).
-7. **Verify live.** Non-empty results, `degraded: false`, and an age stamp equal to step 3. Check
-   `kgDegraded` on `GET /` as well — a lexical-only image answers queries and looks healthy.
+3. **Verify live.** Non-empty results, `degraded: false`, and an age stamp equal to the served stamp
+   from step 1. Check `kgDegraded` on `GET /` as well — a lexical-only image answers queries and looks
+   healthy.
+
+An orchestrator that predates the rail (the route answers 404) is upgraded, not worked around: the
+laptop ingest-and-push path is retired (AII-593), and `snapshot/` on the default branch is written by
+the rail alone.
 
 Steps 5 to 7 exist entirely because of the monolith. In a two-service design the data would be
 reloadable on its own; here it rides a release, so the release has to be sequenced and verified.
@@ -369,9 +367,9 @@ callback URL, local run, or fetch failure), `clone-code-repo` is skipped gracefu
 proceeds without the code repo rather than aborting the pipeline. When the clone succeeds, the
 `kg-ingest` step passes `--code-repo <path>` to `python -m kg_ingest refresh`, giving the ingest
 access to git history, commits, PRs, and files from the implementation repo. If `sources.yml`
-contains no `code_repo` field, the step is also skipped silently. Local `bd-kg-refresh` skill runs
-never carry a dispatch token and therefore always skip `clone-code-repo`; the local operator
-supplies the code repo checkout directly via `--repo` if needed.
+contains no `code_repo` field, the step is also skipped silently. The dev-harness `--phase kg-refresh`
+run (`docs/issueless-runs.md` § 10) exercises the same clone steps locally against the operator's
+GitHub token; it never pushes.
 
 | Endpoint | Method | Purpose |
 |---|---|---|

--- a/src/__tests__/kg-refresh-run.test.ts
+++ b/src/__tests__/kg-refresh-run.test.ts
@@ -4082,19 +4082,21 @@ describe("kgSnapshotPushStep — dryRun flag", () => {
 
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     let result;
+    let printed = "";
     try {
       result = await kgSnapshotPushStep.run(
         ctx,
         makeInputs({ clonedRef, dryRun: true, repoOwner: "acme", repoRepo: "kg-repo" }),
         noopReporter,
       );
+      // Read the calls before mockRestore — restore resets the recorded calls.
+      printed = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     } finally {
       logSpy.mockRestore();
     }
 
     expect(result.snapshotPushed).toBe(false);
     expect(result.prNumber).toBeNull();
-    const printed = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(printed).toContain("kg-refresh report — 20260905T080000Z");
     expect(printed).toContain("**Quads serialized:** 777");
     expect(printed).toContain("- AII: 2");
@@ -4193,7 +4195,8 @@ describe("kgSnapshotPushStep — refresh PR flow", () => {
   }
 
   function branchesOnBare(): string {
-    return execSync("git for-each-ref refs/heads --format=%(refname)", { cwd: bareDir }).toString();
+    // argv form: a shell would choke on the `%(` in the format string.
+    return spawnSync("git", ["for-each-ref", "refs/heads", "--format=%(refname)"], { cwd: bareDir }).stdout.toString();
   }
 
   it("pushes to kg-refresh/<stamp> and opens a PR whose body carries the report", async () => {

--- a/src/__tests__/kg-refresh-run.test.ts
+++ b/src/__tests__/kg-refresh-run.test.ts
@@ -520,7 +520,7 @@ describe("kgSnapshotPushStep", () => {
     }
   });
 
-  it("--force-with-lease rejects a push when the remote advanced concurrently", async () => {
+  it("--force-with-lease rejects a push when the refresh branch already exists on the remote", async () => {
     const bareDir = mkdtempSync(join(tmpdir(), "kgpush-bare2-"));
     // Derive a non-existing path for the clone so git clone creates it fresh.
     const otherDir = `${bareDir}-other`;
@@ -534,16 +534,18 @@ describe("kgSnapshotPushStep", () => {
       execSync("git push origin HEAD:refs/heads/main", { cwd: tmpDir, stdio: "ignore" });
       const clonedRef = resolveHead(tmpDir);
 
-      // Simulate a concurrent commit landing on origin after we cloned.
+      // Simulate someone else having already pushed this exact stamp's refresh branch —
+      // the push's "--force-with-lease=refs/heads/kg-refresh/<stamp>:" expects the ref to
+      // be absent, so a concurrent creation must make our push fail the lease check.
       execSync(`git clone "${bareDir}" "${otherDir}"`, { stdio: "ignore" });
       execSync("git config user.name other", { cwd: otherDir, stdio: "ignore" });
       execSync("git config user.email other@example.com", { cwd: otherDir, stdio: "ignore" });
       writeFileSync(join(otherDir, "concurrent.txt"), "concurrent\n");
       execSync("git add concurrent.txt", { cwd: otherDir, stdio: "ignore" });
       execSync("git commit -m concurrent", { cwd: otherDir, stdio: "ignore" });
-      execSync("git push origin HEAD:refs/heads/main", { cwd: otherDir, stdio: "ignore" });
+      // Stamp below is "2026-09-03T10:00:00Z" → compact branch "kg-refresh/20260903T100000Z".
+      execSync("git push origin HEAD:refs/heads/kg-refresh/20260903T100000Z", { cwd: otherDir, stdio: "ignore" });
 
-      // Now origin/main is ahead of our refs/remotes/origin/main tracking ref.
       mkdirSync(join(tmpDir, "snapshot", "parts"), { recursive: true });
       writeFileSync(join(tmpDir, "snapshot", "parts", "a.nt"), "<s> <p> <o> .\n");
       writeFileSync(join(tmpDir, "snapshot", "embeddings.npz"), "binary");
@@ -1043,7 +1045,7 @@ describe("kgTrackerDataStep", () => {
       { callbackUrl: null, workspaceDir: tmpDir, fetchImpl },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: false, issueCount: 0 });
+    expect(result).toEqual({ fetched: false, issueCount: 0, teamCounts: [] });
     expect(capturedCalls).toHaveLength(0);
   });
 
@@ -1056,7 +1058,7 @@ describe("kgTrackerDataStep", () => {
       { callbackUrl: "http://orch", workspaceDir: tmpDir, fetchImpl },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: false, issueCount: 0 });
+    expect(result).toEqual({ fetched: false, issueCount: 0, teamCounts: [] });
     expect(capturedCalls).toHaveLength(0);
   });
 
@@ -1075,7 +1077,7 @@ describe("kgTrackerDataStep", () => {
       },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: true, issueCount: 1 });
+    expect(result).toEqual({ fetched: true, issueCount: 1, teamCounts: [{ team: "AII", count: 1 }] });
     expect(written).toHaveLength(1);
     expect(written[0][0]).toBe(join(tmpDir, "tracker-data.json"));
     expect(JSON.parse(written[0][1])).toEqual(issues);
@@ -1107,7 +1109,7 @@ describe("kgTrackerDataStep", () => {
       },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: true, issueCount: 2 });
+    expect(result).toEqual({ fetched: true, issueCount: 2, teamCounts: [{ team: "AII", count: 2 }] });
     expect(fetchCalls).toHaveLength(2);
     expect(fetchCalls[0].cursor).toBeUndefined();
     expect(fetchCalls[0].teamKey).toBe("AII");
@@ -1144,7 +1146,7 @@ describe("kgTrackerDataStep", () => {
       },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: false, issueCount: 0 });
+    expect(result).toEqual({ fetched: false, issueCount: 0, teamCounts: [] });
   });
 
   it("throws KgTrackerDataFetchError when fetchImpl rejects (network error)", async () => {
@@ -1209,7 +1211,7 @@ describe("kgTrackerDataStep", () => {
       },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: true, issueCount: 3 });
+    expect(result).toEqual({ fetched: true, issueCount: 3, teamCounts: [{ team: "AII", count: 1 }, { team: "BDS", count: 2 }] });
     expect(requestBodies).toHaveLength(2);
     expect(requestBodies[0].teamKey).toBe("AII");
     expect(requestBodies[1].teamKey).toBe("BDS");
@@ -1253,7 +1255,7 @@ describe("kgTrackerDataStep", () => {
       },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: false, issueCount: 0 });
+    expect(result).toEqual({ fetched: false, issueCount: 0, teamCounts: [] });
     expect(capturedCalls).toHaveLength(0);
   });
 
@@ -1333,7 +1335,7 @@ trackers:
       { callbackUrl: "http://orch", workspaceDir: tmpDir, fetchImpl },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: false, issueCount: 0 });
+    expect(result).toEqual({ fetched: false, issueCount: 0, teamCounts: [] });
     expect(capturedCalls).toHaveLength(0);
   });
 
@@ -1361,7 +1363,7 @@ trackers:
       { callbackUrl: "http://orch", workspaceDir: tmpDir, fetchImpl },
       noopReporter,
     );
-    expect(result).toEqual({ fetched: false, issueCount: 0 });
+    expect(result).toEqual({ fetched: false, issueCount: 0, teamCounts: [] });
     expect(capturedCalls).toHaveLength(0);
   });
 
@@ -4048,7 +4050,7 @@ describe("kgSnapshotPushStep — dryRun flag", () => {
     };
   }
 
-  it("returns { snapshotPushed: false, commitSha: null } without pushing when dryRun=true", async () => {
+  it("returns { snapshotPushed: false, commitSha: null, prNumber: null } without pushing when dryRun=true", async () => {
     initGitRepo(tmpDir);
     const clonedRef = resolveHead(tmpDir);
 
@@ -4061,6 +4063,46 @@ describe("kgSnapshotPushStep — dryRun flag", () => {
     const result = await kgSnapshotPushStep.run(ctx, makeInputs({ clonedRef, dryRun: true }), noopReporter);
     expect(result.snapshotPushed).toBe(false);
     expect(result.commitSha).toBeNull();
+    expect(result.prNumber).toBeNull();
+  });
+
+  it("prints the refresh report (per-part table, quads, team counts, guard verdict) and opens nothing when dryRun=true", async () => {
+    initGitRepo(tmpDir);
+    const clonedRef = resolveHead(tmpDir);
+
+    mkdirSync(join(tmpDir, "snapshot", "parts"), { recursive: true });
+    writeFileSync(join(tmpDir, "snapshot", "parts", "docs.nt"), "<s> <p> <o> .\n<s> <p> <o> .\n");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.npz"), "binary");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.stamp"), "2026-09-05T08:00:00Z");
+    mkdirSync(join(tmpDir, "ai-output"), { recursive: true });
+    writeFileSync(join(tmpDir, "ai-output", "kg-stats.json"), JSON.stringify({ quads: 777 }));
+
+    const ctx = makeContext();
+    ctx.setOutputs("kg-tracker-data", { fetched: true, issueCount: 2, teamCounts: [{ team: "AII", count: 2 }] });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    let result;
+    try {
+      result = await kgSnapshotPushStep.run(
+        ctx,
+        makeInputs({ clonedRef, dryRun: true, repoOwner: "acme", repoRepo: "kg-repo" }),
+        noopReporter,
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(result.snapshotPushed).toBe(false);
+    expect(result.prNumber).toBeNull();
+    const printed = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(printed).toContain("kg-refresh report — 20260905T080000Z");
+    expect(printed).toContain("**Quads serialized:** 777");
+    expect(printed).toContain("- AII: 2");
+    expect(printed).toContain("**Guard verdict:** clean (dry-run — no push)");
+
+    // No branch was created locally — dry run touches no git remote state.
+    const branches = execSync("git branch --list", { cwd: tmpDir }).toString();
+    expect(branches).not.toContain("kg-refresh/");
   });
 
   it("still throws KgSnapshotMissingError for missing parts when dryRun=true", async () => {
@@ -4088,6 +4130,176 @@ describe("kgSnapshotPushStep — dryRun flag", () => {
     await expect(
       kgSnapshotPushStep.run(ctx, makeInputs({ clonedRef, dryRun: true }), noopReporter),
     ).rejects.toBeInstanceOf(KgSnapshotTrackerRegressionError);
+  });
+});
+
+// ── kgSnapshotPushStep — refresh PR flow ──────────────────────────────────────
+// Real git throughout (guards, commit, push); only the GitHub REST call for the PR
+// is stubbed. The token-embedded https://github.com/... origin the step sets is
+// redirected to the local bare remote via `git config url.<bare>.insteadOf <url>`,
+// so the push itself is real and inspectable rather than hitting the network.
+
+describe("kgSnapshotPushStep — refresh PR flow", () => {
+  let tmpDir: string;
+  let bareDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "kgpush-pr-"));
+    bareDir = mkdtempSync(join(tmpdir(), "kgpush-pr-bare-"));
+    execSync("git init --bare", { cwd: bareDir, stdio: "ignore" });
+    delete process.env.AI_IMPLEMENT_WORKSPACE_MODE;
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(bareDir, { recursive: true, force: true });
+    delete process.env.AI_IMPLEMENT_WORKSPACE_MODE;
+    vi.unstubAllGlobals();
+  });
+
+  function makeInputs(overrides: Record<string, unknown> = {}) {
+    return {
+      workspaceDir: tmpDir,
+      githubToken: "fake-token",
+      defaultBranch: "main",
+      clonedRef: resolveHead(tmpDir),
+      repoOwner: "acme",
+      repoRepo: "kg-repo",
+      ...overrides,
+    };
+  }
+
+  /**
+   * The step embeds a fresh token in the origin URL before pushing (`remote set-url
+   * origin https://x-access-token:<token>@github.com/<owner>/<repo>.git`). Rewrite
+   * that literal URL to the local bare remote so the push lands somewhere real and
+   * inspectable instead of trying to reach github.com.
+   */
+  function redirectGithubRemote(): void {
+    execSync(
+      `git config url."${bareDir}".insteadOf "https://x-access-token:fake-token@github.com/acme/kg-repo.git"`,
+      { cwd: tmpDir, stdio: "ignore" },
+    );
+  }
+
+  function stubPrCreate(number: number, url: string): void {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ html_url: url, number }),
+      text: async () => "",
+    } as Response);
+  }
+
+  function branchesOnBare(): string {
+    return execSync("git for-each-ref refs/heads --format=%(refname)", { cwd: bareDir }).toString();
+  }
+
+  it("pushes to kg-refresh/<stamp> and opens a PR whose body carries the report", async () => {
+    initGitRepo(tmpDir);
+    execSync(`git remote add origin "${bareDir}"`, { cwd: tmpDir, stdio: "ignore" });
+    execSync("git push origin HEAD:refs/heads/main", { cwd: tmpDir, stdio: "ignore" });
+    const clonedRef = resolveHead(tmpDir);
+    redirectGithubRemote();
+
+    mkdirSync(join(tmpDir, "snapshot", "parts"), { recursive: true });
+    writeFileSync(join(tmpDir, "snapshot", "parts", "docs.nt"), "<s> <p> <o> .\n");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.npz"), "binary");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.stamp"), "2026-09-05T08:00:00Z");
+    mkdirSync(join(tmpDir, "ai-output"), { recursive: true });
+    writeFileSync(join(tmpDir, "ai-output", "kg-stats.json"), JSON.stringify({ quads: 4242 }));
+
+    stubPrCreate(17, "https://github.com/acme/kg-repo/pull/17");
+
+    const ctx = makeContext();
+    ctx.setOutputs("kg-tracker-data", { fetched: true, issueCount: 2, teamCounts: [{ team: "AII", count: 2 }] });
+
+    const result = await kgSnapshotPushStep.run(ctx, makeInputs({ clonedRef }), noopReporter);
+
+    expect(result.snapshotPushed).toBe(true);
+    expect(result.prNumber).toBe(17);
+    expect(branchesOnBare()).toContain("refs/heads/kg-refresh/20260905T080000Z");
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, req] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe("https://api.github.com/repos/acme/kg-repo/pulls");
+    const body = JSON.parse((req as RequestInit).body as string);
+    expect(body.head).toBe("kg-refresh/20260905T080000Z");
+    expect(body.base).toBe("main");
+    expect(body.title).toBe("kg-refresh: snapshot @ 20260905T080000Z (4242 quads)");
+    expect(body.body).toContain("**Quads serialized:** 4242");
+    expect(body.body).toContain("- AII: 2");
+    expect(body.body).toContain("**Guard verdict:** clean");
+    expect(body.draft).toBeUndefined();
+  });
+
+  it("titles the PR with '?' quads when kg-stats.json is absent", async () => {
+    initGitRepo(tmpDir);
+    execSync(`git remote add origin "${bareDir}"`, { cwd: tmpDir, stdio: "ignore" });
+    execSync("git push origin HEAD:refs/heads/main", { cwd: tmpDir, stdio: "ignore" });
+    const clonedRef = resolveHead(tmpDir);
+    redirectGithubRemote();
+
+    mkdirSync(join(tmpDir, "snapshot", "parts"), { recursive: true });
+    writeFileSync(join(tmpDir, "snapshot", "parts", "docs.nt"), "<s> <p> <o> .\n");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.npz"), "binary");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.stamp"), "2026-09-06T00:00:00Z");
+
+    stubPrCreate(1, "https://github.com/acme/kg-repo/pull/1");
+
+    const ctx = makeContext();
+    const result = await kgSnapshotPushStep.run(ctx, makeInputs({ clonedRef }), noopReporter);
+    expect(result.prNumber).toBe(1);
+
+    const [, req] = vi.mocked(fetch).mock.calls[0];
+    const body = JSON.parse((req as RequestInit).body as string);
+    expect(body.title).toBe("kg-refresh: snapshot @ 20260906T000000Z (? quads)");
+  });
+
+  it("--force-with-lease refuses the push when the stamp's branch already exists on the remote", async () => {
+    initGitRepo(tmpDir);
+    execSync(`git remote add origin "${bareDir}"`, { cwd: tmpDir, stdio: "ignore" });
+    execSync("git push origin HEAD:refs/heads/main", { cwd: tmpDir, stdio: "ignore" });
+    const clonedRef = resolveHead(tmpDir);
+    redirectGithubRemote();
+    // Pre-create the branch this stamp would target — the explicit "must be absent" lease
+    // must refuse rather than silently force-overwriting someone else's push.
+    execSync("git push origin HEAD:refs/heads/kg-refresh/20260907T000000Z", { cwd: tmpDir, stdio: "ignore" });
+
+    mkdirSync(join(tmpDir, "snapshot", "parts"), { recursive: true });
+    writeFileSync(join(tmpDir, "snapshot", "parts", "docs.nt"), "<s> <p> <o> .\n");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.npz"), "binary");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.stamp"), "2026-09-07T00:00:00Z");
+
+    const ctx = makeContext();
+    await expect(
+      kgSnapshotPushStep.run(ctx, makeInputs({ clonedRef }), noopReporter),
+    ).rejects.toThrow(/git push failed/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("pushes but skips opening the PR when repoOwner/repoRepo are absent", async () => {
+    initGitRepo(tmpDir);
+    execSync(`git remote add origin "${bareDir}"`, { cwd: tmpDir, stdio: "ignore" });
+    execSync("git push origin HEAD:refs/heads/main", { cwd: tmpDir, stdio: "ignore" });
+    const clonedRef = resolveHead(tmpDir);
+
+    mkdirSync(join(tmpDir, "snapshot", "parts"), { recursive: true });
+    writeFileSync(join(tmpDir, "snapshot", "parts", "docs.nt"), "<s> <p> <o> .\n");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.npz"), "binary");
+    writeFileSync(join(tmpDir, "snapshot", "embeddings.stamp"), "2026-09-08T00:00:00Z");
+
+    const ctx = makeContext();
+    const result = await kgSnapshotPushStep.run(
+      ctx,
+      makeInputs({ clonedRef, repoOwner: undefined, repoRepo: undefined }),
+      noopReporter,
+    );
+    expect(result.snapshotPushed).toBe(true);
+    expect(result.prNumber).toBeNull();
+    expect(branchesOnBare()).toContain("refs/heads/kg-refresh/20260908T000000Z");
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 
@@ -4126,7 +4338,7 @@ describe("kgTrackerDataStep — KG_TRACKER_DATA_FILE preload", () => {
       noopReporter,
     );
 
-    expect(result).toEqual({ fetched: true, issueCount: 3 });
+    expect(result).toEqual({ fetched: true, issueCount: 3, teamCounts: [] });
     expect(written).toHaveLength(1);
     expect(written[0][0]).toBe(join(tmpDir, "tracker-data.json"));
     expect(JSON.parse(written[0][1])).toEqual(issues);
@@ -4142,7 +4354,7 @@ describe("kgTrackerDataStep — KG_TRACKER_DATA_FILE preload", () => {
       noopReporter,
     );
 
-    expect(result).toEqual({ fetched: true, issueCount: 0 });
+    expect(result).toEqual({ fetched: true, issueCount: 0, teamCounts: [] });
   });
 
   it("falls through to normal flow when KG_TRACKER_DATA_FILE points to a non-existent file", async () => {
@@ -4155,7 +4367,7 @@ describe("kgTrackerDataStep — KG_TRACKER_DATA_FILE preload", () => {
     );
 
     // callbackUrl is null → normal flow returns fetched=false
-    expect(result).toEqual({ fetched: false, issueCount: 0 });
+    expect(result).toEqual({ fetched: false, issueCount: 0, teamCounts: [] });
   });
 });
 

--- a/src/__tests__/kg-refresh.test.ts
+++ b/src/__tests__/kg-refresh.test.ts
@@ -768,6 +768,98 @@ describe("kg-refresh", () => {
       expect(s.stage).toBe("serving");
     });
 
+    // ---- AII-593: refresh PR opened by the runner ----------------------------------
+    it("onRunnerComplete success with snapshotPr merges the PR with the merge method, deletes the branch, then verifies the commit", async () => {
+      const mergePullRequestFn = vi.fn(async () => "merged" as const);
+      const deleteBranchFn = vi.fn(async () => true);
+      buildDispatch({ mergePullRequestFn, deleteBranchFn });
+      await handle.trigger();
+      await waitForStage("ingest-running");
+      handle.onRunnerComplete("success", { snapshotCommit: "abc123", snapshotPr: 7, snapshotBranch: "kg-refresh/20260909T120000Z" });
+      await waitDone();
+      expect(mergePullRequestFn).toHaveBeenCalledWith("tok", "TestOrg", "test-kg", 7, "abc123", "merge");
+      expect(deleteBranchFn).toHaveBeenCalledWith("tok", "TestOrg", "test-kg", "kg-refresh/20260909T120000Z");
+      expect(fetchCommitVisible).toHaveBeenCalledWith("tok", "TestOrg", "test-kg", "abc123");
+      const s = await handle.status();
+      expect(s.lastRefresh?.ok).toBe(true);
+      expect(s.stage).toBe("serving");
+    });
+
+    it("onRunnerComplete success with snapshotPr but no snapshotCommit refuses to merge and fails", async () => {
+      const mergePullRequestFn = vi.fn(async () => "merged" as const);
+      buildDispatch({ mergePullRequestFn });
+      await handle.trigger();
+      await waitForStage("ingest-running");
+      handle.onRunnerComplete("success", { snapshotPr: 7 });
+      await waitDone();
+      expect(mergePullRequestFn).not.toHaveBeenCalled();
+      expect(fetchCommitVisible).not.toHaveBeenCalled();
+      const s = await handle.status();
+      expect(s.stage).toBe("failed");
+      expect(s.running).toBe(false);
+      expect(s.lastRefresh?.ok).toBe(false);
+      expect(s.lastRefresh?.detail).toContain("refusing to merge");
+    });
+
+    it.each(["blocked", "conflict"] as const)("onRunnerComplete success: merge returns %s → failed, detail names the PR, rail does not run", async (result) => {
+      const mergePullRequestFn = vi.fn(async () => result);
+      const deleteBranchFn = vi.fn(async () => true);
+      buildDispatch({ mergePullRequestFn, deleteBranchFn });
+      await handle.trigger();
+      await waitForStage("ingest-running");
+      handle.onRunnerComplete("success", { snapshotCommit: "abc123", snapshotPr: 9, snapshotBranch: "kg-refresh/x" });
+      await waitDone();
+      expect(fetchCommitVisible).not.toHaveBeenCalled();
+      expect(deleteBranchFn).not.toHaveBeenCalled();
+      const s = await handle.status();
+      expect(s.stage).toBe("failed");
+      expect(s.lastRefresh?.detail).toContain("#9");
+      expect(s.lastRefresh?.detail).toContain(result);
+    });
+
+    it("onRunnerComplete success: merge throws → failed with the error in the detail", async () => {
+      const mergePullRequestFn = vi.fn(async () => { throw new Error("HTTP 405"); });
+      buildDispatch({ mergePullRequestFn });
+      await handle.trigger();
+      await waitForStage("ingest-running");
+      handle.onRunnerComplete("success", { snapshotCommit: "abc123", snapshotPr: 9 });
+      await waitDone();
+      const s = await handle.status();
+      expect(s.stage).toBe("failed");
+      expect(s.lastRefresh?.detail).toContain("HTTP 405");
+    });
+
+    it("onRunnerComplete failure with snapshotPr posts the gate comment, closes the PR and deletes the branch", async () => {
+      const postPrCommentFn = vi.fn(async () => undefined);
+      const closePullRequestFn = vi.fn(async () => undefined);
+      const deleteBranchFn = vi.fn(async () => true);
+      buildDispatch({ postPrCommentFn, closePullRequestFn, deleteBranchFn });
+      await handle.trigger();
+      await waitForStage("ingest-running");
+      handle.onRunnerComplete("failure", { failureCode: "KG_SNAPSHOT_CONTENT_REGRESSION", failureReason: "pr.nt shrank", snapshotPr: 11, snapshotBranch: "kg-refresh/20260909T120000Z" });
+      await waitDone();
+      await vi.waitFor(() => expect(deleteBranchFn).toHaveBeenCalled());
+      expect(postPrCommentFn).toHaveBeenCalledTimes(1);
+      const [, , , prNum, body] = postPrCommentFn.mock.calls[0] as unknown as [string, string, string, number, string];
+      expect(prNum).toBe(11);
+      expect(body).toContain("closing this refresh PR");
+      expect(body).toContain("KG_SNAPSHOT_CONTENT_REGRESSION");
+      expect(closePullRequestFn).toHaveBeenCalledWith("tok", "TestOrg", "test-kg", 11);
+      expect(deleteBranchFn).toHaveBeenCalledWith("tok", "TestOrg", "test-kg", "kg-refresh/20260909T120000Z");
+      const s = await handle.status();
+      expect(s.stage).toBe("failed");
+    });
+
+    it("onRunnerComplete failure without snapshotPr closes nothing", async () => {
+      const closePullRequestFn = vi.fn(async () => undefined);
+      buildDispatch({ closePullRequestFn });
+      await handle.trigger();
+      await waitForStage("ingest-running");
+      handle.onRunnerComplete("failure", { failureCode: "TIMEOUT", failureReason: "job timed out" });
+      await waitDone();
+      expect(closePullRequestFn).not.toHaveBeenCalled();
+    });
+
     it("git-cache retry: commit visible on second check proceeds to rail", async () => {
       let visibleCalls = 0;
       buildDispatch({

--- a/src/github.ts
+++ b/src/github.ts
@@ -870,6 +870,27 @@ export async function mergePullRequest(
   });
 }
 
+/**
+ * Closes an open PR without merging (state: "closed"). Used to close a kg-refresh
+ * snapshot PR whose callback reported failure, leaving a record of what was attempted.
+ */
+export async function closePullRequest(
+  token: string, owner: string, repo: string, prNumber: number,
+): Promise<void> {
+  const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`, {
+    method: "PATCH", headers: ghHeaders(token),
+    body: JSON.stringify({ state: "closed" }),
+    signal: defaultFetchSignal(),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new GitHubApiError({
+      status: res.status, path: `/repos/${owner}/${repo}/pulls/${prNumber}`,
+      bodyText: body, message: `closePullRequest(#${prNumber}) failed: HTTP ${res.status}: ${body}`,
+    });
+  }
+}
+
 export async function addCommentReaction(
   token: string,
   owner: string,

--- a/src/kg-refresh.ts
+++ b/src/kg-refresh.ts
@@ -6,7 +6,7 @@ import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import http from "node:http";
 import { getScopedInstallationToken } from "./github-app-auth.js";
-import { fetchRepoTarball } from "./github.js";
+import { fetchRepoTarball, mergePullRequest, closePullRequest, postPrComment } from "./github.js";
 import { extractSource, parseKgSourceRepo } from "./deploy.js";
 import { isDeployHeld } from "./deploy-hold.js";
 import { COMPLETION_MARKER, KG_DIR } from "./kg-sidecar.js";
@@ -128,7 +128,7 @@ export interface KgRefreshHandle {
    */
   onRunnerComplete(
     outcome: "success" | "failure",
-    data: { snapshotCommit?: string; failureCode?: string; failureReason?: string },
+    data: { snapshotCommit?: string; snapshotPr?: number; failureCode?: string; failureReason?: string },
   ): void;
   /**
    * Called by the reaper when the runner machine is found absent from the registry.
@@ -215,6 +215,12 @@ interface KgRefreshInput {
   fetchCommitVisible?: (token: string, owner: string, repo: string, sha: string) => Promise<boolean>;
   /** Delay between snapshot-commit visibility retries (default: 5000ms). */
   snapshotCommitRetryMs?: number;
+  /** Merge the runner-opened snapshot PR. Injectable for tests; defaults to mergePullRequest from github.ts. */
+  mergePullRequestFn?: typeof mergePullRequest;
+  /** Close the snapshot PR on a failed callback. Injectable for tests; defaults to closePullRequest from github.ts. */
+  closePullRequestFn?: typeof closePullRequest;
+  /** Post the closing comment on the snapshot PR. Injectable for tests; defaults to postPrComment from github.ts. */
+  postPrCommentFn?: typeof postPrComment;
   /** Resolve team key + dependency token scope for the mapping whose owner/repo equals the given string. Injectable for tests; defaults to () => undefined. */
   resolveMappingTeamKey?: (ownerRepo: string) => { teamKey: string; dependencyTokenScope: "installation" | null } | undefined;
   /**
@@ -395,6 +401,9 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
   const mintRunTokenFn = input.mintRunTokenFn ?? mintRunToken;
   const fetchCommitVisible = input.fetchCommitVisible ?? defaultFetchCommitVisible;
   const snapshotCommitRetryMs = input.snapshotCommitRetryMs ?? SNAPSHOT_COMMIT_RETRY_MS;
+  const mergePullRequestFn = input.mergePullRequestFn ?? mergePullRequest;
+  const closePullRequestFn = input.closePullRequestFn ?? closePullRequest;
+  const postPrCommentFn = input.postPrCommentFn ?? postPrComment;
   const persistStageFn = input.persistStage ?? defaultPersistStage;
   const loadStageFn = input.loadStage ?? defaultLoadStage;
   const persistLastRefreshFn = input.persistLastRefresh ?? defaultPersistLastRefresh;
@@ -675,6 +684,29 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
       void input.onOutcome?.("failure", { failureReason: outcome.detail, dispatchId: savedId ?? undefined });
     }
     if (savedJobId !== null) input.closeJobLog?.(savedJobId, outcome.ok ? "completed" : "failed");
+  }
+
+  /** Merges the runner-opened snapshot PR with the "merge" method — never squash/rebase, so `sha` (snapshotCommit) is verifiable as an ancestor of the resulting default-branch head. */
+  async function mergeSnapshotPr(owner: string, repoName: string, prNumber: number, sha: string): Promise<"merged" | "blocked" | "conflict"> {
+    const { token } = await mintToken(input.githubAppId, input.githubAppPrivateKey, owner, {
+      permissions: { contents: "write", pull_requests: "write" },
+      repositories: [repoName],
+    });
+    return mergePullRequestFn(token, owner, repoName, prNumber, sha, "merge");
+  }
+
+  /** Closes the snapshot PR with a comment naming the failing gate. Called only when the callback carries a snapshotPr. */
+  async function closeSnapshotPr(owner: string, repoName: string, prNumber: number, gate: string): Promise<void> {
+    const { token } = await mintToken(input.githubAppId, input.githubAppPrivateKey, owner, {
+      permissions: { contents: "write", pull_requests: "write" },
+      repositories: [repoName],
+    });
+    await postPrCommentFn(
+      token, owner, repoName, prNumber,
+      `AI-Implement: closing this refresh PR — the run failed (\`${gate}\`). The default branch was left untouched.`,
+    );
+    await closePullRequestFn(token, owner, repoName, prNumber);
+    console.log(`[kg-refresh] closed snapshot PR #${prNumber} (gate=${gate})`);
   }
 
   /** Shared terminal path for lost/timed-out ingest runners. No-op when stage ≠ ingest-running. */
@@ -995,6 +1027,15 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
         ingestStartedAt = null;
         persistStageFn("failed", Date.now());
         console.error(`[kg-refresh] runner failed: ${detail}`);
+        // A failed callback that still carries a snapshotPr means the runner opened the
+        // refresh PR before whatever failed — leave the default branch untouched, but
+        // close the dangling PR rather than leaving it open and unmerged.
+        if (data.snapshotPr && input.kgSourceRepo) {
+          const repoForClose = parseKgSourceRepo(input.kgSourceRepo);
+          void closeSnapshotPr(repoForClose.owner, repoForClose.repo, data.snapshotPr, detail).catch((err) => {
+            console.error(`[kg-refresh] failed to close snapshot PR #${data.snapshotPr}: ${String(err)}`);
+          });
+        }
         const savedJobIdF = currentJobId;
         currentJobId = null;
         const savedIdF = currentDispatchId;
@@ -1040,8 +1081,83 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
       // Verify the snapshot commit is visible (git-cache lag).
       const repo = parseKgSourceRepo(input.kgSourceRepo);
       const snapshotCommit = data.snapshotCommit;
+      const snapshotPr = data.snapshotPr;
 
       void (async () => {
+        if (snapshotPr) {
+          if (!snapshotCommit) {
+            // Can't safely merge without a sha to check the PR head against — refuse.
+            lastRefresh = {
+              ok: false,
+              at: Date.now(),
+              gate: "staging",
+              detail: `snapshot PR #${snapshotPr} reported without a snapshotCommit — refusing to merge`,
+              stampBefore: null,
+              stampAfter: null,
+            };
+            persistLastRefreshFn(lastRefresh);
+            running = false;
+            stage = "failed";
+            persistStageFn("failed", Date.now());
+            console.error(`[kg-refresh] snapshot PR #${snapshotPr} reported without a snapshotCommit — refusing to merge`);
+            const savedJobIdM = currentJobId;
+            currentJobId = null;
+            const savedIdM = currentDispatchId;
+            currentDispatchId = null;
+            void input.onOutcome?.("failure", {
+              failureReason: `snapshot PR #${snapshotPr} reported without a snapshotCommit`,
+              dispatchId: savedIdM ?? undefined,
+            });
+            if (savedJobIdM !== null) input.closeJobLog?.(savedJobIdM, "failed");
+            return;
+          }
+
+          try {
+            const mergeResult = await mergeSnapshotPr(repo.owner, repo.repo, snapshotPr, snapshotCommit);
+            if (mergeResult !== "merged") {
+              lastRefresh = {
+                ok: false,
+                at: Date.now(),
+                gate: "staging",
+                detail: `merging snapshot PR #${snapshotPr} returned '${mergeResult}'`,
+                stampBefore: null,
+                stampAfter: null,
+              };
+              persistLastRefreshFn(lastRefresh);
+              running = false;
+              stage = "failed";
+              persistStageFn("failed", Date.now());
+              console.error(`[kg-refresh] merging snapshot PR #${snapshotPr} returned '${mergeResult}'`);
+              const savedJobIdB = currentJobId;
+              currentJobId = null;
+              const savedIdB = currentDispatchId;
+              currentDispatchId = null;
+              void input.onOutcome?.("failure", {
+                failureReason: `merging snapshot PR #${snapshotPr} returned '${mergeResult}'`,
+                dispatchId: savedIdB ?? undefined,
+              });
+              if (savedJobIdB !== null) input.closeJobLog?.(savedJobIdB, "failed");
+              return;
+            }
+            console.log(`[kg-refresh] merged snapshot PR #${snapshotPr}`);
+          } catch (err) {
+            const msg = `merging snapshot PR #${snapshotPr} failed: ${String(err)}`;
+            lastRefresh = { ok: false, at: Date.now(), gate: "staging", detail: msg, stampBefore: null, stampAfter: null };
+            persistLastRefreshFn(lastRefresh);
+            running = false;
+            stage = "failed";
+            persistStageFn("failed", Date.now());
+            console.error(`[kg-refresh] ${msg}`);
+            const savedJobIdC = currentJobId;
+            currentJobId = null;
+            const savedIdC = currentDispatchId;
+            currentDispatchId = null;
+            void input.onOutcome?.("failure", { failureReason: msg, dispatchId: savedIdC ?? undefined });
+            if (savedJobIdC !== null) input.closeJobLog?.(savedJobIdC, "failed");
+            return;
+          }
+        }
+
         if (snapshotCommit) {
           // Mint a read token for the source repo to verify commit visibility.
           let visible = false;

--- a/src/kg-refresh.ts
+++ b/src/kg-refresh.ts
@@ -6,7 +6,7 @@ import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import http from "node:http";
 import { getScopedInstallationToken } from "./github-app-auth.js";
-import { fetchRepoTarball, mergePullRequest, closePullRequest, postPrComment } from "./github.js";
+import { fetchRepoTarball, mergePullRequest, closePullRequest, postPrComment, deleteBranch } from "./github.js";
 import { extractSource, parseKgSourceRepo } from "./deploy.js";
 import { isDeployHeld } from "./deploy-hold.js";
 import { COMPLETION_MARKER, KG_DIR } from "./kg-sidecar.js";
@@ -128,7 +128,7 @@ export interface KgRefreshHandle {
    */
   onRunnerComplete(
     outcome: "success" | "failure",
-    data: { snapshotCommit?: string; snapshotPr?: number; failureCode?: string; failureReason?: string },
+    data: { snapshotCommit?: string; snapshotPr?: number; snapshotBranch?: string; failureCode?: string; failureReason?: string },
   ): void;
   /**
    * Called by the reaper when the runner machine is found absent from the registry.
@@ -219,6 +219,8 @@ interface KgRefreshInput {
   mergePullRequestFn?: typeof mergePullRequest;
   /** Close the snapshot PR on a failed callback. Injectable for tests; defaults to closePullRequest from github.ts. */
   closePullRequestFn?: typeof closePullRequest;
+  /** Delete the `kg-refresh/<stamp>` branch after merge or close. Injectable for tests; defaults to deleteBranch from github.ts. */
+  deleteBranchFn?: typeof deleteBranch;
   /** Post the closing comment on the snapshot PR. Injectable for tests; defaults to postPrComment from github.ts. */
   postPrCommentFn?: typeof postPrComment;
   /** Resolve team key + dependency token scope for the mapping whose owner/repo equals the given string. Injectable for tests; defaults to () => undefined. */
@@ -403,6 +405,7 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
   const snapshotCommitRetryMs = input.snapshotCommitRetryMs ?? SNAPSHOT_COMMIT_RETRY_MS;
   const mergePullRequestFn = input.mergePullRequestFn ?? mergePullRequest;
   const closePullRequestFn = input.closePullRequestFn ?? closePullRequest;
+  const deleteBranchFn = input.deleteBranchFn ?? deleteBranch;
   const postPrCommentFn = input.postPrCommentFn ?? postPrComment;
   const persistStageFn = input.persistStage ?? defaultPersistStage;
   const loadStageFn = input.loadStage ?? defaultLoadStage;
@@ -696,7 +699,21 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
   }
 
   /** Closes the snapshot PR with a comment naming the failing gate. Called only when the callback carries a snapshotPr. */
-  async function closeSnapshotPr(owner: string, repoName: string, prNumber: number, gate: string): Promise<void> {
+  /** Best-effort: delete the per-refresh branch so the KG repo does not accumulate one branch per refresh. Never fails the refresh. */
+  async function deleteSnapshotBranch(owner: string, repoName: string, branch: string): Promise<void> {
+    try {
+      const { token } = await mintToken(input.githubAppId, input.githubAppPrivateKey, owner, {
+        permissions: { contents: "write" },
+        repositories: [repoName],
+      });
+      await deleteBranchFn(token, owner, repoName, branch);
+      console.log(`[kg-refresh] deleted snapshot branch ${branch}`);
+    } catch (err) {
+      console.warn(`[kg-refresh] could not delete snapshot branch ${branch}: ${String(err)}`);
+    }
+  }
+
+  async function closeSnapshotPr(owner: string, repoName: string, prNumber: number, gate: string, branch?: string): Promise<void> {
     const { token } = await mintToken(input.githubAppId, input.githubAppPrivateKey, owner, {
       permissions: { contents: "write", pull_requests: "write" },
       repositories: [repoName],
@@ -707,6 +724,7 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
     );
     await closePullRequestFn(token, owner, repoName, prNumber);
     console.log(`[kg-refresh] closed snapshot PR #${prNumber} (gate=${gate})`);
+    if (branch) await deleteSnapshotBranch(owner, repoName, branch);
   }
 
   /** Shared terminal path for lost/timed-out ingest runners. No-op when stage ≠ ingest-running. */
@@ -1032,7 +1050,7 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
         // close the dangling PR rather than leaving it open and unmerged.
         if (data.snapshotPr && input.kgSourceRepo) {
           const repoForClose = parseKgSourceRepo(input.kgSourceRepo);
-          void closeSnapshotPr(repoForClose.owner, repoForClose.repo, data.snapshotPr, detail).catch((err) => {
+          void closeSnapshotPr(repoForClose.owner, repoForClose.repo, data.snapshotPr, detail, data.snapshotBranch).catch((err) => {
             console.error(`[kg-refresh] failed to close snapshot PR #${data.snapshotPr}: ${String(err)}`);
           });
         }
@@ -1082,80 +1100,43 @@ export function makeKgRefresh(input: KgRefreshInput): KgRefreshHandle {
       const repo = parseKgSourceRepo(input.kgSourceRepo);
       const snapshotCommit = data.snapshotCommit;
       const snapshotPr = data.snapshotPr;
+      const snapshotBranch = data.snapshotBranch;
+
+      /** Ends the refresh as failed from the snapshot-PR step: records lastRefresh, clears the ids, reports the outcome. */
+      const failSnapshotPrStep = (detail: string): void => {
+        lastRefresh = { ok: false, at: Date.now(), gate: "staging", detail, stampBefore: null, stampAfter: null };
+        persistLastRefreshFn(lastRefresh);
+        running = false;
+        stage = "failed";
+        persistStageFn("failed", Date.now());
+        console.error(`[kg-refresh] ${detail}`);
+        const savedJobId = currentJobId;
+        currentJobId = null;
+        const savedId = currentDispatchId;
+        currentDispatchId = null;
+        void input.onOutcome?.("failure", { failureReason: detail, dispatchId: savedId ?? undefined });
+        if (savedJobId !== null) input.closeJobLog?.(savedJobId, "failed");
+      };
 
       void (async () => {
         if (snapshotPr) {
           if (!snapshotCommit) {
             // Can't safely merge without a sha to check the PR head against — refuse.
-            lastRefresh = {
-              ok: false,
-              at: Date.now(),
-              gate: "staging",
-              detail: `snapshot PR #${snapshotPr} reported without a snapshotCommit — refusing to merge`,
-              stampBefore: null,
-              stampAfter: null,
-            };
-            persistLastRefreshFn(lastRefresh);
-            running = false;
-            stage = "failed";
-            persistStageFn("failed", Date.now());
-            console.error(`[kg-refresh] snapshot PR #${snapshotPr} reported without a snapshotCommit — refusing to merge`);
-            const savedJobIdM = currentJobId;
-            currentJobId = null;
-            const savedIdM = currentDispatchId;
-            currentDispatchId = null;
-            void input.onOutcome?.("failure", {
-              failureReason: `snapshot PR #${snapshotPr} reported without a snapshotCommit`,
-              dispatchId: savedIdM ?? undefined,
-            });
-            if (savedJobIdM !== null) input.closeJobLog?.(savedJobIdM, "failed");
+            failSnapshotPrStep(`snapshot PR #${snapshotPr} reported without a snapshotCommit — refusing to merge`);
             return;
           }
-
           try {
             const mergeResult = await mergeSnapshotPr(repo.owner, repo.repo, snapshotPr, snapshotCommit);
             if (mergeResult !== "merged") {
-              lastRefresh = {
-                ok: false,
-                at: Date.now(),
-                gate: "staging",
-                detail: `merging snapshot PR #${snapshotPr} returned '${mergeResult}'`,
-                stampBefore: null,
-                stampAfter: null,
-              };
-              persistLastRefreshFn(lastRefresh);
-              running = false;
-              stage = "failed";
-              persistStageFn("failed", Date.now());
-              console.error(`[kg-refresh] merging snapshot PR #${snapshotPr} returned '${mergeResult}'`);
-              const savedJobIdB = currentJobId;
-              currentJobId = null;
-              const savedIdB = currentDispatchId;
-              currentDispatchId = null;
-              void input.onOutcome?.("failure", {
-                failureReason: `merging snapshot PR #${snapshotPr} returned '${mergeResult}'`,
-                dispatchId: savedIdB ?? undefined,
-              });
-              if (savedJobIdB !== null) input.closeJobLog?.(savedJobIdB, "failed");
+              failSnapshotPrStep(`merging snapshot PR #${snapshotPr} returned '${mergeResult}'`);
               return;
             }
             console.log(`[kg-refresh] merged snapshot PR #${snapshotPr}`);
           } catch (err) {
-            const msg = `merging snapshot PR #${snapshotPr} failed: ${String(err)}`;
-            lastRefresh = { ok: false, at: Date.now(), gate: "staging", detail: msg, stampBefore: null, stampAfter: null };
-            persistLastRefreshFn(lastRefresh);
-            running = false;
-            stage = "failed";
-            persistStageFn("failed", Date.now());
-            console.error(`[kg-refresh] ${msg}`);
-            const savedJobIdC = currentJobId;
-            currentJobId = null;
-            const savedIdC = currentDispatchId;
-            currentDispatchId = null;
-            void input.onOutcome?.("failure", { failureReason: msg, dispatchId: savedIdC ?? undefined });
-            if (savedJobIdC !== null) input.closeJobLog?.(savedJobIdC, "failed");
+            failSnapshotPrStep(`merging snapshot PR #${snapshotPr} failed: ${String(err)}`);
             return;
           }
+          if (snapshotBranch) await deleteSnapshotBranch(repo.owner, repo.repo, snapshotBranch);
         }
 
         if (snapshotCommit) {

--- a/src/pipeline/kg-refresh-run.ts
+++ b/src/pipeline/kg-refresh-run.ts
@@ -255,6 +255,7 @@ export async function runKgRefresh(opts: RunKgRefreshOptions = {}): Promise<RunK
     outcome: "success",
     snapshotCommit: typeof snapshotPushOutputs.commitSha === "string" ? snapshotPushOutputs.commitSha : undefined,
     snapshotPr: typeof snapshotPushOutputs.prNumber === "number" ? snapshotPushOutputs.prNumber : undefined,
+    snapshotBranch: typeof snapshotPushOutputs.branchName === "string" ? snapshotPushOutputs.branchName : undefined,
     callbackUrl,
     fetchImpl: opts.fetchImpl,
   });

--- a/src/pipeline/kg-refresh-run.ts
+++ b/src/pipeline/kg-refresh-run.ts
@@ -248,10 +248,13 @@ export async function runKgRefresh(opts: RunKgRefreshOptions = {}): Promise<RunK
     return { exitCode: 1 };
   }
 
+  const snapshotPushOutputs = context.getOutputs("kg-snapshot-push");
   await postRunnerResult({
     phase: "kg-refresh",
     workspaceDir,
     outcome: "success",
+    snapshotCommit: typeof snapshotPushOutputs.commitSha === "string" ? snapshotPushOutputs.commitSha : undefined,
+    snapshotPr: typeof snapshotPushOutputs.prNumber === "number" ? snapshotPushOutputs.prNumber : undefined,
     callbackUrl,
     fetchImpl: opts.fetchImpl,
   });

--- a/src/pipeline/step-utils.ts
+++ b/src/pipeline/step-utils.ts
@@ -1,5 +1,79 @@
 import type { LLMResult } from "./types.js";
 
+export const UNAPPROVED_TITLE_PREFIX = "[NEEDS REVIEW — unapproved] ";
+
+export interface OpenOrFindPullRequestInputs {
+  repoOwner: string;
+  repoRepo: string;
+  githubToken: string;
+  prTitle: string;
+  branchName: string;
+  baseBranch: string;
+  prBody: string;
+  draft: boolean;
+}
+
+/**
+ * Create the PR, tolerating 422 (already exists) by finding the open PR. Shared
+ * between push.ts (implementation PRs, which may be draft) and kg-snapshot-push.ts
+ * (refresh PRs, always non-draft) — see ADR 013: no second PR helper.
+ */
+export async function openOrFindPullRequest(
+  inputs: OpenOrFindPullRequestInputs,
+): Promise<{ url: string; number: number; draft: boolean }> {
+  const { repoOwner, repoRepo, githubToken, prTitle, branchName, baseBranch, prBody, draft } = inputs;
+
+  const create = async (title: string, asDraft: boolean): Promise<Response> =>
+    fetch(`https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${githubToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ title, head: branchName, base: baseBranch, body: prBody, ...(asDraft ? { draft: true } : {}) }),
+    });
+
+  const parseCreated = async (res: Response, asDraft: boolean): Promise<{ url: string; number: number; draft: boolean }> => {
+    const pr = (await res.json()) as { html_url?: unknown; number?: unknown };
+    if (typeof pr.html_url !== "string" || typeof pr.number !== "number") {
+      throw new Error("Unexpected PR creation response shape from GitHub API");
+    }
+    return { url: pr.html_url, number: pr.number, draft: asDraft };
+  };
+
+  const prRes = await create(prTitle, draft);
+  if (prRes.ok) return parseCreated(prRes, draft);
+
+  if (prRes.status === 422) {
+    // Ambiguous: either the PR already exists, or the repo plan rejects draft
+    // PRs. Check for an existing open PR first (existing behavior), then — if
+    // we were drafting — retry as a clearly-titled normal PR so the work is
+    // never vaporized on Free-plan private repos.
+    const listRes = await fetch(
+      `https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls?head=${repoOwner}:${branchName}&state=open`,
+      { headers: { Authorization: `Bearer ${githubToken}` } },
+    );
+    if (!listRes.ok) {
+      const listBody = await listRes.text().catch(() => "");
+      throw new Error(`PR already exists (422) but listing open PRs failed with HTTP ${listRes.status}: ${listBody}`);
+    }
+    const prs = (await listRes.json()) as Array<{ html_url?: unknown; number?: unknown; draft?: unknown }>;
+    if (prs.length > 0) {
+      const existing = prs[0];
+      if (typeof existing.html_url === "string" && typeof existing.number === "number") {
+        return { url: existing.html_url, number: existing.number, draft: existing.draft === true };
+      }
+    }
+    if (draft) {
+      const retryRes = await create(`${UNAPPROVED_TITLE_PREFIX}${prTitle}`, false);
+      if (retryRes.ok) return parseCreated(retryRes, false);
+      const retryBody = await retryRes.text().catch(() => "");
+      throw new Error(`Draft PR rejected (422) and non-draft fallback failed with HTTP ${retryRes.status}: ${retryBody}`);
+    }
+    throw new Error(`PR already exists (422) but no open PR found for branch ${branchName}`);
+  }
+
+  const body = await prRes.text().catch(() => "");
+  throw new Error(`PR creation failed with HTTP ${prRes.status}: ${body}`);
+}
+
 export function formatLlmResultDetail(result: { stdout?: string; stderr?: string }): string {
   const detail = (result.stderr || result.stdout || "").trim();
   return detail ? `: ${detail}` : "";

--- a/src/pipeline/steps/kg-snapshot-push.ts
+++ b/src/pipeline/steps/kg-snapshot-push.ts
@@ -74,6 +74,8 @@ interface KgSnapshotPushOutputs extends Record<string, unknown> {
   commitSha: string | null;
   /** PR number of the opened refresh PR. Null in mounted/dry-run mode or when repoOwner/repoRepo are absent. */
   prNumber: number | null;
+  /** The per-refresh branch (`kg-refresh/<stamp>`) the snapshot was pushed to. Null when nothing was pushed. */
+  branchName: string | null;
 }
 
 interface KgStats {
@@ -264,7 +266,7 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
     if (process.env.AI_IMPLEMENT_WORKSPACE_MODE === "mounted") {
       // Dev-harness mounted workspace: never push. Leave snapshot changes in the
       // mount for the developer to inspect.
-      return { snapshotPushed: false, commitSha: null, prNumber: null };
+      return { snapshotPushed: false, commitSha: null, prNumber: null, branchName: null };
     }
 
     const { workspaceDir, githubToken, defaultBranch, clonedRef, dryRun, repoOwner, repoRepo } = inputs;
@@ -464,7 +466,7 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
     if (dryRun) {
       console.log("[kg-snapshot-push] dry-run: all guards passed; skipping commit, push, and PR");
       console.log(reportBody);
-      return { snapshotPushed: false, commitSha: null, prNumber: null };
+      return { snapshotPushed: false, commitSha: null, prNumber: null, branchName: null };
     }
 
     // ── 5. Commit snapshot/ ──────────────────────────────────────────────────
@@ -534,7 +536,7 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
       // Dev/test scenario with no target repo identity: the branch pushed, but there is
       // nothing to build a GitHub API URL from, so the refresh PR cannot be opened.
       console.warn("[kg-snapshot-push] repoOwner/repoRepo absent — pushed the branch but skipped opening the refresh PR");
-      return { snapshotPushed: true, commitSha, prNumber: null };
+      return { snapshotPushed: true, commitSha, prNumber: null, branchName };
     }
 
     const quadsLabel = stats?.quads != null ? String(stats.quads) : "?";
@@ -551,7 +553,7 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
     });
     console.log(`[kg-snapshot-push] pr opened #${pr.number}`);
 
-    return { snapshotPushed: true, commitSha, prNumber: pr.number };
+    return { snapshotPushed: true, commitSha, prNumber: pr.number, branchName };
   },
 };
 

--- a/src/pipeline/steps/kg-snapshot-push.ts
+++ b/src/pipeline/steps/kg-snapshot-push.ts
@@ -1,8 +1,10 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
 import { refreshRunnerGithubCredentials } from "../../runner-token.js";
+import { openOrFindPullRequest } from "../step-utils.js";
+import { readSecondaryReposFromSourcesYml } from "./kg-tracker-data.js";
 
 /** Coded failure raised when the snapshot parts or embeddings file are absent. */
 export class KgSnapshotMissingError extends Error {
@@ -70,6 +72,8 @@ interface KgSnapshotPushInputs extends Record<string, unknown> {
 interface KgSnapshotPushOutputs extends Record<string, unknown> {
   snapshotPushed: boolean;
   commitSha: string | null;
+  /** PR number of the opened refresh PR. Null in mounted/dry-run mode or when repoOwner/repoRepo are absent. */
+  prNumber: number | null;
 }
 
 interface KgStats {
@@ -147,6 +151,91 @@ function readPreviousStamp(workspaceDir: string, clonedRef: string): string | nu
   return r.stdout.toString().trim() || null;
 }
 
+/** Compacts a validated ISO-8601 stamp (Z or ±HH:MM offset) to YYYYMMDDTHHMMSSZ for the branch name. */
+function compactStamp(stamp: string): string {
+  return new Date(stamp).toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+/** Lines from ai-output/kg-ingest.log tagged WARN(ING) or ERROR — the report's warnings section. */
+function readIngestWarnings(workspaceDir: string): string[] {
+  const logPath = join(workspaceDir, "ai-output", "kg-ingest.log");
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf-8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && /\bWARN(ING)?\b|\bERROR\b/.test(l));
+}
+
+/** Branch + commit for each secondary repo cloned under repos/<name> by clone-secondary-repos. */
+function readSecondaryRepoOutcomes(workspaceDir: string): Array<{ slug: string; branch: string; commit: string }> {
+  const entries = readSecondaryReposFromSourcesYml(workspaceDir);
+  const results: Array<{ slug: string; branch: string; commit: string }> = [];
+  for (const entry of entries) {
+    const dir = join(workspaceDir, "repos", basename(entry.slug));
+    if (!existsSync(dir)) continue;
+    const branchResult = spawnSync("git", ["branch", "--show-current"], { cwd: dir, stdio: ["ignore", "pipe", "pipe"] });
+    const commitResult = spawnSync("git", ["rev-parse", "HEAD"], { cwd: dir, stdio: ["ignore", "pipe", "pipe"] });
+    results.push({
+      slug: entry.slug,
+      branch: branchResult.status === 0 ? (branchResult.stdout.toString().trim() || "unknown") : "unknown",
+      commit: commitResult.status === 0 ? (commitResult.stdout.toString().trim() || "unknown") : "unknown",
+    });
+  }
+  return results;
+}
+
+interface RefreshReportInputs {
+  stampCompact: string;
+  quads: number | null;
+  partRows: Array<{ part: string; prev: string; next: string; delta: string }>;
+  teamCounts: Array<{ team: string; count: number }>;
+  secondaryRepos: Array<{ slug: string; branch: string; commit: string }>;
+  ingestWarnings: string[];
+  guardVerdict: string;
+}
+
+/**
+ * Markdown report: per-part line-count table, quads, issue counts by team,
+ * secondary-repo outcomes, ingest warnings, and the guard verdict. Becomes the
+ * refresh PR body (real run) or is printed to the log (dry run) — same shape either way.
+ */
+function buildRefreshReport(data: RefreshReportInputs): string {
+  const lines: string[] = [
+    `## kg-refresh report — ${data.stampCompact}`,
+    "",
+    `**Guard verdict:** ${data.guardVerdict}`,
+    "",
+    "### Per-part line counts",
+    "",
+    "| Part | Prev | New | Delta |",
+    "|---|---|---|---|",
+  ];
+  if (data.partRows.length === 0) {
+    lines.push("| _(no previous snapshot to diff against)_ | | | |");
+  } else {
+    for (const row of data.partRows) lines.push(`| ${row.part} | ${row.prev} | ${row.next} | ${row.delta} |`);
+  }
+  lines.push("", `**Quads serialized:** ${data.quads ?? "unknown"}`, "", "### Issues by team", "");
+  if (data.teamCounts.length === 0) {
+    lines.push("_(no tracker data fetched this run)_");
+  } else {
+    for (const tc of data.teamCounts) lines.push(`- ${tc.team}: ${tc.count}`);
+  }
+  lines.push("", "### Secondary repositories", "");
+  if (data.secondaryRepos.length === 0) {
+    lines.push("_(none configured)_");
+  } else {
+    for (const r of data.secondaryRepos) lines.push(`- \`${r.slug}\` @ ${r.branch} (${r.commit})`);
+  }
+  lines.push("", "### Ingest warnings", "");
+  if (data.ingestWarnings.length === 0) {
+    lines.push("_(none)_");
+  } else {
+    for (const w of data.ingestWarnings) lines.push(`- ${w}`);
+  }
+  return lines.join("\n");
+}
+
 function buildCommitMessage(stats: KgStats | null): string {
   const parts: string[] = ["kg-refresh: update snapshot"];
   if (stats) {
@@ -175,10 +264,12 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
     if (process.env.AI_IMPLEMENT_WORKSPACE_MODE === "mounted") {
       // Dev-harness mounted workspace: never push. Leave snapshot changes in the
       // mount for the developer to inspect.
-      return { snapshotPushed: false, commitSha: null };
+      return { snapshotPushed: false, commitSha: null, prNumber: null };
     }
 
     const { workspaceDir, githubToken, defaultBranch, clonedRef, dryRun, repoOwner, repoRepo } = inputs;
+    /** Per-part "prev/new/delta" rows for the report table. Populated by guard 0b when a previous snapshot exists. */
+    const partRows: Array<{ part: string; prev: string; next: string; delta: string }> = [];
 
     // ── 0. Tracker regression guard ──────────────────────────────────────────
     // If the tracker-data step did not fetch (fetched=false) and the previous
@@ -251,12 +342,15 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
           const newPartPath = join(workspaceDir, "snapshot", "parts", partName);
           if (!existsSync(newPartPath)) {
             partLogLines.push(`${partName} prev=${prevLines} new=missing`);
+            partRows.push({ part: partName, prev: String(prevLines), next: "missing", delta: "—" });
             regressions.push(`${partName}: missing (was ${prevLines} lines)`);
             continue;
           }
 
           const newLines = readFileSync(newPartPath, "utf-8").split("\n").filter(Boolean).length;
           partLogLines.push(`${partName} prev=${prevLines} new=${newLines}`);
+          const delta = newLines - prevLines;
+          partRows.push({ part: partName, prev: String(prevLines), next: String(newLines), delta: `${delta >= 0 ? "+" : ""}${delta}` });
 
           if (TRACKER_NT_FILES.has(partName) && issueCount > 0 && newLines < prevLines) {
             regressions.push(
@@ -336,15 +430,9 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
       }
     }
 
-    // ── dry-run exit ─────────────────────────────────────────────────────────
-    // All guards and validation passed. In dry-run mode (dev-harness kg-refresh)
-    // skip the commit and push; the per-part table was already printed above.
-    if (dryRun) {
-      console.log("[kg-snapshot-push] dry-run: all guards passed; skipping commit and push");
-      return { snapshotPushed: false, commitSha: null };
-    }
-
-    // ── 4. Read stats (best-effort) ──────────────────────────────────────────
+    // ── 4. Read stats (best-effort) ───────────────────────────────────────────
+    // Read before the dry-run exit: the report (printed in dry-run, and the PR
+    // body on a real run) needs the quads figure either way.
     let stats: KgStats | null = null;
     const statsPath = join(workspaceDir, "ai-output", "kg-stats.json");
     if (existsSync(statsPath)) {
@@ -355,6 +443,28 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
       }
     } else {
       console.warn("[kg-snapshot-push] ai-output/kg-stats.json absent; commit message will be minimal");
+    }
+
+    const stampCompact = compactStamp(currentStamp);
+    const rawTeamCounts = trackerOutputs.teamCounts;
+    const teamCounts = Array.isArray(rawTeamCounts) ? (rawTeamCounts as Array<{ team: string; count: number }>) : [];
+    const reportBody = buildRefreshReport({
+      stampCompact,
+      quads: stats?.quads ?? null,
+      partRows,
+      teamCounts,
+      secondaryRepos: readSecondaryRepoOutcomes(workspaceDir),
+      ingestWarnings: readIngestWarnings(workspaceDir),
+      guardVerdict: dryRun ? "clean (dry-run — no push)" : "clean",
+    });
+
+    // ── dry-run exit ─────────────────────────────────────────────────────────
+    // All guards and validation passed. In dry-run mode (dev-harness kg-refresh)
+    // skip the commit, push, and PR; print the report instead.
+    if (dryRun) {
+      console.log("[kg-snapshot-push] dry-run: all guards passed; skipping commit, push, and PR");
+      console.log(reportBody);
+      return { snapshotPushed: false, commitSha: null, prNumber: null };
     }
 
     // ── 5. Commit snapshot/ ──────────────────────────────────────────────────
@@ -382,7 +492,7 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
     runGit(workspaceDir, ["commit", "-m", commitMessage], githubToken, "git commit");
     const commitSha = resolveHeadSha(workspaceDir);
 
-    // ── 6. Push directly to default branch (no PR, no feature branch) ────────
+    // ── 6. Push to a per-refresh branch and open the refresh PR ──────────────
     // Refresh the dispatch-time token immediately before the push — the same
     // pattern as push.ts. In Fly/local-docker mode the machine nonce re-mints a
     // fresh token; in GHA mode this returns the current token unchanged.
@@ -395,14 +505,13 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
       repo: repoRepo ?? "",
       workspaceDir,
     });
+    const branchName = `kg-refresh/${stampCompact}`;
     // Push with that token embedded in the origin URL — the shape push.ts uses.
     // The entrypoint strips the token from origin at start, and in GitHub Actions
     // mode the refresh does not re-embed it, so without this the push falls to
     // whichever credential helper answers first for github.com; on 2026-09-08
     // that was dependency-auth's read-only token (403). Set through git config,
     // never printed; runGit redacts the token.
-    // --force-with-lease compares against refs/remotes/origin/<defaultBranch>
-    // which the clone step populated.
     if (repoOwner && repoRepo) {
       runGit(
         workspaceDir,
@@ -411,9 +520,38 @@ export const kgSnapshotPushStep: StepModule<KgSnapshotPushInputs, KgSnapshotPush
         "git remote set-url origin",
       );
     }
-    runGit(workspaceDir, ["push", "origin", `HEAD:refs/heads/${defaultBranch}`, "--force-with-lease"], activeGithubToken, "git push");
+    // The branch is new per refresh (stamped), so the lease's expected value is
+    // "ref must not currently exist" — an explicit empty expected-sha, not the
+    // ambiguous bare form, since there is no local tracking ref for a brand-new branch.
+    runGit(
+      workspaceDir,
+      ["push", "origin", `HEAD:refs/heads/${branchName}`, `--force-with-lease=refs/heads/${branchName}:`],
+      activeGithubToken,
+      "git push",
+    );
 
-    return { snapshotPushed: true, commitSha };
+    if (!repoOwner || !repoRepo) {
+      // Dev/test scenario with no target repo identity: the branch pushed, but there is
+      // nothing to build a GitHub API URL from, so the refresh PR cannot be opened.
+      console.warn("[kg-snapshot-push] repoOwner/repoRepo absent — pushed the branch but skipped opening the refresh PR");
+      return { snapshotPushed: true, commitSha, prNumber: null };
+    }
+
+    const quadsLabel = stats?.quads != null ? String(stats.quads) : "?";
+    const prTitle = `kg-refresh: snapshot @ ${stampCompact} (${quadsLabel} quads)`;
+    const pr = await openOrFindPullRequest({
+      repoOwner,
+      repoRepo,
+      githubToken: activeGithubToken,
+      prTitle,
+      branchName,
+      baseBranch: defaultBranch,
+      prBody: reportBody,
+      draft: false,
+    });
+    console.log(`[kg-snapshot-push] pr opened #${pr.number}`);
+
+    return { snapshotPushed: true, commitSha, prNumber: pr.number };
   },
 };
 

--- a/src/pipeline/steps/kg-tracker-data.ts
+++ b/src/pipeline/steps/kg-tracker-data.ts
@@ -17,6 +17,25 @@ interface KgTrackerDataInputs extends Record<string, unknown> {
 interface KgTrackerDataOutputs extends Record<string, unknown> {
   fetched: boolean;
   issueCount: number;
+  /** Per-team issue counts, for the kg-refresh report. Empty when fetched=false. */
+  teamCounts: Array<{ team: string; count: number }>;
+}
+
+/**
+ * Best-effort per-team breakdown for the dev-harness preloaded-data path, which has
+ * no per-team fetch loop to count against. Groups by the identifier prefix (e.g.
+ * "AII" from "AII-593") — the same convention every tracker identifier follows.
+ */
+function deriveTeamCountsFromIdentifiers(issues: unknown[]): Array<{ team: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const issue of issues) {
+    if (issue === null || typeof issue !== "object") continue;
+    const identifier = (issue as Record<string, unknown>).identifier;
+    if (typeof identifier !== "string") continue;
+    const team = identifier.split("-")[0] || "unknown";
+    counts.set(team, (counts.get(team) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([team, count]) => ({ team, count }));
 }
 
 /** Coded failure raised when the tracker-data fetch fails in a dispatched run. */
@@ -260,7 +279,14 @@ export const kgTrackerDataStep: StepModule<KgTrackerDataInputs, KgTrackerDataOut
       }
       writeFn(join(workspaceDir, "tracker-data.json"), content);
       console.log(`[kg-tracker-data] using pre-fetched data from ${preloadedFile}: ${issueCount} issues`);
-      return { fetched: true, issueCount };
+      let teamCounts: Array<{ team: string; count: number }> = [];
+      try {
+        const parsed = JSON.parse(content) as unknown;
+        teamCounts = deriveTeamCountsFromIdentifiers(Array.isArray(parsed) ? parsed : []);
+      } catch {
+        // malformed JSON — leave teamCounts empty
+      }
+      return { fetched: true, issueCount, teamCounts };
     }
 
     // Read the bearer secret directly from the environment so it never appears
@@ -269,23 +295,24 @@ export const kgTrackerDataStep: StepModule<KgTrackerDataInputs, KgTrackerDataOut
 
     if (!callbackUrl) {
       console.log("[kg-tracker-data] no callback URL; skipping");
-      return { fetched: false, issueCount: 0 };
+      return { fetched: false, issueCount: 0, teamCounts: [] };
     }
     if (!progressToken) {
       console.log("[kg-tracker-data] no progress token (RUN_PROGRESS_TOKEN); skipping");
-      return { fetched: false, issueCount: 0 };
+      return { fetched: false, issueCount: 0, teamCounts: [] };
     }
 
     const teams = readTeams(workspaceDir);
     if (teams.length === 0) {
       console.warn("[kg-tracker-data] no teams found in sources.yml; skipping");
-      return { fetched: false, issueCount: 0 };
+      return { fetched: false, issueCount: 0, teamCounts: [] };
     }
     console.log(`[kg-tracker-data] teams from sources.yml: ${teams.join(", ")}`);
 
     const base = callbackUrl.replace(/\/+$/, "");
     const url = `${base}/api/runner/kg-tracker-data`;
     const allIssues: TrackerIssue[] = [];
+    const teamCounts: Array<{ team: string; count: number }> = [];
 
     for (const team of teams) {
       let cursor: string | null = null;
@@ -305,7 +332,7 @@ export const kgTrackerDataStep: StepModule<KgTrackerDataInputs, KgTrackerDataOut
           });
           if (res.status === 503) {
             console.log("[kg-tracker-data] Tracker not configured (503) — skipping");
-            return { fetched: false, issueCount: 0 };
+            return { fetched: false, issueCount: 0, teamCounts: [] };
           }
           if (!res.ok) {
             console.error(`[kg-tracker-data] ${url} returned HTTP ${res.status}`);
@@ -328,11 +355,12 @@ export const kgTrackerDataStep: StepModule<KgTrackerDataInputs, KgTrackerDataOut
           `team ${team} returned 0 issues — a configured team must not be empty`,
         );
       }
+      teamCounts.push({ team, count: teamIssues.length });
       allIssues.push(...teamIssues);
     }
 
     writeFn(join(workspaceDir, "tracker-data.json"), JSON.stringify(allIssues));
     console.log(`[kg-tracker-data] fetched ${allIssues.length} issues`);
-    return { fetched: true, issueCount: allIssues.length };
+    return { fetched: true, issueCount: allIssues.length, teamCounts };
   },
 };

--- a/src/pipeline/steps/push.ts
+++ b/src/pipeline/steps/push.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import type { PipelineContext, StepModule, StepReporter } from "../types.js";
-import { formatGitNameStatusSummary } from "../step-utils.js";
+import { formatGitNameStatusSummary, openOrFindPullRequest, UNAPPROVED_TITLE_PREFIX } from "../step-utils.js";
 import { span } from "../timing.js";
 import { findSensitiveFiles, SensitiveFilesError } from "../sensitive-files.js";
 import { refreshRunnerGithubCredentials } from "../../runner-token.js";
@@ -9,7 +9,7 @@ import { getPublicationCredential } from "../../publication-credential.js";
 const LS_REMOTE_MAX_ATTEMPTS = 3;
 const LS_REMOTE_RETRY_DELAYS_MS = [250, 1000];
 
-export const UNAPPROVED_TITLE_PREFIX = "[NEEDS REVIEW — unapproved] ";
+export { UNAPPROVED_TITLE_PREFIX };
 
 export interface ReviewSummary extends Record<string, unknown> {
   terminationReason: string;
@@ -256,79 +256,11 @@ export const pushStep: StepModule<PushInputs, PushOutputs> = {
     // Span covers the POST and the 422 list-open-PRs fallback so re-runs (which
     // hit 422 and pay an extra round-trip) are timed in full, not just the POST.
     const pr = await span("pr-create", async () =>
-      createOrFindPullRequest({ repoOwner, repoRepo, githubToken: activeGithubToken, prTitle, branchName, baseBranch, prBody, draft }),
+      openOrFindPullRequest({ repoOwner, repoRepo, githubToken: activeGithubToken, prTitle, branchName, baseBranch, prBody, draft }),
     );
     return { prUrl: pr.url, prNumber: pr.number, branchPushed: true, commitSha, draft: pr.draft };
   },
 };
-
-interface CreatePrInputs {
-  repoOwner: string;
-  repoRepo: string;
-  githubToken: string;
-  prTitle: string;
-  branchName: string;
-  baseBranch: string;
-  prBody: string;
-  draft: boolean;
-}
-
-/** Create the PR, tolerating 422 (already exists) by finding the open PR. */
-async function createOrFindPullRequest(
-  inputs: CreatePrInputs,
-): Promise<{ url: string; number: number; draft: boolean }> {
-  const { repoOwner, repoRepo, githubToken, prTitle, branchName, baseBranch, prBody, draft } = inputs;
-
-  const create = async (title: string, asDraft: boolean): Promise<Response> =>
-    fetch(`https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls`, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${githubToken}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ title, head: branchName, base: baseBranch, body: prBody, ...(asDraft ? { draft: true } : {}) }),
-    });
-
-  const parseCreated = async (res: Response, asDraft: boolean): Promise<{ url: string; number: number; draft: boolean }> => {
-    const pr = (await res.json()) as { html_url?: unknown; number?: unknown };
-    if (typeof pr.html_url !== "string" || typeof pr.number !== "number") {
-      throw new Error("Unexpected PR creation response shape from GitHub API");
-    }
-    return { url: pr.html_url, number: pr.number, draft: asDraft };
-  };
-
-  const prRes = await create(prTitle, draft);
-  if (prRes.ok) return parseCreated(prRes, draft);
-
-  if (prRes.status === 422) {
-    // Ambiguous: either the PR already exists, or the repo plan rejects draft
-    // PRs. Check for an existing open PR first (existing behavior), then — if
-    // we were drafting — retry as a clearly-titled normal PR so the work is
-    // never vaporized on Free-plan private repos.
-    const listRes = await fetch(
-      `https://api.github.com/repos/${repoOwner}/${repoRepo}/pulls?head=${repoOwner}:${branchName}&state=open`,
-      { headers: { Authorization: `Bearer ${githubToken}` } },
-    );
-    if (!listRes.ok) {
-      const listBody = await listRes.text().catch(() => "");
-      throw new Error(`PR already exists (422) but listing open PRs failed with HTTP ${listRes.status}: ${listBody}`);
-    }
-    const prs = (await listRes.json()) as Array<{ html_url?: unknown; number?: unknown; draft?: unknown }>;
-    if (prs.length > 0) {
-      const existing = prs[0];
-      if (typeof existing.html_url === "string" && typeof existing.number === "number") {
-        return { url: existing.html_url, number: existing.number, draft: existing.draft === true };
-      }
-    }
-    if (draft) {
-      const retryRes = await create(`${UNAPPROVED_TITLE_PREFIX}${prTitle}`, false);
-      if (retryRes.ok) return parseCreated(retryRes, false);
-      const retryBody = await retryRes.text().catch(() => "");
-      throw new Error(`Draft PR rejected (422) and non-draft fallback failed with HTTP ${retryRes.status}: ${retryBody}`);
-    }
-    throw new Error(`PR already exists (422) but no open PR found for branch ${branchName}`);
-  }
-
-  const body = await prRes.text().catch(() => "");
-  throw new Error(`PR creation failed with HTTP ${prRes.status}: ${body}`);
-}
 
 /**
  * Build the `git push` argv and spawn env. When `trace` is true (driven by

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -77,6 +77,8 @@ export interface RunnerResultBody {
    * Only present for phase=kg-refresh.
    */
   snapshotPr?: number;
+  /** The `kg-refresh/<stamp>` branch behind snapshotPr; deleted by the orchestrator after merge or close. */
+  snapshotBranch?: string;
   /** Reference repository clone outcomes, present only when the run declared entries. */
   referenceRepoResults?: ReferenceRepoResult[];
 }
@@ -94,7 +96,7 @@ export interface HandleRunnerResultInput {
    */
   onKgRefreshRunnerComplete?: (
     outcome: "success" | "failure",
-    data: { snapshotCommit?: string; snapshotPr?: number; failureCode?: string; failureReason?: string },
+    data: { snapshotCommit?: string; snapshotPr?: number; snapshotBranch?: string; failureCode?: string; failureReason?: string },
   ) => void;
 }
 
@@ -279,6 +281,7 @@ export async function handleRunnerResult(
     input.onKgRefreshRunnerComplete?.(input.body.outcome, {
       snapshotCommit: input.body.snapshotCommit,
       snapshotPr: input.body.snapshotPr,
+      snapshotBranch: input.body.snapshotBranch,
       failureCode: input.body.failureCode,
       failureReason: input.body.failureReason,
     });

--- a/src/runner-callback.ts
+++ b/src/runner-callback.ts
@@ -71,6 +71,12 @@ export interface RunnerResultBody {
    * Only present for phase=kg-refresh.
    */
   snapshotCommit?: string;
+  /**
+   * Number of the refresh PR opened by a kg-refresh runner alongside snapshotCommit.
+   * The orchestrator merges it on a successful callback or closes it on a failed one.
+   * Only present for phase=kg-refresh.
+   */
+  snapshotPr?: number;
   /** Reference repository clone outcomes, present only when the run declared entries. */
   referenceRepoResults?: ReferenceRepoResult[];
 }
@@ -88,7 +94,7 @@ export interface HandleRunnerResultInput {
    */
   onKgRefreshRunnerComplete?: (
     outcome: "success" | "failure",
-    data: { snapshotCommit?: string; failureCode?: string; failureReason?: string },
+    data: { snapshotCommit?: string; snapshotPr?: number; failureCode?: string; failureReason?: string },
   ) => void;
 }
 
@@ -272,6 +278,7 @@ export async function handleRunnerResult(
     }
     input.onKgRefreshRunnerComplete?.(input.body.outcome, {
       snapshotCommit: input.body.snapshotCommit,
+      snapshotPr: input.body.snapshotPr,
       failureCode: input.body.failureCode,
       failureReason: input.body.failureReason,
     });

--- a/src/runner-result.ts
+++ b/src/runner-result.ts
@@ -51,6 +51,10 @@ export async function postRunnerResult(params: {
   noWork?: boolean;
   /** Reference repository clone outcomes, present only when the run declared entries. */
   referenceRepoResults?: ReferenceRepoResult[];
+  /** SHA of the snapshot commit pushed by a kg-refresh runner. Only meaningful for phase=kg-refresh. */
+  snapshotCommit?: string | null;
+  /** Number of the refresh PR opened alongside snapshotCommit. Only meaningful for phase=kg-refresh. */
+  snapshotPr?: number | null;
   /**
    * Resolved callback URL, e.g. from resolveRunnerInputs()/the envelope's runnerCallbackUrl.
    * Falls back to the legacy RUNNER_CALLBACK_URL env var (never set in GHA envelope mode,
@@ -76,6 +80,8 @@ export async function postRunnerResult(params: {
   if (params.referenceRepoResults && params.referenceRepoResults.length > 0) {
     body.referenceRepoResults = params.referenceRepoResults;
   }
+  if (params.snapshotCommit) body.snapshotCommit = params.snapshotCommit;
+  if (params.snapshotPr) body.snapshotPr = params.snapshotPr;
   const fetchFn = params.fetchImpl ?? fetch;
   try {
     const res = await fetchFn(`${callbackUrl.replace(/\/$/, "")}/runner/result`, {

--- a/src/runner-result.ts
+++ b/src/runner-result.ts
@@ -55,6 +55,8 @@ export async function postRunnerResult(params: {
   snapshotCommit?: string | null;
   /** Number of the refresh PR opened alongside snapshotCommit. Only meaningful for phase=kg-refresh. */
   snapshotPr?: number | null;
+  /** The `kg-refresh/<stamp>` branch the snapshot was pushed to; the orchestrator deletes it after merge or close. */
+  snapshotBranch?: string | null;
   /**
    * Resolved callback URL, e.g. from resolveRunnerInputs()/the envelope's runnerCallbackUrl.
    * Falls back to the legacy RUNNER_CALLBACK_URL env var (never set in GHA envelope mode,
@@ -82,6 +84,7 @@ export async function postRunnerResult(params: {
   }
   if (params.snapshotCommit) body.snapshotCommit = params.snapshotCommit;
   if (params.snapshotPr) body.snapshotPr = params.snapshotPr;
+  if (params.snapshotBranch) body.snapshotBranch = params.snapshotBranch;
   const fetchFn = params.fetchImpl ?? fetch;
   try {
     const res = await fetchFn(`${callbackUrl.replace(/\/$/, "")}/runner/result`, {


### PR DESCRIPTION
Supersedes #505 (the run's implementation, kept intact as the first commit) with the remaining work done by hand after two gap-fill runs hit the turn cap.

## What the run delivered (unchanged)
`kg-snapshot-push` pushes to `kg-refresh/<stamp>` and opens the refresh PR with the report through the shared `openOrFindPullRequest` helper (extracted from `push.ts`); `kg-tracker-data` exposes `teamCounts`; the callback carries `snapshotPr`; `onRunnerComplete` merges the PR with the merge method on success and closes it with the gate on failure.

## Added here
- **Branch cleanup:** the callback also carries `snapshotBranch`; the orchestrator deletes `kg-refresh/<stamp>` after the merge and after a close (`deleteBranch`, injectable). Without it the KG repo gains one branch per refresh.
- **One failure helper** in `onRunnerComplete` replaces the three copied failure blocks (refuse without sha, merge not merged, merge threw). Behavior unchanged.
- **Orchestrator tests** (`kg-refresh.test.ts`): merge with `merge` then verify; refuse without `snapshotCommit`; `blocked` and `conflict` → failed with the PR named; merge throw → failed; failure callback posts the gate comment, closes the PR, deletes the branch; failure without a PR closes nothing.
- **Runner tests fixed:** the bare-repo fixture ran `git for-each-ref --format=%(refname)` through a shell (`sh` chokes on `%(`); the dry-run report test read the spy's calls after `mockRestore`, which clears them.
- **Docs:** `docs/issueless-runs.md` (diagram, callback shape, §9 the refresh PR as the record and the merge/close rules, §10 dry-run prints the report) and `docs/kg-architecture.md` (the sequencing rule, the process steps, the redeploy fallback, the harness note) no longer describe a laptop ingest or push; the rail is the only writer of `snapshot/`.

Confirmed, no change needed: `src/auto-merge.ts` only considers `ai-implement/feature/*` and `ai-implement/multi-issue/*` bases, so the refresh PR is never picked up by the grouping auto-merge.

## Verification
`npm run typecheck` clean; `npm test` 199 files / 4766 tests passed on this head.

Fixes AII-593