### PR TITLE
CLAUDE.md: drop kg.prefer from the Knowledge graph binding (retired by skills BDS-56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,6 @@ Bindings for the KG skills (bd-kg-search, kg recon — format: skills `plugin/sk
 - kg.mcp_server:   orch-ai-implement-testing
 - kg.search_tool:  mcp__orch-ai-implement-testing__kg_hybrid_search
 - kg.source_repo:  BuildDownAI/knowledge-graph-ai-implement
-- kg.prefer:       orchestrator
 
 Project-specific orchestrator instances can override the bundled graph with `KG_SOURCE_REPO=owner/repo`.
 The value is a GitHub repo identifier, not a URL; see `docs/kg-sidecar.md`.


### PR DESCRIPTION
## Summary
Removes the one remaining `kg.prefer: orchestrator` line from the `## Knowledge graph` block in `CLAUDE.md`.

## Why
BuildDownAI/skills BDS-56 (plugin 1.5.0, skills PR #91) retired dual-target transition mode. The skills query one KG server, the orchestrator's. `kg.prefer`, `kg.local_mcp_server`, and `kg.local_search_tool` are retired binding fields; this repo had already dropped the two `kg.local_*` lines and kept `kg.prefer`. With the field gone the binding is the five fields the skills read: `kg.present`, `kg.orchestrator`, `kg.mcp_server`, `kg.search_tool`, `kg.source_repo`.

No code change. Surfaced by a bd-mega-kg-refresh Phase 2 search on 2026-09-10; supersession note posted on AII-324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)