### PR TITLE
AII-600: dev harness --phase kg-refresh: replace the entrypoint's clone in /workspace instead of failing

### DIFF
--- a/docs/issueless-runs.md
+++ b/docs/issueless-runs.md
@@ -503,7 +503,7 @@ npm run dev:run -- \
 
 **What differs from a dispatched run:**
 
-- The KG source checkout is bind-mounted read-only at `/kg-source`. The `clone` step is replaced with `devHarnessKgCloneStep`, which clones from `file:///kg-source` into the container's scratch workspace. Uncommitted edits to `sources.yml` therefore take effect immediately.
+- The KG source checkout is bind-mounted read-only at `/kg-source`. The `clone` step is replaced with `devHarnessKgCloneStep`, which clones from `file:///kg-source` into the container's scratch workspace. The runner entrypoint has already cloned the repo from GitHub into `/workspace` by then (it does so for every non-mounted run); the harness step clears that throwaway clone and replaces it with the `file:///kg-source` clone (AII-600). Uncommitted edits to `sources.yml` therefore take effect immediately.
 - `--tracker-data <file>` is required. The file is the pre-fetched body of `POST /api/runner/kg-tracker-data` (one team's worth). It is bind-mounted at `/dev-tracker-data.json`; the `kg-tracker-data` step detects `KG_TRACKER_DATA_FILE` and uses it rather than calling the orchestrator.
 - The operator's `GH_TOKEN` is injected as `AI_IMPLEMENT_DEP_TOKEN_OVERRIDE`. This swaps in a stub `dependency-auth` step that marks `acquired=true`, satisfying `clone-secondary-repos` without an orchestrator token vend. If the token lacks `contents: read` on a secondary repo, the clone fails with a 404/403 — exactly the parity check the harness is designed to surface.
 - `kg-snapshot-push` runs in dry-run mode (`AI_IMPLEMENT_KG_DRY_RUN=true`). Guards and validation run in full; the refresh report (the same markdown that becomes the refresh PR body on a real run) is printed to the log; no commit, push, branch or PR happens.

--- a/src/__tests__/kg-refresh-run.test.ts
+++ b/src/__tests__/kg-refresh-run.test.ts
@@ -1483,7 +1483,7 @@ describe("applyWiring for kg-tracker-data", () => {
 
 // ── runKgRefresh() happy and failure paths ────────────────────────────────────
 
-import { runKgRefresh } from "../pipeline/kg-refresh-run.js";
+import { runKgRefresh, devHarnessKgCloneStep } from "../pipeline/kg-refresh-run.js";
 import type { StepModule } from "../pipeline/types.js";
 
 function makeStepModule(outputs: Record<string, unknown> = {}, throwErr?: Error): StepModule {
@@ -4760,5 +4760,50 @@ describe("runKgRefresh — dev-harness dep-token-override", () => {
     });
 
     expect(capturedKgDryRun).toBe(true);
+  });
+});
+
+
+// ── devHarnessKgCloneStep — replaces the entrypoint's clone (AII-600) ────────
+describe("devHarnessKgCloneStep", () => {
+  let srcDir: string;
+  let wsDir: string;
+  beforeEach(() => {
+    srcDir = mkdtempSync(join(tmpdir(), "kg-src-"));
+    wsDir = mkdtempSync(join(tmpdir(), "kg-ws-"));
+    initGitRepo(srcDir);
+    process.env.KG_SOURCE_DIR = srcDir;
+  });
+  afterEach(() => {
+    delete process.env.KG_SOURCE_DIR;
+    rmSync(srcDir, { recursive: true, force: true });
+    rmSync(wsDir, { recursive: true, force: true });
+  });
+
+  it("clones into an empty workspace", async () => {
+    const ctx = makeContext();
+    const out = await devHarnessKgCloneStep.run(ctx, { workspaceDir: wsDir }, noopReporter);
+    expect(out.clonedRef).toBe(resolveHead(srcDir));
+    expect(existsSync(join(wsDir, "README.md"))).toBe(true);
+  });
+
+  it("clears a workspace the entrypoint already populated, then clones from /kg-source", async () => {
+    // Simulate session/entrypoint.sh: a throwaway clone (any content) already sits in the workspace.
+    writeFileSync(join(wsDir, "stale.txt"), "from the entrypoint clone");
+    mkdirSync(join(wsDir, ".git"), { recursive: true });
+    const ctx = makeContext();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    let printed = "";
+    let out: Record<string, unknown>;
+    try {
+      out = await devHarnessKgCloneStep.run(ctx, { workspaceDir: wsDir }, noopReporter);
+      printed = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(printed).toContain("replacing the entrypoint's clone");
+    expect(existsSync(join(wsDir, "stale.txt"))).toBe(false);
+    expect(existsSync(join(wsDir, "README.md"))).toBe(true);
+    expect(out!.clonedRef).toBe(resolveHead(srcDir));
   });
 });

--- a/src/pipeline/kg-refresh-run.ts
+++ b/src/pipeline/kg-refresh-run.ts
@@ -1,3 +1,5 @@
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { decodeRunConfig } from "../run-config.js";
 import { postRunnerResult } from "../runner-result.js";
@@ -20,10 +22,19 @@ import type { LLMExecutor, PipelineContext, StepReporter, StepModule } from "./t
  * operator's KG source checkout bind-mounted read-only by the dev harness) rather
  * than from GitHub, so uncommitted edits to sources.yml take effect immediately.
  */
-const devHarnessKgCloneStep: StepModule = {
+export const devHarnessKgCloneStep: StepModule = {
   async run(context: PipelineContext, inputs: Record<string, unknown>): Promise<Record<string, unknown>> {
     const workspaceDir = inputs.workspaceDir as string;
     const kgSourceDir = process.env.KG_SOURCE_DIR ?? "/kg-source";
+    // session/entrypoint.sh clones the repo into the workspace for every non-mounted
+    // run before the pipeline starts. That clone is throwaway here: the operator's
+    // checkout at /kg-source (uncommitted edits included) is the source of truth, and
+    // git refuses to clone into a non-empty directory. Clear the contents, keep the
+    // directory (it may be the container's working dir), then clone.
+    if (existsSync(workspaceDir) && readdirSync(workspaceDir).length > 0) {
+      console.log(`[clone] dev-harness: replacing the entrypoint's clone at ${workspaceDir} with file://${kgSourceDir}`);
+      for (const entry of readdirSync(workspaceDir)) rmSync(join(workspaceDir, entry), { recursive: true, force: true });
+    }
     console.log(`[clone] dev-harness: cloning from file://${kgSourceDir} into ${workspaceDir}`);
     const cloneResult = spawnSync(
       "git",


### PR DESCRIPTION
`npm run dev:run -- --phase kg-refresh …` failed in five seconds: `session/entrypoint.sh` clones the repo into `/workspace` for every non-mounted run, and `devHarnessKgCloneStep` then ran `git clone file:///kg-source /workspace` into the non-empty directory. Found on the first real proof loop of bd-mega-kg-refresh (2026-09-09).

- `devHarnessKgCloneStep` now clears the workspace contents when it is non-empty (the entrypoint's clone is throwaway here; `/kg-source` with the operator's uncommitted edits is the source of truth), logs one line, then clones as before. The step is exported for tests.
- Two tests: empty workspace; pre-populated workspace is replaced and the log line appears.
- `docs/issueless-runs.md` § 10: one sentence on the replacement.

`npm run typecheck` clean; `kg-refresh-run.test.ts` 258 tests pass.

Fixes AII-600