### PR TITLE
CLAUDE.md: drop the local KG server binding (orchestrator MCP only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,6 @@ Bindings for the KG skills (bd-kg-search, kg recon — format: skills `plugin/sk
 - kg.mcp_server:   orch-ai-implement-testing
 - kg.search_tool:  mcp__orch-ai-implement-testing__kg_hybrid_search
 - kg.source_repo:  BuildDownAI/knowledge-graph-ai-implement
-- kg.local_mcp_server:  ai-implement-kg
-- kg.local_search_tool: mcp__ai-implement-kg__kg_hybrid_search
 - kg.prefer:       orchestrator
 
 Project-specific orchestrator instances can override the bundled graph with `KG_SOURCE_REPO=owner/repo`.


### PR DESCRIPTION
The `ai-implement-kg` stdio server was the transition binding for laptop ingests. The laptop no longer produces a graph the skills should query (the rail is the only writer of `snapshot/`), and two connected KG servers invite confusion. This removes `kg.local_mcp_server` and `kg.local_search_tool` from the binding; `kg.prefer` stays `orchestrator`. The user-level MCP entry is removed separately with `claude mcp remove ai-implement-kg -s user`. bd-mega-kg-refresh's fast loop moves to the checkout's `kg-query` CLI (BDS issue filed).